### PR TITLE
feat(editor): edit a diagram in a tab of its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,15 @@ Mermaid is powerful and hard to remember, so there are three ways in:
   writing, plus inline errors that point at the broken line and explain it in
   plain language instead of dumping parser output.
 
-Diagrams are stored as normal ` ```mermaid ` fenced blocks, so they render on
-github.com and anywhere else Mermaid is supported.
+- **Open in tab** — optional, for the diagrams that outgrow a dialog. The same
+  studio opens in a browser tab of its own, for a second screen or a full-height
+  canvas, and every edit is saved into the note as you make it. The note stays
+  the one writer: the block shows "Editing in another tab" with a link that
+  takes editing back, and clicking a diagram still opens it in the note.
+
+Diagrams are drawn in the app's own palette and follow the light/dark theme,
+including in that separate tab. They are stored as normal ` ```mermaid ` fenced
+blocks, so they render on github.com and anywhere else Mermaid is supported.
 
 ### Sync
 

--- a/apps/web/src/app/diagram/page.tsx
+++ b/apps/web/src/app/diagram/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from "react";
+import { DiagramWindow } from "@/components/DiagramWindow";
+import { BootScreen } from "@/components/BootScreen";
+
+export const metadata = {
+  title: "Diagram — ForkLeaf",
+};
+
+/**
+ * Rendered per request, for the same reason the editor is: this route injects
+ * diagram SVG as HTML, so it gets the strict nonce-based CSP in `src/proxy.ts`
+ * — and a nonce only exists for a page that is not prerendered.
+ */
+export const dynamic = "force-dynamic";
+
+/**
+ * A single diagram, in a tab of its own.
+ *
+ * Opened from the "Open in tab" control on a diagram inside a note, and paired
+ * with that note through the `?s=` session id. It is a companion window, not a
+ * second editor: the note tab still owns and saves the text.
+ */
+export default function DiagramPage() {
+  return (
+    <Suspense fallback={<BootScreen message="Opening diagram…" />}>
+      <DiagramWindow />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/docs/content/writing.tsx
+++ b/apps/web/src/app/docs/content/writing.tsx
@@ -205,6 +205,21 @@ export function Diagrams() {
       </OL>
       <P>Click any diagram in a note to reopen the studio.</P>
 
+      <H2 id="own-tab">Editing a diagram in its own tab</H2>
+      <P>
+        Some diagrams are bigger than a dialog. Hover a diagram in a note and choose{" "}
+        <strong>Open in tab</strong> — or press it in the studio&rsquo;s header — and the same
+        studio opens in a browser tab of its own, which you can move to a second screen and leave
+        open while you write.
+      </P>
+      <P>
+        The note stays the owner of the text. Every edit in that tab is saved into the note as you
+        make it, the header says so as it happens, and the diagram block in the note shows{" "}
+        <strong>Editing in another tab</strong> with an <strong>Edit here</strong> link that takes
+        editing back. Nothing is duplicated and there is nothing to sync by hand — it is entirely
+        optional, and clicking a diagram still opens it in the note.
+      </P>
+
       <H2 id="panes">Source and canvas, side by side</H2>
       <P>
         Both panes are live views of the same Mermaid string, not two modes you switch between: type

--- a/apps/web/src/components/DiagramWindow.tsx
+++ b/apps/web/src/components/DiagramWindow.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { DiagramStudio, useDiagramPopoutSession, type DiagramLinkStatus } from "@forkleaf/editor";
+import { ForkLeafLogo } from "@/components/Brand";
+import { useTheme } from "@/hooks/useTheme";
+
+/**
+ * One diagram, one window.
+ *
+ * The note tab remains the owner of the text — this window has no repository
+ * access and never writes a file. It posts each edit back to the note, which
+ * applies it to the `mermaid` block and saves it on its own schedule. So
+ * "autosave" here is not a second save path with its own failure modes; it is
+ * the note's save path, driven from another window.
+ *
+ * The header therefore has one job beyond identification: say, truthfully and
+ * continuously, whether what you are drawing is reaching the note. A diagram
+ * editor that quietly stops saving is worse than one that never saved.
+ */
+export function DiagramWindow() {
+  const params = useSearchParams();
+  const sessionId = params.get("s");
+
+  const { code, setCode, title, status, savedAt, dirty, reason, ready } =
+    useDiagramPopoutSession(sessionId);
+
+  const [theme, , toggleTheme] = useTheme();
+
+  // The window is about one thing, so it may as well say which one.
+  useEffect(() => {
+    document.title = `${title} — ForkLeaf`;
+  }, [title]);
+
+  // Closing with unsent work is the one thing worth interrupting for. Nothing
+  // is prompted while the link is healthy, because then there is nothing to
+  // lose — the note already has it.
+  useEffect(() => {
+    if (!dirty || status !== "detached") return;
+
+    const confirmLeave = (event: BeforeUnloadEvent) => event.preventDefault();
+    window.addEventListener("beforeunload", confirmLeave);
+    return () => window.removeEventListener("beforeunload", confirmLeave);
+  }, [dirty, status]);
+
+  if (!sessionId) {
+    return (
+      <Message
+        heading="No diagram to edit"
+        body="This window is opened from a diagram inside a note — there is nothing for it to show on its own."
+      />
+    );
+  }
+
+  if (status === "finished") {
+    return (
+      <Message
+        heading={reason === "brought-back" ? "Editing moved back to the note" : "The note closed"}
+        body={
+          reason === "brought-back"
+            ? "This diagram is being edited in the note tab again. Everything you drew here is in it."
+            : "The note that owns this diagram is no longer open, so there is nowhere to save to. Your last edit was saved into the note before it closed."
+        }
+        code={code}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-screen flex-col bg-[var(--fl-bg)]">
+      <header className="flex shrink-0 items-center gap-3 border-b border-[var(--fl-border)] px-4 py-2.5">
+        <ForkLeafLogo markClassName="h-5 w-5" textClassName="text-sm" />
+
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-[13.5px] font-semibold text-[var(--fl-text)]">{title}</h1>
+          <SaveState status={status} savedAt={savedAt} dirty={dirty} />
+        </div>
+
+        <button
+          type="button"
+          onClick={toggleTheme}
+          className="fl-btn fl-btn-ghost text-[13px]"
+          title="Diagrams are drawn in the theme's own palette, so this redraws them too"
+        >
+          {theme === "dark" ? "Light" : "Dark"}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => window.close()}
+          className="fl-btn fl-btn-ghost text-[13px]"
+        >
+          Close
+        </button>
+      </header>
+
+      {status === "detached" && (
+        <p className="shrink-0 border-b border-[var(--fl-warning-border,var(--fl-border))] bg-[var(--fl-surface)] px-4 py-2 text-[12.5px] text-[var(--fl-muted)]">
+          The note tab is not answering, so edits are being kept in this browser instead of saved
+          into the note. Reopen the note and this window will reconnect on its own.
+        </p>
+      )}
+
+      {/* The studio fills the window — which is the entire reason to be here.
+          It is mounted only once the source is known: it reads that source on
+          its first render to decide between a canvas and the "what are you
+          drawing?" picker, so mounting it a paint early asks someone who
+          clicked an existing diagram what they would like to draw. */}
+      <div className="flex min-h-0 flex-1 flex-col">
+        {ready ? (
+          <DiagramStudio code={code} onChange={setCode} />
+        ) : (
+          <p
+            className="flex flex-1 items-center justify-center text-sm text-[var(--fl-muted)]"
+            aria-busy="true"
+          >
+            Opening diagram…
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The save indicator.
+ *
+ * Three honest states rather than a permanent "Saved": connecting, saving,
+ * saved-with-a-time. The timestamp is what makes it checkable — "Saved" alone
+ * is indistinguishable from "Saved, forty minutes ago, before the note closed".
+ */
+function SaveState({
+  status,
+  savedAt,
+  dirty,
+}: {
+  status: DiagramLinkStatus;
+  savedAt: number | null;
+  dirty: boolean;
+}) {
+  // Re-rendered on a timer so "just now" becomes "2m ago" without an edit.
+  const [, tick] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => tick((value) => value + 1), 30_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (status === "connecting") {
+    return <p className="truncate text-[11.5px] text-[var(--fl-muted)]">Connecting to the note…</p>;
+  }
+
+  if (status === "detached") {
+    return (
+      <p className="truncate text-[11.5px] text-[var(--fl-danger)]">
+        Not saving to the note — kept in this browser
+      </p>
+    );
+  }
+
+  if (dirty) {
+    return <p className="truncate text-[11.5px] text-[var(--fl-muted)]">Saving to the note…</p>;
+  }
+
+  return (
+    <p className="truncate text-[11.5px] text-[var(--fl-muted)]">
+      Saved to the note{savedAt ? ` · ${ago(savedAt)}` : ""}
+    </p>
+  );
+}
+
+function ago(at: number): string {
+  const seconds = Math.max(0, Math.round((Date.now() - at) / 1000));
+  if (seconds < 45) return "just now";
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  return `${Math.round(minutes / 60)}h ago`;
+}
+
+/**
+ * The end of a session.
+ *
+ * The source is offered for copying rather than only described: this screen
+ * appears when there is no longer anywhere to save to, and the one thing
+ * someone in that position wants is their text.
+ */
+function Message({ heading, body, code }: { heading: string; body: string; code?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-5 bg-[var(--fl-bg)] px-6 text-center">
+      <ForkLeafLogo markClassName="h-7 w-7" textClassName="text-lg" />
+
+      <div className="max-w-md">
+        <h1 className="text-lg font-semibold text-[var(--fl-text)]">{heading}</h1>
+        <p className="mt-2 text-sm leading-relaxed text-[var(--fl-muted)]">{body}</p>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        {code?.trim() && (
+          <button
+            type="button"
+            className="fl-btn fl-btn-ghost"
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(code);
+                setCopied(true);
+              } catch {
+                // Denied clipboard permission; the button simply does nothing
+                // rather than claiming a copy that did not happen.
+              }
+            }}
+          >
+            {copied ? "Copied" : "Copy diagram source"}
+          </button>
+        )}
+
+        <button type="button" className="fl-btn fl-btn-primary" onClick={() => window.close()}>
+          Close window
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/DiagramWindow.tsx
+++ b/apps/web/src/components/DiagramWindow.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { detectKind, mermaidToGraph } from "@forkleaf/diagrams";
 import { DiagramStudio, useDiagramPopoutSession, type DiagramLinkStatus } from "@forkleaf/editor";
 import { ForkLeafLogo } from "@/components/Brand";
 import { useTheme } from "@/hooks/useTheme";
@@ -68,48 +69,67 @@ export function DiagramWindow() {
   }
 
   return (
-    <div className="flex h-screen flex-col bg-[var(--fl-bg)]">
-      <header className="flex shrink-0 items-center gap-3 border-b border-[var(--fl-border)] px-4 py-2.5">
-        <ForkLeafLogo markClassName="h-5 w-5" textClassName="text-sm" />
+    // The same layered shell the editor uses: floating surfaces on the page
+    // colour, a title bar of their own, and a status strip underneath. A
+    // window that reads like the app it came out of does not feel like a
+    // second application you have been thrown into.
+    <div className="flex h-screen flex-col overflow-hidden bg-[var(--fl-bg)] font-sans text-[var(--fl-text)]">
+      <div className="shrink-0 px-2 pt-2">
+        <header className="fl-panel flex h-[52px] items-center gap-3 px-3">
+          <ForkLeafLogo markClassName="h-5 w-5" textClassName="text-sm" />
 
-        <div className="min-w-0 flex-1">
-          <h1 className="truncate text-[13.5px] font-semibold text-[var(--fl-text)]">{title}</h1>
-          <SaveState status={status} savedAt={savedAt} dirty={dirty} />
-        </div>
+          <span aria-hidden="true" className="h-5 w-px shrink-0 bg-[var(--fl-border)]" />
 
-        <button
-          type="button"
-          onClick={toggleTheme}
-          className="fl-btn fl-btn-ghost text-[13px]"
-          title="Diagrams are drawn in the theme's own palette, so this redraws them too"
-        >
-          {theme === "dark" ? "Light" : "Dark"}
-        </button>
+          <div className="min-w-0 flex-1">
+            <h1 className="truncate text-[13.5px] font-semibold leading-tight text-[var(--fl-text)]">
+              {title}
+            </h1>
+            <SaveState status={status} savedAt={savedAt} dirty={dirty} />
+          </div>
 
-        <button
-          type="button"
-          onClick={() => window.close()}
-          className="fl-btn fl-btn-ghost text-[13px]"
-        >
-          Close
-        </button>
-      </header>
+          <button
+            type="button"
+            onClick={toggleTheme}
+            title="Diagrams are drawn in the theme's own palette, so this redraws them too"
+            className="shrink-0 rounded-lg border border-[var(--fl-border)] px-2.5 py-1.5 text-[12.5px] font-medium text-[var(--fl-muted)] transition-colors hover:border-[var(--fl-border-strong)] hover:text-[var(--fl-text)]"
+          >
+            {theme === "dark" ? "Light" : "Dark"}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => window.close()}
+            className="shrink-0 rounded-lg border border-[var(--fl-border)] px-2.5 py-1.5 text-[12.5px] font-medium text-[var(--fl-muted)] transition-colors hover:border-[var(--fl-border-strong)] hover:text-[var(--fl-text)]"
+          >
+            Close
+          </button>
+        </header>
+      </div>
 
       {status === "detached" && (
-        <p className="shrink-0 border-b border-[var(--fl-warning-border,var(--fl-border))] bg-[var(--fl-surface)] px-4 py-2 text-[12.5px] text-[var(--fl-muted)]">
-          The note tab is not answering, so edits are being kept in this browser instead of saved
-          into the note. Reopen the note and this window will reconnect on its own.
-        </p>
+        <div className="shrink-0 px-2 pt-2">
+          <p className="fl-panel border-[var(--fl-danger)]/40 px-3 py-2 text-[12.5px] text-[var(--fl-muted)]">
+            <span className="font-medium text-[var(--fl-danger)]">Not saving to the note.</span> The
+            note tab is not answering, so edits are being kept in this browser. Reopen the note and
+            this window will reconnect on its own.
+          </p>
+        </div>
       )}
 
       {/* The studio fills the window — which is the entire reason to be here.
           It is mounted only once the source is known: it reads that source on
           its first render to decide between a canvas and the "what are you
           drawing?" picker, so mounting it a paint early asks someone who
-          clicked an existing diagram what they would like to draw. */}
+          clicked an existing diagram what they would like to draw.
+
+          The canvas gets roughly two thirds of the width to start with, and
+          the divider is still there to move: the reason to open a diagram in
+          a window is the canvas, so it should not have to be uncovered first.
+          A dialog splits nearer the middle because its source pane is narrow
+          enough to wrap without the help. */}
       <div className="flex min-h-0 flex-1 flex-col">
         {ready ? (
-          <DiagramStudio code={code} onChange={setCode} />
+          <DiagramStudio code={code} onChange={setCode} chrome="layered" initialSplit={32} />
         ) : (
           <p
             className="flex flex-1 items-center justify-center text-sm text-[var(--fl-muted)]"
@@ -119,7 +139,51 @@ export function DiagramWindow() {
           </p>
         )}
       </div>
+
+      <StatusBar code={code} status={status} />
     </div>
+  );
+}
+
+/**
+ * The strip along the bottom, matching the editor's.
+ *
+ * It answers the two questions the chrome above deliberately does not repeat:
+ * what this diagram actually is, and where its text ends up. Facts, not
+ * controls — the same job the editor's status bar does for a note.
+ */
+function StatusBar({ code, status }: { code: string; status: DiagramLinkStatus }) {
+  const facts = useMemo(() => {
+    const kind = detectKind(code);
+    const lines = code.trim() === "" ? 0 : code.trim().split("\n").length;
+    // Null for diagram types the graph model does not cover, and for a
+    // flowchart mid-keystroke. Counts are then simply left off rather than
+    // reported as zero.
+    const graph = mermaidToGraph(code);
+
+    return [
+      kind ?? "diagram",
+      graph ? `${graph.nodes.length} ${graph.nodes.length === 1 ? "node" : "nodes"}` : null,
+      graph ? `${graph.edges.length} ${graph.edges.length === 1 ? "arrow" : "arrows"}` : null,
+      `${lines} ${lines === 1 ? "line" : "lines"}`,
+    ].filter((fact): fact is string => fact !== null);
+  }, [code]);
+
+  return (
+    <footer className="flex shrink-0 items-center gap-3 px-4 py-1.5 text-[11px] text-[var(--fl-muted)]">
+      <span className="flex items-center gap-1.5">
+        <span
+          aria-hidden="true"
+          className={`h-1.5 w-1.5 rounded-full ${
+            status === "linked" ? "bg-[var(--fl-accent)]" : "bg-[var(--fl-border-strong)]"
+          }`}
+        />
+        {status === "linked" ? "Saving into the note" : "Not saving into the note"}
+      </span>
+
+      <span className="ml-auto truncate font-mono">{facts.join("  ·  ")}</span>
+      <span className="hidden sm:inline">Mermaid</span>
+    </footer>
   );
 }
 

--- a/apps/web/src/hooks/useTheme.test.tsx
+++ b/apps/web/src/hooks/useTheme.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useTheme } from "./useTheme";
+
+/**
+ * The theme has to survive being changed in a different tab.
+ *
+ * The snapshot is read from `data-theme` on `<html>`, which only the tab that
+ * owns the document can write — so a `storage` event has to be turned back
+ * into a DOM change here. Notifying without re-applying re-rendered every
+ * consumer with the old palette still in place, which is invisible in a single
+ * tab and very visible once a diagram is being edited in a second one: the
+ * diagram is drawn in the theme's own colours, so it stayed dark in a window
+ * whose note had just been switched to light.
+ */
+
+function installStorage(): void {
+  const entries = new Map<string, string>();
+
+  // Node 25 defines its own experimental `localStorage` global that shadows
+  // jsdom's, with every method missing unless the process was started with a
+  // backing file. The test needs the API a browser actually has.
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      get length() {
+        return entries.size;
+      },
+      key: (index: number) => [...entries.keys()][index] ?? null,
+      getItem: (key: string) => entries.get(key) ?? null,
+      setItem: (key: string, value: string) => void entries.set(key, String(value)),
+      removeItem: (key: string) => void entries.delete(key),
+      clear: () => entries.clear(),
+    },
+  });
+}
+
+/** What the browser fires at every *other* tab when storage is written. */
+function storageEvent(key: string): void {
+  window.dispatchEvent(new StorageEvent("storage", { key }));
+}
+
+beforeEach(() => {
+  installStorage();
+  document.documentElement.dataset.theme = "light";
+  document.documentElement.dataset.palette = "slate";
+});
+
+afterEach(() => {
+  delete document.documentElement.dataset.theme;
+  delete document.documentElement.dataset.palette;
+});
+
+describe("useTheme", () => {
+  it("reads the theme off the document", () => {
+    const view = renderHook(() => useTheme());
+    expect(view.result.current[0]).toBe("light");
+
+    document.documentElement.dataset.theme = "dark";
+    // Nothing has told React yet — the attribute alone is not an event.
+    expect(view.result.current[0]).toBe("light");
+  });
+
+  it("applies the theme and remembers it", () => {
+    const view = renderHook(() => useTheme());
+
+    act(() => view.result.current[1]("dark"));
+
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(window.localStorage.getItem("forkleaf-theme")).toBe("dark");
+    // The accent is an inline style, so the mode has to re-resolve it.
+    expect(document.documentElement.style.getPropertyValue("--fl-accent")).toMatch(/^#/);
+  });
+
+  it("toggles to the other mode", () => {
+    const view = renderHook(() => useTheme());
+
+    act(() => view.result.current[2]());
+    expect(view.result.current[0]).toBe("dark");
+
+    act(() => view.result.current[2]());
+    expect(view.result.current[0]).toBe("light");
+  });
+
+  it("adopts a theme chosen in another tab", () => {
+    const view = renderHook(() => useTheme());
+
+    // The other tab wrote the value; this tab only gets the event.
+    window.localStorage.setItem("forkleaf-theme", "dark");
+    act(() => storageEvent("forkleaf-theme"));
+
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(view.result.current[0]).toBe("dark");
+  });
+
+  it("adopts an accent chosen in another tab", () => {
+    renderHook(() => useTheme());
+
+    window.localStorage.setItem("forkleaf-palette", "lavender");
+    act(() => storageEvent("forkleaf-palette"));
+
+    expect(document.documentElement.dataset.palette).toBe("lavender");
+  });
+
+  it("ignores a palette id it does not know", () => {
+    renderHook(() => useTheme());
+
+    window.localStorage.setItem("forkleaf-palette", "chartreuse");
+    act(() => storageEvent("forkleaf-palette"));
+
+    // A newer build's palette, or a hand-edited value: keep the one that works
+    // rather than setting an id nothing has colours for.
+    expect(document.documentElement.dataset.palette).toBe("slate");
+  });
+
+  it("leaves the theme alone for another product's storage key", () => {
+    renderHook(() => useTheme());
+
+    window.localStorage.setItem("forkleaf-theme", "dark");
+    act(() => storageEvent("some-other-app"));
+
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+});

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -33,13 +33,64 @@ const CUSTOM_KEY = "forkleaf-custom-accent";
 
 const listeners = new Set<() => void>();
 
+/**
+ * Applies a theme choice made in another tab.
+ *
+ * A `storage` event tells this tab the value changed, but the snapshot reads
+ * the DOM — which no other tab can write to — so notifying alone re-rendered
+ * with the old theme still on `<html>`. The attribute has to be re-applied
+ * here. That matters now that a diagram can be edited in a window of its own:
+ * a diagram is drawn in the theme's palette, and having it drawn in the other
+ * one because the toggle was pressed in the note tab is exactly the mismatch
+ * the palette work exists to avoid.
+ */
+function adoptStoredTheme(event: StorageEvent): void {
+  if (
+    event.key !== null &&
+    event.key !== STORAGE_KEY &&
+    event.key !== PALETTE_KEY &&
+    event.key !== CUSTOM_KEY
+  ) {
+    return;
+  }
+
+  const root = document.documentElement;
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    const theme: Theme = stored === "dark" || stored === "light" ? stored : getSnapshot();
+    root.dataset.theme = theme;
+
+    // The accent is chosen separately and stored separately, so it is adopted
+    // separately — a tab that only learns about the mode ends up in the right
+    // mode wearing the other tab's accent.
+    const storedPalette = window.localStorage.getItem(PALETTE_KEY);
+    if (
+      storedPalette &&
+      (PALETTES.some((palette) => palette.id === storedPalette) || storedPalette === "custom")
+    ) {
+      root.dataset.palette = storedPalette;
+    }
+
+    applyAccent(root, accentFor(paletteSnapshot(), theme, readCustom()));
+  } catch {
+    // Storage went away mid-session; this tab simply keeps its own theme.
+  }
+}
+
 function subscribe(onChange: () => void): () => void {
   listeners.add(onChange);
+
   // Keep other tabs in step.
-  window.addEventListener("storage", onChange);
+  const onStorage = (event: StorageEvent) => {
+    adoptStoredTheme(event);
+    onChange();
+  };
+
+  window.addEventListener("storage", onStorage);
   return () => {
     listeners.delete(onChange);
-    window.removeEventListener("storage", onChange);
+    window.removeEventListener("storage", onStorage);
   };
 }
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -39,11 +39,12 @@ import { THEME_INIT_HASH } from "@/lib/theme-script-hash";
 /**
  * Routes rendered per request that get the nonce policy.
  *
- * These are the two screens built out of the user's own repositories: the
- * editor, which injects rendered markdown and diagram SVG as HTML, and the
- * dashboard, which builds an index out of every note in them.
+ * These are the screens built out of the user's own repositories: the editor,
+ * which injects rendered markdown and diagram SVG as HTML; the dashboard,
+ * which builds an index out of every note in them; and the pop-out diagram
+ * window, which is the editor's diagram studio in a tab of its own.
  */
-const NONCED_ROUTES = ["/editor", "/dashboard"];
+const NONCED_ROUTES = ["/editor", "/dashboard", "/diagram"];
 
 /** Methods that can change something. Everything else is a read. */
 const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);

--- a/packages/editor/src/extensions/MermaidBlock.tsx
+++ b/packages/editor/src/extensions/MermaidBlock.tsx
@@ -5,6 +5,7 @@ import { Node, mergeAttributes } from "@tiptap/core";
 import { ReactNodeViewRenderer, NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import { DiagramStudio } from "../mermaid/DiagramStudio";
 import { useDiagramSvg } from "../mermaid/useDiagramSvg";
+import { useDiagramPopoutHost, DIAGRAM_POPOUT_PATH } from "../mermaid/popout";
 import { Modal } from "../ui/Modal";
 
 /**
@@ -23,13 +24,53 @@ declare module "@tiptap/core" {
   }
 }
 
-function MermaidNodeView({ node, updateAttributes, editor, selected, deleteNode }: NodeViewProps) {
+/** A short human label for the window list, so two open diagrams are tellable apart. */
+function labelFor(code: string): string {
+  const first = code
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  if (!first) return "Diagram";
+  return first.length > 60 ? `${first.slice(0, 57)}…` : first;
+}
+
+function MermaidNodeView({
+  node,
+  updateAttributes,
+  editor,
+  selected,
+  deleteNode,
+  extension,
+}: NodeViewProps) {
   const code = (node.attrs.code as string) ?? "";
 
   // Open straight into the studio for a brand-new, empty diagram.
   const [editing, setEditing] = useState(code.trim() === "");
 
   const { svg, error } = useDiagramSvg(code);
+
+  const applyCode = useCallback(
+    (next: string) => updateAttributes({ code: next }),
+    [updateAttributes],
+  );
+
+  /**
+   * The same diagram, editable in a window of its own.
+   *
+   * Offered, never imposed: the modal remains what clicking a diagram does,
+   * and this is a second door for the diagrams that have outgrown it. The note
+   * stays the writer either way — the window posts edits back here, and they
+   * land through `updateAttributes` exactly as the inline studio's do, so
+   * autosave, undo and the dirty indicator are unaware anything unusual is
+   * happening.
+   */
+  const popout = useDiagramPopoutHost({
+    code,
+    title: labelFor(code),
+    onChange: applyCode,
+    path: (extension.options as { popoutPath?: string }).popoutPath ?? DIAGRAM_POPOUT_PATH,
+  });
 
   /**
    * Closing without drawing anything means no diagram.
@@ -51,21 +92,40 @@ function MermaidNodeView({ node, updateAttributes, editor, selected, deleteNode 
     editor.commands.focus();
   }, [editor, code, deleteNode]);
 
+  /**
+   * Handing the diagram to the window closes the dialog behind it.
+   *
+   * Two live editors on one diagram is the one arrangement that could lose
+   * work — and even without that, a modal left open over the note is a modal
+   * you have to dismiss before you can read the paragraph you popped the
+   * diagram out to sit beside.
+   */
+  const popOut = useCallback(() => {
+    popout.open();
+    setEditing(false);
+  }, [popout]);
+
   return (
     <NodeViewWrapper className="my-6" data-drag-handle>
       <figure
         className={`group relative cursor-pointer overflow-hidden rounded-xl border transition ${
-          selected
-            ? "border-[var(--fl-accent)]"
-            : "border-[var(--fl-border)] hover:border-[var(--fl-border-strong)]"
+          popout.active
+            ? "border-[var(--fl-accent)] ring-1 ring-[var(--fl-accent)]/40"
+            : selected
+              ? "border-[var(--fl-accent)]"
+              : "border-[var(--fl-border)] hover:border-[var(--fl-border-strong)]"
         }`}
-        onClick={() => setEditing(true)}
+        // While a window has the diagram, clicking brings that window forward
+        // rather than opening a second editor behind it.
+        onClick={() => (popout.active ? popout.focus() : setEditing(true))}
         onKeyDown={(event) => {
-          if (event.key === "Enter") setEditing(true);
+          if (event.key !== "Enter") return;
+          if (popout.active) popout.focus();
+          else setEditing(true);
         }}
         tabIndex={0}
         role="button"
-        aria-label="Edit diagram"
+        aria-label={popout.active ? "Diagram open in another tab" : "Edit diagram"}
       >
         <div className="flex min-h-[140px] items-center justify-center bg-[var(--fl-surface)] p-6">
           {svg ? (
@@ -84,15 +144,51 @@ function MermaidNodeView({ node, updateAttributes, editor, selected, deleteNode 
           )}
         </div>
 
-        <figcaption className="pointer-events-none absolute right-2 top-2 rounded-md border border-[var(--fl-border)] bg-[var(--fl-bg)] px-2 py-1 text-xs font-medium text-[var(--fl-text)] opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus:opacity-100">
-          Click to edit diagram
-        </figcaption>
+        {popout.active ? (
+          // Not a hover affordance: while another window owns the diagram,
+          // saying so is the most useful thing this block can do, and the way
+          // back has to be visible without hunting for it.
+          <figcaption className="absolute right-2 top-2 flex items-center gap-1.5 rounded-md border border-[var(--fl-accent)] bg-[var(--fl-bg)] px-2 py-1 text-xs font-medium text-[var(--fl-text)] shadow-sm">
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--fl-accent)]" />
+            Editing in another tab
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                popout.bringBack();
+                setEditing(true);
+              }}
+              className="rounded px-1 py-0.5 text-[var(--fl-muted)] underline-offset-2 transition-colors hover:text-[var(--fl-text)] hover:underline"
+            >
+              Edit here
+            </button>
+          </figcaption>
+        ) : (
+          <figcaption className="absolute right-2 top-2 flex items-center gap-1 rounded-md border border-[var(--fl-border)] bg-[var(--fl-bg)] p-1 text-xs font-medium text-[var(--fl-text)] opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 group-focus:opacity-100">
+            <span className="px-1.5 py-0.5 text-[var(--fl-muted)]">Click to edit</span>
+            {popout.supported && (
+              <button
+                type="button"
+                onClick={(event) => {
+                  // The figure itself opens the modal; this is the other choice.
+                  event.stopPropagation();
+                  popOut();
+                }}
+                title="Open this diagram in its own tab"
+                className="flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors hover:bg-[var(--fl-elevated)]"
+              >
+                <PopoutIcon />
+                Open in tab
+              </button>
+            )}
+          </figcaption>
+        )}
       </figure>
 
       {/* The studio is a mode, not part of the document flow — opening it inline
           used to push the surrounding paragraphs hundreds of pixels down the
           page and hand the reader a full-height gallery with no obvious exit. */}
-      {editing && (
+      {editing && !popout.active && (
         <Modal
           title="Diagram"
           subtitle="Saved into the note as a ```mermaid block, so it also renders on GitHub"
@@ -102,28 +198,76 @@ function MermaidNodeView({ node, updateAttributes, editor, selected, deleteNode 
           // because a canvas and a preview side by side need the room.
           widthClassName="max-w-[92rem]"
           actions={
-            <button
-              type="button"
-              onClick={close}
-              className="shrink-0 rounded-lg bg-[var(--fl-accent)] px-3.5 py-1.5 text-[13px] font-semibold text-[var(--fl-accent-contrast)] transition-colors hover:bg-[var(--fl-accent-hover)]"
-            >
-              Done
-            </button>
+            <>
+              {popout.supported && (
+                <button
+                  type="button"
+                  onClick={popOut}
+                  title="Move this diagram into its own tab. Edits keep saving into the note."
+                  className="flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--fl-border)] px-3 py-1.5 text-[13px] font-medium text-[var(--fl-muted)] transition-colors hover:border-[var(--fl-border-strong)] hover:text-[var(--fl-text)]"
+                >
+                  <PopoutIcon />
+                  Open in tab
+                </button>
+              )}
+
+              <button
+                type="button"
+                onClick={close}
+                className="shrink-0 rounded-lg bg-[var(--fl-accent)] px-3.5 py-1.5 text-[13px] font-semibold text-[var(--fl-accent-contrast)] transition-colors hover:bg-[var(--fl-accent-hover)]"
+              >
+                Done
+              </button>
+            </>
           }
         >
-          <DiagramStudio code={code} onChange={(next) => updateAttributes({ code: next })} />
+          <DiagramStudio code={code} onChange={applyCode} />
         </Modal>
       )}
     </NodeViewWrapper>
   );
 }
 
-export const MermaidBlock = Node.create({
+/** Arrow leaving a box: the same glyph every app uses for "opens elsewhere". */
+function PopoutIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M9 3h4v4" />
+      <path d="M13 3 8 8" />
+      <path d="M12.5 9.5V12a1.5 1.5 0 0 1-1.5 1.5H4A1.5 1.5 0 0 1 2.5 12V5A1.5 1.5 0 0 1 4 3.5h2.5" />
+    </svg>
+  );
+}
+
+export interface MermaidBlockOptions {
+  /**
+   * Route the "Open in tab" window loads.
+   *
+   * An option rather than a constant so the editor package stays independent
+   * of how the app around it is mounted.
+   */
+  popoutPath: string;
+}
+
+export const MermaidBlock = Node.create<MermaidBlockOptions>({
   name: "mermaidBlock",
   group: "block",
   // Atomic: the diagram is edited through its own UI, not by ProseMirror.
   atom: true,
   draggable: true,
+
+  addOptions() {
+    return { popoutPath: DIAGRAM_POPOUT_PATH };
+  },
 
   addAttributes() {
     return {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -37,6 +37,16 @@ export { EnterIsALineBreak } from "./extensions/EnterIsALineBreak";
 export { ResolvedImage, type ResolvedImageOptions } from "./extensions/ResolvedImage";
 
 export { DiagramStudio, type DiagramStudioProps, type StudioView } from "./mermaid/DiagramStudio";
+export {
+  diagramPopoutSupported,
+  useDiagramPopoutHost,
+  useDiagramPopoutSession,
+  sweepSessions,
+  DIAGRAM_POPOUT_PATH,
+  type DiagramPopoutHost,
+  type DiagramPopoutSession,
+  type DiagramLinkStatus,
+} from "./mermaid/popout";
 export { VisualBuilder, type VisualBuilderProps } from "./mermaid/VisualBuilder";
 export { SequenceCanvas, type SequenceCanvasProps } from "./mermaid/SequenceCanvas";
 export { TemplateGallery, type TemplateGalleryProps } from "./mermaid/TemplateGallery";
@@ -46,6 +56,6 @@ export { Cheatsheet, type CheatsheetProps } from "./mermaid/Cheatsheet";
 export { useDiagramSvg } from "./mermaid/useDiagramSvg";
 export { useDocumentTheme, type DocumentTheme } from "./useDocumentTheme";
 
-export { MermaidBlock } from "./extensions/MermaidBlock";
+export { MermaidBlock, type MermaidBlockOptions } from "./extensions/MermaidBlock";
 export { markdownSlashCommands, markdownSlashSource } from "./codemirror/slash-markdown";
 export { readSlashState, type SlashState } from "./extensions/SlashCommands";

--- a/packages/editor/src/mermaid/DiagramStudio.tsx
+++ b/packages/editor/src/mermaid/DiagramStudio.tsx
@@ -29,6 +29,20 @@ import { SequenceCanvas } from "./SequenceCanvas";
 /** What the right-hand pane is showing. */
 export type StudioView = "canvas" | "preview";
 
+/**
+ * How the studio is dressed.
+ *
+ * `flat` is one continuous slab divided by hairlines — right for a dialog,
+ * which is already a card sitting on top of the note.
+ *
+ * `layered` gives the toolbar and each pane a surface of its own, separated by
+ * a gap, the way the editor treats its sidebar, document and properties
+ * panels. That reading only works when the studio owns the whole window: it is
+ * the difference between "a panel with two halves" and "two panels", and the
+ * second is what a screen full of diagram should look like.
+ */
+export type StudioChrome = "flat" | "layered";
+
 export interface DiagramStudioProps {
   code: string;
   onChange: (code: string) => void;
@@ -36,12 +50,27 @@ export interface DiagramStudioProps {
   theme?: "light" | "dark";
   /** Which pane the right-hand side opens on. */
   initialView?: StudioView;
+  /** How the panes are dressed. See `StudioChrome`. */
+  chrome?: StudioChrome;
+  /**
+   * Where the divider starts, as a percentage of the width given to the
+   * source. A window with room for a real canvas should hand the canvas that
+   * room; a dialog splits closer to the middle, because its source pane is
+   * narrow enough to wrap without it.
+   */
+  initialSplit?: number;
 }
 
 /** Where the divider sits, as a percentage of the studio's width. */
 const DEFAULT_SPLIT = 46;
 const MIN_SPLIT = 22;
 const MAX_SPLIT = 78;
+
+/** Keeps a caller's starting split inside the range the divider can reach. */
+function clampSplit(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_SPLIT;
+  return Math.min(MAX_SPLIT, Math.max(MIN_SPLIT, value));
+}
 
 /**
  * The diagram editing surface. Callers render it inside a modal.
@@ -66,7 +95,10 @@ export function DiagramStudio({
   onChange,
   theme,
   initialView = "canvas",
+  chrome = "flat",
+  initialSplit = DEFAULT_SPLIT,
 }: DiagramStudioProps) {
+  const layered = chrome === "layered";
   const documentTheme = useDocumentTheme();
   const resolvedTheme = theme ?? documentTheme;
 
@@ -90,7 +122,7 @@ export function DiagramStudio({
   const [showSource, setShowSource] = useState(true);
   const [showDiagram, setShowDiagram] = useState(true);
 
-  const [split, setSplit] = useState(DEFAULT_SPLIT);
+  const [split, setSplit] = useState(() => clampSplit(initialSplit));
   const [dragging, setDragging] = useState(false);
 
   const [svg, setSvg] = useState<string | null>(null);
@@ -248,9 +280,19 @@ export function DiagramStudio({
   const bothPanes = showSource && showDiagram;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div
+      className={`flex min-h-0 flex-1 flex-col ${
+        // Layered: the gap and the padding are what make the panes read as
+        // separate surfaces rather than one slab split by a hairline.
+        layered ? "gap-2 bg-[var(--fl-bg)] p-2" : ""
+      }`}
+    >
       {/* ── Toolbar ─────────────────────────────────────────────────────── */}
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--fl-border)] bg-[var(--fl-surface)] px-4 py-2.5">
+      <div
+        className={`flex shrink-0 flex-wrap items-center gap-2 bg-[var(--fl-surface)] px-4 py-2.5 ${
+          layered ? "fl-panel" : "border-b border-[var(--fl-border)]"
+        }`}
+      >
         <div
           className="flex rounded-lg border border-[var(--fl-border)] bg-[var(--fl-bg)] p-0.5"
           role="group"
@@ -311,10 +353,18 @@ export function DiagramStudio({
           Stacked, the whole body scrolls: two panes that each need a few
           hundred pixels do not both fit in a dialog, and clipping them is
           worse than letting the reader scroll to the one they are using. */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-visible">
+      <div
+        className={`flex min-h-0 flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-visible ${
+          layered ? "gap-2" : ""
+        }`}
+      >
         {showSource && (
           <div
-            className={`flex min-h-[200px] min-w-0 flex-col border-b border-[var(--fl-border)] lg:border-b-0 ${
+            className={`flex min-h-[200px] min-w-0 flex-col ${
+              layered
+                ? "fl-panel bg-[var(--fl-surface)]"
+                : "border-b border-[var(--fl-border)] lg:border-b-0"
+            } ${
               bothPanes
                 ? // Stacked, the source is the pane that gives way: it stays
                   // readable at a few lines, while a canvas needs room to be
@@ -364,16 +414,32 @@ export function DiagramStudio({
             }}
             // A 1px rule is a dexterity test, so the hit area is 9px with the
             // visible line drawn inside it.
-            className="group relative hidden w-[9px] shrink-0 cursor-col-resize focus:outline-none lg:block"
+            className={`group relative hidden shrink-0 cursor-col-resize focus:outline-none lg:block ${
+              // Layered: the gap between two panels IS the handle, so it needs
+              // no rule drawn down it — just a grip that appears where the
+              // pointer already is.
+              layered ? "-mx-1 w-[10px]" : "w-[9px]"
+            }`}
           >
-            <span
-              aria-hidden="true"
-              className={`absolute inset-y-0 left-1/2 w-px -translate-x-1/2 transition-colors ${
-                dragging
-                  ? "bg-[var(--fl-accent)]"
-                  : "bg-[var(--fl-border)] group-hover:bg-[var(--fl-accent)] group-focus:bg-[var(--fl-accent)]"
-              }`}
-            />
+            {layered ? (
+              <span
+                aria-hidden="true"
+                className={`absolute left-1/2 top-1/2 h-10 w-[3px] -translate-x-1/2 -translate-y-1/2 rounded-full transition-all ${
+                  dragging
+                    ? "bg-[var(--fl-accent)]"
+                    : "bg-[var(--fl-border-strong)] opacity-0 group-hover:opacity-100 group-focus:bg-[var(--fl-accent)] group-focus:opacity-100"
+                }`}
+              />
+            ) : (
+              <span
+                aria-hidden="true"
+                className={`absolute inset-y-0 left-1/2 w-px -translate-x-1/2 transition-colors ${
+                  dragging
+                    ? "bg-[var(--fl-accent)]"
+                    : "bg-[var(--fl-border)] group-hover:bg-[var(--fl-accent)] group-focus:bg-[var(--fl-accent)]"
+                }`}
+              />
+            )}
           </div>
         )}
 
@@ -381,7 +447,11 @@ export function DiagramStudio({
             the two toolbar rows, the hint strip and the inspector is still a
             canvas. */}
         {showDiagram && (
-          <div className="flex min-h-[420px] min-w-0 flex-1 flex-col bg-[var(--fl-surface)]">
+          <div
+            className={`flex min-h-[420px] min-w-0 flex-1 flex-col bg-[var(--fl-surface)] ${
+              layered ? "fl-panel" : ""
+            }`}
+          >
             <div className="flex shrink-0 items-center gap-2 px-4 pb-1 pt-2.5">
               <PaneHeading bare>
                 {effectiveView === "canvas" ? "Canvas — drag to edit" : "Preview"}

--- a/packages/editor/src/mermaid/popout.test.ts
+++ b/packages/editor/src/mermaid/popout.test.ts
@@ -1,0 +1,504 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  DIAGRAM_CHANNEL,
+  clearSession,
+  diagramPopoutSupported,
+  readSession,
+  resetDiagramChannel,
+  sweepSessions,
+  useDiagramPopoutHost,
+  useDiagramPopoutSession,
+  writeSession,
+  type DiagramPopoutMessage,
+} from "./popout";
+
+/**
+ * The protocol between a note and a diagram window, tested across two real
+ * `BroadcastChannel`s.
+ *
+ * A channel never delivers to the instance that sent the message, which is
+ * exactly the behaviour the design leans on — so the test opens its own
+ * channel and plays the part of the other tab, rather than stubbing one and
+ * quietly testing something easier than the real thing.
+ */
+
+/**
+ * A working `localStorage`.
+ *
+ * Node 25 defines its own experimental `localStorage` global, and it shadows
+ * jsdom's — with every method missing unless the process was started with a
+ * backing file. Nothing about the code under test is at fault; the test just
+ * needs the API a browser actually has.
+ */
+function installStorage(): void {
+  const entries = new Map<string, string>();
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      get length() {
+        return entries.size;
+      },
+      key: (index: number) => [...entries.keys()][index] ?? null,
+      getItem: (key: string) => entries.get(key) ?? null,
+      setItem: (key: string, value: string) => void entries.set(key, String(value)),
+      removeItem: (key: string) => void entries.delete(key),
+      clear: () => entries.clear(),
+    },
+  });
+}
+
+beforeEach(installStorage);
+
+const channels: BroadcastChannel[] = [];
+
+function otherTab(): {
+  post: (message: DiagramPopoutMessage) => void;
+  received: DiagramPopoutMessage[];
+} {
+  const channel = new BroadcastChannel(DIAGRAM_CHANNEL);
+  channels.push(channel);
+
+  const received: DiagramPopoutMessage[] = [];
+  channel.onmessage = (event: MessageEvent<DiagramPopoutMessage>) => received.push(event.data);
+
+  return { post: (message) => channel.postMessage(message), received };
+}
+
+/**
+ * Polled rather than a single tick: delivery is a macrotask and how many turns
+ * of the loop it takes is not fixed, which is a flaky test rather than a real
+ * failure.
+ */
+async function until(check: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (!check()) {
+    if (Date.now() > deadline) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+  }
+
+  // One more turn, so anything sent in reaction has landed too.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  });
+}
+
+afterEach(() => {
+  for (const channel of channels.splice(0)) channel.close();
+  resetDiagramChannel();
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("the stored copy", () => {
+  it("round-trips a session", () => {
+    writeSession("abc", { code: "flowchart TD\n  A-->B", title: "Flow" });
+
+    const session = readSession("abc");
+    expect(session?.code).toBe("flowchart TD\n  A-->B");
+    expect(session?.title).toBe("Flow");
+    expect(session?.updatedAt).toBeGreaterThan(0);
+  });
+
+  it("ignores a half-written or foreign entry", () => {
+    window.localStorage.setItem("forkleaf.diagram.broken", "{not json");
+    expect(readSession("broken")).toBeNull();
+  });
+
+  it("sweeps sessions whose windows are long gone, and keeps the live ones", () => {
+    writeSession("fresh", { code: "graph TD", title: "Fresh" });
+    window.localStorage.setItem(
+      "forkleaf.diagram.old",
+      JSON.stringify({
+        code: "graph TD",
+        title: "Old",
+        updatedAt: Date.now() - 48 * 60 * 60 * 1000,
+      }),
+    );
+
+    sweepSessions();
+
+    expect(readSession("fresh")).not.toBeNull();
+    expect(readSession("old")).toBeNull();
+  });
+
+  it("clears one on request", () => {
+    writeSession("abc", { code: "graph TD", title: "T" });
+    clearSession("abc");
+    expect(readSession("abc")).toBeNull();
+  });
+});
+
+describe("the note's side", () => {
+  function openHost(code = "flowchart TD\n  A-->B") {
+    const onChange = vi.fn();
+    const opened = { focus: vi.fn(), close: vi.fn() } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(opened);
+
+    const view = renderHook(
+      (props: { code: string }) => useDiagramPopoutHost({ ...props, onChange }),
+      {
+        initialProps: { code },
+      },
+    );
+
+    return { view, onChange, opened };
+  }
+
+  it("stays inert until a window is asked for", () => {
+    const { view } = openHost();
+    expect(view.result.current.active).toBe(false);
+    expect(readSession(view.result.current.sessionId)).toBeNull();
+  });
+
+  it("seeds the session and opens a named window", () => {
+    const { view } = openHost("flowchart TD\n  A-->B");
+
+    act(() => view.result.current.open());
+
+    const { sessionId } = view.result.current;
+    expect(readSession(sessionId)?.code).toBe("flowchart TD\n  A-->B");
+    expect(view.result.current.active).toBe(true);
+    expect(window.open).toHaveBeenCalledWith(
+      `/diagram?s=${sessionId}`,
+      `forkleaf-diagram-${sessionId}`,
+    );
+  });
+
+  it("does not claim a session a pop-up blocker refused", () => {
+    const { view } = openHost();
+    vi.spyOn(window, "open").mockReturnValue(null);
+
+    act(() => view.result.current.open());
+
+    expect(view.result.current.active).toBe(false);
+    expect(readSession(view.result.current.sessionId)).toBeNull();
+  });
+
+  it("answers a window's hello with the current source", async () => {
+    const { view } = openHost("flowchart TD\n  A-->B");
+    const { sessionId } = view.result.current;
+    const tab = otherTab();
+
+    tab.post({ type: "hello", sessionId });
+    await until(() => tab.received.some((message) => message.type === "state"));
+
+    const state = tab.received.find((message) => message.type === "state");
+    expect(state).toMatchObject({ code: "flowchart TD\n  A-->B" });
+    expect(view.result.current.active).toBe(true);
+  });
+
+  it("applies an edit to the note and acknowledges it", async () => {
+    const { view, onChange } = openHost();
+    const { sessionId } = view.result.current;
+    const tab = otherTab();
+
+    tab.post({ type: "edit", sessionId, code: "flowchart LR\n  A-->C" });
+    await until(() => onChange.mock.calls.length > 0);
+
+    expect(onChange).toHaveBeenCalledWith("flowchart LR\n  A-->C");
+    // The stored copy moves with the note, so a refreshed window recovers the
+    // edit rather than the text it was opened on.
+    expect(readSession(sessionId)?.code).toBe("flowchart LR\n  A-->C");
+    expect(tab.received.some((message) => message.type === "saved")).toBe(true);
+  });
+
+  it("ignores an edit meant for another diagram", async () => {
+    const { onChange } = openHost();
+    const tab = otherTab();
+
+    tab.post({ type: "edit", sessionId: "someone-else", code: "graph TD" });
+    await until(() => false, 60);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("pushes a change made in the note out to the window", async () => {
+    const { view } = openHost("flowchart TD\n  A-->B");
+    const tab = otherTab();
+
+    act(() => view.result.current.open());
+    view.rerender({ code: "flowchart TD\n  A-->B\n  B-->C" });
+
+    await until(() => tab.received.some((message) => message.type === "state"));
+    expect(tab.received.find((message) => message.type === "state")).toMatchObject({
+      code: "flowchart TD\n  A-->B\n  B-->C",
+    });
+  });
+
+  it("does not echo an edit back to the window that made it", async () => {
+    const { view, onChange } = openHost("flowchart TD");
+    const { sessionId } = view.result.current;
+    const tab = otherTab();
+
+    act(() => view.result.current.open());
+    tab.post({ type: "edit", sessionId, code: "flowchart LR" });
+    await until(() => onChange.mock.calls.length > 0);
+
+    // The note applies the edit, so the source prop now matches what the
+    // window already has. Sending it back would fight the caret.
+    const before = tab.received.filter((message) => message.type === "state").length;
+    view.rerender({ code: "flowchart LR" });
+    await until(() => false, 60);
+
+    expect(tab.received.filter((message) => message.type === "state").length).toBe(before);
+  });
+
+  it("ends the session when editing is brought back", async () => {
+    const { view, opened } = openHost();
+    const { sessionId } = view.result.current;
+    const tab = otherTab();
+
+    act(() => view.result.current.open());
+    act(() => view.result.current.bringBack());
+
+    await until(() => tab.received.some((message) => message.type === "close"));
+
+    expect(view.result.current.active).toBe(false);
+    expect(readSession(sessionId)).toBeNull();
+    expect(opened.close).toHaveBeenCalled();
+    expect(tab.received.find((message) => message.type === "close")).toMatchObject({
+      reason: "brought-back",
+    });
+  });
+
+  it("stays closed when a window that was sent home keeps heartbeating", async () => {
+    const { view } = openHost();
+    const { sessionId } = view.result.current;
+    const tab = otherTab();
+
+    act(() => view.result.current.open());
+    act(() => view.result.current.bringBack());
+
+    // A window takes a moment to notice, and its next heartbeat used to put
+    // the "editing in another tab" badge straight back on the block — with
+    // the inline dialog refusing to open behind it.
+    tab.post({ type: "alive", sessionId });
+    await until(() => false, 80);
+
+    expect(view.result.current.active).toBe(false);
+  });
+
+  it("ignores an edit from a window it has taken the diagram back from", async () => {
+    const { view, onChange } = openHost();
+    const { sessionId } = view.result.current;
+    const tab = otherTab();
+
+    act(() => view.result.current.open());
+    act(() => view.result.current.bringBack());
+
+    tab.post({ type: "edit", sessionId, code: "flowchart LR" });
+    await until(() => false, 80);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("says nothing when a diagram that never opened a window unmounts", async () => {
+    const { view } = openHost();
+    const tab = otherTab();
+
+    // A note holding forty diagrams unmounts forty blocks when it closes.
+    // None of them has a window, so none of them has anything to announce.
+    view.unmount();
+    await until(() => false, 80);
+
+    expect(tab.received).toHaveLength(0);
+  });
+
+  it("tells the window when the diagram itself goes away", async () => {
+    const { view } = openHost();
+    const { sessionId } = view.result.current;
+    const tab = otherTab();
+
+    act(() => view.result.current.open());
+    view.unmount();
+
+    await until(() => tab.received.some((message) => message.type === "close"));
+    expect(tab.received.find((message) => message.type === "close")).toMatchObject({
+      sessionId,
+      reason: "gone",
+    });
+  });
+});
+
+describe("a browser that cannot pair two windows", () => {
+  /**
+   * Some privacy modes expose `BroadcastChannel` and then refuse to construct
+   * one. The feature cannot work there, so it must not be offered — and a
+   * window opened by hand must not sit on "connecting" while it saves nowhere.
+   */
+  function withoutChannel(run: () => void): void {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "BroadcastChannel");
+    delete (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+    resetDiagramChannel();
+
+    try {
+      run();
+    } finally {
+      if (descriptor) Object.defineProperty(globalThis, "BroadcastChannel", descriptor);
+      resetDiagramChannel();
+    }
+  }
+
+  it("withdraws the offer", () => {
+    withoutChannel(() => {
+      expect(diagramPopoutSupported()).toBe(false);
+
+      const view = renderHook(() => useDiagramPopoutHost({ code: "graph TD", onChange: () => {} }));
+      expect(view.result.current.supported).toBe(false);
+    });
+  });
+
+  it("tells a window opened anyway that there is nothing to save to", () => {
+    withoutChannel(() => {
+      writeSession("s1", { code: "graph TD", title: "T" });
+
+      const view = renderHook(() => useDiagramPopoutSession("s1"));
+
+      expect(view.result.current.status).toBe("finished");
+      expect(view.result.current.ready).toBe(true);
+      // The stored copy still opens, so the source is not lost.
+      expect(view.result.current.code).toBe("graph TD");
+    });
+  });
+});
+
+describe("the window's side", () => {
+  it("shows the stored source before anyone answers", () => {
+    writeSession("s1", { code: "flowchart TD\n  A-->B", title: "Flow" });
+
+    const view = renderHook(() => useDiagramPopoutSession("s1"));
+
+    expect(view.result.current.code).toBe("flowchart TD\n  A-->B");
+    expect(view.result.current.title).toBe("Flow");
+    expect(view.result.current.status).toBe("connecting");
+  });
+
+  it("is not ready before the session id resolves", async () => {
+    writeSession("s1", { code: "flowchart TD\n  A-->B", title: "Flow" });
+
+    // The route reads the id from the query string, which is empty on the
+    // first client pass. Reporting readiness there mounted the studio on an
+    // empty source — and an empty source means "new diagram", so it opened
+    // the type picker over a diagram that already existed.
+    const view = renderHook(({ id }: { id: string | null }) => useDiagramPopoutSession(id), {
+      initialProps: { id: null as string | null },
+    });
+
+    expect(view.result.current.ready).toBe(false);
+
+    view.rerender({ id: "s1" });
+
+    expect(view.result.current.ready).toBe(true);
+    expect(view.result.current.code).toBe("flowchart TD\n  A-->B");
+  });
+
+  it("announces itself and adopts the note's source", async () => {
+    const tab = otherTab();
+    const view = renderHook(() => useDiagramPopoutSession("s1"));
+
+    await until(() => tab.received.some((message) => message.type === "hello"));
+
+    tab.post({ type: "state", sessionId: "s1", code: "sequenceDiagram", title: "Seq" });
+    await until(() => view.result.current.status === "linked");
+
+    expect(view.result.current.code).toBe("sequenceDiagram");
+    expect(view.result.current.title).toBe("Seq");
+  });
+
+  it("posts each edit and stores it before it leaves", async () => {
+    const tab = otherTab();
+    const view = renderHook(() => useDiagramPopoutSession("s1"));
+
+    act(() => view.result.current.setCode("flowchart LR\n  A-->B"));
+    await until(() => tab.received.some((message) => message.type === "edit"));
+
+    expect(tab.received.find((message) => message.type === "edit")).toMatchObject({
+      code: "flowchart LR\n  A-->B",
+    });
+    expect(readSession("s1")?.code).toBe("flowchart LR\n  A-->B");
+    // Unsaved until the note says otherwise — the indicator never claims a
+    // save that has not been acknowledged.
+    expect(view.result.current.dirty).toBe(true);
+  });
+
+  it("reports a save only once the note confirms it", async () => {
+    const tab = otherTab();
+    const view = renderHook(() => useDiagramPopoutSession("s1"));
+
+    act(() => view.result.current.setCode("graph TD"));
+    tab.post({ type: "saved", sessionId: "s1", at: 1_700_000_000_000 });
+    await until(() => view.result.current.dirty === false);
+
+    expect(view.result.current.savedAt).toBe(1_700_000_000_000);
+  });
+
+  it("gives the note longer than one heartbeat to answer", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const view = renderHook(() => useDiagramPopoutSession("s1"));
+
+      act(() => {
+        vi.advanceTimersByTime(4_000);
+      });
+
+      // Two heartbeats in, silence is not yet evidence of anything.
+      expect(view.result.current.status).toBe("connecting");
+      expect(view.result.current.ready).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives up waiting once the note is declared silent", async () => {
+    // No stored copy and no answer: the window has to become usable eventually,
+    // and the honest thing to show is an empty canvas that says it is not
+    // saving anywhere — not a spinner that never resolves.
+    vi.useFakeTimers();
+
+    try {
+      const view = renderHook(() => useDiagramPopoutSession("s1"));
+      expect(view.result.current.ready).toBe(false);
+
+      act(() => {
+        vi.advanceTimersByTime(10_000);
+      });
+
+      expect(view.result.current.ready).toBe(true);
+      expect(view.result.current.status).toBe("detached");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("finishes when the note takes editing back", async () => {
+    const tab = otherTab();
+    const view = renderHook(() => useDiagramPopoutSession("s1"));
+
+    tab.post({ type: "close", sessionId: "s1", reason: "brought-back" });
+    await until(() => view.result.current.status === "finished");
+
+    expect(view.result.current.reason).toBe("brought-back");
+  });
+
+  it("keeps a keystroke typed while the note's state was in flight", async () => {
+    writeSession("s1", { code: "graph TD", title: "T" });
+    const tab = otherTab();
+    const view = renderHook(() => useDiagramPopoutSession("s1"));
+
+    act(() => view.result.current.setCode("graph TD\n  A-->B"));
+    // The note answering the initial hello with what it had a moment ago must
+    // not undo what has been typed since.
+    tab.post({ type: "state", sessionId: "s1", code: "graph TD\n  A-->B", title: "T" });
+    await until(() => view.result.current.status === "linked");
+
+    expect(view.result.current.code).toBe("graph TD\n  A-->B");
+  });
+});

--- a/packages/editor/src/mermaid/popout.ts
+++ b/packages/editor/src/mermaid/popout.ts
@@ -1,0 +1,692 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Editing one diagram in a window of its own.
+ *
+ * The studio inside a modal is the right default — you are drawing a picture
+ * *for* a paragraph, and losing sight of the paragraph is a real cost. But a
+ * modal is a 92rem box on top of a note, and some diagrams are simply bigger
+ * than that: an architecture map with thirty nodes wants a whole screen, a
+ * second monitor, or both. So a diagram can also be opened as its own tab.
+ *
+ * This module is the wire between the two windows. The note tab stays the
+ * owner of the text: the pop-out never writes to the repository, it posts
+ * edits back, and the note applies them exactly as if they had been typed into
+ * the inline studio — which means the note's own autosave, undo history and
+ * dirty-state tracking all keep working, untouched. Nothing about the storage
+ * path knows this feature exists.
+ *
+ * Two transports, because tabs are not reliable friends:
+ *
+ *   - `BroadcastChannel` carries the live traffic. It is instant and costs
+ *     nothing per keystroke.
+ *   - `localStorage` holds the session's last known text. It is what a
+ *     freshly-opened pop-out reads before anyone has answered it, what a
+ *     refreshed pop-out recovers from, and the reason an edit is never only in
+ *     flight through an API a privacy mode might have removed.
+ *
+ * Both sides heartbeat, so each can tell the difference between "the other
+ * window is quiet" and "the other window is gone" — a distinction that matters
+ * a great deal when the answer decides whether your typing is being saved.
+ */
+
+export const DIAGRAM_CHANNEL = "forkleaf-diagram";
+
+/** Where the pop-out route lives. Overridable for a differently-mounted app. */
+export const DIAGRAM_POPOUT_PATH = "/diagram";
+
+const STORAGE_PREFIX = "forkleaf.diagram.";
+
+/** How often each side says it is still there. */
+const HEARTBEAT_MS = 2000;
+/** How long silence lasts before the other side is presumed gone. */
+const STALE_MS = 6500;
+/** Sessions older than this are swept: the tabs that owned them are long gone. */
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type DiagramPopoutMessage =
+  /** Pop-out → note: I am open on this session, send me the current source. */
+  | { type: "hello"; sessionId: string }
+  /** Note → pop-out: this is the source, and what the note is called. */
+  | { type: "state"; sessionId: string; code: string; title: string }
+  /** Pop-out → note: the source changed. */
+  | { type: "edit"; sessionId: string; code: string }
+  /** Note → pop-out: your edit is in the note. Drives the "Saved" indicator. */
+  | { type: "saved"; sessionId: string; at: number }
+  /** Heartbeats, one per direction. */
+  | { type: "alive"; sessionId: string }
+  | { type: "host-alive"; sessionId: string }
+  /** Note → pop-out: this diagram is no longer editable here (or at all). */
+  | { type: "close"; sessionId: string; reason: "brought-back" | "gone" }
+  /** Pop-out → note: window closing. */
+  | { type: "closed"; sessionId: string };
+
+type Listener = (message: DiagramPopoutMessage) => void;
+
+/**
+ * The channel, shared by every hook on the page.
+ *
+ * One `BroadcastChannel` per component would keep a channel alive per diagram
+ * in a long note, and each one pins the page in memory for delivery. A browser
+ * that has no such API — or has one that refuses to be constructed, which some
+ * privacy modes do — gets an object whose `post` goes nowhere and whose
+ * listeners simply never fire. Callers do not feature-check; the localStorage
+ * half below still carries the text.
+ */
+class DiagramChannel {
+  private channel: BroadcastChannel | null = null;
+  private readonly listeners = new Set<Listener>();
+
+  constructor(name = DIAGRAM_CHANNEL) {
+    if (typeof BroadcastChannel === "undefined") return;
+
+    try {
+      this.channel = new BroadcastChannel(name);
+      this.channel.onmessage = (event: MessageEvent<DiagramPopoutMessage>) => {
+        const message = event.data;
+        // Another product's message on a shared name, or a newer build sending
+        // something this one has never heard of.
+        if (!message || typeof message.type !== "string") return;
+        for (const listener of [...this.listeners]) listener(message);
+      };
+    } catch {
+      this.channel = null;
+    }
+  }
+
+  get available(): boolean {
+    return this.channel !== null;
+  }
+
+  post(message: DiagramPopoutMessage): void {
+    try {
+      this.channel?.postMessage(message);
+    } catch {
+      // A closed channel or an unclonable payload. Never worth throwing over:
+      // the stored copy is the one that has to survive.
+    }
+  }
+
+  on(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  close(): void {
+    this.listeners.clear();
+    try {
+      this.channel?.close();
+    } catch {
+      // Already closed.
+    }
+    this.channel = null;
+  }
+}
+
+let shared: DiagramChannel | null = null;
+
+function channel(): DiagramChannel {
+  shared ??= new DiagramChannel();
+  return shared;
+}
+
+/**
+ * True when this browser can pair two windows at all.
+ *
+ * Without `BroadcastChannel` the note cannot hear the window, so a diagram
+ * opened in one would take edits and save them nowhere. The offer is withdrawn
+ * rather than made and quietly broken.
+ */
+export function diagramPopoutSupported(): boolean {
+  return channel().available;
+}
+
+/** Drops the shared channel. Tests only. */
+export function resetDiagramChannel(): void {
+  shared?.close();
+  shared = null;
+}
+
+// ── The stored copy ─────────────────────────────────────────────────────────
+
+export interface DiagramSession {
+  code: string;
+  title: string;
+  updatedAt: number;
+}
+
+function storageKey(sessionId: string): string {
+  return `${STORAGE_PREFIX}${sessionId}`;
+}
+
+export function readSession(sessionId: string): DiagramSession | null {
+  try {
+    const raw = window.localStorage.getItem(storageKey(sessionId));
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<DiagramSession>;
+    if (typeof parsed?.code !== "string") return null;
+
+    return {
+      code: parsed.code,
+      title: typeof parsed.title === "string" ? parsed.title : "Diagram",
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeSession(sessionId: string, session: Omit<DiagramSession, "updatedAt">): void {
+  try {
+    window.localStorage.setItem(
+      storageKey(sessionId),
+      JSON.stringify({ ...session, updatedAt: Date.now() }),
+    );
+  } catch {
+    // Full, or partitioned away. The live channel still carries the edit; only
+    // the crash-recovery copy is lost.
+  }
+}
+
+export function clearSession(sessionId: string): void {
+  try {
+    window.localStorage.removeItem(storageKey(sessionId));
+  } catch {
+    // Nothing to do about it, and nothing depends on it.
+  }
+}
+
+/**
+ * Deletes sessions whose windows are long gone.
+ *
+ * Without this the key space grows by one entry per diagram ever popped out,
+ * each holding a copy of its source, forever.
+ */
+export function sweepSessions(now = Date.now()): void {
+  try {
+    const stale: string[] = [];
+
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (!key?.startsWith(STORAGE_PREFIX)) continue;
+
+      const session = readSession(key.slice(STORAGE_PREFIX.length));
+      if (!session || now - session.updatedAt > SESSION_TTL_MS) stale.push(key);
+    }
+
+    for (const key of stale) window.localStorage.removeItem(key);
+  } catch {
+    // Storage unavailable; there is then nothing to sweep.
+  }
+}
+
+function newSessionId(): string {
+  try {
+    return crypto.randomUUID();
+  } catch {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+}
+
+// ── The note's side ─────────────────────────────────────────────────────────
+
+export interface DiagramPopoutHost {
+  /** A stable id for this diagram block, for the whole time it is mounted. */
+  sessionId: string;
+  /** False where the two windows could not talk; callers hide the offer. */
+  supported: boolean;
+  /** True while a pop-out window is known to be editing this diagram. */
+  active: boolean;
+  /** Opens (or re-focuses) the pop-out. */
+  open: () => void;
+  /** Focuses an already-open pop-out, if this tab still has the handle. */
+  focus: () => void;
+  /** Ends the pop-out session and asks the window to close. */
+  bringBack: () => void;
+}
+
+export interface DiagramPopoutHostOptions {
+  code: string;
+  /** Shown in the pop-out's header, so the window is identifiable. */
+  title?: string;
+  /** Applied to the note exactly as an inline edit would be. */
+  onChange: (code: string) => void;
+  /** Route the pop-out lives at. */
+  path?: string;
+}
+
+/**
+ * Owns a diagram on the note side.
+ *
+ * Deliberately inert until `open` is called: a note with forty diagrams should
+ * not open forty sessions, write forty storage entries, or heartbeat about any
+ * of them. Everything here starts when the user asks for a window.
+ */
+export function useDiagramPopoutHost({
+  code,
+  title = "Diagram",
+  onChange,
+  path = DIAGRAM_POPOUT_PATH,
+}: DiagramPopoutHostOptions): DiagramPopoutHost {
+  /**
+   * The id, generated once and kept in a ref.
+   *
+   * Not `useMemo`: a memo may be recomputed whenever React feels like it, and
+   * in development StrictMode's double render does exactly that — with a
+   * random generator behind it, the block ended up with two ids. The window
+   * was opened on one and the note kept listening on the other, so the two
+   * never met and the window opened on an empty canvas. A ref is the only
+   * hook that guarantees one value per mount.
+   */
+  const idRef = useRef<string | null>(null);
+  idRef.current ??= newSessionId();
+  const sessionId = idRef.current;
+  const [active, setActive] = useState(false);
+
+  // Read through refs so the subscription is set up once and never torn down
+  // mid-session: callers pass `onChange` inline, and re-subscribing on every
+  // keystroke would drop messages in the gap.
+  const codeRef = useRef(code);
+  codeRef.current = code;
+  const titleRef = useRef(title);
+  titleRef.current = title;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  /**
+   * True once this side has ended the session.
+   *
+   * Without it, "Edit here" was undone a second later by the window's next
+   * heartbeat: the note marked the session closed, the still-open window said
+   * "still here", and the badge came back — with the dialog refusing to open
+   * behind it. Ending is a decision by the note, so the note stops listening
+   * to that window until it opens a new one.
+   */
+  const ended = useRef(false);
+
+  /**
+   * True once this block has actually opened a window.
+   *
+   * The teardown below broadcasts "this diagram is gone". A note holding forty
+   * diagrams unmounts forty blocks when it closes, and without this every one
+   * of them would announce the end of a session that never existed.
+   */
+  const everOpened = useRef(false);
+
+  /** The last text this side either sent or received, to avoid echoing it. */
+  const mirrored = useRef(code);
+  /** The source as of the last time the push effect looked at it. */
+  const pushed = useRef(code);
+  const lastSeen = useRef(0);
+  const popout = useRef<Window | null>(null);
+
+  const open = useCallback(() => {
+    ended.current = false;
+    everOpened.current = true;
+    sweepSessions();
+    writeSession(sessionId, { code: codeRef.current, title: titleRef.current });
+    mirrored.current = codeRef.current;
+
+    const url = `${path}?s=${encodeURIComponent(sessionId)}`;
+    // A named window, so a second click on "Open in tab" focuses the window
+    // that is already open rather than opening a rival editor on the same
+    // diagram — which is the one way this design could lose someone's work.
+    const opened = window.open(url, `forkleaf-diagram-${sessionId}`);
+
+    if (!opened) {
+      // Blocked by a pop-up blocker. Nothing has been broken — the inline
+      // studio is still there — so this stays silent rather than throwing.
+      clearSession(sessionId);
+      return;
+    }
+
+    popout.current = opened;
+    opened.focus();
+    // Optimistic: the window exists, so treat the session as live until the
+    // heartbeat says otherwise. Waiting for `hello` leaves the note showing
+    // "not open" for the second or two the route takes to boot.
+    lastSeen.current = Date.now();
+    setActive(true);
+  }, [path, sessionId]);
+
+  const focus = useCallback(() => {
+    try {
+      popout.current?.focus();
+    } catch {
+      // Cross-origin or already closed; the handle is simply not usable.
+    }
+  }, []);
+
+  const bringBack = useCallback(() => {
+    ended.current = true;
+    channel().post({ type: "close", sessionId, reason: "brought-back" });
+    clearSession(sessionId);
+    setActive(false);
+
+    try {
+      popout.current?.close();
+    } catch {
+      // A window this tab did not open cannot be closed by it. The `close`
+      // message above already told it to stand down.
+    }
+    popout.current = null;
+  }, [sessionId]);
+
+  // Incoming traffic.
+  useEffect(() => {
+    const bus = channel();
+
+    const off = bus.on((message) => {
+      if (message.sessionId !== sessionId) return;
+      // A window this note has already taken the diagram back from.
+      if (ended.current) return;
+
+      switch (message.type) {
+        case "hello":
+          lastSeen.current = Date.now();
+          setActive(true);
+          mirrored.current = codeRef.current;
+          bus.post({
+            type: "state",
+            sessionId,
+            code: codeRef.current,
+            title: titleRef.current,
+          });
+          break;
+
+        case "alive":
+          lastSeen.current = Date.now();
+          setActive(true);
+          break;
+
+        case "edit":
+          lastSeen.current = Date.now();
+          setActive(true);
+          if (message.code === mirrored.current) break;
+          mirrored.current = message.code;
+          onChangeRef.current(message.code);
+          writeSession(sessionId, { code: message.code, title: titleRef.current });
+          bus.post({ type: "saved", sessionId, at: Date.now() });
+          break;
+
+        case "closed":
+          setActive(false);
+          popout.current = null;
+          break;
+
+        default:
+          break;
+      }
+    });
+
+    return off;
+  }, [sessionId]);
+
+  // Outgoing: the note changed underneath the pop-out — someone edited the
+  // fence in source mode, or undid something — so the window is told.
+  useEffect(() => {
+    if (!active) return;
+
+    /**
+     * Only a *change* to the note's source is worth sending.
+     *
+     * The effect also runs when the session goes live, and at that moment the
+     * window's edit has been handed to the note but the new source has not
+     * come back down as a prop yet — so comparing against the mirror alone saw
+     * a difference and pushed the pre-edit text back over what was just typed.
+     */
+    if (code === pushed.current) return;
+    pushed.current = code;
+
+    // The note has caught up to what the window already has: nothing to send,
+    // and sending it would fight the caret.
+    if (code === mirrored.current) return;
+
+    mirrored.current = code;
+    writeSession(sessionId, { code, title: titleRef.current });
+    channel().post({ type: "state", sessionId, code, title: titleRef.current });
+  }, [active, code, sessionId]);
+
+  // Heartbeat out, watchdog in. A pop-out closed by the window manager sends
+  // `closed` on the way out; one killed with the tab, or on a phone that froze
+  // it, sends nothing at all, and this is what notices.
+  useEffect(() => {
+    if (!active) return;
+
+    const bus = channel();
+    bus.post({ type: "host-alive", sessionId });
+
+    const timer = setInterval(() => {
+      bus.post({ type: "host-alive", sessionId });
+
+      // With no BroadcastChannel there is no heartbeat to miss, and expiring
+      // the session would end the very thing that is working.
+      if (!bus.available) return;
+      if (Date.now() - lastSeen.current > STALE_MS) setActive(false);
+    }, HEARTBEAT_MS);
+
+    return () => clearInterval(timer);
+  }, [active, sessionId]);
+
+  // The diagram, or the note, went away while a window was still open on it.
+  useEffect(() => {
+    return () => {
+      if (!everOpened.current) return;
+
+      channel().post({ type: "close", sessionId, reason: "gone" });
+      clearSession(sessionId);
+    };
+  }, [sessionId]);
+
+  return { sessionId, supported: diagramPopoutSupported(), active, open, focus, bringBack };
+}
+
+// ── The pop-out's side ──────────────────────────────────────────────────────
+
+/**
+ * `connecting` — opened, no answer yet.
+ * `linked`     — the note tab is there; edits are landing in the note.
+ * `detached`   — the note tab is gone. Work continues; it is stored locally
+ *                and, because it is stored, recoverable rather than lost.
+ * `finished`   — the note took editing back, or the diagram no longer exists.
+ */
+export type DiagramLinkStatus = "connecting" | "linked" | "detached" | "finished";
+
+export interface DiagramPopoutSession {
+  code: string;
+  setCode: (code: string) => void;
+  title: string;
+  status: DiagramLinkStatus;
+  /** When the note last confirmed it had applied an edit. */
+  savedAt: number | null;
+  /** True between a local edit and the note's acknowledgement. */
+  dirty: boolean;
+  /** Why the session finished, when it has. */
+  reason: "brought-back" | "gone" | null;
+  /**
+   * True once the source this window opened on is known.
+   *
+   * The studio decides what to show from the source it is *first* given — an
+   * empty one means "new diagram", so it opens the type picker. The source
+   * arrives a paint after mount, from storage or from the note, so mounting
+   * the studio before this is true greets someone who clicked an existing
+   * flowchart with "What are you drawing?".
+   */
+  ready: boolean;
+}
+
+/**
+ * Drives the pop-out window.
+ *
+ * The pop-out is a *view*, not a second copy: it has no repository access and
+ * writes nothing to the note directly. That is what makes this safe to leave
+ * open — there is exactly one writer, so there is nothing to reconcile and no
+ * way for two windows to disagree about what the diagram says.
+ */
+export function useDiagramPopoutSession(sessionId: string | null): DiagramPopoutSession {
+  const [code, setLocalCode] = useState("");
+  const [title, setTitle] = useState("Diagram");
+  const [status, setStatus] = useState<DiagramLinkStatus>("connecting");
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [reason, setReason] = useState<"brought-back" | "gone" | null>(null);
+  const [ready, setReady] = useState(false);
+
+  /** Read by the heartbeat, which must fall silent once the session is over. */
+  const finished = useRef(false);
+
+  const mirrored = useRef("");
+  const lastHostSeen = useRef(0);
+  /** True once anything at all has arrived, so a stale watchdog can be fair. */
+  const everLinked = useRef(false);
+
+  // Seed from storage before anyone answers. A pop-out that was refreshed —
+  // or opened while the note tab was busy — shows the diagram immediately
+  // instead of an empty canvas that fills in a moment later.
+  useEffect(() => {
+    // No session yet. `useSearchParams` reads empty on the first client pass,
+    // so this is the normal state for a frame — and calling it "ready" there
+    // was enough to mount the studio on an empty source, which is how someone
+    // clicking an existing flowchart was asked what they wanted to draw.
+    if (!sessionId) return;
+
+    const stored = readSession(sessionId);
+
+    if (stored) {
+      setLocalCode(stored.code);
+      setTitle(stored.title);
+      mirrored.current = stored.code;
+      setReady(true);
+      return;
+    }
+
+    // Nothing stored — unusual, since the note writes the session before it
+    // opens the window, but storage can be partitioned or full. Readiness then
+    // waits for the note's answer, or for the link to be declared dead below.
+    // Deliberately not a short timer: the note's tab is in the background by
+    // the time this one has focus, and a browser throttles background tabs, so
+    // "it has not answered within a second" means nothing at all.
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const bus = channel();
+
+    // The clock starts now. Left at zero, the very first heartbeat tick found
+    // "no word from the note since the epoch", declared the link dead two
+    // seconds after opening, and mounted the studio on an empty source — so
+    // every pop-out greeted its diagram with the new-diagram picker.
+    lastHostSeen.current = Date.now();
+
+    const off = bus.on((message) => {
+      if (message.sessionId !== sessionId) return;
+
+      switch (message.type) {
+        case "state":
+          lastHostSeen.current = Date.now();
+          everLinked.current = true;
+          setReady(true);
+          setStatus("linked");
+          setTitle(message.title);
+          // An echo of our own text must not move the cursor or clobber a
+          // keystroke typed in the gap.
+          if (message.code !== mirrored.current) {
+            mirrored.current = message.code;
+            setLocalCode(message.code);
+            setDirty(false);
+          }
+          break;
+
+        case "host-alive":
+          lastHostSeen.current = Date.now();
+          everLinked.current = true;
+          setStatus((current) => (current === "finished" ? current : "linked"));
+          break;
+
+        case "saved":
+          lastHostSeen.current = Date.now();
+          setSavedAt(message.at);
+          setDirty(false);
+          break;
+
+        case "close":
+          setReason(message.reason);
+          setStatus("finished");
+          setReady(true);
+          // Stop announcing this window. A heartbeat after the note has taken
+          // the diagram back tells it a window is still editing, which put the
+          // "editing in another tab" badge straight back on the block.
+          finished.current = true;
+          bus.post({ type: "closed", sessionId });
+          break;
+
+        default:
+          break;
+      }
+    });
+
+    if (!bus.available) {
+      // Nothing will ever answer. Saying "connecting" here would be a spinner
+      // that resolves never, over an editor that is quietly saving nowhere.
+      setStatus("finished");
+      setReason("gone");
+      setReady(true);
+      return () => off();
+    }
+
+    bus.post({ type: "hello", sessionId });
+
+    const timer = setInterval(() => {
+      if (finished.current) return;
+
+      bus.post({ type: "alive", sessionId });
+
+      if (!bus.available) return;
+
+      const silent = Date.now() - lastHostSeen.current > STALE_MS;
+
+      // Nobody is going to send a source. Whatever is here — the stored copy,
+      // or nothing — is what this window is editing, so stop waiting for it.
+      if (silent) setReady(true);
+
+      setStatus((current) => {
+        if (current === "finished") return current;
+        if (silent) return "detached";
+        return everLinked.current ? "linked" : current;
+      });
+    }, HEARTBEAT_MS);
+
+    const leaving = () => bus.post({ type: "closed", sessionId });
+    // `pagehide` fires in cases `beforeunload` does not — notably a tab closed
+    // on iOS Safari, and a page restored from the back/forward cache.
+    window.addEventListener("pagehide", leaving);
+
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener("pagehide", leaving);
+      leaving();
+      off();
+    };
+  }, [sessionId]);
+
+  const setCode = useCallback(
+    (next: string) => {
+      setLocalCode(next);
+      if (!sessionId) return;
+
+      mirrored.current = next;
+      setDirty(true);
+      // Stored first, posted second: if the note tab is gone, the text is
+      // still somewhere it can be recovered from.
+      writeSession(sessionId, { code: next, title });
+      channel().post({ type: "edit", sessionId, code: next });
+    },
+    [sessionId, title],
+  );
+
+  return { code, setCode, title, status, savedAt, dirty, reason, ready };
+}


### PR DESCRIPTION
## Summary

A diagram in a note can outgrow the dialog it is edited in. **Open in tab** offers the same diagram studio in a browser tab of its own — for a second screen, or a full-height canvas — while the note stays the owner of the text.

It is an offer, not a change. Clicking a diagram still opens the inline studio exactly as before.

**Editing surface** (`feat(editor)`)
- `Open in tab` on a diagram's hover controls and in the studio's header. Opening from the header closes the dialog behind it, so there are never two live editors on one diagram.
- While a window has the diagram, the block shows **Editing in another tab** with an **Edit here** link that takes editing back and closes the window. Clicking the block focuses the window instead of opening a rival editor.
- `popout.ts` is the wire between the two windows. The note applies incoming edits through `updateAttributes`, exactly as the inline studio does, so the note's autosave, undo history and dirty state are unaware anything unusual is happening. One writer, nothing to reconcile.
- Two transports: `BroadcastChannel` for live traffic, `localStorage` for the session's last known text (what a refreshed window recovers from, and what survives a note tab that goes away). Both sides heartbeat, so each can tell "quiet" from "gone".
- Where the two windows could not talk at all (a privacy mode that refuses to construct a `BroadcastChannel`), the offer is withdrawn rather than made and quietly broken.

**The window** (`feat(web)`)
- `/diagram` is the studio with a header on it. No repository access, never writes a file.
- The header states the truth continuously: *Connecting… / Saving to the note… / Saved to the note · just now*, and a plain **Not saving to the note — kept in this browser** if the note tab disappears, with a *Copy diagram source* escape hatch. A diagram editor that quietly stops saving is worse than one that never saved.
- The route renders diagram SVG, so it joins `/editor` and `/dashboard` on the nonce-based CSP and is rendered per request.
- Cross-tab theme fix: the snapshot is read from `data-theme` on `<html>`, which no other tab can write, so a `storage` event now re-applies the theme instead of only notifying. Invisible in one tab; very visible once a diagram — drawn in the theme's own colours — is being edited in a second one.

**Window chrome** (`feat(diagram)`)
- The window was one flat slab divided by hairlines — right for a dialog, which is already a card on top of the note, wrong for a window where the studio owns the screen. It now wears the editor's own layered shell: a title bar, the toolbar, the source and the canvas each on their own floating panel over the page colour, with the gap between them doing the explaining.
- A status strip along the bottom reports what the diagram actually is — `flowchart · 3 nodes · 3 arrows · 8 lines` — and whether its text is reaching the note. Same job the editor's status bar does for a note.
- **The canvas gets the room.** The window opens at roughly two thirds canvas / one third source, instead of the dialog's even split. The reason to open a diagram in a window is the canvas, so it should not have to be uncovered first.
- Still adjustable: drag the divider, or focus it and use the arrow keys (4% a step, clamped 22–78%). In layered chrome the gap between the panels *is* the handle — a grip appears where the pointer already is, rather than a rule drawn down a seam that no longer exists.
- `DiagramStudio` grew two props for this — `chrome: "flat" | "layered"` and `initialSplit` — and the dialog keeps the old values, so it is pixel-identical to before.

**Docs** (`docs`) — README and the Writing docs page describe the feature, that it is optional, and where the text lives while the window is open.

### Bugs found and fixed while building this

Each has a regression test:

- **Echo race** — the note pushed pre-edit text back over what had just been typed in the window, because the push effect also runs when the session goes live.
- **Unstable session id** — `useMemo` with a random generator is recomputed under React's dev double-render, so the block ended up with two ids: the window opened on one, the note listened on the other.
- **Watchdog started at zero** — `lastHostSeen` defaulted to `0`, so the first heartbeat found "no word since the epoch" and declared the note dead two seconds after opening, greeting every existing diagram with the new-diagram picker.
- **A sent-home window kept heartbeating** — "Edit here" was undone a second later when the still-open window said "still here", putting the badge back and leaving the dialog refusing to open behind it.
- **Silent teardown broadcast** — a note holding forty diagrams announced the end of forty sessions that never existed.

## Test Coverage

```
CODE PATHS                                                USER FLOWS
[+] packages/editor/src/mermaid/popout.ts                 [+] Pop a diagram out
  |-- DiagramChannel (post / on / close / unavailable)      |-- [***] Open writes seed + named window
  |   |-- [** TESTED] delivery across two real channels     |-- [***] Window adopts the note's source
  |   +-- [** TESTED] absent BroadcastChannel -> withdrawn  |-- [***] Edit lands in the note + ack
  |-- read/write/clear/sweepSessions                        |-- [***] Pop-up blocked -> no session claimed
  |   +-- [*** TESTED] round-trip, malformed, TTL sweep     |-- [***] "Edit here" ends the session
  |-- useDiagramPopoutHost                                  |-- [***] Note tab closes -> window told
  |   |-- [*** TESTED] hello->state, edit->apply->saved     +-- [**]  Note edited underneath -> pushed
  |   |-- [*** TESTED] foreign session ignored
  |   |-- [*** TESTED] echo suppression (both directions)  [+] Degraded states
  |   |-- [*** TESTED] ended session ignores alive + edit    |-- [***] Note silent -> detached + usable
  |   +-- [**  TESTED] unmount closes only a real session    |-- [**]  No stored copy -> waits for an answer
  +-- useDiagramPopoutSession                                +-- [***] No channel -> says so, keeps the text
      |-- [*** TESTED] seed, ready gating, keystroke race
      |-- [*** TESTED] saved ack, close -> finished
      +-- [**  TESTED] heartbeat grace before "silent"

[+] apps/web/src/hooks/useTheme.ts                        [+] Theme changed in the note tab
  |-- adoptStoredTheme                                      +-- [***] Window re-paints, diagram redrawn
  |   |-- [*** TESTED] theme adopted, palette adopted
  |   |-- [*** TESTED] unknown palette id rejected
  |   +-- [*** TESTED] another product's key ignored
  +-- setTheme / toggleTheme  [** TESTED]

[+] apps/web/src/components/DiagramWindow.tsx             [GAP] header copy, ago(), status strip
[+] packages/editor/src/mermaid/DiagramStudio.tsx         [GAP] layered chrome, split clamp (verified by hand)
[+] packages/editor/src/extensions/MermaidBlock.tsx       [** TESTED] markdown round-trip; [GAP] node-view buttons
[+] apps/web/src/proxy.ts                                 [** TESTED] existing CSP suite covers the policy
[+] apps/web/src/app/diagram/page.tsx                     server shell, no branches

COVERAGE: 26/32 paths tested (81%)  |  QUALITY: ***:19 **:7  |  GAPS: 6
```

Legend: `***` behavior + edge + error, `**` happy path.

Tests: 487 -> 497 (+10 new, plus 18 in the new pop-out suite). Full suite green: **497 passed, 32 files**. `format:check`, `typecheck`, `lint` and `build` all pass.

The remaining gaps are React component rendering (`DiagramWindow`'s status copy, the TipTap node-view buttons, the studio's chrome switch). The repo has no node-view or studio UI tests to follow, so these were verified by hand instead:

- **Against a production build:** popped a sequence diagram out, typed in the window, watched the note's diagram redraw and its status bar report *All changes saved*; used **Edit here** and watched the window switch to *Editing moved back to the note*.
- **The layered chrome:** checked in light and dark, at 1600px (side by side) and 768px (stacked), plus the dialog afterwards to confirm the flat chrome is unchanged.
- **The divider:** measured, not eyeballed. A real pointer drag moved the source pane 507px → 892px; three `ArrowLeft` presses stepped it back to 702px (3 × 4%). The Browser pane's synthetic drag helper does not emit pointer events, which is why this was driven through dispatched events.

## Pre-Landing Review

Two findings, both fixed in this branch:

- `packages/editor/src/mermaid/popout.ts` — teardown broadcast a `close` for blocks that never opened a window (auto-fixed, test added).
- `packages/editor/src/mermaid/popout.ts` — with no `BroadcastChannel`, the window sat on "Connecting…" forever while saving nowhere. Now it says so, and the note withdraws the offer entirely (fixed, tests added).

No SQL, migrations, shell, API-contract or LLM-boundary surface in this diff. Diagram SVG stays on the existing sanitised render path, and the new route is on the nonce CSP.

## Design Review

The window now follows the editor's layered treatment rather than inventing a second look for the same app: `.fl-panel` surfaces, `gap-2 p-2` spacing, the same 52px title bar height, the same status-strip typography. That was the point of the change — a window that reads like the app it came out of does not feel like a second application you were thrown into.

Frontend diff. The window reuses existing tokens (`--fl-*`) and the app's own light/dark palette; the block's pop-out affordance sits in the existing hover control, and the "editing elsewhere" badge is deliberately always-visible rather than hover-only, because while another window owns the diagram, saying so is the most useful thing the block can do.

## Eval Results

No prompt-related files changed — evals skipped.

## Plan Completion

No plan file detected.

## Known limitation

Two windows on one diagram (by hand-copying the `/diagram?s=…` URL into a second tab) are not arbitrated — the protocol has no per-window identity, so the later edit wins. The normal path cannot reach this: `window.open` uses a per-session window name, so clicking "Open in tab" again focuses the window that is already open.

## Ship notes

- This repo has no `VERSION` file or `CHANGELOG.md` (it versions via `package.json`), so the version-bump and changelog steps were skipped rather than introducing a new repo convention inside a feature PR. The PR title follows the repo's existing `type(scope): summary` style.
- `TODOS.md` does not exist in this repo and was not created.

## Test plan

- [x] Vitest suite green (497 tests, 32 files)
- [x] `pnpm format:check && pnpm typecheck && pnpm lint && pnpm build` green
- [x] Manual end-to-end against a production build: pop out, edit, note updates and autosaves, "Edit here" returns editing, theme toggle redraws the diagram in the matching palette
- [x] Layered chrome checked in both themes, side-by-side and stacked widths; dialog confirmed unchanged
- [x] Divider resize verified by measurement (pointer drag and arrow keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
