### PR TITLE
fix: unstick the boot path, and make the diagram canvas usable

### DIFF
--- a/apps/web/src/app/editor/page.tsx
+++ b/apps/web/src/app/editor/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { EditorWorkspace } from "@/components/editor/EditorWorkspace";
-import { ForkLeafLogo } from "@/components/Brand";
+import { BootScreen } from "@/components/BootScreen";
 
 export const metadata = {
   title: "Editor — ForkLeaf",
@@ -25,19 +25,8 @@ export const dynamic = "force-dynamic";
  */
 export default function EditorPage() {
   return (
-    <Suspense fallback={<Booting />}>
+    <Suspense fallback={<BootScreen />}>
       <EditorWorkspace />
     </Suspense>
-  );
-}
-
-function Booting() {
-  return (
-    <div className="flex h-screen flex-col items-center justify-center gap-4 bg-[var(--fl-bg)]">
-      <ForkLeafLogo markClassName="h-8 w-8" textClassName="text-xl" />
-      <p className="text-sm text-[var(--fl-muted)]" aria-busy="true">
-        Starting ForkLeaf…
-      </p>
-    </div>
   );
 }

--- a/apps/web/src/components/BootScreen.tsx
+++ b/apps/web/src/components/BootScreen.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ForkLeafLogo } from "@/components/Brand";
+
+/** How long a boot may take before the screen stops claiming progress. */
+const STALL_AFTER_MS = 12_000;
+
+/**
+ * The screen shown while ForkLeaf starts — and, if it does not, the screen
+ * that admits it.
+ *
+ * A spinner is a promise that something is happening. When the thing it is
+ * waiting on never arrives, that promise becomes a lie, and the user is left
+ * looking at a logo with no error, no console message and nothing to click.
+ * Every individual cause has been given a bound elsewhere; this is the
+ * backstop for the ones that have not been thought of yet — a chunk that
+ * fails to load, an extension that blocks a request, a promise nobody found.
+ *
+ * After twelve seconds it stops pretending and offers a way out.
+ */
+export function BootScreen({ message = "Starting ForkLeaf…" }: { message?: string }) {
+  const [stalled, setStalled] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setStalled(true), STALL_AFTER_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!stalled) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-4 bg-[var(--fl-bg)]">
+        <ForkLeafLogo markClassName="h-8 w-8" textClassName="text-xl" />
+        <p className="text-sm text-[var(--fl-muted)]" aria-busy="true">
+          {message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-5 bg-[var(--fl-bg)] px-6 text-center">
+      <ForkLeafLogo markClassName="h-8 w-8" textClassName="text-xl" />
+
+      <div className="max-w-md">
+        <h1 className="text-lg font-semibold text-[var(--fl-text)]">
+          ForkLeaf did not finish starting
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-[var(--fl-muted)]">
+          This is nearly always another ForkLeaf tab holding this browser&rsquo;s local storage, or
+          an extension blocking part of the page. Close any other ForkLeaf tabs, then reload.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <button type="button" className="fl-btn fl-btn-primary" onClick={() => location.reload()}>
+          Reload
+        </button>
+        <button type="button" className="fl-btn fl-btn-ghost" onClick={resetLocalData}>
+          Reset local data and reload
+        </button>
+      </div>
+
+      <p className="max-w-md text-xs leading-relaxed text-[var(--fl-muted)]">
+        Resetting deletes the copy of your notes held in this browser. Anything already pushed to a
+        connected repository is safe and comes back; notes only ever written on this device do not.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The escape hatch, for a database that cannot be opened or read at all.
+ *
+ * Deliberately blunt about what it costs, and deliberately not automatic: it
+ * is the right answer for a corrupt store and the wrong one for anything else,
+ * and only the person whose notes they are can tell the difference.
+ */
+function resetLocalData(): void {
+  const confirmed = window.confirm(
+    "Delete ForkLeaf's local data in this browser and reload?\n\n" +
+      "Notes pushed to a connected repository will come back. Notes only ever written on this device will not.",
+  );
+  if (!confirmed) return;
+
+  const request = indexedDB.deleteDatabase("forkleaf");
+  // Reload either way: a delete that cannot finish is itself a reason to
+  // start the page over.
+  request.onsuccess = () => location.reload();
+  request.onerror = () => location.reload();
+  request.onblocked = () => location.reload();
+}

--- a/apps/web/src/components/ProfilePanel.tsx
+++ b/apps/web/src/components/ProfilePanel.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { EditorViewMode, SessionUser, SyncPreference, Workspace } from "@forkleaf/types";
 import { DEFAULT_SYNC_PREFERENCE } from "@forkleaf/types";
-import { createLocalDatabase, indexedDbAvailable, type LocalDatabase } from "@forkleaf/store";
+import { openLocalDatabase, type LocalDatabase } from "@forkleaf/store";
 import { documentStats } from "@forkleaf/markdown-engine";
 import { signOut } from "@/lib/gateway";
 import { useTheme, type Theme } from "@/hooks/useTheme";
@@ -63,6 +63,7 @@ export function ProfilePanel({ user, githubAvailable }: ProfilePanelProps) {
   const [theme, setTheme] = useTheme();
   const [library, setLibrary] = useState<Library | null>(null);
   const [unavailable, setUnavailable] = useState(false);
+  const [blocked, setBlocked] = useState(false);
   const [db, setDb] = useState<LocalDatabase | null>(null);
 
   useEffect(() => {
@@ -70,15 +71,19 @@ export function ProfilePanel({ user, githubAvailable }: ProfilePanelProps) {
 
     void (async () => {
       try {
-        // Inside the async body rather than as an early return: a bare
-        // `setState` in an effect body is a cascading render, and the check
-        // belongs with the thing it guards anyway.
-        if (!indexedDbAvailable()) {
-          if (!cancelled) setUnavailable(true);
+        // Opened inside the async body rather than guarded by an early return:
+        // a bare `setState` in an effect body is a cascading render, and this
+        // has to await the open anyway to know which case it is in.
+        const { db: database, status } = await openLocalDatabase();
+        if (cancelled) return;
+        if (status !== "ready") {
+          // An in-memory store would report a library of zero notes and zero
+          // words, which is a lie the profile page should not tell.
+          if (status === "blocked") setBlocked(true);
+          else setUnavailable(true);
           return;
         }
 
-        const database = await createLocalDatabase();
         const workspaces = await database.listWorkspaces();
         const queue = await database.listQueue();
 
@@ -225,7 +230,12 @@ export function ProfilePanel({ user, githubAvailable }: ProfilePanelProps) {
       <section className="mt-10">
         <SectionHeading>What you have written</SectionHeading>
 
-        {unavailable ? (
+        {blocked ? (
+          <p className="fl-card mt-3 p-6 text-[14px] leading-relaxed text-[var(--fl-muted)]">
+            Another ForkLeaf tab is holding local storage open, so these counts cannot be read.
+            Close the other tabs and reload.
+          </p>
+        ) : unavailable ? (
           <p className="fl-card mt-3 p-6 text-[14px] leading-relaxed text-[var(--fl-muted)]">
             This browser is not letting ForkLeaf use local storage, so there is nothing to count.
             Private windows and blocked third-party storage both do this.

--- a/apps/web/src/components/StorageBlocked.tsx
+++ b/apps/web/src/components/StorageBlocked.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { openLocalDatabase } from "@forkleaf/store";
+import { ForkLeafLogo } from "@/components/Brand";
+
+/**
+ * Shown when another tab is holding local storage open.
+ *
+ * IndexedDB allows exactly one version of a database at a time, so a second
+ * tab can find itself locked out — briefly, while the first one lets go, or
+ * indefinitely if that tab is asleep in a background window. The editor could
+ * open anyway on an in-memory store, and for a while it did: it looked like a
+ * working ForkLeaf, took everything you typed, and threw it away on reload.
+ *
+ * A dead end you can see is better than a working screen that lies, so this
+ * takes over the page instead — and keeps trying, so closing the other tab is
+ * all the user has to do.
+ */
+export function StorageBlocked() {
+  const [waited, setWaited] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      while (!cancelled) {
+        // Each attempt already takes a few seconds when it is blocked; the
+        // pause is so a fast rejection does not become a spin.
+        const { status } = await openLocalDatabase();
+        if (cancelled) return;
+        if (status === "ready") {
+          window.location.reload();
+          return;
+        }
+        setWaited((count) => count + 1);
+        await new Promise((resolve) => setTimeout(resolve, 2_000));
+      }
+    };
+
+    void poll();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-5 bg-[var(--fl-bg)] px-6 text-center">
+      <ForkLeafLogo markClassName="h-8 w-8" textClassName="text-xl" />
+
+      <div className="max-w-md">
+        <h1 className="text-lg font-semibold text-[var(--fl-text)]">
+          ForkLeaf is open in another tab
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-[var(--fl-muted)]">
+          Your notes live in this browser&rsquo;s local storage, and only one tab can hold it at a
+          time. Close the other ForkLeaf tabs and this one picks up on its own — no notes are lost.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button type="button" className="fl-btn fl-btn-primary" onClick={() => location.reload()}>
+          Try again now
+        </button>
+      </div>
+
+      <p className="text-xs text-[var(--fl-muted)]" aria-live="polite">
+        {waited === 0 ? "Checking…" : `Still waiting for the other tab (${waited} attempts).`}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/DashboardPanel.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanel.tsx
@@ -9,6 +9,7 @@ import { queryIndex, tagCounts, type IndexEntry, type SortKey } from "@/lib/libr
 import { signOut } from "@/lib/gateway";
 import { useTheme } from "@/hooks/useTheme";
 import { useIndexView, type IndexView } from "@/hooks/useIndexView";
+import { StorageBlocked } from "@/components/StorageBlocked";
 import { ForkLeafLogo } from "@/components/Brand";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
 import { RepoChooser } from "./RepoChooser";
@@ -166,6 +167,10 @@ export function DashboardPanel({
   }, [router]);
 
   // ── Loading ─────────────────────────────────────────────────────────────
+  // The library cannot be read while another tab holds the database, and an
+  // empty dashboard would read as "you have no notes".
+  if (library.storage === "blocked") return <StorageBlocked />;
+
   if (!library.ready) {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-[var(--fl-bg)]">
@@ -586,6 +591,7 @@ function Stat({ label, value, hint }: { label: string; value: string; hint?: str
 /** "all 155 read" / "120 of 155 read" — never silent about what is missing. */
 function coverage(read: number, total: number): string {
   if (total === 0) return "";
+  if (total === 1) return read >= 1 ? "from the one note" : "from 0 of 1 note read so far";
   if (read >= total) return `from all ${total.toLocaleString()} notes`;
   return `from ${read.toLocaleString()} of ${total.toLocaleString()} notes read so far`;
 }

--- a/apps/web/src/components/dashboard/DashboardPanel.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanel.tsx
@@ -10,6 +10,7 @@ import { signOut } from "@/lib/gateway";
 import { useTheme } from "@/hooks/useTheme";
 import { useIndexView, type IndexView } from "@/hooks/useIndexView";
 import { StorageBlocked } from "@/components/StorageBlocked";
+import { BootScreen } from "@/components/BootScreen";
 import { ForkLeafLogo } from "@/components/Brand";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
 import { RepoChooser } from "./RepoChooser";
@@ -171,16 +172,7 @@ export function DashboardPanel({
   // empty dashboard would read as "you have no notes".
   if (library.storage === "blocked") return <StorageBlocked />;
 
-  if (!library.ready) {
-    return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-[var(--fl-bg)]">
-        <ForkLeafLogo markClassName="h-8 w-8" textClassName="text-xl" />
-        <p className="text-sm text-[var(--fl-muted)]" aria-busy="true">
-          Reading your library…
-        </p>
-      </div>
-    );
-  }
+  if (!library.ready) return <BootScreen message="Reading your library…" />;
 
   const firstRun = library.needsRepoChoice && !skippedChoice;
 

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -27,6 +27,7 @@ import { HelpDialog } from "@/components/HelpDialog";
 import { HistoryDialog } from "@/components/HistoryDialog";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
 import { CommandPalette, type Command } from "@/components/CommandPalette";
+import { StorageBlocked } from "@/components/StorageBlocked";
 import { ForkLeafLogo } from "@/components/Brand";
 import { LocalOnlyBanner } from "@/components/LocalOnlyBanner";
 import { signOut } from "@/lib/gateway";
@@ -542,6 +543,10 @@ export function EditorWorkspace() {
   }, [note, notebook, handleCreate, router]);
 
   // ── Render ──────────────────────────────────────────────────────────────
+
+  // Another tab is holding local storage. Nothing typed here could be saved,
+  // so the editor does not open at all.
+  if (notebook.storage === "blocked") return <StorageBlocked />;
 
   if (!notebook.ready) {
     return (

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -28,6 +28,7 @@ import { HistoryDialog } from "@/components/HistoryDialog";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
 import { CommandPalette, type Command } from "@/components/CommandPalette";
 import { StorageBlocked } from "@/components/StorageBlocked";
+import { BootScreen } from "@/components/BootScreen";
 import { ForkLeafLogo } from "@/components/Brand";
 import { LocalOnlyBanner } from "@/components/LocalOnlyBanner";
 import { signOut } from "@/lib/gateway";
@@ -548,16 +549,7 @@ export function EditorWorkspace() {
   // so the editor does not open at all.
   if (notebook.storage === "blocked") return <StorageBlocked />;
 
-  if (!notebook.ready) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 bg-[var(--fl-bg)]">
-        <ForkLeafLogo markClassName="h-8 w-8" textClassName="text-xl" />
-        <p className="text-sm text-[var(--fl-muted)]" aria-busy="true">
-          {notebook.busy ?? "Starting ForkLeaf…"}
-        </p>
-      </div>
-    );
-  }
+  if (!notebook.ready) return <BootScreen message={notebook.busy ?? undefined} />;
 
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-[var(--fl-bg)] font-sans text-[var(--fl-text)]">

--- a/apps/web/src/hooks/useLibrary.ts
+++ b/apps/web/src/hooks/useLibrary.ts
@@ -4,8 +4,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   NoteRepository,
   SyncEngine,
-  createLocalDatabase,
+  openLocalDatabase,
   type LocalDatabase,
+  type LocalDatabaseStatus,
 } from "@forkleaf/store";
 import { workspaceId, type Note, type PendingChange, type Workspace } from "@forkleaf/types";
 import { GitHubGateway, LocalGateway, fetchSession, type SessionResponse } from "@/lib/gateway";
@@ -43,12 +44,19 @@ export interface LibraryState {
   needsRepoChoice: boolean;
   /** True while notes are being read to fill in titles, tags and counts. */
   indexing: boolean;
+  /** Whether local storage is real, held by another tab, or missing entirely. */
+  storage: LocalDatabaseStatus;
   error: string | null;
 }
 
-/** Shown when the browser will not give ForkLeaf durable local storage. */
+/**
+ * Shown when the browser will not give ForkLeaf durable local storage at all.
+ *
+ * The recoverable case — another tab holding the database — is `StorageBlocked`
+ * instead, so this text stays about the case that cannot be recovered from.
+ */
 const STORAGE_UNAVAILABLE =
-  "This browser is not letting ForkLeaf use local storage, so nothing written here will survive a reload. Another ForkLeaf tab may be holding it open — close the others and reload, or leave private browsing.";
+  "This browser will not let ForkLeaf use local storage, so your notes cannot be listed here. Leaving private browsing, or allowing site data for this page, fixes it.";
 
 /** How many notes to read at once while filling in the index. */
 const HYDRATE_BATCH = 6;
@@ -68,6 +76,7 @@ export function useLibrary() {
     workspaces: [],
     needsRepoChoice: false,
     indexing: false,
+    storage: "ready",
     error: null,
   });
 
@@ -102,12 +111,14 @@ export function useLibrary() {
         }));
         if (cancelled) return;
 
-        const db = await createLocalDatabase();
-        // `createLocalDatabase` never throws — a browser that refuses
-        // IndexedDB gets an in-memory store instead. That store is empty and
-        // dies with the tab, so the one thing that must not happen is showing
-        // it as though it were the user's library.
-        const ephemeral = !db.persistent;
+        // Never throws: a browser that refuses IndexedDB gets an in-memory
+        // store instead. That store is empty and dies with the tab, so the one
+        // thing that must not happen is showing it as the user's library.
+        const { db, status: storage } = await openLocalDatabase();
+        if (storage === "blocked") {
+          patch({ ready: true, storage });
+          return;
+        }
         const gateway = session.mode === "github" ? new GitHubGateway() : new LocalGateway();
         // The engine is created only so the repository can be, and is never
         // started: nothing on the dashboard pushes.
@@ -153,7 +164,8 @@ export function useLibrary() {
           session,
           workspaces: sortWorkspaces(slices),
           needsRepoChoice: session.mode === "github" && connected.length === 0,
-          error: ephemeral ? STORAGE_UNAVAILABLE : null,
+          storage,
+          error: storage === "unavailable" ? STORAGE_UNAVAILABLE : null,
         });
 
         // ── Pass two: reconcile with GitHub, one repository at a time.

--- a/apps/web/src/hooks/useLibrary.ts
+++ b/apps/web/src/hooks/useLibrary.ts
@@ -5,7 +5,6 @@ import {
   NoteRepository,
   SyncEngine,
   createLocalDatabase,
-  indexedDbAvailable,
   type LocalDatabase,
 } from "@forkleaf/store";
 import { workspaceId, type Note, type PendingChange, type Workspace } from "@forkleaf/types";
@@ -46,6 +45,10 @@ export interface LibraryState {
   indexing: boolean;
   error: string | null;
 }
+
+/** Shown when the browser will not give ForkLeaf durable local storage. */
+const STORAGE_UNAVAILABLE =
+  "This browser is not letting ForkLeaf use local storage, so nothing written here will survive a reload. Another ForkLeaf tab may be holding it open — close the others and reload, or leave private browsing.";
 
 /** How many notes to read at once while filling in the index. */
 const HYDRATE_BATCH = 6;
@@ -99,17 +102,12 @@ export function useLibrary() {
         }));
         if (cancelled) return;
 
-        if (!indexedDbAvailable()) {
-          patch({
-            ready: true,
-            session,
-            error:
-              "This browser is not letting ForkLeaf use local storage, so your notes cannot be listed here.",
-          });
-          return;
-        }
-
         const db = await createLocalDatabase();
+        // `createLocalDatabase` never throws — a browser that refuses
+        // IndexedDB gets an in-memory store instead. That store is empty and
+        // dies with the tab, so the one thing that must not happen is showing
+        // it as though it were the user's library.
+        const ephemeral = !db.persistent;
         const gateway = session.mode === "github" ? new GitHubGateway() : new LocalGateway();
         // The engine is created only so the repository can be, and is never
         // started: nothing on the dashboard pushes.
@@ -155,6 +153,7 @@ export function useLibrary() {
           session,
           workspaces: sortWorkspaces(slices),
           needsRepoChoice: session.mode === "github" && connected.length === 0,
+          error: ephemeral ? STORAGE_UNAVAILABLE : null,
         });
 
         // ── Pass two: reconcile with GitHub, one repository at a time.

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -93,6 +93,10 @@ const syncPrefKey = (workspace: Workspace) =>
 /** Folders made locally that have no note in them yet. See `emptyFolders`. */
 const emptyFoldersKey = (workspace: string) => `emptyFolders:${workspace}`;
 
+/** Shown when the browser will not give ForkLeaf durable local storage. */
+const STORAGE_UNAVAILABLE =
+  "This browser is not letting ForkLeaf use local storage, so nothing written here will survive a reload. Another ForkLeaf tab may be holding it open — close the others and reload, or leave private browsing.";
+
 /** How many notes may be open at once, to bound memory and tab-strip width. */
 const MAX_OPEN_NOTES = 12;
 
@@ -166,6 +170,10 @@ export function useNotebook(request: NotebookRequest = {}) {
         if (cancelled) return;
 
         const db = await createLocalDatabase();
+        // A browser that refuses IndexedDB gets an in-memory store rather than
+        // a boot failure, so the editor still opens — but nothing typed into
+        // it survives the tab, and saying so is the whole point of the banner.
+        const ephemeral = !db.persistent;
         const gateway: RemoteGateway =
           session.mode === "github" ? new GitHubGateway() : new LocalGateway();
 
@@ -222,6 +230,7 @@ export function useNotebook(request: NotebookRequest = {}) {
           needsRepoChoice,
           ready: true,
           busy: null,
+          error: ephemeral ? STORAGE_UNAVAILABLE : null,
         });
       } catch (error) {
         if (!cancelled) {

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -4,8 +4,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   SyncEngine,
   NoteRepository,
-  createLocalDatabase,
+  openLocalDatabase,
   type LocalDatabase,
+  type LocalDatabaseStatus,
   type RemoteGateway,
 } from "@forkleaf/store";
 import {
@@ -55,6 +56,8 @@ export interface NotebookState {
    */
   syncPreference: SyncPreference;
   error: string | null;
+  /** Whether local storage is real, held by another tab, or missing entirely. */
+  storage: LocalDatabaseStatus;
   /** Set while a slow operation (bootstrap, opening a note) is running. */
   busy: string | null;
   /**
@@ -93,9 +96,15 @@ const syncPrefKey = (workspace: Workspace) =>
 /** Folders made locally that have no note in them yet. See `emptyFolders`. */
 const emptyFoldersKey = (workspace: string) => `emptyFolders:${workspace}`;
 
-/** Shown when the browser will not give ForkLeaf durable local storage. */
+/**
+ * Shown when the browser will not give ForkLeaf durable local storage at all.
+ *
+ * Deliberately does not mention other tabs: that case is recoverable and gets
+ * `StorageBlocked` instead, so anyone reading this is in a private window or
+ * has storage switched off, and telling them to close tabs would be a dead end.
+ */
 const STORAGE_UNAVAILABLE =
-  "This browser is not letting ForkLeaf use local storage, so nothing written here will survive a reload. Another ForkLeaf tab may be holding it open — close the others and reload, or leave private browsing.";
+  "This browser will not let ForkLeaf use local storage, so nothing written here survives a reload. Leaving private browsing, or allowing site data for this page, fixes it.";
 
 /** How many notes may be open at once, to bound memory and tab-strip width. */
 const MAX_OPEN_NOTES = 12;
@@ -129,6 +138,7 @@ export function useNotebook(request: NotebookRequest = {}) {
     },
     syncPreference: DEFAULT_SYNC_PREFERENCE,
     error: null,
+    storage: "ready",
     busy: null,
     emptyFolders: [],
     needsRepoChoice: false,
@@ -169,11 +179,15 @@ export function useNotebook(request: NotebookRequest = {}) {
         }));
         if (cancelled) return;
 
-        const db = await createLocalDatabase();
-        // A browser that refuses IndexedDB gets an in-memory store rather than
-        // a boot failure, so the editor still opens — but nothing typed into
-        // it survives the tab, and saying so is the whole point of the banner.
-        const ephemeral = !db.persistent;
+        // Never throws: a browser that refuses IndexedDB gets an in-memory
+        // store rather than a boot failure. Nothing typed into that store
+        // survives the tab, though, so `storage` is carried into the state and
+        // the editor refuses to pretend otherwise.
+        const { db, status: storage } = await openLocalDatabase();
+        if (storage === "blocked") {
+          patch({ ready: true, busy: null, storage });
+          return;
+        }
         const gateway: RemoteGateway =
           session.mode === "github" ? new GitHubGateway() : new LocalGateway();
 
@@ -230,7 +244,8 @@ export function useNotebook(request: NotebookRequest = {}) {
           needsRepoChoice,
           ready: true,
           busy: null,
-          error: ephemeral ? STORAGE_UNAVAILABLE : null,
+          storage,
+          error: storage === "unavailable" ? STORAGE_UNAVAILABLE : null,
         });
       } catch (error) {
         if (!cancelled) {

--- a/apps/web/src/lib/assets.test.ts
+++ b/apps/web/src/lib/assets.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { Workspace } from "@forkleaf/types";
 import {
   isRepoRelative,
+  MISSING_IMAGE_SRC,
   relativeSrc,
   resolveAgainstNote,
   resolveImageSrc,
@@ -84,9 +85,26 @@ describe("resolveImageSrc", () => {
     );
   });
 
-  it("leaves a local workspace's paths alone — there is nothing to proxy to", () => {
-    expect(resolveImageSrc(local, "plan.md", "assets/a.png")).toBe("assets/a.png");
+  it("uses the copy on this device when there is one", () => {
+    const local_ = { "assets/a.png": "blob:forkleaf/abc" };
+    expect(resolveImageSrc(local, "plan.md", "assets/a.png", local_)).toBe("blob:forkleaf/abc");
+  });
+
+  /**
+   * A local workspace has nowhere to proxy to, so an asset that is not on this
+   * device is not going to appear. Returning the note-relative path made the
+   * browser fetch `/assets/a.png` from the app's own origin, 404, and draw the
+   * broken-image icon — which reads as a broken note rather than a missing
+   * file.
+   */
+  it("stands a placeholder in for a local image this device does not have", () => {
+    expect(resolveImageSrc(local, "plan.md", "assets/a.png")).toBe(MISSING_IMAGE_SRC);
+    expect(MISSING_IMAGE_SRC).toContain("Image%20not%20on%20this%20device");
+  });
+
+  it("leaves the src alone when there is no workspace or note to resolve against", () => {
     expect(resolveImageSrc(null, "plan.md", "assets/a.png")).toBe("assets/a.png");
+    expect(resolveImageSrc(local, null, "assets/a.png")).toBe("assets/a.png");
   });
 });
 

--- a/apps/web/src/lib/assets.ts
+++ b/apps/web/src/lib/assets.ts
@@ -121,6 +121,22 @@ export function isRepoRelative(src: string): boolean {
 }
 
 /**
+ * Stand-in for an image whose bytes are nowhere to be found.
+ *
+ * Inline SVG rather than a hosted file so it renders with no request at all,
+ * including offline, which is when it is most likely to be needed.
+ */
+export const MISSING_IMAGE_SRC =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="120" viewBox="0 0 320 120" role="img" aria-label="Image not on this device">` +
+      `<rect x="0.5" y="0.5" width="319" height="119" rx="7" fill="none" stroke="#8b8b8b" stroke-opacity="0.45" stroke-dasharray="5 4"/>` +
+      `<text x="160" y="56" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#8b8b8b">Image not on this device</text>` +
+      `<text x="160" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11.5" fill="#8b8b8b" fill-opacity="0.75">Connect the repository it was saved to</text>` +
+      `</svg>`,
+  );
+
+/**
  * The URL the browser should actually load for an image in a note.
  *
  * Absolute URLs and `data:` images are already loadable and pass through
@@ -145,7 +161,12 @@ export function resolveImageSrc(
   const stored = local?.[path];
   if (stored) return stored;
 
-  if (workspace.isLocal) return src;
+  // A workspace with no repository has exactly one place the bytes could be,
+  // and they are not there. Returning the note-relative path made the browser
+  // ask the app's own origin for `/assets/…`, get a 404, and draw the broken
+  // image icon with the filename next to it — which reads like a bug in the
+  // note rather than a file this device does not have.
+  if (workspace.isLocal) return MISSING_IMAGE_SRC;
 
   const params = new URLSearchParams({
     owner: workspace.repo.owner,

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -27,13 +27,20 @@ export class ApiGatewayError extends Error {
   }
 }
 
-async function call<T>(url: string, init?: RequestInit): Promise<T> {
+async function call<T>(url: string, init?: RequestInit & { timeoutMs?: number }): Promise<T> {
   let response: Response;
+  const { timeoutMs, ...rest } = init ?? {};
 
   try {
     response = await fetch(url, {
-      ...init,
+      ...rest,
       headers: { "Content-Type": "application/json", ...init?.headers },
+      // A `fetch` with no signal waits forever on a server that accepts the
+      // connection and then says nothing, which is not a hypothetical: a
+      // suspended laptop and a proxy that holds the socket both do it. Only
+      // the calls whose duration is bounded in principle opt in — a commit of
+      // fifty notes is allowed to take its time.
+      ...(timeoutMs ? { signal: AbortSignal.timeout(timeoutMs) } : {}),
     });
   } catch {
     // Genuine network failure — the sync engine treats this as "still offline"
@@ -162,9 +169,20 @@ export interface SessionResponse {
   githubAvailable: boolean;
 }
 
+/**
+ * Who the user is, according to the server.
+ *
+ * Bounded, because both the editor and the dashboard await this before they
+ * render anything at all: an unanswered request here is a loading screen with
+ * no way out. The callers already treat a failure as "local mode", which is
+ * the right answer when the server cannot be reached anyway.
+ */
 export function fetchSession(): Promise<SessionResponse> {
-  return call<SessionResponse>("/api/session");
+  return call<SessionResponse>("/api/session", { timeoutMs: SESSION_TIMEOUT_MS });
 }
+
+/** Generous — this is a guard against never, not a latency budget. */
+const SESSION_TIMEOUT_MS = 10_000;
 
 export function signOut(): Promise<{ ok: boolean }> {
   return call<{ ok: boolean }>("/api/auth/logout", { method: "POST" });

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -109,8 +109,16 @@ function policy(nonce: string | null, isDev: boolean): string {
   const script = nonce
     ? // The hash covers the theme script inlined in the document head, which is
       // a build-time constant rather than a per-request tag.
+      //
+      // No host allowlist here on purpose: `strict-dynamic` makes host sources
+      // be ignored, and covers gtag anyway, since Firebase Analytics injects
+      // that tag from the nonced bundle.
       `'self' 'nonce-${nonce}' '${THEME_INIT_HASH}' 'strict-dynamic'`
-    : `'self' 'unsafe-inline'`;
+    : // The prerendered routes have no nonce and so no `strict-dynamic`, which
+      // means the tag Firebase Analytics injects has to be named explicitly.
+      // Without it the landing page loaded analytics and the browser blocked
+      // it on every visit — `connect-src` below already expects it to work.
+      `'self' 'unsafe-inline' https://www.googletagmanager.com`;
 
   return [
     "default-src 'self'",
@@ -143,7 +151,10 @@ function policy(nonce: string | null, isDev: boolean): string {
     "base-uri 'self'",
     "form-action 'self'",
     "frame-ancestors 'none'",
-    "frame-src 'none'",
+    // The GitHub Sponsors card is an iframe, and the only one in the app. With
+    // `'none'` here it was blocked everywhere it appears — the landing page and
+    // the profile both drew an empty bordered box where the card should be.
+    "frame-src https://github.com",
     "worker-src 'self' blob:",
     "manifest-src 'self'",
     ...(isDev ? [] : ["upgrade-insecure-requests"]),

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.1.0",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^28.0.0",
     "prettier": "^3.6.2",
     "turbo": "^2.10.10",

--- a/packages/editor/src/mermaid/DiagramStudio.tsx
+++ b/packages/editor/src/mermaid/DiagramStudio.tsx
@@ -307,11 +307,21 @@ export function DiagramStudio({
       </div>
 
       {/* ── Body ────────────────────────────────────────────────────────── */}
-      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+      {/* Side by side once there is width for it, stacked below that.
+          Stacked, the whole body scrolls: two panes that each need a few
+          hundred pixels do not both fit in a dialog, and clipping them is
+          worse than letting the reader scroll to the one they are using. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-visible">
         {showSource && (
           <div
-            className={`flex min-h-[220px] min-w-0 flex-col border-b border-[var(--fl-border)] lg:border-b-0 ${
-              bothPanes ? "lg:w-[var(--fl-split)] lg:flex-none" : "flex-1"
+            className={`flex min-h-[200px] min-w-0 flex-col border-b border-[var(--fl-border)] lg:border-b-0 ${
+              bothPanes
+                ? // Stacked, the source is the pane that gives way: it stays
+                  // readable at a few lines, while a canvas needs room to be
+                  // usable at all. It used to be the other way round, which
+                  // left the canvas a 66px sliver on any screen under 1024px.
+                  "max-h-[38vh] shrink-0 lg:max-h-none lg:w-[var(--fl-split)] lg:flex-none"
+                : "flex-1"
             }`}
             // Carried as a custom property rather than an inline width: the
             // panes stack on a narrow screen, where a percentage width would
@@ -367,8 +377,11 @@ export function DiagramStudio({
           </div>
         )}
 
+        {/* The diagram pane is tall enough that what is left after the heading,
+            the two toolbar rows, the hint strip and the inspector is still a
+            canvas. */}
         {showDiagram && (
-          <div className="flex min-h-[240px] min-w-0 flex-1 flex-col bg-[var(--fl-surface)]">
+          <div className="flex min-h-[420px] min-w-0 flex-1 flex-col bg-[var(--fl-surface)]">
             <div className="flex shrink-0 items-center gap-2 px-4 pb-1 pt-2.5">
               <PaneHeading bare>
                 {effectiveView === "canvas" ? "Canvas — drag to edit" : "Preview"}

--- a/packages/editor/src/mermaid/DraftInput.tsx
+++ b/packages/editor/src/mermaid/DraftInput.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+
+/**
+ * A text input that shows what you typed, not what the model made of it.
+ *
+ * Every field on the canvas edits the diagram through the Mermaid source:
+ * the keystroke updates the graph, the graph is serialised to text, and the
+ * text is parsed straight back into the graph the field is then re-rendered
+ * from. That parse normalises — and normalising is lossy.
+ *
+ * A trailing space is the case that bit. Typing "Collect " serialises to
+ * `n1[Collect ]`, which parses back to "Collect", so the space is gone before
+ * the next letter arrives: you could type one word and never start a second.
+ *
+ * Rather than teach the parser to preserve half-finished input — a trailing
+ * space is genuinely not meaningful in a saved diagram — the field keeps its
+ * own copy of the text while it has focus. Every keystroke is still pushed
+ * outwards, so the canvas, the source and the preview all stay live; only the
+ * value shown belongs to the person typing. On blur the draft is dropped and
+ * the model's own text takes over again.
+ */
+export function DraftInput({
+  value,
+  onValueChange,
+  onBlur,
+  ...rest
+}: {
+  value: string;
+  onValueChange: (next: string) => void;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange">) {
+  /** The in-progress text, or null when the model's value is authoritative. */
+  const [draft, setDraft] = useState<string | null>(null);
+
+  return (
+    <input
+      {...rest}
+      value={draft ?? value}
+      onChange={(event) => {
+        setDraft(event.target.value);
+        onValueChange(event.target.value);
+      }}
+      onBlur={(event) => {
+        setDraft(null);
+        onBlur?.(event);
+      }}
+    />
+  );
+}

--- a/packages/editor/src/mermaid/SequenceCanvas.tsx
+++ b/packages/editor/src/mermaid/SequenceCanvas.tsx
@@ -15,6 +15,7 @@ import {
   type MessageArrow,
   type SequenceDiagram,
 } from "@forkleaf/diagrams";
+import { DraftInput } from "./DraftInput";
 
 export interface SequenceCanvasProps {
   diagram: SequenceDiagram;
@@ -434,14 +435,10 @@ export function SequenceCanvas({ diagram, onChange }: SequenceCanvasProps) {
         <div className="flex shrink-0 flex-wrap items-center gap-2 border-t border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-2 text-[12.5px]">
           {selectedParticipant && (
             <>
-              <input
+              <DraftInput
                 value={selectedParticipant.label}
-                onChange={(event) =>
-                  onChange(
-                    updateParticipant(diagram, selectedParticipant.id, {
-                      label: event.target.value,
-                    }),
-                  )
+                onValueChange={(next) =>
+                  onChange(updateParticipant(diagram, selectedParticipant.id, { label: next }))
                 }
                 aria-label="Participant name"
                 className="w-48 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-bg)] px-2 py-1 text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
@@ -476,13 +473,11 @@ export function SequenceCanvas({ diagram, onChange }: SequenceCanvasProps) {
 
           {selectedMessage && (
             <>
-              <input
+              <DraftInput
                 value={selectedMessage.label}
                 placeholder="What is being sent"
-                onChange={(event) =>
-                  onChange(
-                    updateMessage(diagram, selectedMessage.id, { label: event.target.value }),
-                  )
+                onValueChange={(next) =>
+                  onChange(updateMessage(diagram, selectedMessage.id, { label: next }))
                 }
                 aria-label="Message"
                 className="w-56 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-bg)] px-2 py-1 text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"

--- a/packages/editor/src/mermaid/VisualBuilder.tsx
+++ b/packages/editor/src/mermaid/VisualBuilder.tsx
@@ -27,6 +27,8 @@ import {
   type GraphNode,
   type NodeShape,
 } from "@forkleaf/diagrams";
+import { DraftInput } from "./DraftInput";
+import { resolveDrop } from "./drag";
 
 export interface VisualBuilderProps {
   graph: Graph;
@@ -431,18 +433,41 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
       }
       pending.current = null;
 
-      // Commit happens here, once, rather than on every frame.
-      if (drag.kind === "move" && drag.moved) {
-        // The whole selection moves with the node being dragged.
-        const moved = [...selection].filter((id) => graph.nodes.some((node) => node.id === id));
-        const dx = drag.preview.x - (graph.nodes.find((n) => n.id === drag.nodeId)?.x ?? 0);
-        const dy = drag.preview.y - (graph.nodes.find((n) => n.id === drag.nodeId)?.y ?? 0);
+      // Commit happens here, once, rather than on every frame — and from the
+      // release point rather than from `drag.preview`.
+      //
+      // `preview` and `moved` are only ever written inside the animation
+      // frame, and the frame this very handler just cancelled is usually the
+      // one that would have written them. A drag completed inside a single
+      // frame — a quick flick, a fast mouse, a synthetic event with no
+      // intermediate moves — therefore ended with `moved` still false and the
+      // node snapped back to where it started, having visibly followed the
+      // cursor the whole way. The marquee branch below already worked this
+      // out; the two branches that move things did not.
+      if (drag.kind === "move") {
+        const origin = graph.nodes.find((node) => node.id === drag.nodeId);
+        const to = origin
+          ? resolveDrop({
+              world: toWorld(event),
+              grab: { x: drag.grabX, y: drag.grabY },
+              origin,
+              freeform: event.altKey,
+              snap,
+            })
+          : null;
 
-        commit(
-          moved.length > 1 && moved.includes(drag.nodeId)
-            ? moveNodes(graph, moved, dx, dy)
-            : updateNode(graph, drag.nodeId, { x: drag.preview.x, y: drag.preview.y }),
-        );
+        if (origin && to) {
+          // The whole selection moves with the node being dragged.
+          const together = [...selection].filter((id) =>
+            graph.nodes.some((node) => node.id === id),
+          );
+
+          commit(
+            together.length > 1 && together.includes(drag.nodeId)
+              ? moveNodes(graph, together, to.x - origin.x, to.y - origin.y)
+              : updateNode(graph, drag.nodeId, { x: to.x, y: to.y }),
+          );
+        }
       } else if (drag.kind === "connect") {
         const world = toWorld(event);
         const target = nodeAt(graph, world);
@@ -520,7 +545,9 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
       if (frame.current !== null) cancelAnimationFrame(frame.current);
       frame.current = null;
     };
-  }, [drag, graph, onChange, toWorld, zoom]);
+    // `selection` and `commit` are read inside `onUp`; without them here a
+    // drag begun before a selection change committed against the stale set.
+  }, [drag, graph, onChange, toWorld, zoom, selection, commit]);
 
   // ── Zoom ────────────────────────────────────────────────────────────────
   // Anchored at the cursor, so the point under the pointer stays put — the
@@ -530,6 +557,8 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
     if (!host) return;
 
     const onWheel = (event: WheelEvent) => {
+      touched.current = true;
+
       // Plain scroll pans vertically; ctrl/cmd (or a pinch, which browsers
       // report as ctrl+wheel) zooms. Matches every canvas app.
       if (!event.ctrlKey && !event.metaKey) {
@@ -592,14 +621,41 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
     });
   }, [graph.nodes, viewport]);
 
-  // Frame the diagram the first time one exists, so opening the visual tab on
-  // a template does not drop you in an empty corner of the canvas.
-  const framed = useRef(false);
+  /**
+   * Whether the reader has taken control of the view by panning or zooming.
+   *
+   * Once they have, the canvas must never move on its own again — nothing is
+   * more disorienting than a view that re-centres itself while being used.
+   */
+  const touched = useRef(false);
+  const markTouched = useCallback(() => {
+    touched.current = true;
+  }, []);
+
+  /**
+   * Frame the diagram until the reader takes over.
+   *
+   * This used to fire exactly once, against whatever the pane happened to
+   * measure at that instant — which, while a dialog is still settling, is not
+   * the size it ends up. A canvas framed for a 700px pane and then resized to
+   * 292px left every node outside the viewBox: an empty grid, with the diagram
+   * parked somewhere off-screen and nothing on screen to say so.
+   *
+   * Re-framing on each new viewport size fixes that, and keying on the size
+   * means a pane that is not changing shape does not re-frame under a reader
+   * who is placing boxes.
+   */
+  const framedFor = useRef("");
   useEffect(() => {
-    if (framed.current || graph.nodes.length === 0 || viewport.width <= 1) return;
-    framed.current = true;
+    if (touched.current || graph.nodes.length === 0) return;
+    if (viewport.width <= 1 || viewport.height <= 1) return;
+
+    const signature = `${Math.round(viewport.width)}x${Math.round(viewport.height)}`;
+    if (framedFor.current === signature) return;
+
+    framedFor.current = signature;
     fit();
-  }, [graph.nodes.length, viewport.width, fit]);
+  }, [graph.nodes.length, viewport.width, viewport.height, fit]);
 
   // ── Actions ─────────────────────────────────────────────────────────────
 
@@ -892,7 +948,10 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
           <div className="flex items-center rounded-lg border border-[var(--fl-border)] bg-[var(--fl-bg)]">
             <ZoomButton
               label="Zoom out"
-              onClick={() => setZoom((z) => clamp(z / 1.2, MIN_ZOOM, MAX_ZOOM))}
+              onClick={() => {
+                markTouched();
+                setZoom((z) => clamp(z / 1.2, MIN_ZOOM, MAX_ZOOM));
+              }}
             >
               −
             </ZoomButton>
@@ -906,7 +965,10 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
             </button>
             <ZoomButton
               label="Zoom in"
-              onClick={() => setZoom((z) => clamp(z * 1.2, MIN_ZOOM, MAX_ZOOM))}
+              onClick={() => {
+                markTouched();
+                setZoom((z) => clamp(z * 1.2, MIN_ZOOM, MAX_ZOOM));
+              }}
             >
               +
             </ZoomButton>
@@ -933,6 +995,8 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
             // Middle-click pans from anywhere; otherwise this only fires on
             // the empty canvas, because nodes and edges stop the event.
             if (event.target !== event.currentTarget && event.button !== 1) return;
+
+            markTouched();
 
             setEditingLabel(null);
 
@@ -1110,6 +1174,7 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
               dragging={drag.kind === "move" && drag.nodeId === node.id}
               onPointerDown={(event) => {
                 event.stopPropagation();
+                markTouched();
                 const world = toWorld(event);
                 toggleSelected(node.id, event.shiftKey);
                 setDrag({
@@ -1155,16 +1220,14 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
             if (!node) return null;
 
             return (
-              <input
+              <DraftInput
                 autoFocus
                 // Selected on open, so double-clicking a box and typing
                 // replaces its name. Without this the caret landed at one end
                 // and "Process" became "ProcessBuild step".
                 onFocus={(event) => event.currentTarget.select()}
                 value={node.label}
-                onChange={(event) =>
-                  onChange(updateNode(graph, node.id, { label: event.target.value }))
-                }
+                onValueChange={(next) => onChange(updateNode(graph, node.id, { label: next }))}
                 onBlur={() => setEditingLabel(null)}
                 onKeyDown={(event) => {
                   if (event.key === "Enter" || event.key === "Escape") setEditingLabel(null);
@@ -1219,18 +1282,18 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
         <div className="flex shrink-0 flex-wrap items-center gap-2 border-t border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-2 text-[12.5px]">
           {selectedNode && (
             <>
-              <input
+              <DraftInput
                 value={
                   hasMembers(selectedNode.shape)
                     ? splitMembers(selectedNode.label).name
                     : selectedNode.label
                 }
-                onChange={(event) =>
+                onValueChange={(next) =>
                   onChange(
                     updateNode(graph, selectedNode.id, {
                       label: hasMembers(selectedNode.shape)
-                        ? joinMembers(event.target.value, splitMembers(selectedNode.label).members)
-                        : event.target.value,
+                        ? joinMembers(next, splitMembers(selectedNode.label).members)
+                        : next,
                     }),
                   )
                 }
@@ -1241,17 +1304,17 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
               {/* Fields and methods, one per line — the same shape as the
                   mermaid block, so what is typed here is what is written. */}
               {hasMembers(selectedNode.shape) && (
-                <input
+                <DraftInput
                   value={splitMembers(selectedNode.label).members.join("; ")}
                   placeholder={
                     graph.kind === "er" ? "string name; int age" : "+string id; +save() void"
                   }
-                  onChange={(event) =>
+                  onValueChange={(next) =>
                     onChange(
                       updateNode(graph, selectedNode.id, {
                         label: joinMembers(
                           splitMembers(selectedNode.label).name,
-                          event.target.value
+                          next
                             .split(";")
                             .map((member) => member.trim())
                             .filter((member) => member !== ""),
@@ -1294,14 +1357,14 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
 
           {selectedEdge && (
             <>
-              <input
+              <DraftInput
                 value={selectedEdge.label ?? ""}
                 placeholder="Arrow label"
-                onChange={(event) =>
+                onValueChange={(next) =>
                   onChange({
                     ...graph,
                     edges: graph.edges.map((e) =>
-                      e.id === selectedEdge.id ? { ...e, label: event.target.value } : e,
+                      e.id === selectedEdge.id ? { ...e, label: next } : e,
                     ),
                   })
                 }
@@ -1333,27 +1396,21 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
                   list the types is to say how many of each there are. */}
               {(graph.kind === "class" || graph.kind === "er") && (
                 <>
-                  <input
+                  <DraftInput
                     value={selectedEdge.fromCardinality ?? ""}
                     placeholder="1"
-                    onChange={(event) =>
-                      onChange(
-                        updateEdge(graph, selectedEdge.id, {
-                          fromCardinality: event.target.value,
-                        }),
-                      )
+                    onValueChange={(next) =>
+                      onChange(updateEdge(graph, selectedEdge.id, { fromCardinality: next }))
                     }
                     aria-label="Multiplicity at the source"
                     className="w-14 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-bg)] px-2 py-1 text-center text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
                   />
                   <span className="text-[var(--fl-muted)]">→</span>
-                  <input
+                  <DraftInput
                     value={selectedEdge.toCardinality ?? ""}
                     placeholder="*"
-                    onChange={(event) =>
-                      onChange(
-                        updateEdge(graph, selectedEdge.id, { toCardinality: event.target.value }),
-                      )
+                    onValueChange={(next) =>
+                      onChange(updateEdge(graph, selectedEdge.id, { toCardinality: next }))
                     }
                     aria-label="Multiplicity at the target"
                     className="w-14 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-bg)] px-2 py-1 text-center text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"

--- a/packages/editor/src/mermaid/drag.test.ts
+++ b/packages/editor/src/mermaid/drag.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { resolveDrop } from "./drag";
+
+const GRID = 8;
+const snap = (value: number) => Math.round(value / GRID) * GRID;
+
+describe("resolveDrop", () => {
+  /**
+   * The regression. The old handler read the landing position out of state
+   * that only an animation frame ever wrote, and cancelled that frame on
+   * release — so a drag completed within one frame moved nothing. Nothing
+   * here may depend on a frame having run.
+   */
+  it("lands the node from the release position alone", () => {
+    expect(
+      resolveDrop({
+        world: { x: 200, y: 100 },
+        grab: { x: 24, y: 16 },
+        origin: { x: 344, y: 24 },
+        freeform: false,
+        snap,
+      }),
+    ).toEqual({ x: 176, y: 88 });
+  });
+
+  it("returns null when the node has not moved, so a click is not an undo step", () => {
+    expect(
+      resolveDrop({
+        world: { x: 368, y: 40 },
+        grab: { x: 24, y: 16 },
+        origin: { x: 344, y: 24 },
+        freeform: false,
+        snap,
+      }),
+    ).toBeNull();
+  });
+
+  it("snaps to the grid, and stops snapping while alt is held", () => {
+    const request = {
+      world: { x: 203, y: 99 },
+      grab: { x: 0, y: 0 },
+      origin: { x: 0, y: 0 },
+      snap,
+    };
+
+    expect(resolveDrop({ ...request, freeform: false })).toEqual({ x: 200, y: 96 });
+    expect(resolveDrop({ ...request, freeform: true })).toEqual({ x: 203, y: 99 });
+  });
+});

--- a/packages/editor/src/mermaid/drag.ts
+++ b/packages/editor/src/mermaid/drag.ts
@@ -1,0 +1,43 @@
+/**
+ * Where a dragged node lands.
+ *
+ * Pulled out of the pointer handler because of the bug it used to hide. The
+ * committed position was read from state written inside a `requestAnimationFrame`
+ * callback — and the release handler cancelled that frame before it ran, so a
+ * drag finished inside a single frame committed nothing and the node snapped
+ * back after visibly following the cursor the whole way.
+ *
+ * The fix is to derive the landing position from the release position alone,
+ * which is knowable without any frame having run. As a pure function it can
+ * also be tested, which the handler it came from could not be.
+ */
+export interface DropRequest {
+  /** Pointer position, in world coordinates, at the moment of release. */
+  world: { x: number; y: number };
+  /** Offset from the node's origin to where it was grabbed. */
+  grab: { x: number; y: number };
+  /** Where the node was before the drag. */
+  origin: { x: number; y: number };
+  /** True while alt is held, which drags free of the grid. */
+  freeform: boolean;
+  /** Rounds a coordinate to the grid. */
+  snap: (value: number) => number;
+}
+
+/**
+ * The node's new position, or null when it has not actually moved.
+ *
+ * Returning null for an unmoved node is what keeps a plain click on a box —
+ * which is a drag of zero distance — from landing an empty entry in the undo
+ * history.
+ */
+export function resolveDrop({ world, grab, origin, freeform, snap }: DropRequest): {
+  x: number;
+  y: number;
+} | null {
+  const raw = { x: world.x - grab.x, y: world.y - grab.y };
+  const to = freeform ? raw : { x: snap(raw.x), y: snap(raw.y) };
+
+  if (to.x === origin.x && to.y === origin.y) return null;
+  return to;
+}

--- a/packages/store/src/idb-db.test.ts
+++ b/packages/store/src/idb-db.test.ts
@@ -1,18 +1,52 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { createLocalDatabase, indexedDbAvailable } from "./idb-db";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// `/auto` rather than the bare import: `idb` reaches for `IDBRequest` and the
+// other IDB constructors as globals, not just `indexedDB`.
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+import { openLocalDatabase, indexedDbAvailable } from "./idb-db";
 
 /**
  * The boot path, not the storage itself.
  *
  * ForkLeaf used to hand back an `IndexedDbDatabase` without ever checking that
- * the database opened, and `openDB` never rejects when another tab is holding
- * an older version — so a stale tab left open across a `DB_VERSION` bump hung
- * every other tab on "Starting ForkLeaf…" forever. These tests pin down the
- * two things that stop that: a bounded open, and a store that always comes
- * back so the app can boot and say what is wrong.
+ * the database opened, and `openDB` never rejects while another tab holds an
+ * older version — it fires no event at all. So a tab left open across a
+ * `DB_VERSION` bump hung every other tab on "Starting ForkLeaf…" forever.
+ *
+ * These tests use a real IndexedDB implementation rather than a hand-written
+ * stub, because the thing being pinned down is precisely the browser's own
+ * locking behaviour: a stub would only assert what the stub does.
  */
 
+const DB_NAME = "forkleaf";
+/** Well under the real ceiling, so a blocked open does not stall the suite. */
+const TIMEOUT = 50;
+
 const original = Object.getOwnPropertyDescriptor(globalThis, "indexedDB");
+
+/** Replaces the global, or removes it when given nothing. */
+function stubIndexedDb(value?: unknown) {
+  if (value === undefined) {
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    return;
+  }
+  Object.defineProperty(globalThis, "indexedDB", { value, configurable: true, writable: true });
+}
+
+/** Opens a raw connection and holds it, ignoring `versionchange` — a stale tab. */
+function holdStaleConnection(version: number): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, version);
+    request.onupgradeneeded = () => request.result.createObjectStore("notes", { keyPath: "id" });
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+beforeEach(() => {
+  // A fresh factory per test: these share one database name on purpose.
+  stubIndexedDb(new IDBFactory());
+});
 
 afterEach(() => {
   if (original) Object.defineProperty(globalThis, "indexedDB", original);
@@ -20,21 +54,12 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** Replaces the global with something `openDB` will use. */
-function stubIndexedDb(value: unknown) {
-  Object.defineProperty(globalThis, "indexedDB", {
-    value,
-    configurable: true,
-    writable: true,
-  });
-}
-
 describe("indexedDbAvailable", () => {
   it("is false when reading the global throws, as in a sandboxed frame", () => {
     Object.defineProperty(globalThis, "indexedDB", {
       configurable: true,
       get() {
-        throw new DOMException("The operation is insecure.", "SecurityError");
+        throw new Error("The operation is insecure.");
       },
     });
 
@@ -42,30 +67,111 @@ describe("indexedDbAvailable", () => {
   });
 });
 
-describe("createLocalDatabase", () => {
-  it("falls back to a non-persistent store when there is no IndexedDB", async () => {
-    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+describe("openLocalDatabase", () => {
+  it("opens a usable, durable database", async () => {
+    const { db, status } = await openLocalDatabase({ timeoutMs: TIMEOUT });
 
-    const db = await createLocalDatabase();
+    expect(status).toBe("ready");
+    expect(db.persistent).toBe(true);
 
+    // Exercises a store and its index, which is what the upgrade has to get
+    // right for every later read to work.
+    await db.putNote({
+      id: "w::a.md",
+      workspaceId: "w",
+      path: "a.md",
+      content: "# hello",
+      frontmatter: {},
+      baseSha: null,
+      updatedAt: null,
+      dirty: false,
+    });
+    expect(await db.listNotes("w")).toHaveLength(1);
+  });
+
+  it("reports `unavailable` and a usable store when there is no IndexedDB", async () => {
+    stubIndexedDb();
+
+    const { db, status } = await openLocalDatabase({ timeoutMs: TIMEOUT });
+
+    expect(status).toBe("unavailable");
     expect(db.persistent).toBe(false);
-    // Usable, so the editor still opens — just not durable.
+    // Still usable, so nothing downstream has to special-case a null database.
     await db.putMeta("hello", "world");
     expect(await db.getMeta("hello")).toBe("world");
   });
 
-  it("falls back rather than hanging when the open request never settles", async () => {
-    vi.useFakeTimers();
+  /**
+   * The bug, reproduced: a tab from before the `assets` store went in is
+   * holding v1, and this tab wants v2. Before the fix that wait never ended.
+   */
+  it("reports `blocked` rather than hanging when another tab holds an older version", async () => {
+    const stale = await holdStaleConnection(1);
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    // What a blocked upgrade looks like: a request that fires no event at all.
-    stubIndexedDb({ open: () => ({ addEventListener() {}, removeEventListener() {} }) });
 
-    const pending = createLocalDatabase();
-    await vi.advanceTimersByTimeAsync(10_000);
-    const db = await pending;
-    vi.useRealTimers();
+    const { db, status } = await openLocalDatabase({ timeoutMs: TIMEOUT });
 
+    expect(status).toBe("blocked");
+    // Distinguishable from `unavailable`, because the two want opposite
+    // handling: this one clears when the other tab goes away.
     expect(db.persistent).toBe(false);
-    expect(console.warn).toHaveBeenCalled();
+
+    stale.close();
+  });
+
+  /**
+   * A database written by a newer build than this one.
+   *
+   * IndexedDB refuses to open at a lower version, full stop, so without a
+   * second attempt one newer deploy — or one rollback — strands every note in
+   * that browser behind a `VersionError` forever.
+   */
+  it("opens a database left behind by a newer version of ForkLeaf", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Same shape, higher number: what a later release would leave behind.
+    const ahead = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, 99);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        for (const name of ["notes", "queue", "assets"]) {
+          db.createObjectStore(name, { keyPath: "id" }).createIndex("by-workspace", "workspaceId");
+        }
+        db.createObjectStore("workspaces", { keyPath: "id" });
+        db.createObjectStore("trees", { keyPath: "workspaceId" });
+        db.createObjectStore("meta", { keyPath: "key" });
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    ahead.close();
+
+    const { db, status } = await openLocalDatabase({ timeoutMs: TIMEOUT });
+
+    expect(status).toBe("ready");
+    await db.putMeta("hello", "world");
+    expect(await db.getMeta("hello")).toBe("world");
+  });
+
+  /**
+   * The other half: we must not be the tab doing the blocking. Our connection
+   * closes on `versionchange` so another tab's upgrade goes through.
+   */
+  it("gives up its connection so another tab can upgrade", async () => {
+    const { status } = await openLocalDatabase({ timeoutMs: TIMEOUT });
+    expect(status).toBe("ready");
+
+    const upgraded = await new Promise<string>((resolve) => {
+      const request = indexedDB.open(DB_NAME, 99);
+      request.onsuccess = () => {
+        request.result.close();
+        resolve("upgraded");
+      };
+      request.onblocked = () => resolve("blocked");
+      request.onerror = () => resolve("error");
+      setTimeout(() => resolve("hung"), 2_000);
+    });
+
+    expect(upgraded).toBe("upgraded");
   });
 });

--- a/packages/store/src/idb-db.test.ts
+++ b/packages/store/src/idb-db.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLocalDatabase, indexedDbAvailable } from "./idb-db";
+
+/**
+ * The boot path, not the storage itself.
+ *
+ * ForkLeaf used to hand back an `IndexedDbDatabase` without ever checking that
+ * the database opened, and `openDB` never rejects when another tab is holding
+ * an older version — so a stale tab left open across a `DB_VERSION` bump hung
+ * every other tab on "Starting ForkLeaf…" forever. These tests pin down the
+ * two things that stop that: a bounded open, and a store that always comes
+ * back so the app can boot and say what is wrong.
+ */
+
+const original = Object.getOwnPropertyDescriptor(globalThis, "indexedDB");
+
+afterEach(() => {
+  if (original) Object.defineProperty(globalThis, "indexedDB", original);
+  else delete (globalThis as { indexedDB?: unknown }).indexedDB;
+  vi.restoreAllMocks();
+});
+
+/** Replaces the global with something `openDB` will use. */
+function stubIndexedDb(value: unknown) {
+  Object.defineProperty(globalThis, "indexedDB", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("indexedDbAvailable", () => {
+  it("is false when reading the global throws, as in a sandboxed frame", () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      get() {
+        throw new DOMException("The operation is insecure.", "SecurityError");
+      },
+    });
+
+    expect(indexedDbAvailable()).toBe(false);
+  });
+});
+
+describe("createLocalDatabase", () => {
+  it("falls back to a non-persistent store when there is no IndexedDB", async () => {
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+
+    const db = await createLocalDatabase();
+
+    expect(db.persistent).toBe(false);
+    // Usable, so the editor still opens — just not durable.
+    await db.putMeta("hello", "world");
+    expect(await db.getMeta("hello")).toBe("world");
+  });
+
+  it("falls back rather than hanging when the open request never settles", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    // What a blocked upgrade looks like: a request that fires no event at all.
+    stubIndexedDb({ open: () => ({ addEventListener() {}, removeEventListener() {} }) });
+
+    const pending = createLocalDatabase();
+    await vi.advanceTimersByTimeAsync(10_000);
+    const db = await pending;
+    vi.useRealTimers();
+
+    expect(db.persistent).toBe(false);
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/store/src/idb-db.ts
+++ b/packages/store/src/idb-db.ts
@@ -41,14 +41,18 @@ interface ForkLeafSchema extends DBSchema {
 
 const DB_NAME = "forkleaf";
 /**
- * Bumped to 2 for the `assets` store, and to 3 so `upgrade` runs once more and
- * repairs any database whose stores and indexes have come apart.
+ * Bumped to 2 for the `assets` store.
  *
  * Every store is created behind a `contains` check rather than in a
  * version-numbered branch, so an existing database gains the new store and
  * keeps everything already in it.
+ *
+ * Worth being reluctant about the next bump: an upgrade needs every other tab
+ * to let go of the database first, so bumping this is the one change that can
+ * make a second tab briefly unable to open it. Only bump it when a new store
+ * actually requires it.
  */
-const DB_VERSION = 3;
+const DB_VERSION = 2;
 
 /**
  * How long to wait for the database to open before giving up on it.
@@ -58,11 +62,19 @@ const DB_VERSION = 3;
  */
 const OPEN_TIMEOUT_MS = 8_000;
 
+/** Every store the code below reads from. Checked when no upgrade can run. */
+const REQUIRED_STORES = ["notes", "workspaces", "queue", "trees", "assets", "meta"] as const;
+
 export class IndexedDbDatabase implements LocalDatabase {
   readonly persistent = true;
 
+  /** Overridable only so tests do not have to wait out the real ceiling. */
+  constructor(private readonly openTimeoutMs = OPEN_TIMEOUT_MS) {}
+
   private dbPromise: Promise<IDBPDatabase<ForkLeafSchema>> | null = null;
   private handle: IDBPDatabase<ForkLeafSchema> | null = null;
+  /** Set when another tab was holding the database during the last open. */
+  private blockedByAnotherTab = false;
 
   private get db(): Promise<IDBPDatabase<ForkLeafSchema>> {
     // Opened lazily so importing this module during SSR does not touch
@@ -80,66 +92,23 @@ export class IndexedDbDatabase implements LocalDatabase {
    */
   private async open(): Promise<IDBPDatabase<ForkLeafSchema>> {
     try {
-      const db = await withTimeout(
-        openDB<ForkLeafSchema>(DB_NAME, DB_VERSION, {
-          /**
-           * Brings the database up to the shape above, whatever shape it is in
-           * now.
-           *
-           * Stores *and* their indexes are both checked, because the two can
-           * come apart: an upgrade transaction that aborts halfway leaves a
-           * store with no index behind, and every later read of it fails with
-           * "the specified index was not found" — permanently, since the
-           * store-only guard sees the store and skips it.
-           */
-          upgrade(db, _oldVersion, _newVersion, tx) {
-            const store = <
-              Name extends "notes" | "queue" | "assets" | "workspaces" | "trees" | "meta",
-            >(
-              name: Name,
-              keyPath: string,
-            ) =>
-              db.objectStoreNames.contains(name)
-                ? tx.objectStore(name)
-                : db.createObjectStore(name, { keyPath });
-
-            for (const name of ["notes", "queue", "assets"] as const) {
-              const created = store(name, "id");
-              if (!created.indexNames.contains("by-workspace")) {
-                created.createIndex("by-workspace", "workspaceId");
-              }
-            }
-            store("workspaces", "id");
-            store("trees", "workspaceId");
-            store("meta", "key");
-          },
-          /**
-           * Another tab has this database open at an older version and is in
-           * the way of our upgrade. It will get `blocking` and close, so this
-           * is only worth reporting — the timeout below is what stops us
-           * waiting on a tab that never answers.
-           */
-          blocked: (currentVersion, blockedVersion) => {
-            console.warn(
-              `[forkleaf] waiting on another ForkLeaf tab holding the database at v${currentVersion} (wanted v${blockedVersion}).`,
-            );
-          },
-          /**
-           * We are the older connection standing in the way of another tab's
-           * upgrade. Close, so that tab can proceed; the next read reopens at
-           * the new version instead of deadlocking both tabs.
-           *
-           * Without this, an old tab left open across a `DB_VERSION` bump —
-           * or a "clear site data" — hangs every other tab on the loading
-           * screen indefinitely.
-           */
-          blocking: () => this.release(),
-          /** The browser dropped the connection; reopen on the next read. */
-          terminated: () => this.release(),
-        }),
-        OPEN_TIMEOUT_MS,
-        "Local storage did not open. Another ForkLeaf tab may be holding it — close the other tabs and reload.",
-      );
+      let db: IDBPDatabase<ForkLeafSchema>;
+      try {
+        db = await this.openAt(DB_VERSION);
+      } catch (error) {
+        // A database written by a newer build of ForkLeaf than this one.
+        // IndexedDB refuses a downgrade outright, and there is no way to talk
+        // it round — so take the database as it stands instead.
+        //
+        // This is survivable only because the schema is additive: every store
+        // this version knows about still exists in a later one. It matters
+        // because the alternative is a browser that can never open its own
+        // notes again — one tab left on a newer deploy, or a rolled-back
+        // release, and the data is stranded behind an error.
+        if (!isVersionError(error)) throw error;
+        console.warn("[forkleaf] local storage is newer than this build; opening it as it is.");
+        db = await this.openExisting();
+      }
 
       this.handle = db;
       return db;
@@ -151,6 +120,96 @@ export class IndexedDbDatabase implements LocalDatabase {
     }
   }
 
+  /** Opens — and if need be upgrades — the database at a known version. */
+  private openAt(version: number): Promise<IDBPDatabase<ForkLeafSchema>> {
+    return withTimeout(
+      openDB<ForkLeafSchema>(DB_NAME, version, {
+        /**
+         * Brings the database up to the shape above, whatever shape it is in
+         * now.
+         *
+         * Stores *and* their indexes are both checked, because the two can
+         * come apart: an upgrade transaction that aborts halfway leaves a
+         * store with no index behind, and every later read of it fails with
+         * "the specified index was not found" — permanently, since the
+         * store-only guard sees the store and skips it.
+         */
+        upgrade(db, _oldVersion, _newVersion, tx) {
+          const store = <
+            Name extends "notes" | "queue" | "assets" | "workspaces" | "trees" | "meta",
+          >(
+            name: Name,
+            keyPath: string,
+          ) =>
+            db.objectStoreNames.contains(name)
+              ? tx.objectStore(name)
+              : db.createObjectStore(name, { keyPath });
+
+          for (const name of ["notes", "queue", "assets"] as const) {
+            const created = store(name, "id");
+            if (!created.indexNames.contains("by-workspace")) {
+              created.createIndex("by-workspace", "workspaceId");
+            }
+          }
+          store("workspaces", "id");
+          store("trees", "workspaceId");
+          store("meta", "key");
+        },
+        /**
+         * Another tab has this database open at an older version and is in
+         * the way of our upgrade. It will get `blocking` and close, so this
+         * is only worth reporting — the timeout below is what stops us
+         * waiting on a tab that never answers.
+         */
+        blocked: (currentVersion, blockedVersion) => {
+          this.blockedByAnotherTab = true;
+          console.warn(
+            `[forkleaf] waiting on another ForkLeaf tab holding the database at v${currentVersion} (wanted v${blockedVersion}).`,
+          );
+        },
+        /**
+         * We are the older connection standing in the way of another tab's
+         * upgrade. Close, so that tab can proceed; the next read reopens at
+         * the new version instead of deadlocking both tabs.
+         *
+         * Without this, an old tab left open across a `DB_VERSION` bump —
+         * or a "clear site data" — hangs every other tab on the loading
+         * screen indefinitely.
+         */
+        blocking: () => this.release(),
+        /** The browser dropped the connection; reopen on the next read. */
+        terminated: () => this.release(),
+      }),
+      this.openTimeoutMs,
+      "Local storage did not open. Another ForkLeaf tab may be holding it — close the other tabs and reload.",
+    );
+  }
+
+  /**
+   * Opens whatever version already exists, without asking for one.
+   *
+   * No `upgrade` runs, so this cannot create anything missing — which is why
+   * the stores are checked afterwards rather than assumed.
+   */
+  private async openExisting(): Promise<IDBPDatabase<ForkLeafSchema>> {
+    const db = await withTimeout(
+      openDB<ForkLeafSchema>(DB_NAME, undefined, {
+        blocking: () => this.release(),
+        terminated: () => this.release(),
+      }),
+      this.openTimeoutMs,
+      "Local storage did not open.",
+    );
+
+    const missing = REQUIRED_STORES.filter((name) => !db.objectStoreNames.contains(name));
+    if (missing.length > 0) {
+      db.close();
+      throw new Error(`Local storage is missing the ${missing.join(", ")} store.`);
+    }
+
+    return db;
+  }
+
   /** Drops this tab's connection so another one can upgrade or delete. */
   private release(): void {
     this.handle?.close();
@@ -160,7 +219,20 @@ export class IndexedDbDatabase implements LocalDatabase {
 
   /** Resolves once the database is open, rejecting if it cannot be. */
   async ready(): Promise<void> {
+    this.blockedByAnotherTab = false;
     await this.db;
+  }
+
+  /**
+   * Whether the last failed open was another tab's fault.
+   *
+   * The two failures want opposite handling: a browser with no IndexedDB is
+   * permanent and the best we can do is say so, while another tab holding the
+   * database clears the moment that tab goes away — and is worth waiting for,
+   * because the alternative is writing notes into a store that is thrown away.
+   */
+  get blocked(): boolean {
+    return this.blockedByAnotherTab;
   }
 
   async getNote(id: string): Promise<Note | undefined> {
@@ -262,6 +334,16 @@ export class IndexedDbDatabase implements LocalDatabase {
   }
 }
 
+/**
+ * True for the browser's refusal to open a database at a lower version.
+ *
+ * Matched by name rather than by instance: this is a `DOMException` in the
+ * browser and a plain error in the polyfills the tests run against.
+ */
+function isVersionError(error: unknown): boolean {
+  return error instanceof Error && error.name === "VersionError";
+}
+
 /** Rejects if `promise` has not settled within `ms`. */
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
@@ -289,25 +371,51 @@ export function indexedDbAvailable(): boolean {
 }
 
 /**
- * Picks IndexedDB in the browser and an in-memory store everywhere else.
+ * Why the store you were handed is the store you were handed.
+ *
+ * - `ready` — real, durable IndexedDB.
+ * - `blocked` — another tab is holding the database. Temporary: it clears when
+ *   that tab closes, so the caller should offer to wait rather than pretend.
+ * - `unavailable` — this browser will not give us IndexedDB at all. Permanent
+ *   for the session; all the caller can do is say so.
+ */
+export type LocalDatabaseStatus = "ready" | "blocked" | "unavailable";
+
+export interface OpenedLocalDatabase {
+  db: LocalDatabase;
+  status: LocalDatabaseStatus;
+}
+
+/**
+ * Opens local storage, and says what happened.
  *
  * The database is opened here rather than on first read, so a browser that
- * refuses IndexedDB — private windows, blocked storage, a tab stuck holding an
- * older version — costs a few seconds and a degraded session instead of a
- * loading screen that never resolves. Callers can tell the two apart with
- * `persistent`, and should say so in the UI: nothing written to a
- * `MemoryDatabase` survives a reload.
+ * refuses IndexedDB costs a few seconds and a degraded session instead of a
+ * loading screen that never resolves. The fallback is a `MemoryDatabase`, so
+ * callers always get something usable — but nothing written to it survives the
+ * tab, which is why `status` exists and why no caller should ignore it.
  */
-export async function createLocalDatabase(): Promise<LocalDatabase> {
+export async function openLocalDatabase(options?: {
+  /** Overridable only so tests do not have to wait out the real ceiling. */
+  timeoutMs?: number;
+}): Promise<OpenedLocalDatabase> {
   if (indexedDbAvailable()) {
-    const db = new IndexedDbDatabase();
+    const db = new IndexedDbDatabase(options?.timeoutMs);
     try {
       await db.ready();
-      return db;
+      return { db, status: "ready" };
     } catch (error) {
       console.warn("[forkleaf] falling back to in-memory storage:", error);
+      const { MemoryDatabase } = await import("./memory-db");
+      return { db: new MemoryDatabase(), status: db.blocked ? "blocked" : "unavailable" };
     }
   }
+
   const { MemoryDatabase } = await import("./memory-db");
-  return new MemoryDatabase();
+  return { db: new MemoryDatabase(), status: "unavailable" };
+}
+
+/** `openLocalDatabase` for callers that have nothing useful to do with `status`. */
+export async function createLocalDatabase(): Promise<LocalDatabase> {
+  return (await openLocalDatabase()).db;
 }

--- a/packages/store/src/idb-db.ts
+++ b/packages/store/src/idb-db.ts
@@ -41,46 +41,126 @@ interface ForkLeafSchema extends DBSchema {
 
 const DB_NAME = "forkleaf";
 /**
- * Bumped to 2 for the `assets` store.
+ * Bumped to 2 for the `assets` store, and to 3 so `upgrade` runs once more and
+ * repairs any database whose stores and indexes have come apart.
  *
  * Every store is created behind a `contains` check rather than in a
  * version-numbered branch, so an existing database gains the new store and
  * keeps everything already in it.
  */
-const DB_VERSION = 2;
+const DB_VERSION = 3;
+
+/**
+ * How long to wait for the database to open before giving up on it.
+ *
+ * An `open` that is blocked by another tab never rejects on its own, so
+ * without a ceiling the loading screen is permanent.
+ */
+const OPEN_TIMEOUT_MS = 8_000;
 
 export class IndexedDbDatabase implements LocalDatabase {
+  readonly persistent = true;
+
   private dbPromise: Promise<IDBPDatabase<ForkLeafSchema>> | null = null;
+  private handle: IDBPDatabase<ForkLeafSchema> | null = null;
 
   private get db(): Promise<IDBPDatabase<ForkLeafSchema>> {
     // Opened lazily so importing this module during SSR does not touch
     // `indexedDB`, which only exists in the browser.
-    this.dbPromise ??= openDB<ForkLeafSchema>(DB_NAME, DB_VERSION, {
-      upgrade(db) {
-        if (!db.objectStoreNames.contains("notes")) {
-          const notes = db.createObjectStore("notes", { keyPath: "id" });
-          notes.createIndex("by-workspace", "workspaceId");
-        }
-        if (!db.objectStoreNames.contains("workspaces")) {
-          db.createObjectStore("workspaces", { keyPath: "id" });
-        }
-        if (!db.objectStoreNames.contains("queue")) {
-          const queue = db.createObjectStore("queue", { keyPath: "id" });
-          queue.createIndex("by-workspace", "workspaceId");
-        }
-        if (!db.objectStoreNames.contains("trees")) {
-          db.createObjectStore("trees", { keyPath: "workspaceId" });
-        }
-        if (!db.objectStoreNames.contains("assets")) {
-          const assets = db.createObjectStore("assets", { keyPath: "id" });
-          assets.createIndex("by-workspace", "workspaceId");
-        }
-        if (!db.objectStoreNames.contains("meta")) {
-          db.createObjectStore("meta", { keyPath: "key" });
-        }
-      },
-    });
+    this.dbPromise ??= this.open();
     return this.dbPromise;
+  }
+
+  /**
+   * Opens the database, or fails in a bounded amount of time.
+   *
+   * Every one of these callbacks exists because the browser can leave an open
+   * request pending forever, and a pending request here is a ForkLeaf that
+   * never finishes starting.
+   */
+  private async open(): Promise<IDBPDatabase<ForkLeafSchema>> {
+    try {
+      const db = await withTimeout(
+        openDB<ForkLeafSchema>(DB_NAME, DB_VERSION, {
+          /**
+           * Brings the database up to the shape above, whatever shape it is in
+           * now.
+           *
+           * Stores *and* their indexes are both checked, because the two can
+           * come apart: an upgrade transaction that aborts halfway leaves a
+           * store with no index behind, and every later read of it fails with
+           * "the specified index was not found" — permanently, since the
+           * store-only guard sees the store and skips it.
+           */
+          upgrade(db, _oldVersion, _newVersion, tx) {
+            const store = <
+              Name extends "notes" | "queue" | "assets" | "workspaces" | "trees" | "meta",
+            >(
+              name: Name,
+              keyPath: string,
+            ) =>
+              db.objectStoreNames.contains(name)
+                ? tx.objectStore(name)
+                : db.createObjectStore(name, { keyPath });
+
+            for (const name of ["notes", "queue", "assets"] as const) {
+              const created = store(name, "id");
+              if (!created.indexNames.contains("by-workspace")) {
+                created.createIndex("by-workspace", "workspaceId");
+              }
+            }
+            store("workspaces", "id");
+            store("trees", "workspaceId");
+            store("meta", "key");
+          },
+          /**
+           * Another tab has this database open at an older version and is in
+           * the way of our upgrade. It will get `blocking` and close, so this
+           * is only worth reporting — the timeout below is what stops us
+           * waiting on a tab that never answers.
+           */
+          blocked: (currentVersion, blockedVersion) => {
+            console.warn(
+              `[forkleaf] waiting on another ForkLeaf tab holding the database at v${currentVersion} (wanted v${blockedVersion}).`,
+            );
+          },
+          /**
+           * We are the older connection standing in the way of another tab's
+           * upgrade. Close, so that tab can proceed; the next read reopens at
+           * the new version instead of deadlocking both tabs.
+           *
+           * Without this, an old tab left open across a `DB_VERSION` bump —
+           * or a "clear site data" — hangs every other tab on the loading
+           * screen indefinitely.
+           */
+          blocking: () => this.release(),
+          /** The browser dropped the connection; reopen on the next read. */
+          terminated: () => this.release(),
+        }),
+        OPEN_TIMEOUT_MS,
+        "Local storage did not open. Another ForkLeaf tab may be holding it — close the other tabs and reload.",
+      );
+
+      this.handle = db;
+      return db;
+    } catch (error) {
+      // Not cached as a rejection: closing the other tab should be enough to
+      // make the next attempt work.
+      this.dbPromise = null;
+      throw error;
+    }
+  }
+
+  /** Drops this tab's connection so another one can upgrade or delete. */
+  private release(): void {
+    this.handle?.close();
+    this.handle = null;
+    this.dbPromise = null;
+  }
+
+  /** Resolves once the database is open, rejecting if it cannot be. */
+  async ready(): Promise<void> {
+    await this.db;
   }
 
   async getNote(id: string): Promise<Note | undefined> {
@@ -182,14 +262,52 @@ export class IndexedDbDatabase implements LocalDatabase {
   }
 }
 
-/** True when this runtime can actually persist to IndexedDB. */
-export function indexedDbAvailable(): boolean {
-  return typeof indexedDB !== "undefined";
+/** Rejects if `promise` has not settled within `ms`. */
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer)) as Promise<T>;
 }
 
-/** Picks IndexedDB in the browser and an in-memory store everywhere else. */
+/**
+ * True when this runtime can actually persist to IndexedDB.
+ *
+ * Reading the global is inside a `try` because a sandboxed iframe, and Firefox
+ * with cookies fully blocked, throw a `SecurityError` on the property access
+ * itself rather than leaving it undefined.
+ */
+export function indexedDbAvailable(): boolean {
+  try {
+    return typeof indexedDB !== "undefined" && indexedDB !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Picks IndexedDB in the browser and an in-memory store everywhere else.
+ *
+ * The database is opened here rather than on first read, so a browser that
+ * refuses IndexedDB — private windows, blocked storage, a tab stuck holding an
+ * older version — costs a few seconds and a degraded session instead of a
+ * loading screen that never resolves. Callers can tell the two apart with
+ * `persistent`, and should say so in the UI: nothing written to a
+ * `MemoryDatabase` survives a reload.
+ */
 export async function createLocalDatabase(): Promise<LocalDatabase> {
-  if (indexedDbAvailable()) return new IndexedDbDatabase();
+  if (indexedDbAvailable()) {
+    const db = new IndexedDbDatabase();
+    try {
+      await db.ready();
+      return db;
+    } catch (error) {
+      console.warn("[forkleaf] falling back to in-memory storage:", error);
+    }
+  }
   const { MemoryDatabase } = await import("./memory-db");
   return new MemoryDatabase();
 }

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -3,5 +3,12 @@ export type { LocalDatabase, RemoteGateway, RemoteCommitInput, RemoteCommitResul
 export { coalesce, describeChanges, changeId, type CoalesceInput } from "./queue";
 export { SyncEngine, type SyncEngineOptions } from "./sync-engine";
 export { MemoryDatabase } from "./memory-db";
-export { IndexedDbDatabase, createLocalDatabase, indexedDbAvailable } from "./idb-db";
+export {
+  IndexedDbDatabase,
+  createLocalDatabase,
+  openLocalDatabase,
+  indexedDbAvailable,
+  type LocalDatabaseStatus,
+  type OpenedLocalDatabase,
+} from "./idb-db";
 export { NoteRepository, type NoteRepositoryOptions } from "./note-repository";

--- a/packages/store/src/memory-db.ts
+++ b/packages/store/src/memory-db.ts
@@ -10,6 +10,8 @@ import type { LocalDatabase } from "./ports";
  * IndexedDB behaves.
  */
 export class MemoryDatabase implements LocalDatabase {
+  readonly persistent = false;
+
   private notes = new Map<string, Note>();
   private workspaces = new Map<string, Workspace>();
   private queue = new Map<string, PendingChange>();

--- a/packages/store/src/ports.ts
+++ b/packages/store/src/ports.ts
@@ -10,6 +10,15 @@ import type { LocalAsset, Note, PendingChange, TreeNode, Workspace } from "@fork
 
 /** Local durable storage. Implemented by IndexedDB in the browser. */
 export interface LocalDatabase {
+  /**
+   * False when this store is thrown away with the tab.
+   *
+   * The in-memory implementation is a fallback for browsers that refuse
+   * IndexedDB; the UI reads this so it can warn instead of quietly losing
+   * whatever gets written.
+   */
+  readonly persistent: boolean;
+
   getNote(id: string): Promise<Note | undefined>;
   putNote(note: Note): Promise<void>;
   deleteNote(id: string): Promise<void>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.0
         version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       jsdom:
         specifier: ^28.0.0
         version: 28.1.0
@@ -2914,6 +2917,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -7525,6 +7532,8 @@ snapshots:
   expect-type@1.4.0: {}
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 


### PR DESCRIPTION
Three commits. The first two are the loading-screen deadlock; the third is the diagram canvas.

---

## 1 & 2 — the screens that never resolved

`openDB` was called with an `upgrade` handler and nothing else. No `blocking` handler means a tab already holding the database never yields it when another tab wants to upgrade, and **a blocked open request fires no event at all** — it is not an error you can catch, it is a wait. Both `useLibrary` and `useNotebook` boot with a bare `await createLocalDatabase()`, and that function returned a database without ever checking it opened. The wait became the loading screen.

- `blocking`/`terminated` release the connection; the open is bounded at 8s.
- **The `DB_VERSION` bump in the first commit was a mistake and is reverted.** Forcing an upgrade is exactly what another tab can block, and a browser that reached v3 could never go back — IndexedDB refuses to open at a lower version. Caught in the preview browser as a `VersionError` after the revert.
- A database **newer** than the running build is now opened as it stands. The schema is additive, so one newer deploy or one rollback no longer strands a browser's notes.
- The in-memory fallback was too quiet. `blocked` (another tab) gets a screen that says so and retries until that tab closes; `unavailable` (private window) degrades to memory with a banner. `ProfilePanel` had its own stale copy of the check and would have reported a library of zero notes.
- `fetchSession` had no timeout — same failure class, same symptom. Bounded.
- Missing local images get a placeholder instead of a broken icon; the markdown keeps the real path.
- `frame-src 'none'` blocked the GitHub Sponsors iframe, so the sponsor card was an empty box on the landing page and the profile.
- Analytics was CSP-blocked on every landing-page visit — prerendered routes have no nonce, so no `strict-dynamic`, while `connect-src` already expected it to report.

## 3 — the diagram canvas

Five defects, each making the canvas look broken differently.

**You could type one word and never start a second.** Every field edits through the Mermaid source: keystroke → graph → serialise → parse → back into the graph the field re-renders from. That parse trims. `"Collect "` became `n1[Collect ]` became `"Collect"` — the space gone before the next letter arrived. Eight fields now hold their own text while focused.

**Dragging a node often did nothing.** The commit was guarded on `drag.moved`, only ever written inside a `requestAnimationFrame` callback — and the release handler cancels that frame before it runs. Any drag finishing inside one frame committed nothing and snapped back, having followed the cursor the whole way. The landing position now comes from the release event. (The marquee branch had already worked this out; the branches that move things had not.)

**The canvas was a 66px sliver below 1024px.** Stacked, the source pane took `flex-1` while the diagram pane sat at its 240px minimum, of which chrome ate 174. The source now gives way and the body scrolls.

**Opening the canvas showed an empty grid.** The initial fit ran once against whatever the pane measured mid-settle — framed for 700px, then resized to 292px, leaving every node outside the viewBox. It re-frames per viewport size, and stops once you pan or zoom.

**A plain click landed an empty undo step**, since a zero-distance drag was still a drag.

The drop calculation is now a pure, tested function instead of logic buried in a pointer handler.

Also: the boot spinner itself had no bound. Every individual cause now does, but anything unforeseen still showed a logo indefinitely. After twelve seconds it says so and offers a reload and a last-resort reset.

## Verification

Every row reproduced in the browser against the running app.

| | before | after |
|---|---|---|
| `/editor`, stale tab holding v1 | hangs indefinitely | recovery screen in 8s, auto-recovers on close |
| `deleteDatabase` from the app tab | pending at 30s | deleted in 4ms |
| database newer than the build | `VersionError`, memory forever | opens, notes intact |
| typing `one two three` in a node | space eaten each time | types correctly, source `n1[one two three]` |
| drag finished inside one frame | node snaps back | commits (`344,24` → `264,-32`) |
| plain click on a node | empty undo entry | no commit |
| canvas height at 900px wide | 66px | 292px |
| canvas on open | empty grid, node off-view | framed on the content |
| Sponsors card / gtag | blocked by CSP | both load |

`pnpm typecheck`, `pnpm lint`, `pnpm test` (354), `pnpm build` all pass. Store tests run against a real IndexedDB (`fake-indexeddb`) rather than a stub, since what is being pinned down is the browser's own locking.

## Not done here

- **New canvas features.** This PR fixes what was broken; it does not add editing options. Worth a follow-up: copy/paste, align/distribute, edge waypoints, and per-node colour.
- `firebase.googleapis.com/…/webConfig` 401s in dev — handled, and a Firebase project setting rather than code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)