### PR TITLE
Stop throwing away edits that fail to push, and stop claiming they saved

### DIFF
--- a/apps/web/src/components/EditorStatusBar.tsx
+++ b/apps/web/src/components/EditorStatusBar.tsx
@@ -187,6 +187,16 @@ function describe(sync: SyncState): { label: string; className: string; dot: str
         dot: "bg-[var(--fl-danger)]",
       };
 
+    case "blocked":
+      // The one status that must never be mistaken for progress. These changes
+      // have stopped retrying and will not move until somebody asks them to,
+      // so the label says what is true and what to do about it.
+      return {
+        label: `${sync.blockedCount} change${sync.blockedCount === 1 ? "" : "s"} not on GitHub — click to retry`,
+        className: "text-[var(--fl-danger)] font-medium",
+        dot: "bg-[var(--fl-danger)]",
+      };
+
     case "local":
       return { label: "Saved on this device", className: "", dot: "bg-[var(--fl-muted)]" };
 

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -22,7 +22,7 @@ import {
   type Workspace,
   type EditorViewMode,
 } from "@forkleaf/types";
-import { dirname } from "@forkleaf/markdown-engine";
+import { dirname, serializeDocument } from "@forkleaf/markdown-engine";
 import { GitHubGateway, LocalGateway, fetchSession, type SessionResponse } from "@/lib/gateway";
 import { LOCAL_WORKSPACE } from "@/lib/workspaces";
 import { assetFrom, assetObjectUrl } from "@/lib/assets";
@@ -152,6 +152,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       status: "idle",
       mode: DEFAULT_SYNC_PREFERENCE.mode,
       pendingCount: 0,
+      blockedCount: 0,
       lastSyncedAt: null,
       lastError: null,
       conflicts: [],
@@ -317,6 +318,20 @@ export function useNotebook(request: NotebookRequest = {}) {
       if (!cancelled) {
         syncRef.current?.setMode(preference.mode, preference.intervalMinutes);
         patch({ syncPreference: preference });
+      }
+
+      // Rescue anything a previous version stranded.
+      //
+      // The sync engine used to delete a change from its queue after five
+      // failed pushes, leaving the note marked dirty with nothing that would
+      // ever push it — and an empty queue reporting "All changes saved". The
+      // discard is gone, but that does nothing for notes already stranded on
+      // this device, which are the ones with writing in them. Every dirty note
+      // with no queue entry is put back in the queue on load.
+      if (!workspace.isLocal) {
+        void syncRef.current?.recoverStrandedEdits(workspace.id, (note) =>
+          serializeDocument(note.content, note.frontmatter),
+        );
       }
 
       const folders = (await dbRef.current?.getMeta<string[]>(emptyFoldersKey(workspace.id))) ?? [];

--- a/packages/store/src/sync-engine.test.ts
+++ b/packages/store/src/sync-engine.test.ts
@@ -449,14 +449,127 @@ describe("SyncEngine", () => {
     expect(ctx.engine.state.pendingCount).toBe(0);
   });
 
-  it("gives up on a change that keeps failing rather than blocking the queue forever", async () => {
+  /**
+   * What happens to a change that can never be pushed.
+   *
+   * This used to be asserted the other way round — the change was deleted from
+   * the queue and from storage after five attempts, and the test called that
+   * "gives up rather than blocking the queue forever". It did stop blocking the
+   * queue. It also emptied it, which moved the status to "idle" and put "All
+   * changes saved" on screen for a note that had never reached GitHub and, now
+   * that the only record of it was gone, never would.
+   *
+   * Nothing may be discarded. It is parked: kept, counted, and reported as
+   * something that has stopped rather than something in progress.
+   */
+  it("parks a change that keeps failing, and never throws it away", async () => {
     ctx.gateway.files.set("a.md", { content: "old", sha: "sha-original" });
     ctx.gateway.failNext = 99;
 
     await ctx.engine.recordUpsert(makeNote(), "doomed");
-    for (let i = 0; i < 5; i += 1) await ctx.engine.flushNow();
+    // The automatic path, which is what actually retries: each tick runs the
+    // flush and schedules the next attempt.
+    for (let i = 0; i < 6; i += 1) await ctx.timers.tick();
 
+    expect(ctx.engine.state.blockedCount).toBe(1);
+    expect(ctx.engine.state.pendingCount).toBe(1);
+
+    // The text is still there to be pushed once whatever was wrong is fixed.
+    expect(await ctx.db.listQueue()).toHaveLength(1);
+    expect((await ctx.db.listQueue())[0]?.content).toBe("doomed");
+  });
+
+  it("never says everything is saved while a change is parked", async () => {
+    ctx.gateway.files.set("a.md", { content: "old", sha: "sha-original" });
+    ctx.gateway.failNext = 99;
+
+    await ctx.engine.recordUpsert(makeNote(), "doomed");
+    for (let i = 0; i < 6; i += 1) await ctx.timers.tick();
+
+    expect(ctx.engine.state.status).toBe("blocked");
+    expect(ctx.engine.state.status).not.toBe("idle");
+  });
+
+  it("stops retrying a parked change, so the queue behind it still drains", async () => {
+    ctx.gateway.files.set("a.md", { content: "old", sha: "sha-original" });
+    ctx.gateway.failNext = 99;
+
+    await ctx.engine.recordUpsert(makeNote(), "doomed");
+    for (let i = 0; i < 6; i += 1) await ctx.timers.tick();
+    expect(ctx.engine.state.blockedCount).toBe(1);
+
+    // A second note, in a workspace that is working again.
+    ctx.gateway.failNext = 0;
+    await ctx.engine.recordUpsert(makeNote({ id: "ws::b.md", path: "b.md" }), "fine");
+    await ctx.timers.tick();
+
+    const pushed = ctx.gateway.commits.flatMap((c) => c.changes.map((x) => x.path));
+    expect(pushed).toContain("b.md");
+    // And the parked one is still parked rather than quietly re-attempted.
+    expect(ctx.engine.state.blockedCount).toBe(1);
+  });
+
+  it("tries a parked change again when asked, which is what retry means", async () => {
+    ctx.gateway.files.set("a.md", { content: "old", sha: "sha-original" });
+    ctx.gateway.failNext = 99;
+
+    await ctx.engine.recordUpsert(makeNote(), "doomed");
+    for (let i = 0; i < 6; i += 1) await ctx.timers.tick();
+    expect(ctx.engine.state.blockedCount).toBe(1);
+
+    // Whatever was wrong is fixed, and the reader presses sync.
+    ctx.gateway.failNext = 0;
+    await ctx.engine.flushNow();
+
+    expect(ctx.engine.state.blockedCount).toBe(0);
     expect(ctx.engine.state.pendingCount).toBe(0);
+    expect(ctx.gateway.files.get("a.md")?.content).toBe("doomed");
+  });
+
+  it("remembers why it stopped, so the reason can be shown", async () => {
+    ctx.gateway.files.set("a.md", { content: "old", sha: "sha-original" });
+    ctx.gateway.failNext = 99;
+
+    await ctx.engine.recordUpsert(makeNote(), "doomed");
+    for (let i = 0; i < 6; i += 1) await ctx.timers.tick();
+
+    expect((await ctx.db.listQueue())[0]?.lastError).toContain("server error");
+  });
+
+  /**
+   * Healing the damage the old discard left behind.
+   *
+   * Fixing the discard stops new notes being stranded. It does nothing for the
+   * ones already sitting on somebody's device, dirty, with no queue entry and
+   * an "All changes saved" label above them — and those are the ones with
+   * writing in them.
+   */
+  it("re-queues a dirty note that nothing is left to push", async () => {
+    const stranded = makeNote({ content: "words nobody pushed", dirty: true });
+    await ctx.db.putNote(stranded);
+
+    const recovered = await ctx.engine.recoverStrandedEdits("ws", (note) => note.content);
+
+    expect(recovered).toBe(1);
+    expect(ctx.engine.state.pendingCount).toBe(1);
+
+    await ctx.engine.flushNow();
+    expect(ctx.gateway.files.get("a.md")?.content).toBe("words nobody pushed");
+  });
+
+  it("leaves a note that is already in sync alone", async () => {
+    await ctx.db.putNote(makeNote({ dirty: false }));
+
+    expect(await ctx.engine.recoverStrandedEdits("ws", (n) => n.content)).toBe(0);
+    expect(ctx.engine.state.pendingCount).toBe(0);
+  });
+
+  it("does not queue a second copy of something already queued", async () => {
+    await ctx.engine.recordUpsert(makeNote(), "already queued");
+    expect(ctx.engine.state.pendingCount).toBe(1);
+
+    expect(await ctx.engine.recoverStrandedEdits("ws", (n) => n.content)).toBe(0);
+    expect(ctx.engine.state.pendingCount).toBe(1);
   });
 
   it("notifies subscribers as the status changes", async () => {

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -123,8 +123,55 @@ export class SyncEngine {
   /** Reloads the queue left over from a previous session. */
   async start(): Promise<void> {
     this.queue = await this.db.listQueue();
-    if (this.queue.length > 0) this.scheduleFlush();
     this.emit();
+  }
+
+  /**
+   * Re-queues local edits that have no queue entry to push them.
+   *
+   * This repairs damage rather than preventing it. An earlier version of this
+   * engine deleted a change from the queue once it had failed five times, which
+   * left the note marked dirty with nothing anywhere that would ever push it —
+   * and the empty queue then reported "All changes saved". Fixing the discard
+   * stops it happening again; it does nothing for the notes already stranded on
+   * somebody's device, and those are the ones with writing in them.
+   *
+   * So every dirty note without a queue entry is queued again. Safe to run on
+   * every load: a note that is genuinely in sync is not dirty, and one that is
+   * already queued is skipped. Called per workspace, because the note store is
+   * addressed that way.
+   */
+  async recoverStrandedEdits(
+    workspaceId: string,
+    serialize: (note: Note) => string,
+  ): Promise<number> {
+    const queued = new Set(
+      this.queue
+        .filter((change) => change.workspaceId === workspaceId)
+        .map((change) => (change.op === "rename" ? (change.toPath ?? change.path) : change.path)),
+    );
+
+    let recovered = 0;
+
+    for (const note of await this.db.listNotes(workspaceId)) {
+      if (!note.dirty || queued.has(note.path)) continue;
+
+      this.queue = coalesce(this.queue, {
+        workspaceId,
+        path: note.path,
+        op: "upsert",
+        content: serialize(note),
+        baseSha: note.baseSha,
+        now: this.now().toISOString(),
+      });
+      recovered += 1;
+    }
+
+    if (recovered > 0) {
+      await this.persistQueue();
+      this.scheduleFlush();
+    }
+    return recovered;
   }
 
   subscribe(listener: Listener): () => void {
@@ -138,6 +185,7 @@ export class SyncEngine {
       status: this.status,
       mode: this.mode,
       pendingCount: this.queue.length,
+      blockedCount: this.blocked().length,
       lastSyncedAt: this.lastSyncedAt,
       lastError: this.lastError,
       conflicts: this.conflicts,
@@ -266,12 +314,20 @@ export class SyncEngine {
     }, delay);
   }
 
-  /** Pushes everything pending right now, bypassing the debounce. */
+  /**
+   * Pushes everything pending right now, bypassing the debounce.
+   *
+   * Un-parks first. This is somebody pressing "sync now", which is a direct
+   * request to try the things that are not being tried — and a Sync Now that
+   * pointedly skipped the changes that had failed would be the least useful
+   * possible reading of the button.
+   */
   async flushNow(): Promise<void> {
     if (this.timer !== null) {
       this.cancel(this.timer);
       this.timer = null;
     }
+    await this.unpark();
     await this.flush();
   }
 
@@ -282,8 +338,8 @@ export class SyncEngine {
       this.dirtyDuringFlush = true;
       return;
     }
-    if (this.queue.length === 0) {
-      this.setStatus("idle");
+    if (this.pushable().length === 0) {
+      this.setStatus(this.restingStatus());
       return;
     }
     if (!this.isOnline()) {
@@ -299,7 +355,9 @@ export class SyncEngine {
 
     try {
       // One commit per workspace: a batch cannot span two repositories.
-      for (const [workspaceId, changes] of groupByWorkspace(this.queue)) {
+      // Parked changes are skipped — they have already had their attempts and
+      // retrying them on every flush would hold up everything behind them.
+      for (const [workspaceId, changes] of groupByWorkspace(this.pushable())) {
         await this.flushWorkspace(workspaceId, changes);
       }
 
@@ -309,7 +367,11 @@ export class SyncEngine {
       this.setStatus(this.restingStatus());
     } catch (err) {
       this.lastError = err instanceof Error ? err.message : String(err);
-      this.setStatus(this.isOnline() ? "error" : "offline");
+      // "error" means a push failed and will be tried again by itself. Once
+      // nothing is left that *will* be tried again, that reading is wrong and
+      // the honest word is "blocked" — it has stopped, and it needs asking.
+      const stalled = this.pushable().length === 0 && this.blocked().length > 0;
+      this.setStatus(this.isOnline() ? (stalled ? "blocked" : "error") : "offline");
       // A failed push used to sit there until the user happened to type again,
       // which is why notes could stay unsynced indefinitely after one blip.
       this.scheduleRetry();
@@ -329,7 +391,7 @@ export class SyncEngine {
    * gets a prompt attempt rather than inheriting a long backoff.
    */
   private scheduleRetry(): void {
-    if (this.queue.length === 0) return;
+    if (this.pushable().length === 0) return;
 
     this.retryDelay = this.retryDelay ? Math.min(this.retryDelay * 2, RETRY_MAX_MS) : RETRY_BASE_MS;
 
@@ -348,7 +410,24 @@ export class SyncEngine {
    */
   retryNow(): void {
     this.retryDelay = 0;
+    // Asking again is exactly what a parked change is waiting for, so this
+    // clears the parking. Without it "click to retry" would do nothing at all
+    // for the changes that most need retrying.
+    void this.unpark();
     if (this.queue.length > 0) this.scheduleFlush();
+  }
+
+  /** Puts every parked change back in line and gives it its attempts back. */
+  private async unpark(): Promise<void> {
+    const parked = this.blocked();
+    if (parked.length === 0) return;
+
+    for (const change of parked) {
+      change.blocked = false;
+      change.attempts = 0;
+      delete change.lastError;
+      await this.db.putQueueItem(change);
+    }
   }
 
   private async flushWorkspace(workspaceId: string, changes: PendingChange[]): Promise<void> {
@@ -369,16 +448,23 @@ export class SyncEngine {
         })),
       });
     } catch (err) {
-      // Count the attempt so a change that can never succeed (a deleted repo,
-      // a revoked token) eventually stops blocking everything behind it.
+      // Count the attempt so a change that can never succeed — a deleted repo,
+      // a revoked token — stops blocking everything queued behind it.
+      //
+      // Parked, never discarded. This used to delete the change from the queue
+      // and from storage once it ran out of attempts, with nothing recorded and
+      // nothing shown. The queue then went empty, the status went to "idle",
+      // and the status bar said "All changes saved" about a note that had never
+      // reached GitHub and now never would, because the only thing that knew
+      // about it had been thrown away. Keeping it costs a row in IndexedDB;
+      // dropping it costs somebody their writing.
+      const message = err instanceof Error ? err.message : String(err);
+
       for (const change of safe) {
         change.attempts += 1;
-        if (change.attempts >= MAX_ATTEMPTS) {
-          this.queue = this.queue.filter((c) => c.id !== change.id);
-          await this.db.deleteQueueItem(change.id);
-        } else {
-          await this.db.putQueueItem(change);
-        }
+        change.lastError = message;
+        if (change.attempts >= MAX_ATTEMPTS) change.blocked = true;
+        await this.db.putQueueItem(change);
       }
       throw err;
     }
@@ -567,7 +653,20 @@ export class SyncEngine {
    */
   private restingStatus(): SyncStatus {
     if (this.conflicts.length > 0) return "conflict";
+    // Outranks "pending": a parked change is not waiting its turn, it has
+    // stopped, and the one thing the status must never do is imply otherwise.
+    if (this.blocked().length > 0) return "blocked";
     return this.queue.length > 0 ? "pending" : "idle";
+  }
+
+  /** Queued changes still eligible for an automatic push. */
+  private pushable(): PendingChange[] {
+    return this.queue.filter((change) => change.blocked !== true);
+  }
+
+  /** Queued changes that have run out of retries and are waiting to be asked. */
+  private blocked(): PendingChange[] {
+    return this.queue.filter((change) => change.blocked === true);
   }
 
   private setStatus(status: SyncStatus): void {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -132,7 +132,15 @@ export type SyncStatus =
   | "syncing" // a push is in flight
   | "offline" // no network; changes are queued
   | "conflict" // remote moved on; needs user resolution
-  | "error";
+  | "error"
+  /**
+   * Changes that have run out of retries and are parked.
+   *
+   * Distinct from `error`, which is a push that just failed and will be tried
+   * again on its own. This one will not retry until somebody asks it to, so it
+   * is the state that must never be mistaken for "saved".
+   */
+  | "blocked";
 
 /**
  * How eagerly changes are pushed to GitHub.
@@ -164,8 +172,15 @@ export interface SyncState {
   status: SyncStatus;
   /** How this workspace is configured to push. */
   mode: SyncMode;
-  /** Number of notes with unpushed changes. */
+  /** Number of notes with unpushed changes, parked ones included. */
   pendingCount: number;
+  /**
+   * Changes that gave up retrying and are waiting to be asked again.
+   *
+   * Reported separately because it is the one number that means something is
+   * wrong rather than merely in progress.
+   */
+  blockedCount: number;
   lastSyncedAt: string | null;
   lastError: string | null;
   conflicts: Conflict[];
@@ -184,6 +199,18 @@ export interface PendingChange {
   baseSha: string | null;
   queuedAt: string;
   attempts: number;
+  /**
+   * True once this has exhausted its retries.
+   *
+   * It stays in the queue. A change that cannot be pushed used to be deleted
+   * from the queue and from storage after five attempts — no record, nothing
+   * shown — which emptied the queue, moved the status to "idle" and put "All
+   * changes saved" on screen for a note that had never reached GitHub. Parking
+   * it keeps the text and keeps the app honest.
+   */
+  blocked?: boolean;
+  /** Why it stopped, for the message offering to try again. */
+  lastError?: string;
 }
 
 /** A remote change that collides with an unpushed local change. */


### PR DESCRIPTION
This is the "it says **All changes saved** but my note is not on GitHub" bug. It
was doing exactly what it looked like.

## What was happening

After five failed pushes the sync engine deleted the change from the queue
**and from IndexedDB**:

```ts
if (change.attempts >= MAX_ATTEMPTS) {
  this.queue = this.queue.filter((c) => c.id !== change.id);
  await this.db.deleteQueueItem(change.id);
}
```

Nothing recorded it, nothing surfaced it, and nothing would ever retry it — the
only thing that knew the note had unsaved work was the thing that had just been
deleted. The queue then went empty, `restingStatus()` returned `idle`, and the
status bar said "All changes saved" above a note whose text had never left the
device. The note stayed marked `dirty` forever with nothing left to push it.

A test asserted this as correct behaviour, under the name *"gives up on a change
that keeps failing rather than blocking the queue forever"*. It did stop
blocking the queue — by discarding somebody's writing. That test is rewritten.

## What it does now

**Nothing is discarded.** A change that runs out of attempts is *parked*: kept
in the queue and in storage, with the reason it stopped, excluded from automatic
retries so it does not hold up everything behind it, and counted separately as
`blockedCount`.

**The status cannot claim otherwise.** `restingStatus()` returns `blocked`,
which outranks `pending` — a parked change is not waiting its turn, it has
stopped. The failure path reports `blocked` too once nothing retryable is left,
because "error" implies something will try again on its own. The status bar
reads "N changes not on GitHub — click to retry".

**Retry means retry.** That click and Sync Now both un-park everything and reset
its attempts, since being asked is precisely what a parked change is waiting
for. Previously "click to retry" would have skipped the changes that most needed
retrying.

**The damage already done is repaired.** Fixing the discard does nothing for
notes already stranded on somebody's device — which are the ones with writing in
them. `recoverStrandedEdits` re-queues every dirty note with no queue entry, and
runs on every workspace load. A note genuinely in sync is not dirty, and one
already queued is skipped, so it is safe to run always.

## Also verified

Folder creation, checked in the browser rather than assumed: `SOC 101/Phishing
analysis` created in one go produces both levels, and a note created inside is
stored at the full nested path — read out of IndexedDB, not off the tree UI,
because the stored path is what actually reaches GitHub.

## Checks

647 tests pass (7 new here, all on this bug), typecheck and lint clean across
all nine packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
