### PR TITLE
chore: add .vercel to .gitignore and commit OAuth setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage/
 .env*.local
 !.env.example
 .gstack/
+.vercel

--- a/setup-production-oauth.sh
+++ b/setup-production-oauth.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Configures GitHub OAuth on the ForkLeaf production deployment.
+#
+# Run from the repository root:  ./setup-production-oauth.sh
+#
+# You are asked for the OAuth app's Client ID and Client Secret. Both come from
+# github.com/settings/applications/3798270. The secret is shown only once when
+# it is generated, so click "Generate a new client secret" if you no longer have
+# it. Nothing is written to disk by this script.
+set -euo pipefail
+
+APP_URL="https://forkleaf.vercel.app"
+
+command -v vercel >/dev/null || { echo "vercel CLI not found. Install it: npm i -g vercel"; exit 1; }
+
+echo "Vercel account signed in here: $(vercel whoami 2>/dev/null || echo none)"
+echo
+echo "ForkLeaf is deployed under the 'praneethdev' account. If the name above is"
+echo "not that account, switch now, or the env vars land on the wrong project."
+read -rp "Switch accounts? [y/N] " switch
+if [[ "$switch" =~ ^[Yy]$ ]]; then
+  vercel logout || true
+  vercel login
+fi
+
+# Links this checkout to the Vercel project. Choose the EXISTING ForkLeaf
+# project when prompted; creating a new one gives you a second deployment at a
+# different URL and fixes nothing.
+[ -f .vercel/project.json ] || vercel link
+
+read -rp  "GitHub OAuth Client ID: " CLIENT_ID
+read -rsp "GitHub OAuth Client Secret: " CLIENT_SECRET; echo
+[ -n "$CLIENT_ID" ] && [ -n "$CLIENT_SECRET" ] || { echo "Both values are required."; exit 1; }
+
+SESSION_SECRET="$(openssl rand -base64 32)"
+
+# Remove before adding: `vercel env add` fails on a name that already exists,
+# and a half-configured project is the state this script exists to get out of.
+for name in GITHUB_OAUTH_CLIENT_ID GITHUB_OAUTH_CLIENT_SECRET SESSION_SECRET NEXT_PUBLIC_APP_URL; do
+  vercel env rm "$name" production --yes >/dev/null 2>&1 || true
+done
+
+printf '%s' "$CLIENT_ID"      | vercel env add GITHUB_OAUTH_CLIENT_ID production
+printf '%s' "$CLIENT_SECRET"  | vercel env add GITHUB_OAUTH_CLIENT_SECRET production
+printf '%s' "$SESSION_SECRET" | vercel env add SESSION_SECRET production
+printf '%s' "$APP_URL"        | vercel env add NEXT_PUBLIC_APP_URL production
+
+# NEXT_PUBLIC_ values are inlined at build time, and the deployment now serving
+# traffic was built without any of these. It needs a fresh build to pick them up.
+vercel --prod
+
+echo
+echo "Verifying..."
+sleep 5
+curl -s -o /dev/null -w 'auth/github -> %{http_code} %{redirect_url}\n' "$APP_URL/api/auth/github"
+echo
+echo "Want:    307 to github.com/login/oauth/authorize"
+echo "Not:     307 to /?error=oauth_not_configured"


### PR DESCRIPTION
## Summary

Adds two small but important files that were missing from the repository:

### Changes

#### `.gitignore` — add `.vercel` directory
The `.vercel/` directory is auto-generated by `vercel link` and contains project-specific configuration (project ID, org ID). It should not be committed as it's specific to each developer's local Vercel setup.

#### `setup-production-oauth.sh` — OAuth setup script
A helper script that configures GitHub OAuth environment variables on the Vercel production deployment. This is essential because:

1. **`NEXT_PUBLIC_APP_URL` is inlined at build time** — any deployment built without it will have the wrong OAuth callback URL
2. **Without OAuth env vars, ForkLeaf runs in local-only mode** — users see a warning banner and can't sign in with GitHub

The script handles:
- Linking the checkout to the correct Vercel project
- Prompting for the GitHub OAuth Client ID and Secret
- Generating a cryptographically random `SESSION_SECRET`
- Setting all 4 required env vars (`GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, `SESSION_SECRET`, `NEXT_PUBLIC_APP_URL`)
- Triggering a fresh production deployment
- Verifying the OAuth redirect works

### Context

The production deployment at forkleaf.vercel.app currently shows:
> ⚠️ "GitHub sign-in is not configured on this deployment"

This is because the env vars were added to Vercel AFTER the last deployment was built. A fresh `vercel --prod` deployment will pick up the env vars and enable OAuth.

### Verification
- No code changes — only `.gitignore` and a new shell script
- Build, typecheck, lint, and tests are unaffected