### PR TITLE
fix(editor): show pasted images instantly, and embed YouTube videos

### DIFF
--- a/apps/web/src/app/docs/content/writing.tsx
+++ b/apps/web/src/app/docs/content/writing.tsx
@@ -81,6 +81,7 @@ export function Editor() {
           ["Divider", "Horizontal rule", <Code key="h">---</Code>],
           ["Link", "Asks for the text and the address", <Code key="i">[](…)</Code>],
           ["Image", "Opens the image picker", <Code key="j">![](…)</Code>],
+          ["YouTube video", "Asks for the video's address", <Code key="k">https://youtu.be/…</Code>],
         ]}
       />
       <P>
@@ -120,6 +121,24 @@ export function Editor() {
         You can also link to an image already on the web. Those are stored as the URL you give,
         untouched.
       </P>
+
+      <H2 id="videos">YouTube videos</H2>
+      <P>
+        Put a YouTube link on a line of its own — paste it into an empty line, or use the{" "}
+        <strong>YouTube video</strong> item in the <Code>/</Code> menu — and Rich view and the
+        preview show the player. Watch links, <Code>youtu.be</Code> short links, Shorts and live
+        URLs are all understood, and a <Code>?t=</Code> start time is kept.
+      </P>
+      <P>
+        Nothing unusual is written to the file: the note holds the plain Markdown link and nothing
+        else, so it reads as a link on github.com, in an IDE and in every other Markdown tool. A
+        link inside a sentence stays a link — only a line that is nothing but the link becomes a
+        player — which leaves you a way to mention a video without embedding it.
+      </P>
+      <Note>
+        The player is loaded from <Code>youtube-nocookie.com</Code>, so opening a note that contains
+        a video does not drop tracking cookies on whoever is reading it.
+      </Note>
 
       <H2 id="formatting">Inline formatting</H2>
       <P>

--- a/apps/web/src/app/docs/content/writing.tsx
+++ b/apps/web/src/app/docs/content/writing.tsx
@@ -81,7 +81,11 @@ export function Editor() {
           ["Divider", "Horizontal rule", <Code key="h">---</Code>],
           ["Link", "Asks for the text and the address", <Code key="i">[](…)</Code>],
           ["Image", "Opens the image picker", <Code key="j">![](…)</Code>],
-          ["YouTube video", "Asks for the video's address", <Code key="k">https://youtu.be/…</Code>],
+          [
+            "YouTube video",
+            "Asks for the video's address",
+            <Code key="k">https://youtu.be/…</Code>,
+          ],
         ]}
       />
       <P>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -646,6 +646,28 @@ select:focus-visible {
   border-radius: 8px;
 }
 
+/* A video in a rendered note. The note itself holds a plain link; this is the
+   player the preview and the export draw for it. 16:9 by padding rather than
+   `aspect-ratio` so the box is the right size before the frame loads. */
+.fl-embed {
+  position: relative;
+  height: 0;
+  width: 100%;
+  padding-bottom: 56.25%;
+  margin: 1.5rem 0;
+  overflow: hidden;
+  border-radius: 10px;
+  background: #000;
+}
+
+.fl-embed .fl-embed-frame {
+  position: absolute;
+  inset: 0;
+  height: 100%;
+  width: 100%;
+  border: 0;
+}
+
 .fl-diagram,
 .fl-diagram-preview {
   margin: 1.5rem 0;

--- a/packages/editor/src/WysiwygEditor.tsx
+++ b/packages/editor/src/WysiwygEditor.tsx
@@ -63,6 +63,7 @@ export function markdownOf(editor: Editor): string {
 }
 import { CodeBlock } from "./extensions/CodeBlock";
 import { ResolvedImage } from "./extensions/ResolvedImage";
+import { YoutubeEmbed } from "./extensions/YoutubeEmbed";
 import { TextSelection } from "@tiptap/pm/state";
 import { imagesFrom, type ImageBridge } from "./images";
 import { MermaidBlock } from "./extensions/MermaidBlock";
@@ -130,6 +131,32 @@ export function WysiwygEditor({
   const linksRef = useRef<LinkBridge | undefined>(links);
   linksRef.current = links;
 
+  /**
+   * Images waiting to hear that the resolver knows something new.
+   *
+   * The bridge resolves a note-relative path against a store that fills up
+   * while the note is open, so an image inserted before its bytes are
+   * published there resolves to a placeholder. Each rendered image subscribes
+   * and re-asks whenever a new bridge arrives, which is what a new entry in
+   * that store looks like from in here.
+   */
+  const resolveListeners = useRef<Set<() => void>>(new Set());
+  const subscribeToResolver = useCallback((listener: () => void) => {
+    resolveListeners.current.add(listener);
+    return () => {
+      resolveListeners.current.delete(listener);
+    };
+  }, []);
+
+  // Deliberately without a dependency list. What images need to hear about is
+  // a change in what the resolver *answers*, and the bridge is a closure over
+  // state held by the app — its identity says nothing reliable about that.
+  // Re-asking is a lookup per image, and only touches the DOM when the answer
+  // has actually changed.
+  useEffect(() => {
+    for (const listener of resolveListeners.current) listener();
+  });
+
   // Guards the value-sync effect: without it, our own serialised output feeds
   // straight back in and resets the cursor to the top on every keystroke.
   const applyingExternal = useRef(false);
@@ -176,6 +203,7 @@ export function WysiwygEditor({
         inline: false,
         allowBase64: true,
         resolveSrc: (src: string) => imagesRef.current?.resolve?.(src) ?? src,
+        subscribe: subscribeToResolver,
         HTMLAttributes: { loading: "lazy" },
       }),
       Link.configure({
@@ -191,6 +219,7 @@ export function WysiwygEditor({
       TableCell,
       CodeBlock,
       MermaidBlock,
+      YoutubeEmbed,
       // Read through the ref, not captured: the extension list is built once,
       // and the bridge arrives a render later once the workspace resolves.
       Wikilink.configure({ bridge: () => linksRef.current }),
@@ -221,7 +250,7 @@ export function WysiwygEditor({
         linkify: true,
       }),
     ],
-    [placeholder],
+    [placeholder, subscribeToResolver],
   );
 
   /**
@@ -255,6 +284,14 @@ export function WysiwygEditor({
         // Anything after the first lands below the one before it.
         position = target + node.nodeSize;
       }
+      // The upload stored the image locally and called setAssetUrls(), which
+      // is a React state update. That update was processed while `await`
+      // yielded — *before* the node was created and its view registered a
+      // resolve listener. So the useEffect that normally notifies listeners
+      // already ran against an empty set. Fire every listener now so the
+      // freshly-registered paint() callbacks re-ask the resolver, which
+      // already has the correct blob URL.
+      for (const listener of resolveListeners.current) listener();
       onImageStatusRef.current?.({ busy: false, error: null });
     } catch (error) {
       onImageStatusRef.current?.({

--- a/packages/editor/src/extensions/ResolvedImage.ts
+++ b/packages/editor/src/extensions/ResolvedImage.ts
@@ -8,6 +8,18 @@ export interface ResolvedImageOptions {
    * unaware of where images live.
    */
   resolveSrc?: (src: string) => string;
+  /**
+   * Tells us the resolver's answers have changed, so images can re-ask.
+   *
+   * Resolving is not a pure function of the `src`: it is a lookup in a store
+   * that fills up while the note is open — an image pasted a second ago is
+   * still being written to the local asset store when its node is inserted.
+   * Without this, the first answer is the only answer, and "not on this
+   * device" is what a freshly pasted screenshot renders as forever.
+   *
+   * Returns an unsubscribe function.
+   */
+  subscribe?: (listener: () => void) => () => void;
 }
 
 /**
@@ -27,6 +39,7 @@ export const ResolvedImage = Image.extend<ResolvedImageOptions & Record<string, 
     return {
       ...this.parent?.(),
       resolveSrc: undefined,
+      subscribe: undefined,
     };
   },
 
@@ -48,6 +61,81 @@ export const ResolvedImage = Image.extend<ResolvedImageOptions & Record<string, 
           return resolved === src ? { src } : { src: resolved, "data-src": src };
         },
       },
+    };
+  },
+
+  /**
+   * The rendered `<img>`, kept in step with the resolver.
+   *
+   * ProseMirror renders a node's DOM once and reuses it for as long as the
+   * node itself does not change, so `renderHTML` alone gives an image exactly
+   * one chance to be resolved. For a pasted screenshot that chance comes a
+   * moment too early: the node is inserted as soon as the bytes are stored,
+   * and the store the resolver reads has not yet published the new entry, so
+   * the image resolved to the "not on this device" placeholder and stayed
+   * there until the note was closed and opened again.
+   *
+   * A node view can re-ask. The node's own `src` attribute — the one that gets
+   * serialised back to markdown — is never touched, so re-resolving cannot
+   * change what is written to the file, and it never marks the note dirty.
+   */
+  addNodeView() {
+    return ({ node, HTMLAttributes }) => {
+      const options = this.options as ResolvedImageOptions;
+      const dom = document.createElement("img");
+
+      for (const [key, value] of Object.entries(HTMLAttributes)) {
+        if (key === "src" || key === "data-src") continue;
+        if (value === null || value === undefined) continue;
+        dom.setAttribute(key, String(value));
+      }
+
+      let attrs = node.attrs as Record<string, unknown>;
+
+      const paint = () => {
+        const src = typeof attrs.src === "string" ? attrs.src : "";
+        if (!src) {
+          dom.removeAttribute("src");
+          return;
+        }
+
+        const resolved = options.resolveSrc?.(src) ?? src;
+        // Only on a real change: reassigning the same src restarts the load,
+        // which flickers the image on every keystroke in the note.
+        if (dom.getAttribute("src") !== resolved) dom.setAttribute("src", resolved);
+        // What the markdown says, carried through any HTML round trip so
+        // copying an image between notes does not paste a proxy URL.
+        if (resolved !== src) dom.setAttribute("data-src", src);
+        else dom.removeAttribute("data-src");
+      };
+
+      const applyText = () => {
+        const alt = typeof attrs.alt === "string" ? attrs.alt : "";
+        const title = typeof attrs.title === "string" ? attrs.title : "";
+        if (alt) dom.setAttribute("alt", alt);
+        else dom.removeAttribute("alt");
+        if (title) dom.setAttribute("title", title);
+        else dom.removeAttribute("title");
+      };
+
+      applyText();
+      paint();
+
+      const unsubscribe = options.subscribe?.(paint);
+
+      return {
+        dom,
+        update: (updated) => {
+          if (updated.type.name !== node.type.name) return false;
+          attrs = updated.attrs as Record<string, unknown>;
+          applyText();
+          paint();
+          return true;
+        },
+        destroy: () => {
+          unsubscribe?.();
+        },
+      };
     };
   },
 

--- a/packages/editor/src/extensions/YoutubeEmbed.tsx
+++ b/packages/editor/src/extensions/YoutubeEmbed.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { Node, mergeAttributes } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { ReactNodeViewRenderer, NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
+import { youtubeEmbedUrl, youtubeVideoFrom, youtubeWatchUrl } from "@forkleaf/markdown-engine";
+
+/**
+ * A YouTube video as a block in the WYSIWYG editor.
+ *
+ * The note stores an ordinary markdown link on a line of its own — nothing
+ * app-specific, no HTML, no custom syntax — so a note with a video in it still
+ * reads correctly on github.com, in an IDE, and in every other markdown tool,
+ * where it shows up as the link it is. The player is how *this* editor and the
+ * preview choose to draw that line, and the same rule governs both: a link
+ * that is the whole paragraph becomes the video, a link inside a sentence
+ * stays a link.
+ */
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    youtubeEmbed: {
+      /** Inserts a video. Returns false for a URL that names no video. */
+      insertYoutubeEmbed: (url: string) => ReturnType;
+    };
+  }
+}
+
+function YoutubeNodeView({ node, selected }: NodeViewProps) {
+  const src = (node.attrs.src as string) ?? "";
+  const video = youtubeVideoFrom(src);
+
+  return (
+    <NodeViewWrapper
+      className="fl-embed-node my-4"
+      data-type="youtube"
+      data-drag-handle
+      draggable="true"
+    >
+      {video ? (
+        <figure
+          className={`relative overflow-hidden rounded-xl border bg-black transition-colors ${
+            selected ? "border-[var(--fl-accent)]" : "border-[var(--fl-border)]"
+          }`}
+        >
+          {/* 16:9, held by the padding trick rather than `aspect-ratio` so the
+              box is the right size before the player has loaded anything. */}
+          <div className="relative h-0 w-full pb-[56.25%]">
+            <iframe
+              className="absolute inset-0 h-full w-full"
+              src={youtubeEmbedUrl(video)}
+              title="YouTube video player"
+              loading="lazy"
+              allow="accelerometer; encrypted-media; picture-in-picture; web-share; fullscreen"
+              allowFullScreen
+              referrerPolicy="strict-origin-when-cross-origin"
+            />
+          </div>
+        </figure>
+      ) : (
+        <p className="rounded-lg border border-dashed border-[var(--fl-border)] px-3 py-2 text-sm text-[var(--fl-muted)]">
+          Not a YouTube link: {src}
+        </p>
+      )}
+
+      {/* The URL stays visible. It is what the file actually contains, and a
+          player with no link under it gives no way to see or copy that. */}
+      <figcaption className="mt-1 truncate text-xs text-[var(--fl-muted)]">
+        <a
+          href={video ? youtubeWatchUrl(video) : src}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline-offset-2 hover:underline"
+        >
+          {video ? youtubeWatchUrl(video) : src}
+        </a>
+      </figcaption>
+    </NodeViewWrapper>
+  );
+}
+
+export const YoutubeEmbed = Node.create({
+  name: "youtubeEmbed",
+  group: "block",
+  // Atomic: there is nothing inside it for ProseMirror to edit.
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      src: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-src") ?? "",
+        renderHTML: (attributes) => ({ "data-src": attributes.src as string }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="youtube"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes(HTMLAttributes, { "data-type": "youtube" })];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(YoutubeNodeView);
+  },
+
+  addCommands() {
+    return {
+      insertYoutubeEmbed:
+        (url: string) =>
+        ({ commands }) => {
+          const video = youtubeVideoFrom(url);
+          if (!video) return false;
+          return commands.insertContent({
+            type: this.name,
+            attrs: { src: youtubeWatchUrl(video) },
+          });
+        },
+    };
+  },
+
+  /**
+   * Pasting a video link where the whole paragraph would be that link.
+   *
+   * Without this the embed would only appear the next time the note was parsed
+   * from markdown — paste a link, get a link; reopen the note an hour later,
+   * find a player. Pasting into the middle of a sentence still just pastes the
+   * link, which is the same rule the renderer applies.
+   */
+  addProseMirrorPlugins() {
+    const type = this.type;
+
+    return [
+      new Plugin({
+        key: new PluginKey("youtubeEmbedPaste"),
+        props: {
+          handlePaste: (view, event) => {
+            const text = event.clipboardData?.getData("text/plain").trim() ?? "";
+            if (!text || /\s/.test(text)) return false;
+
+            const video = youtubeVideoFrom(text);
+            if (!video) return false;
+
+            const { $from, empty } = view.state.selection;
+            // Only where the link would stand alone: an empty paragraph, or
+            // the whole of one selected.
+            const parent = $from.parent;
+            if (parent.type.name !== "paragraph") return false;
+            if (empty ? parent.content.size > 0 : !selectionCoversBlock(view.state)) return false;
+
+            event.preventDefault();
+            const node = type.create({ src: youtubeWatchUrl(video) });
+            const tr = view.state.tr.replaceSelectionWith(node);
+            view.dispatch(tr);
+            return true;
+          },
+        },
+      }),
+    ];
+  },
+
+  /**
+   * Markdown bridge.
+   *
+   * Out: the watch URL on a line of its own, which GFM autolinks — a plain
+   * link in the file, readable anywhere. In: a paragraph that holds nothing
+   * but a link to a video becomes this node again.
+   */
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownSerializerLike, node: { attrs: { src?: string } }) {
+          state.write(node.attrs.src ?? "");
+          state.closeBlock(node);
+        },
+        parse: {
+          updateDOM(element: HTMLElement) {
+            for (const paragraph of Array.from(element.querySelectorAll<HTMLElement>("p"))) {
+              const children = Array.from(paragraph.childNodes).filter(
+                (child) => child.nodeType !== 3 || (child.textContent ?? "").trim() !== "",
+              );
+
+              const only = children.length === 1 ? children[0] : null;
+              if (!only || !(only instanceof HTMLAnchorElement)) continue;
+
+              const video = youtubeVideoFrom(only.getAttribute("href") ?? "");
+              if (!video) continue;
+
+              const replacement = element.ownerDocument.createElement("div");
+              replacement.setAttribute("data-type", "youtube");
+              replacement.setAttribute("data-src", youtubeWatchUrl(video));
+              paragraph.replaceWith(replacement);
+            }
+          },
+        },
+      },
+    };
+  },
+});
+
+/** True when the selection is exactly the block it sits in. */
+function selectionCoversBlock(state: {
+  selection: {
+    $from: { parent: { content: { size: number } }; parentOffset: number };
+    to: number;
+    from: number;
+  };
+}): boolean {
+  const { $from, from, to } = state.selection;
+  return $from.parentOffset === 0 && to - from === $from.parent.content.size;
+}
+
+/** The subset of prosemirror-markdown's serializer state that we use. */
+interface MarkdownSerializerLike {
+  write(text: string): void;
+  closeBlock(node: unknown): void;
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -35,6 +35,7 @@ export { type LinkBridge, wikilinkResolver, handleWikilinkClick } from "./links"
 export { Wikilink, type WikilinkOptions } from "./extensions/Wikilink";
 export { EnterIsALineBreak } from "./extensions/EnterIsALineBreak";
 export { ResolvedImage, type ResolvedImageOptions } from "./extensions/ResolvedImage";
+export { YoutubeEmbed } from "./extensions/YoutubeEmbed";
 
 export { DiagramStudio, type DiagramStudioProps, type StudioView } from "./mermaid/DiagramStudio";
 export {

--- a/packages/editor/src/insert-actions.tsx
+++ b/packages/editor/src/insert-actions.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import type { Editor } from "@tiptap/core";
 import type { InsertAction } from "./EditorToolbar";
 import type { SourceEditorHandle } from "./SourceEditor";
+import { isYoutubeUrl } from "@forkleaf/markdown-engine";
 
 /** Matches any ATX heading marker, so switching levels replaces rather than stacks. */
 const HEADING_PATTERN = /^#{1,6} /;
@@ -79,6 +80,18 @@ function promptImageUrl(): string | null {
     return null;
   }
   return url;
+}
+
+/** Prompts for a YouTube URL, rejecting anything that is not a video. */
+function promptYoutubeUrl(): string | null {
+  const url = window.prompt("YouTube video URL");
+  if (!url) return null;
+
+  if (!isYoutubeUrl(url.trim())) {
+    window.alert("That does not look like a YouTube video link.");
+    return null;
+  }
+  return url.trim();
 }
 
 const MERMAID_STARTER = "flowchart TD\n  A[Start] --> B[Finish]";
@@ -246,6 +259,19 @@ export const INSERT_DEFINITIONS: InsertDefinition[] = [
       if (url) editor.chain().focus().setImage({ src: url }).run();
     },
     markdown: { text: "![](https://)", cursor: 2 },
+  },
+  {
+    id: "youtube",
+    keywords: ["video", "youtube", "embed", "watch", "clip"],
+    label: "YouTube video",
+    hint: "Embed a video — saved as a plain link",
+    icon: <Glyph d="M1.5 4.5h13v7h-13zM6.5 6.5l3.5 1.5-3.5 1.5z" />,
+    rich: (editor) => {
+      const url = promptYoutubeUrl();
+      if (url) editor.chain().focus().insertYoutubeEmbed(url).run();
+    },
+    // On its own line, which is what makes it an embed rather than a link.
+    markdown: { text: "https://www.youtube.com/watch?v=", cursor: 32 },
   },
   {
     id: "h4",

--- a/packages/editor/src/pasted-image.test.tsx
+++ b/packages/editor/src/pasted-image.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { WysiwygEditor } from "./WysiwygEditor";
+import type { ImageBridge } from "./images";
+
+afterEach(cleanup);
+
+/**
+ * A pasted screenshot showing up.
+ *
+ * Resolving an image is a lookup in a store that is still being written to
+ * when the image is inserted: the bytes are put away and the node goes in, and
+ * only afterwards does the app publish the entry the resolver reads. So the
+ * first answer for a freshly pasted image is "not on this device" — and since
+ * ProseMirror renders a node's DOM once, that first answer used to be the last
+ * one, leaving a placeholder where the screenshot was until the note was
+ * closed and opened again.
+ */
+describe("a pasted image", () => {
+  it("appears as soon as its bytes can be resolved", async () => {
+    // Empty when the paste lands, filled a moment later — the local asset
+    // store, in miniature.
+    const store = new Map<string, string>();
+
+    const bridge: ImageBridge = {
+      canUpload: true,
+      resolve: (src) => store.get(src) ?? "MISSING",
+      upload: async (file) => `assets/${file.name}`,
+    };
+
+    let editor: Editor | null = null;
+    const note = () => (
+      <WysiwygEditor
+        value="hello"
+        onChange={vi.fn()}
+        images={bridge}
+        onReady={(instance) => {
+          editor = instance;
+        }}
+      />
+    );
+    const { rerender } = render(note());
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    const view = editor!.view;
+    const file = new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: { files: [file], items: [], types: ["Files"], getData: () => "" },
+    });
+    view.dom.dispatchEvent(event);
+
+    await waitFor(() => expect(view.dom.querySelector("img")).not.toBeNull(), { timeout: 4000 });
+
+    // The bytes land, and the app re-renders — which is what storing an asset
+    // does.
+    store.set("assets/shot.png", "blob:the-image");
+    rerender(note());
+
+    await waitFor(
+      () => expect(view.dom.querySelector("img")?.getAttribute("src")).toBe("blob:the-image"),
+      { timeout: 2000 },
+    );
+  });
+
+  it("keeps the markdown pointing at the path, not the resolved URL", async () => {
+    const bridge: ImageBridge = {
+      canUpload: true,
+      resolve: () => "blob:the-image",
+      upload: async (file) => `assets/${file.name}`,
+    };
+
+    let editor: Editor | null = null;
+    render(
+      <WysiwygEditor
+        value="hello"
+        onChange={vi.fn()}
+        images={bridge}
+        onReady={(instance) => {
+          editor = instance;
+        }}
+      />,
+    );
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    const view = editor!.view;
+    const file = new File([new Uint8Array([1])], "shot.png", { type: "image/png" });
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: { files: [file], items: [], types: ["Files"], getData: () => "" },
+    });
+    view.dom.dispatchEvent(event);
+
+    await waitFor(() => expect(view.dom.querySelector("img")).not.toBeNull(), { timeout: 4000 });
+
+    let src = "";
+    editor!.state.doc.descendants((node) => {
+      if (node.type.name === "image") src = node.attrs.src as string;
+    });
+    expect(src).toBe("assets/shot.png");
+  });
+});

--- a/packages/editor/src/youtube-embed.test.tsx
+++ b/packages/editor/src/youtube-embed.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { WysiwygEditor, markdownOf } from "./WysiwygEditor";
+
+afterEach(cleanup);
+
+async function mount(markdown: string): Promise<Editor> {
+  let editor: Editor | null = null;
+  render(<WysiwygEditor value={markdown} onChange={vi.fn()} onReady={(i) => (editor = i)} />);
+  await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+  return editor!;
+}
+
+describe("YouTube videos in rich text", () => {
+  it("turns a link on its own line into a player", async () => {
+    const editor = await mount("Watch this\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ");
+
+    const node = editor.state.doc.child(editor.state.doc.childCount - 1);
+    expect(node.type.name).toBe("youtubeEmbed");
+    expect(node.attrs.src).toBe("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+  });
+
+  it("writes it back as the same plain link", async () => {
+    const editor = await mount("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    expect(markdownOf(editor).trim()).toBe("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+  });
+
+  it("keeps a link inside a sentence as a link", async () => {
+    const editor = await mount("See https://youtu.be/dQw4w9WgXcQ for the demo.");
+    expect(editor.state.doc.firstChild?.type.name).toBe("paragraph");
+  });
+
+  it("embeds a video pasted into an empty paragraph", async () => {
+    const editor = await mount("");
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        files: [],
+        items: [],
+        types: ["text/plain"],
+        getData: () => "https://youtu.be/dQw4w9WgXcQ?t=42",
+      },
+    });
+    editor.view.dom.dispatchEvent(event);
+
+    await waitFor(() => {
+      const found: string[] = [];
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === "youtubeEmbed") found.push(node.attrs.src as string);
+      });
+      expect(found).toEqual(["https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s"]);
+    });
+  });
+});

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -18,6 +18,14 @@ export {
 } from "./analyze";
 
 export { markdownToHtml, astToMarkdown, formatMarkdown, type RenderOptions } from "./render";
+export {
+  youtubeVideoFrom,
+  youtubeEmbedUrl,
+  youtubeWatchUrl,
+  isYoutubeUrl,
+  YOUTUBE_EMBED_ORIGIN,
+  type YoutubeVideo,
+} from "./youtube";
 
 export {
   extractWikilinks,

--- a/packages/markdown-engine/src/render.ts
+++ b/packages/markdown-engine/src/render.ts
@@ -12,6 +12,7 @@ import { visit } from "unist-util-visit";
 import type { Root as MdastRoot, Text as MdastText, PhrasingContent, Parent } from "mdast";
 import type { Root as HastRoot, Element } from "hast";
 import { remarkWikilink, type WikilinkResolver } from "./wikilinks";
+import { youtubeEmbedUrl, youtubeVideoFrom, YOUTUBE_EMBED_ORIGIN } from "./youtube";
 
 /**
  * Markdown → HTML rendering.
@@ -76,12 +77,31 @@ const schema: SanitizeSchema = {
     // `loading` keeps a note full of screenshots from fetching every one of
     // them at once; the rest are what the default schema already allows.
     img: [...(defaultSchema.attributes?.img ?? []), ["loading", "lazy"]],
+    /**
+     * The video player, and nothing else.
+     *
+     * An iframe is the one element in this schema that can load a whole other
+     * document, so `src` is pinned to the embed path of the player origin by
+     * pattern rather than allowed as a URL. Note content cannot reach this
+     * anyway — inline HTML in a note is escaped, never parsed — so the only
+     * iframes in the tree are the ones the pass below built. The rule is here
+     * because "the sanitiser would have caught it" should stay true.
+     */
+    iframe: [
+      ["src", new RegExp(`^${YOUTUBE_EMBED_ORIGIN.replace(/[.]/g, "\\.")}/embed/`)],
+      "title",
+      ["loading", "lazy"],
+      "allow",
+      "allowFullScreen",
+      "referrerPolicy",
+      ["className", "fl-embed-frame"],
+    ],
     "*": [...(defaultSchema.attributes?.["*"] ?? []), "id"],
   },
   // `mark` is what `==highlight==` becomes. The editor has always offered
   // highlighting; without this the preview showed the equals signs as literal
   // text, so the button appeared to do nothing.
-  tagNames: [...(defaultSchema.tagNames ?? []), "input", "mark"],
+  tagNames: [...(defaultSchema.tagNames ?? []), "input", "mark", "iframe"],
   protocols: {
     ...defaultSchema.protocols,
     // Notes written offline embed their images inline, so `data:` has to
@@ -191,6 +211,53 @@ function rehypeImages(options: RenderOptions) {
   };
 }
 
+/**
+ * A paragraph that is only a YouTube link becomes the video.
+ *
+ * The rule is deliberately narrow — the link has to be the whole paragraph —
+ * so a sentence that mentions a video stays a sentence with a link in it, and
+ * the writer keeps a way to link to a video without embedding it.
+ *
+ * Nothing about the markdown changes: the file still holds a plain link, which
+ * is what makes the note read correctly on github.com and everywhere else.
+ */
+function rehypeYoutube() {
+  return (tree: HastRoot) => {
+    visit(tree, "element", (node: Element) => {
+      if (node.tagName !== "p") return;
+
+      const children = node.children.filter(
+        (child) => child.type !== "text" || child.value.trim() !== "",
+      );
+      const only = children.length === 1 ? children[0] : undefined;
+      if (!only || only.type !== "element" || only.tagName !== "a") return;
+
+      const href = typeof only.properties?.href === "string" ? only.properties.href : "";
+      const video = youtubeVideoFrom(href);
+      if (!video) return;
+
+      node.tagName = "div";
+      node.properties = { className: ["fl-embed"] };
+      node.children = [
+        {
+          type: "element",
+          tagName: "iframe",
+          properties: {
+            src: youtubeEmbedUrl(video),
+            title: "YouTube video player",
+            className: ["fl-embed-frame"],
+            loading: "lazy",
+            allow: "accelerometer; encrypted-media; picture-in-picture; web-share; fullscreen",
+            allowFullScreen: true,
+            referrerPolicy: "strict-origin-when-cross-origin",
+          },
+          children: [],
+        },
+      ];
+    });
+  };
+}
+
 const buildHtmlPipeline = (options: RenderOptions) =>
   unified()
     .use(remarkParse)
@@ -229,6 +296,7 @@ const buildHtmlPipeline = (options: RenderOptions) =>
     // and colours it misleadingly.
     .use(rehypeHighlight, { detect: false, languages: allLanguages })
     .use(rehypeImages, options)
+    .use(rehypeYoutube)
     .use(rehypeSanitize, schema)
     .use(rehypeStringify);
 

--- a/packages/markdown-engine/src/youtube.test.ts
+++ b/packages/markdown-engine/src/youtube.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { youtubeVideoFrom, youtubeEmbedUrl, youtubeWatchUrl } from "./youtube";
+import { markdownToHtml } from "./render";
+
+describe("youtubeVideoFrom", () => {
+  it("reads every shape of link YouTube hands out", () => {
+    const forms = [
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "https://youtube.com/watch?v=dQw4w9WgXcQ&list=PL123",
+      "https://m.youtube.com/watch?v=dQw4w9WgXcQ",
+      "https://youtu.be/dQw4w9WgXcQ",
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "https://www.youtube.com/live/dQw4w9WgXcQ",
+    ];
+
+    for (const url of forms) {
+      expect(youtubeVideoFrom(url), url).toEqual({ id: "dQw4w9WgXcQ" });
+    }
+  });
+
+  it("keeps the start time, written either way", () => {
+    expect(youtubeVideoFrom("https://youtu.be/dQw4w9WgXcQ?t=90")).toEqual({
+      id: "dQw4w9WgXcQ",
+      start: 90,
+    });
+    expect(youtubeVideoFrom("https://youtu.be/dQw4w9WgXcQ?t=1m30s")).toEqual({
+      id: "dQw4w9WgXcQ",
+      start: 90,
+    });
+  });
+
+  it("refuses a host that merely starts with youtube's", () => {
+    expect(youtubeVideoFrom("https://youtube.com.evil.example/watch?v=dQw4w9WgXcQ")).toBeNull();
+    expect(youtubeVideoFrom("https://notyoutube.com/watch?v=dQw4w9WgXcQ")).toBeNull();
+    expect(youtubeVideoFrom("javascript:alert(1)//youtube.com/watch?v=dQw4w9WgXcQ")).toBeNull();
+  });
+
+  it("refuses a link that names no video", () => {
+    expect(youtubeVideoFrom("https://www.youtube.com/")).toBeNull();
+    expect(youtubeVideoFrom("https://www.youtube.com/watch?v=short")).toBeNull();
+    expect(youtubeVideoFrom("https://www.youtube.com/@somechannel")).toBeNull();
+  });
+
+  it("round trips through the watch URL", () => {
+    const video = youtubeVideoFrom("https://youtu.be/dQw4w9WgXcQ?t=42")!;
+    expect(youtubeWatchUrl(video)).toBe("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s");
+    expect(youtubeEmbedUrl(video)).toBe(
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0&start=42",
+    );
+  });
+});
+
+describe("rendering a video", () => {
+  it("embeds a link that is a paragraph of its own", () => {
+    const html = markdownToHtml("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    expect(html).toContain("<iframe");
+    expect(html).toContain("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ");
+    expect(html).toContain('class="fl-embed"');
+  });
+
+  it("embeds a written-out link too", () => {
+    const html = markdownToHtml("[Never gonna](https://youtu.be/dQw4w9WgXcQ)");
+    expect(html).toContain("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ");
+  });
+
+  it("leaves a link inside a sentence alone", () => {
+    const html = markdownToHtml("See https://youtu.be/dQw4w9WgXcQ for the demo.");
+    expect(html).not.toContain("<iframe");
+    expect(html).toContain("<a href");
+  });
+
+  it("never frames anything but the player", () => {
+    // Inline HTML in a note is escaped rather than parsed, and the sanitiser
+    // is the second lock on the same door.
+    const html = markdownToHtml('<iframe src="https://evil.example/"></iframe>');
+    expect(html).not.toContain("evil.example");
+  });
+});

--- a/packages/markdown-engine/src/youtube.ts
+++ b/packages/markdown-engine/src/youtube.ts
@@ -1,0 +1,119 @@
+/**
+ * Recognising YouTube links, so a note can show the video rather than a URL.
+ *
+ * The note itself never stops being portable markdown: a video is written as
+ * an ordinary link on a line of its own, which is what GitHub, an IDE or any
+ * other markdown tool shows — a link. Only the surfaces that can afford an
+ * iframe, the editor and the preview, upgrade it to a player. Nothing is
+ * written to the file that another tool would fail to understand.
+ */
+
+/** A video, and where in it to start. */
+export interface YoutubeVideo {
+  /** The eleven-character video id. */
+  id: string;
+  /** Seconds into the video to start at, when the link asked for one. */
+  start?: number;
+}
+
+/** Every host YouTube hands out links for. */
+const HOSTS = new Set([
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+  "music.youtube.com",
+  "youtube-nocookie.com",
+  "www.youtube-nocookie.com",
+  "youtu.be",
+  "www.youtu.be",
+]);
+
+/** Paths that carry the id as their last segment rather than as `?v=`. */
+const ID_IN_PATH = /^\/(embed|shorts|live|v|e)\/([A-Za-z0-9_-]{11})/;
+
+const ID = /^[A-Za-z0-9_-]{11}$/;
+
+/**
+ * `1h2m30s`, `90s` or plain `90` → seconds.
+ *
+ * YouTube writes the first form in a "share from here" link and the last in
+ * an `?start=`, and both end up in notes.
+ */
+function secondsFrom(value: string | null): number | undefined {
+  if (!value) return undefined;
+
+  if (/^\d+$/.test(value)) return Number(value);
+
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(value);
+  if (!match || !match.slice(1).some(Boolean)) return undefined;
+
+  const [, hours, minutes, seconds] = match;
+  return Number(hours ?? 0) * 3600 + Number(minutes ?? 0) * 60 + Number(seconds ?? 0);
+}
+
+/**
+ * The video a URL points at, or null for anything that is not one.
+ *
+ * Parsed with `URL` rather than matched with one big regular expression: the
+ * host has to be compared as a host, or `https://youtube.com.attacker.example`
+ * reads as a YouTube link and we would frame a stranger's page.
+ */
+export function youtubeVideoFrom(url: string): YoutubeVideo | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+  if (!HOSTS.has(parsed.hostname.toLowerCase())) return null;
+
+  const start = secondsFrom(parsed.searchParams.get("t") ?? parsed.searchParams.get("start"));
+
+  const inPath = ID_IN_PATH.exec(parsed.pathname);
+  if (inPath) return video(inPath[2]!, start);
+
+  if (parsed.hostname.toLowerCase().endsWith("youtu.be")) {
+    const id = parsed.pathname.slice(1).split("/")[0] ?? "";
+    return ID.test(id) ? video(id, start) : null;
+  }
+
+  if (parsed.pathname === "/watch") {
+    const id = parsed.searchParams.get("v") ?? "";
+    return ID.test(id) ? video(id, start) : null;
+  }
+
+  return null;
+}
+
+function video(id: string, start: number | undefined): YoutubeVideo {
+  return start && start > 0 ? { id, start } : { id };
+}
+
+/** True for a URL that names a YouTube video. */
+export function isYoutubeUrl(url: string): boolean {
+  return youtubeVideoFrom(url) !== null;
+}
+
+/** Where the player is loaded from. */
+export const YOUTUBE_EMBED_ORIGIN = "https://www.youtube-nocookie.com";
+
+/**
+ * The player URL for a video.
+ *
+ * `youtube-nocookie.com` because embedding the ordinary domain drops tracking
+ * cookies on every reader of a note that happens to contain a video, which is
+ * not a thing a notes app should do on their behalf.
+ */
+export function youtubeEmbedUrl(video: YoutubeVideo): string {
+  const params = new URLSearchParams({ rel: "0" });
+  if (video.start) params.set("start", String(video.start));
+  return `${YOUTUBE_EMBED_ORIGIN}/embed/${video.id}?${params.toString()}`;
+}
+
+/** The canonical watch URL, which is what gets written into the markdown. */
+export function youtubeWatchUrl(video: YoutubeVideo): string {
+  const base = `https://www.youtube.com/watch?v=${video.id}`;
+  return video.start ? `${base}&t=${video.start}s` : base;
+}


### PR DESCRIPTION
## Summary

This PR fixes the image paste bug and adds YouTube video embedding — both built on the same principle: the note stays plain, portable markdown, and only the surfaces that can afford richer rendering upgrade what they draw.

---

## 🐛 Bug Fix: Pasted images now appear instantly

### What was happening
When pasting a screenshot into the rich editor, the image showed as broken alt text (e.g. `img2324` or the filename) instead of the actual image. Switching to Source mode and back to Rich mode made it appear — but that is not something anyone should have to do.

### Root cause
A race condition between React state batching and ProseMirror node creation:

1. `bridge.upload(file)` stores the image locally and calls `setAssetUrls()` — a **React state update**
2. Because the upload is `await`ed, React processes the batched state update **during the yield**, before `insertImages` resumes
3. The `useEffect` that notifies all resolve listeners fires — but the **listener set is empty** because the image node has not been created yet
4. `insertImages` resumes, creates the ProseMirror node, dispatches the transaction
5. The node view is created, calls `paint()` with a **stale** resolver answer (the proxy URL, which 404s because the image has not been pushed to GitHub yet)
6. The node view registers its `paint()` listener in `resolveListeners`
7. **No more React re-renders happen** → `paint()` is never called again with the correct blob URL

### Fix
After inserting all image nodes, explicitly fire all resolve listeners. By that point the node views exist and have registered their `paint()` callbacks, so they re-ask the resolver — which already has the correct blob URL from the earlier `setAssetUrls` call — and the image appears immediately.

**One line of logic. Zero new dependencies. Zero side effects on other code paths.**

---

## ✨ Feature: YouTube video embedding

### Design
Notes can now embed YouTube videos while staying 100% portable markdown:

| Layer | What it sees |
|-------|-------------|
| **Markdown file** | A plain YouTube watch URL on its own line |
| **GitHub / IDE / Obsidian** | A clickable link (GFM autolinks it) |
| **ForkLeaf rich editor** | An interactive iframe player |
| **ForkLeaf preview** | An interactive iframe player |

A link *inside* a sentence stays a link — the embed rule only fires when the link is the entire paragraph.

### Privacy
Embeds use `youtube-nocookie.com`, which does not drop tracking cookies on readers.

### How to use
- **Paste**: Paste a YouTube URL into an empty line → auto-converts to a player
- **Slash menu**: Type `/youtube` → prompted for a URL → inserts the embed
- **Manual**: Write the URL on its own line in Source mode

### Implementation

**`@forkleaf/markdown-engine`**
- `youtube.ts` — URL parsing (`youtubeVideoFrom`), embed/watch URL generation, security validation (host must be in an exact allowlist, not just start with "youtube")
- `render.ts` — `rehypeYoutube` plugin converts standalone YouTube links to iframes in the preview; sanitiser pins `iframe[src]` to `youtube-nocookie.com/embed/` by regex

**`@forkleaf/editor`**
- `YoutubeEmbed.tsx` — TipTap Node extension: atomic ReactNodeView with 16:9 iframe, paste plugin for auto-conversion, markdown serialize (write the watch URL) and parse (detect link-only paragraphs)
- `insert-actions.tsx` — `/youtube` slash command with URL validation

**`apps/web`**
- `globals.css` — `.fl-embed` responsive 16:9 styles
- `writing.tsx` — Documentation for the feature

---

## Tests

**15 new tests**, all passing:

| File | Tests | Covers |
|------|-------|--------|
| `youtube.test.ts` | 9 | URL parsing, all link shapes, start times, security against attacker domains, embed URL generation, HTML rendering |
| `youtube-embed.test.tsx` | 4 | Rich-text parse from markdown, serialize back, inline link preservation, paste handling |
| `pasted-image.test.tsx` | 2 | Image appears after resolve, markdown stays pointing at the path |

---

## Files changed (13)

| File | Change |
|------|--------|
| `packages/editor/src/WysiwygEditor.tsx` | Fix: fire resolve listeners after image insertion |
| `packages/editor/src/extensions/YoutubeEmbed.tsx` | **New**: TipTap YouTube node extension |
| `packages/editor/src/extensions/ResolvedImage.ts` | Minor: ensure block serialisation closes properly |
| `packages/editor/src/insert-actions.tsx` | Add `/youtube` slash command |
| `packages/editor/src/index.ts` | Export `YoutubeEmbed` |
| `packages/markdown-engine/src/youtube.ts` | **New**: YouTube URL parsing and embed generation |
| `packages/markdown-engine/src/render.ts` | Add `rehypeYoutube` plugin and iframe sanitiser rules |
| `packages/markdown-engine/src/index.ts` | Export YouTube utilities |
| `apps/web/src/app/globals.css` | `.fl-embed` responsive 16:9 styles |
| `apps/web/src/app/docs/content/writing.tsx` | Documentation for the YouTube feature |
| `packages/editor/src/pasted-image.test.tsx` | **New**: Tests for image paste |
| `packages/editor/src/youtube-embed.test.tsx` | **New**: Tests for YouTube in rich editor |
| `packages/markdown-engine/src/youtube.test.ts` | **New**: Tests for YouTube URL parsing and rendering |