### PR TITLE
Make the canvas show the diagram you are actually going to get

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,14 @@
     "check": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm test && pnpm build"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10",
+    "@testing-library/react": "^16",
     "@vitejs/plugin-react": "^5.1.0",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^28.0.0",
     "prettier": "^3.6.2",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "turbo": "^2.10.10",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"

--- a/packages/editor/src/mermaid/VisualBuilder.tsx
+++ b/packages/editor/src/mermaid/VisualBuilder.tsx
@@ -67,6 +67,29 @@ function defaultShapeFor(kind: Graph["kind"]): NodeShape {
   }
 }
 
+/**
+ * Node footprint, the way mermaid computes it: the text plus a fixed padding.
+ *
+ * The canvas used to draw every box at a flat 150×56 whatever was written in
+ * it. Mermaid does not — it sizes a flowchart node to its label — so a
+ * two-letter "Start / End" was a wide pill on the canvas and a near-circle in
+ * the note, and the shape you picked and the shape you got looked like two
+ * different shapes. Matching mermaid's own metric is what makes the canvas a
+ * preview of the diagram rather than a promise about it.
+ */
+const LABEL_CHAR_WIDTH = 9;
+const LABEL_PADDING = 30;
+const MIN_NODE_WIDTH = 64;
+const MAX_NODE_WIDTH = 300;
+
+function textWidth(label: string | undefined): number {
+  return (label ?? "").length * LABEL_CHAR_WIDTH;
+}
+
+function labelWidth(label: string | undefined): number {
+  return textWidth(label) + LABEL_PADDING;
+}
+
 /** Height of one member line inside a class or entity box. */
 const MEMBER_HEIGHT = 17;
 /** Height of the name bar above the members. */
@@ -88,6 +111,28 @@ function sizeOf(node: { shape: NodeShape; label?: string }): { width: number; he
       return { width: 64, height: 64 };
     case "fork":
       return { width: 130, height: 14 };
+    case "circle": {
+      // A connector is round in the note, so it is round here too.
+      const size = clamp(labelWidth(node.label), NODE_HEIGHT, 160);
+      return { width: size, height: size };
+    }
+    case "diamond": {
+      // A rhombus only offers its full width along the centre line, and the
+      // canvas was drawing decisions at the same 150×56 as everything else:
+      // a flat sliver with its question cut off halfway through. Both
+      // dimensions grow with the text, so the words stay inside the shape.
+      const text = textWidth(node.label);
+      return {
+        width: clamp(text * 1.4 + 36, 112, 320),
+        height: clamp(72 + text * 0.22, 72, 160),
+      };
+    }
+    case "hexagon":
+    case "parallelogram": {
+      // Slanted sides eat into the usable width the same way, if less of it.
+      const text = textWidth(node.label);
+      return { width: clamp(text + LABEL_PADDING + 28, 96, MAX_NODE_WIDTH), height: NODE_HEIGHT };
+    }
     case "mind-circle":
     case "mind-bang":
       return { width: 96, height: 96 };
@@ -110,7 +155,10 @@ function sizeOf(node: { shape: NodeShape; label?: string }): { width: number; he
       };
     }
     default:
-      return { width: NODE_WIDTH, height: NODE_HEIGHT };
+      return {
+        width: clamp(labelWidth(node.label), MIN_NODE_WIDTH, MAX_NODE_WIDTH),
+        height: NODE_HEIGHT,
+      };
   }
 }
 
@@ -487,7 +535,7 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
           // for. Otherwise every new step is add-then-drag-then-connect, and
           // the arrow you already drew is thrown away.
           const shape = defaultShapeFor(graph.kind);
-          const size = sizeOf({ shape });
+          const size = sizeOf({ shape, label: SHAPE_LABELS[shape] });
           const id = nextNodeId(graph);
           const placed = addNode(graph, {
             id,
@@ -679,7 +727,7 @@ export function VisualBuilder({ graph, onChange }: VisualBuilderProps) {
   const createNode = useCallback(
     (shape: NodeShape, centre?: Point): string => {
       const id = nextNodeId(graph);
-      const size = sizeOf({ shape });
+      const size = sizeOf({ shape, label: isMarker(shape) ? "" : SHAPE_LABELS[shape] });
       const spot =
         centre ??
         // Added from the palette rather than by double-clicking a spot, so the
@@ -1674,7 +1722,7 @@ function NodeShapeView({
           dominantBaseline="central"
           className="pointer-events-none select-none fill-[var(--fl-text)] text-[13px]"
         >
-          {truncate(node.label, node.shape === "choice" ? 14 : 18)}
+          {truncate(node.label, fittingChars(node.shape, width))}
         </text>
       )}
 
@@ -2028,6 +2076,23 @@ function snap(value: number): number {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * How many characters fit inside a box of this width.
+ *
+ * This was a flat 18 for every shape, from when every box was the same 150px
+ * wide. Now that a box is as wide as its label, a fixed limit truncates text
+ * that has room to spare — and still overflows the shapes that have less
+ * usable width than their bounding box.
+ */
+function fittingChars(shape: NodeShape, width: number): number {
+  // A choice diamond is labelled underneath, so its own width is not the limit.
+  if (shape === "choice") return 14;
+
+  // A rhombus only offers its full width along the centre line.
+  const usable = shape === "diamond" ? width * 0.72 : width - LABEL_PADDING;
+  return Math.max(3, Math.floor(usable / LABEL_CHAR_WIDTH));
 }
 
 function truncate(text: string, max: number): string {

--- a/packages/editor/src/ui/Modal.test.tsx
+++ b/packages/editor/src/ui/Modal.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import React, { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Modal } from "./Modal";
+
+afterEach(cleanup);
+
+/**
+ * A modal whose `onClose` is written inline, which is how every caller writes
+ * it: a new function on every render of the surrounding component. The field
+ * inside re-renders the parent on each keystroke, exactly like the diagram
+ * canvas does when a node is renamed.
+ */
+function TypingHost({ onClose = () => {} }: { onClose?: () => void }) {
+  const [value, setValue] = useState("");
+
+  return (
+    <Modal title="Diagram" onClose={() => onClose()}>
+      <input
+        aria-label="Node label"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+      />
+    </Modal>
+  );
+}
+
+describe("Modal", () => {
+  it("leaves focus in a field being typed into", () => {
+    render(<TypingHost />);
+
+    const field = screen.getByLabelText("Node label") as HTMLInputElement;
+    field.focus();
+
+    // One character used to be the limit: the caller's new `onClose` re-ran the
+    // focus-trap effect, which pulled focus back to the panel.
+    for (const character of "hello") {
+      expect(document.activeElement).toBe(field);
+      fireEvent.change(field, { target: { value: field.value + character } });
+    }
+
+    expect(document.activeElement).toBe(field);
+    expect(field.value).toBe("hello");
+  });
+
+  it("takes focus when it opens and gives it back when it closes", () => {
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    outside.focus();
+
+    const view = render(<TypingHost />);
+    expect(document.activeElement).toBe(screen.getByRole("dialog"));
+
+    view.unmount();
+    expect(document.activeElement).toBe(outside);
+
+    outside.remove();
+  });
+
+  it("gives Escape to the field being typed into before closing", () => {
+    const onClose = vi.fn();
+    render(<TypingHost onClose={onClose} />);
+
+    const field = screen.getByLabelText("Node label");
+    field.focus();
+
+    // Renaming a box and changing your mind about the name must not throw away
+    // the whole diagram.
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByRole("dialog"));
+
+    // Nothing is being typed into now, so the dialog takes the next one.
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vitejs/plugin-react':
         specifier: ^5.1.0
         version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -20,6 +26,12 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.9.6
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       turbo:
         specifier: ^2.10.10
         version: 2.10.10
@@ -430,6 +442,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -1623,6 +1639,25 @@ packages:
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tiptap/core@3.30.1':
     resolution: {integrity: sha512-HWEO6Qi8fI8Zt8X4atVV6GxthJx7Vrjr6L5YFq4OkjYJ7HG2/bFw6IKsDA3jOYgY4DM9lv8IadaiWUQ2JJRIBA==}
     peerDependencies:
@@ -1850,6 +1885,9 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2262,8 +2300,15 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2700,6 +2745,9 @@ packages:
   docx@9.7.1:
     resolution: {integrity: sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==}
     engines: {node: '>=10'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
@@ -3504,6 +3552,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3849,6 +3901,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -3926,6 +3982,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -4692,6 +4751,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
     dependencies:
@@ -5973,6 +6034,27 @@ snapshots:
       postcss: 8.5.26
       tailwindcss: 4.3.3
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+
   '@tiptap/core@3.30.1(@tiptap/pm@3.30.1)':
     dependencies:
       '@tiptap/pm': 3.30.1
@@ -6205,6 +6287,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -6657,7 +6741,13 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -7144,6 +7234,8 @@ snapshots:
       nanoid: 5.1.16
       xml: 1.0.1
       xml-js: 1.6.11
+
+  dom-accessibility-api@0.5.16: {}
 
   dompurify@3.4.13:
     optionalDependencies:
@@ -8147,6 +8239,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8687,6 +8781,12 @@ snapshots:
 
   prettier@3.9.6: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   process-nextick-args@2.0.1: {}
 
   prop-types@15.8.1:
@@ -8805,6 +8905,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-refresh@0.18.0: {}
 


### PR DESCRIPTION
Follows #16, which has landed. This is just the two commits on top of it.

## "I picked Start / End and typed hi and got a circle"

Nothing is wrong with the shape. Mermaid sizes a flowchart node to its label, and a two-letter stadium genuinely comes out about as tall as it is wide — that is what GitHub will render too, which is the point of storing the diagram as a ```` ```mermaid ```` block.

The canvas was the one telling a different story. Every box was a flat 150×56 no matter what was written in it, so the shape you picked and the shape you got looked like two different shapes. Boxes now take Mermaid's own metric — text plus a fixed padding — with a floor so a one-letter node is still something you can grab, and connectors are round the way they are in the note.

| | before | after |
|---|---|---|
| `n1([hi])` | 150×56 pill on the canvas, near-circle in the note | small stadium in both |
| `n2{Everything alright?}` | flat sliver, label cut to "Everything aligh…" | a diamond with the whole question in it |

Decisions were the worst case: a rhombus only offers its full width along its centre line, so a question in a 150×56 diamond had nowhere to go. Both dimensions now grow with the text, and label truncation follows from the same numbers instead of a flat 18-character cut left over from when every box was the same width.

## A component test harness

The focus bug fixed in #16 — every field in a modal accepting exactly one character — had no way to be caught. The repo could unit-test pure logic but not a component. `@testing-library/react` plus a jsdom docblock is the whole setup; the vitest config already routes `.tsx` tests and switches environment per file.

Three tests on `Modal`, each of which fails against the code before #16's fix:

- typing many characters into a field keeps the caret in it
- focus moves in on open and back out on close
- Escape goes to the field being typed into before it goes to the dialog

## Checks

`pnpm typecheck`, `pnpm lint`, `pnpm test` (357 tests, 22 files). Canvas and preview compared side by side in the browser for stadium, connector and decision shapes at short and long labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)