### PR TITLE
fix: commit pasted images to the same path the markdown references

### DIFF
--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -183,7 +183,11 @@ export function EditorWorkspace() {
         // Pushed in the background. A failure here is worth saying out loud —
         // the note renders either way, so silence would leave someone
         // believing an image had been committed when it had not.
-        void uploadImage({ workspace, notePath, file, taken: takenPaths })
+        // The repoPath computed above is passed through so that the file
+        // committed to GitHub lands at the same path the markdown references.
+        // Without it, uploadImage recomputed a new random filename and the
+        // note pointed at a file that did not exist on GitHub.
+        void uploadImage({ workspace, notePath, file, taken: takenPaths, repoPath })
           .then(() => notebook.putAsset(repoPath, file, true))
           .catch((error: unknown) => {
             notebook.reportError(

--- a/apps/web/src/lib/assets.ts
+++ b/apps/web/src/lib/assets.ts
@@ -190,6 +190,10 @@ export async function uploadImage(options: {
   notePath: string;
   file: File;
   taken: Iterable<string>;
+  /** When supplied, the file is committed at this path instead of computing a
+   *  new one. The caller already chose a path for local storage and wrote it
+   *  into the markdown, so the GitHub commit must land at the same place. */
+  repoPath?: string;
 }): Promise<UploadedImage> {
   const { workspace, notePath, file, taken } = options;
 
@@ -197,7 +201,9 @@ export async function uploadImage(options: {
     throw new Error("That image is larger than 10 MB.");
   }
 
-  const repoPath = assetPathFor(workspace, file, taken);
+  // Use the caller's path when one was supplied, so the file on GitHub
+  // matches the path already written into the note's markdown.
+  const repoPath = options.repoPath ?? assetPathFor(workspace, file, taken);
   const content = await readAsBase64(file);
 
   const response = await fetch("/api/gh/asset", {


### PR DESCRIPTION
## Summary

This fixes the bug where images pasted in the editor work locally but appear as broken links on GitHub.

**The Bug:**
The image upload pipeline was calling `assetPathFor()` a second time when committing the image to GitHub, which generated a new random timestamped filename (e.g. `...xyz9.png`). The markdown file, however, was already updated to point at the path from the *first* call (e.g. `...abc1.png`). The images worked locally because they were read from the browser's blob cache, but on GitHub, the file `...abc1.png` did not exist.

**The Fix:**
Passed the already-computed `repoPath` from the caller (`EditorWorkspace`) directly into the `uploadImage` function, so the image is committed to GitHub at the exact same path that the markdown file references.