### PR TITLE
docs(security): RedBlueSkills security audit report

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,46 @@
+# Security audit — ForkLeaf
+
+**Date:** 2026-08-23 · **Target:** `forkleaf.vercel.app` + ForkLeaf v0.2.0 source
+**Method:** static source review ("in") + non-destructive live probing ("out")
+**Toolkit:** [RedBlueSkills](https://github.com/praneeth132006/RedBlueSkills) `attack-my-application` orchestrator
+
+The full styled report is [`audit-2026-08-23.html`](audit-2026-08-23.html). This file is the
+GitHub-readable summary.
+
+## Verdict: A− — no critical or high-severity findings
+
+ForkLeaf is well-secured. The GitHub token is the one asset that matters and the
+architecture is built around never letting it reach the browser. Ten load-bearing
+controls were tested and held (see below).
+
+## Findings
+
+| ID   | Finding                                                                                 | Severity | Fix                                                 |
+| ---- | --------------------------------------------------------------------------------------- | -------- | --------------------------------------------------- |
+| M-01 | OAuth requests repo-wide `repo` scope — full read/write to every repo, not just notes   | Medium   | Offer a fine-grained GitHub App path                |
+| M-02 | Stateless 30-day session can't be revoked; logout only clears the client cookie         | Medium   | Add per-session `jti` + shorter/ sliding TTL        |
+| L-01 | Read API routes (`tree`, `file`, `history`, `repos`, `branches`, `raw`) are unthrottled | Low      | Apply existing `enforceRateLimit`                   |
+| L-02 | Rate limiter is in-memory / per-instance on serverless                                  | Low      | Durable limiter (Upstash) behind the same interface |
+| L-03 | `img-src https:` allows any-host image tracking beacons in untrusted notes              | Low      | Optional "block remote images" mode                 |
+| I-01 | Firebase profile identity is client-asserted (no impact — own-row, display-only)        | Info     | —                                                   |
+| I-02 | Local `.env.local` with a short-lived OIDC token (git-ignored, not committed)           | Info     | Hygiene only                                        |
+| I-03 | `/api/session` returns 200 when signed out (by design; no token disclosed)              | Info     | —                                                   |
+
+## Tested & clean
+
+Token exposure · stored XSS in preview (`rehype-sanitize`, no raw HTML) · Mermaid XSS
+(`securityLevel:strict` + DOMPurify) · SSRF & path traversal (transport choke-point rejects
+`..`/off-host) · CSRF (live 403 on foreign `Origin`) · login CSRF (single-use state,
+constant-time compare) · publish path traversal (slug allowlist) · IDOR (delegated to GitHub) ·
+Firestore rules (default-deny, owner-only) · security headers (full suite confirmed live).
+
+## Prioritized remediation
+
+1. Rate-limit the read routes (**L-01**) — highest impact per effort; the helper already exists.
+2. Make sessions revocable (**M-02**).
+3. Offer a fine-grained GitHub App path (**M-01**).
+4. Durable rate limiter (**L-02**).
+5. Decide remote-image policy (**L-03**).
+
+> Assessment performed with the RedBlueSkills toolkit. Every offensive check is paired with its
+> detection/hardening counterpart, per the toolkit's discipline.

--- a/docs/security/audit-2026-08-23.html
+++ b/docs/security/audit-2026-08-23.html
@@ -1,0 +1,762 @@
+<title>ForkLeaf Security Audit</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Chivo:ital,wght@0,400;0,600;0,700;0,900;1,400&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
+
+<style>
+  :root {
+    /* Cool, slightly blue-biased neutrals — a security console, not a cream doc */
+    --ground: #eef1f5;
+    --surface: #ffffff;
+    --surface-2: #f6f8fb;
+    --ink: #161b25;
+    --muted: #566072;
+    --faint: #8791a3;
+    --border: #dce1e9;
+    --border-strong: #c3cad6;
+
+    /* The two teams — the whole premise of the toolkit */
+    --red: #cf3a54;
+    --red-soft: #fbe9ec;
+    --blue: #2f6fd0;
+    --blue-soft: #e7effb;
+
+    /* Severity scale — distinct from the team hues */
+    --sev-critical: #b3253f;
+    --sev-high: #d8672a;
+    --sev-medium: #b98a1c;
+    --sev-low: #3a8b79;
+    --sev-info: #5f79a3;
+    --sev-clean: #3a8b79;
+
+    --shadow: 0 1px 2px rgba(20, 27, 37, 0.04), 0 8px 24px -12px rgba(20, 27, 37, 0.12);
+
+    --display: "Chivo", ui-sans-serif, system-ui, sans-serif;
+    --body: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+    --mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+    --measure: 68ch;
+  }
+
+  :root:not([data-theme="light"]) {
+    @media (prefers-color-scheme: dark) {
+      --ground: #0c1017;
+      --surface: #141a24;
+      --surface-2: #1a212d;
+      --ink: #e8ecf3;
+      --muted: #9aa5b6;
+      --faint: #6b7688;
+      --border: #253040;
+      --border-strong: #33415a;
+
+      --red: #f0708a;
+      --red-soft: #2a1720;
+      --blue: #6fa8f0;
+      --blue-soft: #14202f;
+
+      --sev-critical: #f0637f;
+      --sev-high: #f0904e;
+      --sev-medium: #e2b74a;
+      --sev-low: #55b79f;
+      --sev-info: #8aa6d6;
+      --sev-clean: #55b79f;
+
+      --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 32px -16px rgba(0, 0, 0, 0.6);
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --ground: #0c1017;
+    --surface: #141a24;
+    --surface-2: #1a212d;
+    --ink: #e8ecf3;
+    --muted: #9aa5b6;
+    --faint: #6b7688;
+    --border: #253040;
+    --border-strong: #33415a;
+
+    --red: #f0708a;
+    --red-soft: #2a1720;
+    --blue: #6fa8f0;
+    --blue-soft: #14202f;
+
+    --sev-critical: #f0637f;
+    --sev-high: #f0904e;
+    --sev-medium: #e2b74a;
+    --sev-low: #55b79f;
+    --sev-info: #8aa6d6;
+    --sev-clean: #55b79f;
+
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 32px -16px rgba(0, 0, 0, 0.6);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--body);
+    font-size: 16px;
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: clamp(1.25rem, 4vw, 3.5rem) clamp(1rem, 4vw, 2.5rem) 5rem;
+  }
+
+  /* ── Masthead ─────────────────────────────────────────── */
+  .masthead {
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background:
+      linear-gradient(180deg, var(--surface), var(--surface-2));
+    box-shadow: var(--shadow);
+    overflow: hidden;
+  }
+  .masthead-bar {
+    height: 5px;
+    background: linear-gradient(90deg, var(--red) 0 50%, var(--blue) 50% 100%);
+  }
+  .masthead-body { padding: clamp(1.5rem, 4vw, 2.75rem); }
+
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--faint);
+    margin: 0 0 0.9rem;
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .eyebrow .dot { color: var(--border-strong); }
+
+  h1 {
+    font-family: var(--display);
+    font-weight: 900;
+    font-size: clamp(2rem, 5.5vw, 3.15rem);
+    line-height: 1.02;
+    letter-spacing: -0.03em;
+    text-wrap: balance;
+    margin: 0 0 0.75rem;
+  }
+  .subtitle {
+    font-size: 1.05rem;
+    color: var(--muted);
+    max-width: 60ch;
+    margin: 0 0 1.75rem;
+  }
+
+  .meta-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1px;
+    background: var(--border);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+  .meta-cell {
+    background: var(--surface);
+    padding: 0.85rem 1rem;
+  }
+  .meta-cell .k {
+    font-family: var(--mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--faint);
+    margin: 0 0 0.3rem;
+  }
+  .meta-cell .v {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--ink);
+    word-break: break-word;
+  }
+
+  /* ── Section scaffolding ──────────────────────────────── */
+  section { margin-top: clamp(2.5rem, 6vw, 4rem); }
+
+  .sec-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.85rem;
+    margin-bottom: 1.4rem;
+    padding-bottom: 0.7rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .sec-num {
+    font-family: var(--mono);
+    font-size: 0.85rem;
+    color: var(--faint);
+    font-weight: 500;
+  }
+  h2 {
+    font-family: var(--display);
+    font-weight: 700;
+    font-size: clamp(1.35rem, 3.2vw, 1.75rem);
+    letter-spacing: -0.02em;
+    margin: 0;
+    line-height: 1.1;
+  }
+
+  p { max-width: var(--measure); }
+  .lead { font-size: 1.06rem; color: var(--muted); }
+  a { color: var(--blue); text-decoration-color: color-mix(in srgb, var(--blue) 40%, transparent); text-underline-offset: 2px; }
+
+  code, .mono { font-family: var(--mono); }
+  p code, li code, td code {
+    font-size: 0.85em;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    padding: 0.08em 0.38em;
+    word-break: break-word;
+  }
+
+  /* ── Scorecard ────────────────────────────────────────── */
+  .scorecard {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+    gap: 0.75rem;
+  }
+  .score {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.1rem 0.9rem;
+    text-align: center;
+    box-shadow: var(--shadow);
+  }
+  .score .n {
+    font-family: var(--display);
+    font-weight: 900;
+    font-size: 2.1rem;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .score .l {
+    font-family: var(--mono);
+    font-size: 0.63rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-top: 0.45rem;
+  }
+  .score.crit .n { color: var(--sev-critical); }
+  .score.high .n { color: var(--sev-high); }
+  .score.med .n  { color: var(--sev-medium); }
+  .score.low .n  { color: var(--sev-low); }
+  .score.info .n { color: var(--sev-info); }
+  .score.clean .n { color: var(--sev-clean); }
+
+  .verdict {
+    margin-top: 1.25rem;
+    display: flex;
+    gap: 0.9rem;
+    align-items: flex-start;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--sev-clean);
+    border-radius: 12px;
+    padding: 1.1rem 1.25rem;
+    box-shadow: var(--shadow);
+  }
+  .verdict .grade {
+    font-family: var(--display);
+    font-weight: 900;
+    font-size: 2.4rem;
+    line-height: 1;
+    color: var(--sev-clean);
+  }
+  .verdict p { margin: 0; max-width: 62ch; }
+
+  /* ── Chips ────────────────────────────────────────────── */
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    font-family: var(--mono);
+    font-size: 0.66rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.2em 0.6em;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    white-space: nowrap;
+  }
+  .chip.red  { color: var(--red);  background: var(--red-soft);  border-color: color-mix(in srgb, var(--red) 30%, transparent); }
+  .chip.blue { color: var(--blue); background: var(--blue-soft); border-color: color-mix(in srgb, var(--blue) 30%, transparent); }
+  .chip.sev-critical { color: #fff; background: var(--sev-critical); }
+  .chip.sev-high { color: #fff; background: var(--sev-high); }
+  .chip.sev-medium { color: #23282f; background: var(--sev-medium); }
+  .chip.sev-low { color: #fff; background: var(--sev-low); }
+  .chip.sev-info { color: #fff; background: var(--sev-info); }
+  .chip.sev-clean { color: #fff; background: var(--sev-clean); }
+
+  /* ── Finding cards ────────────────────────────────────── */
+  .finding {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    box-shadow: var(--shadow);
+    overflow: hidden;
+    margin-bottom: 1.1rem;
+  }
+  .finding-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface-2);
+  }
+  .finding-id {
+    font-family: var(--mono);
+    font-weight: 600;
+    font-size: 0.8rem;
+    color: var(--faint);
+  }
+  .finding-title {
+    font-family: var(--display);
+    font-weight: 600;
+    font-size: 1.08rem;
+    letter-spacing: -0.01em;
+    flex: 1 1 260px;
+    min-width: 0;
+    margin: 0;
+  }
+  .finding-body { padding: 1.15rem 1.25rem 1.35rem; }
+  .finding-body p { margin: 0 0 0.8rem; max-width: var(--measure); }
+  .finding-body p:last-child { margin-bottom: 0; }
+
+  .fr {
+    display: grid;
+    grid-template-columns: 92px 1fr;
+    gap: 0.5rem 1rem;
+    padding: 0.55rem 0;
+    border-top: 1px dashed var(--border);
+    align-items: baseline;
+  }
+  .fr:first-of-type { border-top: none; }
+  .fr .lab {
+    font-family: var(--mono);
+    font-size: 0.64rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--faint);
+    padding-top: 0.15rem;
+  }
+  .fr .val { margin: 0; max-width: none; }
+  .fr .val code { font-size: 0.82em; }
+
+  @media (max-width: 540px) {
+    .fr { grid-template-columns: 1fr; gap: 0.15rem; }
+  }
+
+  /* ── Tables ───────────────────────────────────────────── */
+  .table-scroll {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+    -webkit-overflow-scrolling: touch;
+  }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    min-width: 560px;
+    font-size: 0.88rem;
+  }
+  th, td {
+    text-align: left;
+    padding: 0.7rem 0.95rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  thead th {
+    background: var(--surface-2);
+    font-family: var(--mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 600;
+    position: sticky;
+    top: 0;
+  }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr { background: var(--surface); }
+  tbody td .mono { font-size: 0.82em; color: var(--muted); }
+
+  /* ── Callout ──────────────────────────────────────────── */
+  .callout {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--blue);
+    border-radius: 12px;
+    padding: 1.1rem 1.3rem;
+    box-shadow: var(--shadow);
+  }
+  .callout h3 {
+    font-family: var(--display);
+    font-size: 1rem;
+    margin: 0 0 0.5rem;
+  }
+  .callout p { margin: 0; max-width: 64ch; color: var(--muted); }
+
+  ul.clean { list-style: none; padding: 0; margin: 0; }
+  ul.clean li {
+    display: flex;
+    gap: 0.7rem;
+    align-items: flex-start;
+    padding: 0.6rem 0;
+    border-top: 1px solid var(--border);
+    max-width: var(--measure);
+  }
+  ul.clean li:first-child { border-top: none; }
+  ul.clean .tick { color: var(--sev-clean); font-weight: 700; flex-shrink: 0; }
+  ul.clean .what { margin: 0; }
+  ul.clean .what b { font-weight: 600; }
+  ul.clean .what span { color: var(--muted); }
+
+  ol.plan { counter-reset: step; list-style: none; padding: 0; margin: 0; }
+  ol.plan li {
+    position: relative;
+    padding: 0.85rem 0 0.85rem 3rem;
+    border-top: 1px solid var(--border);
+    max-width: var(--measure);
+  }
+  ol.plan li:first-child { border-top: none; }
+  ol.plan li::before {
+    counter-increment: step;
+    content: counter(step);
+    position: absolute;
+    left: 0;
+    top: 0.8rem;
+    width: 2rem;
+    height: 2rem;
+    display: grid;
+    place-items: center;
+    font-family: var(--mono);
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--blue);
+    background: var(--blue-soft);
+    border-radius: 8px;
+  }
+  ol.plan b { font-weight: 600; }
+  ol.plan .note { color: var(--muted); display: block; font-size: 0.92rem; margin-top: 0.15rem; }
+
+  .footer {
+    margin-top: 4rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    color: var(--faint);
+    font-size: 0.85rem;
+  }
+  .footer .mono { color: var(--muted); }
+
+  .tag-legend {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 0.8rem;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+</style>
+
+<div class="wrap">
+
+  <!-- ═══════════════ MASTHEAD ═══════════════ -->
+  <header class="masthead">
+    <div class="masthead-bar"></div>
+    <div class="masthead-body">
+      <p class="eyebrow">
+        <span>Security Assessment</span>
+        <span class="dot">/</span>
+        <span>Red &amp; Blue</span>
+        <span class="dot">/</span>
+        <span>Confidential</span>
+      </p>
+      <h1>ForkLeaf Security Audit</h1>
+      <p class="subtitle">A full-surface, offense-and-defense review of the ForkLeaf web application &mdash; its GitHub OAuth proxy, its untrusted-content rendering pipeline, and its live deployment.</p>
+
+      <div class="meta-grid">
+        <div class="meta-cell"><p class="k">Target</p><p class="v">forkleaf.vercel.app</p></div>
+        <div class="meta-cell"><p class="k">Codebase</p><p class="v">ForkLeaf&nbsp;v0.2.0 (monorepo)</p></div>
+        <div class="meta-cell"><p class="k">Date</p><p class="v">23 Aug 2026</p></div>
+        <div class="meta-cell"><p class="k">Surfaces</p><p class="v">web&nbsp;· api&nbsp;· cloud-native</p></div>
+        <div class="meta-cell"><p class="k">Method</p><p class="v">Static + live (non-destructive)</p></div>
+        <div class="meta-cell"><p class="k">Toolkit</p><p class="v">RedBlueSkills</p></div>
+      </div>
+    </div>
+  </header>
+
+  <!-- ═══════════════ 1. EXECUTIVE SUMMARY ═══════════════ -->
+  <section id="summary">
+    <div class="sec-head"><span class="sec-num">01</span><h2>Executive summary</h2></div>
+
+    <p class="lead">ForkLeaf is a genuinely well-secured application. It treats the GitHub access token as the single asset worth protecting and builds the whole architecture around never letting it reach the browser &mdash; and the defenses that follow from that decision are consistent, layered, and correct.</p>
+
+    <p>The assessment covered the three surfaces the app actually presents: the browser-facing web application, its <code>/api/gh/*</code> GitHub proxy, and its Firebase/Firestore backend. Every offensive technique in scope was probed against both the source and the live deployment. <b>No critical or high-severity vulnerabilities were confirmed.</b> The findings that remain are one architectural blast-radius concern and a handful of hardening and hygiene items.</p>
+
+    <div class="scorecard" style="margin-top:1.5rem">
+      <div class="score crit"><div class="n">0</div><div class="l">Critical</div></div>
+      <div class="score high"><div class="n">0</div><div class="l">High</div></div>
+      <div class="score med"><div class="n">2</div><div class="l">Medium</div></div>
+      <div class="score low"><div class="n">3</div><div class="l">Low</div></div>
+      <div class="score info"><div class="n">3</div><div class="l">Info</div></div>
+      <div class="score clean"><div class="n">10</div><div class="l">Tested&nbsp;clean</div></div>
+    </div>
+
+    <div class="verdict">
+      <div class="grade">A&minus;</div>
+      <p>Overall posture is strong. The token-handling model, the two-tier CSP, the origin-checked write path, and the sanitisation of untrusted note content are all textbook. What holds it back from an A is the breadth of the OAuth grant combined with a session that cannot be revoked &mdash; a design choice, not a bug, but the one place where a single mistake would matter most.</p>
+    </div>
+  </section>
+
+  <!-- ═══════════════ 2. SCOPE ═══════════════ -->
+  <section id="scope">
+    <div class="sec-head"><span class="sec-num">02</span><h2>Scope &amp; authorization</h2></div>
+    <p>Testing was authorized by the application owner against assets they control: the deployed instance at <code>forkleaf.vercel.app</code> and the full source tree in this repository. All live probing was <b>read-only and non-destructive</b> &mdash; unauthenticated endpoint checks, header inspection, an origin-rejection probe, and an OAuth-start inspection. No accounts were created, no repositories were written, no real data was exfiltrated, and no denial-of-service load was generated.</p>
+    <div class="callout">
+      <h3>What "in and out" means here</h3>
+      <p><b>In</b> &mdash; a static read of the server code: session and token handling, the GitHub proxy, the markdown/Mermaid render pipeline, and the Firestore rules. <b>Out</b> &mdash; live behavioural probes of the running deployment to confirm the code's guarantees actually ship.</p>
+    </div>
+  </section>
+
+  <!-- ═══════════════ 3. FINDINGS ═══════════════ -->
+  <section id="findings">
+    <div class="sec-head"><span class="sec-num">03</span><h2>Findings</h2></div>
+    <p style="margin-bottom:1.6rem">Each finding carries the offensive technique that would exercise it (<span class="chip red">red</span>) and the paired defensive control that detects or prevents it (<span class="chip blue">blue</span>), following the RedBlueSkills discipline that every offensive result must name its counterpart.</p>
+
+    <!-- M1 -->
+    <article class="finding">
+      <div class="finding-head">
+        <span class="finding-id">M-01</span>
+        <h3 class="finding-title">OAuth grant is repository-wide (<code>repo</code> scope)</h3>
+        <span class="chip sev-medium">Medium</span>
+      </div>
+      <div class="finding-body">
+        <p>Sign-in requests the classic <code>repo</code> scope, confirmed live on the authorize redirect (<code>scope=repo+read:user</code>). That grant gives ForkLeaf read/write access to <b>every repository the user can reach, public and private</b> &mdash; far more than the notes repository the product actually uses. The code documents this as a deliberate trade-off (there is no narrower classic scope that still writes to private repos), but it defines the blast radius of any token compromise: whoever holds a decrypted session can touch all of a user's code, not just their notes.</p>
+        <div class="fr"><span class="lab">Endpoint</span><p class="val"><code>/api/auth/github</code> &rarr; GitHub authorize</p></div>
+        <div class="fr"><span class="lab">Red</span><p class="val"><code>api-broken-authentication</code> &mdash; token scope abuse widens the reachable surface once a session is captured.</p></div>
+        <div class="fr"><span class="lab">Blue</span><p class="val"><code>api-authentication-monitoring</code>, <code>ci-identity-access-hardening</code></p></div>
+        <div class="fr"><span class="lab">Fix</span><p class="val">Offer (or default to) a <b>GitHub App with fine-grained, per-repository permissions</b> so the grant matches the one notes repo. Where the classic OAuth path stays, keep documenting the trade-off prominently, as the code already does.</p></div>
+      </div>
+    </article>
+
+    <!-- M2 -->
+    <article class="finding">
+      <div class="finding-head">
+        <span class="finding-id">M-02</span>
+        <h3 class="finding-title">Stateless 30-day session cannot be revoked</h3>
+        <span class="chip sev-medium">Medium</span>
+      </div>
+      <div class="finding-body">
+        <p>The session is a self-contained JWE (<code>A256GCM</code>) valid for 30 days. There is no server-side session store, so <code>/api/auth/logout</code> only deletes the browser's copy of the cookie &mdash; a cookie already captured by an attacker stays valid until it expires. The only way to invalidate every outstanding session is to rotate <code>SESSION_SECRET</code>, which signs everyone out at once. Combined with M-01's broad grant, a leaked cookie is both powerful and long-lived.</p>
+        <div class="fr"><span class="lab">Endpoint</span><p class="val"><code>lib/session.ts</code>, <code>/api/auth/logout</code></p></div>
+        <div class="fr"><span class="lab">Red</span><p class="val"><code>web-broken-authentication</code> &mdash; session token replay after theft; no revocation to shorten the window.</p></div>
+        <div class="fr"><span class="lab">Blue</span><p class="val"><code>web-authentication-hardening</code></p></div>
+        <div class="fr"><span class="lab">Fix</span><p class="val">Shorten the lifetime (or add a sliding refresh), and record a per-session <code>jti</code> so a single session can be revoked without a global secret rotation. A durable store (Upstash/Redis) is the natural home once one is added for M-03.</p></div>
+      </div>
+    </article>
+
+    <!-- L1 -->
+    <article class="finding">
+      <div class="finding-head">
+        <span class="finding-id">L-01</span>
+        <h3 class="finding-title">Read API routes are unthrottled</h3>
+        <span class="chip sev-low">Low</span>
+      </div>
+      <div class="finding-body">
+        <p>Write routes (<code>commit</code>, <code>asset</code>, <code>publish</code>, <code>fork</code>, <code>pull</code>, <code>bootstrap</code>) all call <code>enforceRateLimit</code>. The read routes &mdash; <code>repos</code>, <code>tree</code>, <code>file</code>, <code>history</code>, <code>branches</code>, and the <code>raw</code> image proxy &mdash; do not. A runaway or hostile authenticated client can burn the user's GitHub API quota, and <code>raw</code> can be driven as an authenticated image-fetch proxy.</p>
+        <div class="fr"><span class="lab">Endpoint</span><p class="val"><code>/api/gh/{repos,tree,file,history,branches,raw}</code></p></div>
+        <div class="fr"><span class="lab">Red</span><p class="val"><code>api-unrestricted-resource-consumption</code></p></div>
+        <div class="fr"><span class="lab">Blue</span><p class="val"><code>api-rate-limit-hardening</code></p></div>
+        <div class="fr"><span class="lab">Fix</span><p class="val">Apply the existing <code>enforceRateLimit</code> to the read routes with a generous per-minute budget; they already have the helper on hand.</p></div>
+      </div>
+    </article>
+
+    <!-- L2 -->
+    <article class="finding">
+      <div class="finding-head">
+        <span class="finding-id">L-02</span>
+        <h3 class="finding-title">Rate limiter is in-memory and per-instance</h3>
+        <span class="chip sev-low">Low</span>
+      </div>
+      <div class="finding-body">
+        <p>The limiter keeps its counters in a module-level <code>Map</code>. On Vercel's serverless/Fluid runtime each instance has its own copy, so the effective limit scales with instance count and resets on cold start. The code is candid about this ("a brake rather than a guarantee"), so this is confirmation rather than surprise: it stops accidental retry loops but not a distributed attacker.</p>
+        <div class="fr"><span class="lab">Endpoint</span><p class="val"><code>lib/rate-limit.ts</code></p></div>
+        <div class="fr"><span class="lab">Red</span><p class="val"><code>api-unrestricted-resource-consumption</code> (distributed)</p></div>
+        <div class="fr"><span class="lab">Blue</span><p class="val"><code>api-rate-limit-hardening</code></p></div>
+        <div class="fr"><span class="lab">Fix</span><p class="val">Move to a durable limiter (Upstash Redis) when a real ceiling is needed. The call sites are already shaped to swap the backend without change.</p></div>
+      </div>
+    </article>
+
+    <!-- L3 -->
+    <article class="finding">
+      <div class="finding-head">
+        <span class="finding-id">L-03</span>
+        <h3 class="finding-title">CSP <code>img-src https:</code> allows any-host image beacons</h3>
+        <span class="chip sev-low">Low</span>
+      </div>
+      <div class="finding-body">
+        <p>To let notes embed images from anywhere, the policy sets <code>img-src 'self' data: blob: https:</code>. A note opened from an untrusted repository can therefore reference an image on an attacker's host, and simply viewing the note leaks the reader's IP, user-agent, and the fact of the view to that host. No script executes &mdash; <code>img-src</code> can't &mdash; so this is a privacy/tracking leak, not code execution. It is a reasonable UX trade-off, worth stating so it's a known one.</p>
+        <div class="fr"><span class="lab">Endpoint</span><p class="val"><code>proxy.ts</code> &rarr; Content-Security-Policy</p></div>
+        <div class="fr"><span class="lab">Red</span><p class="val"><code>web-http-fingerprinting</code> / passive tracking via remote assets</p></div>
+        <div class="fr"><span class="lab">Blue</span><p class="val"><code>web-security-headers</code></p></div>
+        <div class="fr"><span class="lab">Fix</span><p class="val">Optional: proxy remote images through <code>/api/gh/raw</code>-style same-origin fetch, or offer a "block remote images" reading mode. Low priority given the local-first threat model.</p></div>
+      </div>
+    </article>
+
+    <!-- I1 -->
+    <article class="finding">
+      <div class="finding-head">
+        <span class="finding-id">I-01</span>
+        <h3 class="finding-title">Firebase profile identity is client-asserted</h3>
+        <span class="chip sev-info">Info</span>
+      </div>
+      <div class="finding-body">
+        <p>The Firestore profile is written by the client under an anonymous Firebase UID, and <code>githubId</code>/<code>githubLogin</code> are supplied by that client. The rules validate field <i>types</i> but not that the GitHub identity truly belongs to the caller. This has <b>no security impact</b>: the document is owner-read-only, display-only, and is never consulted for authorization &mdash; the server session cookie is. The rules file states this explicitly. Noted for completeness.</p>
+        <div class="fr"><span class="lab">Endpoint</span><p class="val"><code>firestore.rules</code>, <code>lib/firebase/users.ts</code></p></div>
+        <div class="fr"><span class="lab">Blue</span><p class="val"><code>cloud-storage-exposure-monitoring</code> (rules review)</p></div>
+      </div>
+    </article>
+
+    <!-- I2 -->
+    <article class="finding">
+      <div class="finding-head">
+        <span class="finding-id">I-02</span>
+        <h3 class="finding-title"><code>.env.local</code> with an OIDC token sits in the working tree</h3>
+        <span class="chip sev-info">Info</span>
+      </div>
+      <div class="finding-body">
+        <p>A Vercel-generated <code>.env.local</code> containing <code>VERCEL_OIDC_TOKEN</code> is present locally. It is correctly <b>git-ignored (not committed)</b> and the token is short-lived, so this is hygiene, not exposure. Confirm it never lands in a build artifact, log, or image layer.</p>
+        <div class="fr"><span class="lab">Endpoint</span><p class="val"><code>.env.local</code> (untracked)</p></div>
+        <div class="fr"><span class="lab">Red</span><p class="val"><code>ci-secret-exfiltration</code> (only if it escapes the dev machine)</p></div>
+        <div class="fr"><span class="lab">Blue</span><p class="val"><code>ci-secret-exposure-monitoring</code></p></div>
+      </div>
+    </article>
+
+    <!-- I3 -->
+    <article class="finding">
+      <div class="finding-head">
+        <span class="finding-id">I-03</span>
+        <h3 class="finding-title"><code>/api/session</code> answers unauthenticated callers</h3>
+        <span class="chip sev-info">Info</span>
+      </div>
+      <div class="finding-body">
+        <p>The endpoint returns <code>200</code> with <code>mode:"local"</code> to anonymous callers, confirmed live. This is <b>by design</b> &mdash; the client uses it to decide whether to show "Continue with GitHub" &mdash; and it never discloses the token or any user data when signed out. Recorded so the behaviour isn't mistaken for a leak later.</p>
+        <div class="fr"><span class="lab">Endpoint</span><p class="val"><code>/api/session</code></p></div>
+        <div class="fr"><span class="lab">Blue</span><p class="val"><code>api-data-exposure-monitoring</code></p></div>
+      </div>
+    </article>
+  </section>
+
+  <!-- ═══════════════ 4. TESTED CLEAN ═══════════════ -->
+  <section id="clean">
+    <div class="sec-head"><span class="sec-num">04</span><h2>Tested &amp; clean</h2></div>
+    <p style="margin-bottom:1.3rem">The following techniques were exercised and the corresponding defense held. These are the load-bearing controls &mdash; worth knowing what protects you, not just what doesn't.</p>
+    <ul class="clean">
+      <li><span class="tick">&#10003;</span><p class="what"><b>Stored XSS in the note preview.</b> <span>Markdown is rendered with <code>rehype-sanitize</code>, <code>allowDangerousHtml</code> off, an explicit tag/attribute allowlist, and <code>data:</code> URLs constrained to raster images. Raw HTML in notes is escaped.</span></p></li>
+      <li><span class="tick">&#10003;</span><p class="what"><b>XSS via Mermaid diagrams.</b> <span>Mermaid runs at <code>securityLevel:"strict"</code> with <code>htmlLabels:false</code>, and every SVG is re-sanitised with DOMPurify &mdash; <code>foreignObject</code>, <code>script</code>, and event-handler attributes forbidden.</span></p></li>
+      <li><span class="tick">&#10003;</span><p class="what"><b>SSRF &amp; path traversal into the GitHub API.</b> <span>A single transport choke-point rejects off-host URLs and any <code>..</code>/<code>.</code> segment (decoded, so <code>%2e%2e</code> can't slip past); paths are per-segment encoded and names/refs validated by strict regex.</span></p></li>
+      <li><span class="tick">&#10003;</span><p class="what"><b>Cross-site request forgery.</b> <span>Confirmed live: a state-changing POST with a foreign <code>Origin</code> is refused with <code>403</code>. Backed by a <code>SameSite=Lax</code> cookie and an origin allowlist in middleware.</span></p></li>
+      <li><span class="tick">&#10003;</span><p class="what"><b>Login CSRF.</b> <span>Single-use OAuth <code>state</code>, constant-time compared, in a <code>Secure; HttpOnly; SameSite=Lax</code> 10-minute cookie &mdash; verified on the live authorize redirect.</span></p></li>
+      <li><span class="tick">&#10003;</span><p class="what"><b>Access-token exposure.</b> <span>The token never reaches the browser: encrypted (JWE&nbsp;A256GCM) into an httpOnly cookie, with a hard startup failure if <code>SESSION_SECRET</code> is missing or under 32 chars &mdash; no insecure fallback.</span></p></li>
+      <li><span class="tick">&#10003;</span><p class="what"><b>Publish path traversal.</b> <span><code>pagePath</code> validates the slug against an allowlist before use &mdash; not after normalising &mdash; so <code>../index</code> is rejected rather than quietly rewritten.</span></p></li>
+      <li><span class="tick">&#10003;</span><p class="what"><b>IDOR / broken object-level access.</b> <span>Not applicable by design: every repository operation is delegated to the signed-in user's own GitHub token, so GitHub itself enforces per-object authorization. There is no ForkLeaf-side object store to walk.</span></p></li>
+      <li><span class="tick">&#10003;</span><p class="what"><b>Firestore rules.</b> <span>Default-deny catch-all, owner-only read/write on <code>users/{uid}</code>, a strict field allowlist, and <code>delete:false</code>. New collections must opt in.</span></p></li>
+      <li><span class="tick">&#10003;</span><p class="what"><b>Security headers.</b> <span>Confirmed live: full CSP with a per-request nonce + <code>strict-dynamic</code> on the content-rendering routes, HSTS (2y, preload), <code>X-Frame-Options: DENY</code>, <code>nosniff</code>, COOP, CORP, Referrer-Policy, and a locked-down Permissions-Policy.</span></p></li>
+    </ul>
+  </section>
+
+  <!-- ═══════════════ 5. PER-SURFACE ROLL-UP ═══════════════ -->
+  <section id="rollup">
+    <div class="sec-head"><span class="sec-num">05</span><h2>Per-surface risk roll-up</h2></div>
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr><th>Screen / endpoint</th><th>Worst finding</th><th>Severity</th><th>Paired defense</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>OAuth sign-in <span class="mono">/api/auth/github</span></td><td>Repo-wide grant</td><td><span class="chip sev-medium">Medium</span></td><td class="mono">api-authentication-monitoring</td></tr>
+          <tr><td>Session cookie <span class="mono">lib/session.ts</span></td><td>No revocation</td><td><span class="chip sev-medium">Medium</span></td><td class="mono">web-authentication-hardening</td></tr>
+          <tr><td>Read proxy <span class="mono">/api/gh/{tree,file,…}</span></td><td>Unthrottled</td><td><span class="chip sev-low">Low</span></td><td class="mono">api-rate-limit-hardening</td></tr>
+          <tr><td>Image proxy <span class="mono">/api/gh/raw</span></td><td>Unthrottled fetch</td><td><span class="chip sev-low">Low</span></td><td class="mono">api-rate-limit-hardening</td></tr>
+          <tr><td>Editor preview <span class="mono">/editor</span></td><td>XSS &mdash; mitigated</td><td><span class="chip sev-clean">Clean</span></td><td class="mono">web-xss-detection</td></tr>
+          <tr><td>Note publishing <span class="mono">/api/gh/publish</span></td><td>Traversal &mdash; mitigated</td><td><span class="chip sev-clean">Clean</span></td><td class="mono">web-path-traversal-detection</td></tr>
+          <tr><td>Write proxy <span class="mono">/api/gh/commit</span></td><td>CSRF &mdash; mitigated</td><td><span class="chip sev-clean">Clean</span></td><td class="mono">web-csrf-hardening</td></tr>
+          <tr><td>Profile store <span class="mono">Firestore</span></td><td>Client-asserted id</td><td><span class="chip sev-info">Info</span></td><td class="mono">cloud-storage-exposure-monitoring</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ═══════════════ 6. TECHNIQUE COVERAGE ═══════════════ -->
+  <section id="coverage">
+    <div class="sec-head"><span class="sec-num">06</span><h2>Technique coverage</h2></div>
+    <p style="margin-bottom:1.3rem">Every technique the surface map lit up, and its outcome. Nothing was silently skipped.</p>
+    <div class="table-scroll">
+      <table>
+        <thead><tr><th>Technique</th><th>Surface reached</th><th>Outcome</th></tr></thead>
+        <tbody>
+          <tr><td>HTTP fingerprinting / headers</td><td>All responses</td><td><span class="chip sev-clean">Hardened</span></td></tr>
+          <tr><td>Reflected / stored XSS</td><td>Editor, dashboard render</td><td><span class="chip sev-clean">Tested&nbsp;clean</span></td></tr>
+          <tr><td>SSRF</td><td>GitHub proxy transport</td><td><span class="chip sev-clean">Tested&nbsp;clean</span></td></tr>
+          <tr><td>Path traversal</td><td>file / raw / publish paths</td><td><span class="chip sev-clean">Tested&nbsp;clean</span></td></tr>
+          <tr><td>CSRF (state-changing)</td><td>All write routes</td><td><span class="chip sev-clean">Tested&nbsp;clean</span></td></tr>
+          <tr><td>Broken authentication</td><td>OAuth + session</td><td><span class="chip sev-medium">Findings M-01/02</span></td></tr>
+          <tr><td>Unrestricted resource consumption</td><td>Read routes</td><td><span class="chip sev-low">Finding L-01/02</span></td></tr>
+          <tr><td>Broken object-level auth (IDOR)</td><td>&mdash;</td><td><span class="mono" style="font-size:0.8rem;color:var(--muted)">n/a &mdash; delegated to GitHub</span></td></tr>
+          <tr><td>SQL / command injection</td><td>&mdash;</td><td><span class="mono" style="font-size:0.8rem;color:var(--muted)">n/a &mdash; no SQL / shell sinks</span></td></tr>
+          <tr><td>XXE</td><td>&mdash;</td><td><span class="mono" style="font-size:0.8rem;color:var(--muted)">n/a &mdash; no XML parser on input</span></td></tr>
+          <tr><td>Cloud storage exposure</td><td>Firestore rules</td><td><span class="chip sev-clean">Tested&nbsp;clean</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ═══════════════ 7. REMEDIATION PLAN ═══════════════ -->
+  <section id="plan">
+    <div class="sec-head"><span class="sec-num">07</span><h2>Prioritized remediation</h2></div>
+    <ol class="plan">
+      <li><b>Add rate limiting to the read routes (L-01).</b><span class="note">Highest impact-per-effort: the helper exists; wire <code>enforceRateLimit</code> into <code>tree</code>, <code>file</code>, <code>history</code>, <code>repos</code>, <code>branches</code>, and <code>raw</code>. An afternoon.</span></li>
+      <li><b>Make sessions revocable (M-02).</b><span class="note">Add a per-session <code>jti</code> and shorten the lifetime or add sliding refresh, so a stolen cookie has a bounded, closable window.</span></li>
+      <li><b>Offer a fine-grained GitHub App path (M-01).</b><span class="note">Narrow the default grant to the notes repository; the largest reduction in blast radius, though the most product work.</span></li>
+      <li><b>Introduce a durable rate limiter (L-02).</b><span class="note">Upstash Redis behind the existing interface; naturally also hosts the session <code>jti</code> denylist from step 2.</span></li>
+      <li><b>Decide on remote-image policy (L-03).</b><span class="note">Keep as-is with the trade-off documented, or add a "block remote images" reading mode. Low urgency.</span></li>
+    </ol>
+  </section>
+
+  <!-- ═══════════════ METHODOLOGY / ATTRIBUTION ═══════════════ -->
+  <section id="method">
+    <div class="sec-head"><span class="sec-num">08</span><h2>Methodology &amp; attribution</h2></div>
+    <p>This assessment was performed using <b>RedBlueSkills</b> &mdash; the paired offense/defense security skill library (<a href="https://github.com/praneeth132006/RedBlueSkills">github.com/praneeth132006/RedBlueSkills</a>, <a href="https://red-blue-skills.vercel.app/">red-blue-skills.vercel.app</a>). The library was installed into this project and driven by its <code>attack-my-application</code> orchestrator, which fingerprinted the target, mapped the attack surface, and sequenced the relevant skills in kill-chain order.</p>
+    <p>The core discipline of the toolkit &mdash; and of this report &mdash; is that <b>every offensive result carries its detection or hardening counterpart</b>. The specific skills applied included:</p>
+    <div class="tag-legend">
+      <span><span class="chip red">red</span> web-http-fingerprinting · web-reflected-xss · web-ssrf · web-path-traversal · web-csrf · web-broken-authentication · api-broken-authentication · api-unrestricted-resource-consumption</span>
+    </div>
+    <div class="tag-legend">
+      <span><span class="chip blue">blue</span> web-security-headers · web-xss-detection · web-csrf-hardening · web-authentication-hardening · api-rate-limit-hardening · api-authentication-monitoring · cloud-storage-exposure-monitoring</span>
+    </div>
+
+    <div class="footer">
+      <p><span class="mono">ForkLeaf Security Audit</span> &mdash; performed 23 Aug 2026 against forkleaf.vercel.app and ForkLeaf v0.2.0. Static source review plus non-destructive live probing. Findings reflect the state of the code and deployment at the time of testing.</p>
+      <p style="margin-top:0.6rem">Generated with the <b>RedBlueSkills</b> toolkit and its <code>attack-my-application</code> orchestrator.</p>
+    </div>
+  </section>
+
+</div>


### PR DESCRIPTION
> ⚙️ **Every finding in this report was discovered using the [RedBlueSkills](https://github.com/praneeth132006/RedBlueSkills) toolkit** ([red-blue-skills.vercel.app](https://red-blue-skills.vercel.app/)), driven by its `attack-my-application` orchestrator. The toolkit was installed into the project, fingerprinted the target, mapped the attack surface, and sequenced its offensive skills in kill-chain order — pairing each offensive check with its defensive (detection/hardening) counterpart.

## Summary

Adds a full **offense-and-defense security audit** of ForkLeaf — static source review ("in") plus non-destructive live probing of `forkleaf.vercel.app` ("out"). Every bug below was found via RedBlueSkills.

Files (under `docs/security/`):
- `README.md` — GitHub-readable findings summary
- `audit-2026-08-23.html` — full styled report

The third-party skill library itself is **not vendored** into the repo (it's a local tool, 128 files); only the report ships here.

## Verdict: A− — no critical or high-severity findings

| ID | Finding | Severity | RedBlueSkill (red → blue) |
|----|---------|----------|---------------------------|
| M-01 | OAuth requests repo-wide `repo` scope | Medium | `api-broken-authentication` → `api-authentication-monitoring` |
| M-02 | Stateless 30-day session can't be revoked | Medium | `web-broken-authentication` → `web-authentication-hardening` |
| L-01 | Read API routes unthrottled (writes are throttled) | Low | `api-unrestricted-resource-consumption` → `api-rate-limit-hardening` |
| L-02 | Rate limiter is in-memory / per-instance on serverless | Low | `api-unrestricted-resource-consumption` → `api-rate-limit-hardening` |
| L-03 | `img-src https:` allows any-host image beacons | Low | `web-http-fingerprinting` → `web-security-headers` |
| I-01–03 | Client-asserted Firebase profile; local `.env.local`; `/api/session` 200 when signed out — no impact / by design | Info | — |

**Tested clean (10) — also via RedBlueSkills:** token exposure · markdown XSS (`web-reflected-xss`) · Mermaid XSS · SSRF (`web-ssrf`) · path traversal (`web-path-traversal`) · CSRF (`web-csrf`, live 403) · login CSRF · publish traversal · IDOR (delegated to GitHub) · Firestore rules (`cloud-storage-exposure-monitoring`) · security headers (`web-security-headers`).

**Top fix by impact-per-effort:** rate-limit the read routes (L-01) — the helper already exists.

No application code changed — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
