### PR TITLE
feat: sync error details, PDF fixes & unused asset cleanup

### DIFF
--- a/apps/web/src/components/EditorStatusBar.tsx
+++ b/apps/web/src/components/EditorStatusBar.tsx
@@ -182,8 +182,8 @@ function describe(sync: SyncState): { label: string; className: string; dot: str
 
     case "error":
       return {
-        label: "Couldn't sync — click to retry",
-        className: "text-[var(--fl-danger)]",
+        label: `Couldn't sync: ${sync.lastError ?? "Unknown error"} — click to retry`,
+        className: "text-[var(--fl-danger)] truncate max-w-[500px]",
         dot: "bg-[var(--fl-danger)]",
       };
 

--- a/packages/exporter/src/index.ts
+++ b/packages/exporter/src/index.ts
@@ -153,7 +153,7 @@ export async function printToPdf(
   const frame = document.createElement("iframe");
   frame.setAttribute("aria-hidden", "true");
   frame.style.cssText =
-    "position:fixed;right:0;bottom:0;width:0;height:0;border:0;visibility:hidden";
+    "position:absolute;top:-10000px;left:-10000px;width:1px;height:1px;border:0;";
   document.body.appendChild(frame);
 
   const doc = frame.contentDocument;
@@ -168,8 +168,22 @@ export async function printToPdf(
 
   await new Promise<void>((resolve) => {
     // Wait for fonts and inline SVGs to settle, or the first page prints blank.
-    if (doc.readyState === "complete") resolve();
-    else frame.onload = () => resolve();
+    if (doc.readyState === "complete") {
+      resolve();
+    } else {
+      // frame.onload doesn't always fire reliably for doc.write().
+      const fallback = setTimeout(resolve, 1500);
+      frame.onload = () => {
+        clearTimeout(fallback);
+        resolve();
+      };
+      doc.addEventListener("readystatechange", () => {
+        if (doc.readyState === "complete") {
+          clearTimeout(fallback);
+          resolve();
+        }
+      });
+    }
   });
 
   // And for the images to decode. They are `data:` URLs so nothing is
@@ -177,14 +191,28 @@ export async function printToPdf(
   // produces a PDF with gaps where the pictures should be, which is the exact
   // failure this export is meant to have stopped having.
   await Promise.all(
-    Array.from(doc.images).map((image) =>
-      image.complete
-        ? Promise.resolve()
-        : new Promise<void>((resolve) => {
-            image.addEventListener("load", () => resolve(), { once: true });
-            image.addEventListener("error", () => resolve(), { once: true });
-          }),
-    ),
+    Array.from(doc.images).map((image) => {
+      if (image.complete) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        const fallback = setTimeout(resolve, 3000);
+        image.addEventListener(
+          "load",
+          () => {
+            clearTimeout(fallback);
+            resolve();
+          },
+          { once: true },
+        );
+        image.addEventListener(
+          "error",
+          () => {
+            clearTimeout(fallback);
+            resolve();
+          },
+          { once: true },
+        );
+      });
+    }),
   );
   await new Promise((r) => setTimeout(r, 150));
 

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -6,6 +6,8 @@ import {
   joinPath,
   slugifyFilename,
   uniquePath,
+  dirname,
+  normalizePath,
 } from "@forkleaf/markdown-engine";
 import type { LocalDatabase, RemoteGateway } from "./ports";
 import type { SyncEngine } from "./sync-engine";
@@ -258,7 +260,21 @@ export class NoteRepository {
 
   async deleteNote(note: Note): Promise<void> {
     const current = await this.db.getNote(note.id);
-    await this.sync.recordDelete(current ?? note);
+    const target = current ?? note;
+    await this.sync.recordDelete(target);
+
+    // Clean up assets referenced by this note so they don't linger on GitHub.
+    const matches = Array.from(target.content.matchAll(/!\[.*?\]\(([^)]+)\)/g));
+    for (const match of matches) {
+      const src = match[1];
+      // Simple check to ensure it's a repo-relative path, not an external URL.
+      if (!/^[a-z][a-z0-9+.-]*:/i.test(src) && !src.startsWith("//") && !src.startsWith("/")) {
+        const assetPath = normalizePath(`${dirname(target.path)}/${src}`);
+        await this.sync.recordAssetDelete(target.workspaceId, assetPath);
+        // Clean up from local IDB cache too.
+        await this.db.deleteAsset(`${target.workspaceId}::${assetPath}`);
+      }
+    }
   }
 
   async renameNote(note: Note, toPath: string): Promise<Note> {

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -36,7 +36,7 @@ export interface NoteRepositoryOptions {
  * frontmatter as a table above the document, so this is both a credit and the
  * most direct route from someone else's repository back to the project.
  */
-const GENERATOR = "ForkLeaf — https://github.com/praneeth132006/ForkLeaf";
+const GENERATOR = "forkleaf.vercel.app";
 
 /**
  * The API the UI actually talks to.

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -267,6 +267,7 @@ export class NoteRepository {
     const matches = Array.from(target.content.matchAll(/!\[.*?\]\(([^)]+)\)/g));
     for (const match of matches) {
       const src = match[1];
+      if (!src) continue;
       // Simple check to ensure it's a repo-relative path, not an external URL.
       if (!/^[a-z][a-z0-9+.-]*:/i.test(src) && !src.startsWith("//") && !src.startsWith("/")) {
         const assetPath = normalizePath(`${dirname(target.path)}/${src}`);

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -268,6 +268,19 @@ export class SyncEngine {
     this.scheduleFlush();
   }
 
+  async recordAssetDelete(workspaceId: string, path: string): Promise<void> {
+    this.queue = coalesce(this.queue, {
+      workspaceId,
+      path,
+      op: "delete",
+      baseSha: null,
+      now: this.now().toISOString(),
+    });
+
+    await this.persistQueue();
+    this.scheduleFlush();
+  }
+
   async recordRename(note: Note, toPath: string, fileContent: string): Promise<void> {
     await this.db.deleteNote(note.id);
     await this.db.putNote({


### PR DESCRIPTION
## Summary

When deleting a folder or a note in the editor, the `.md` files were correctly deleted from GitHub, but any uploaded images (assets) referenced by those notes were left behind, permanently cluttering the repository.

This PR adds logic so that when a note is deleted, we parse its markdown to find any repo-relative asset links (`![alt](assets/...)`). We then explicitly queue a delete operation for those asset paths so they are cleaned up from GitHub alongside the note.

## Update: Generator Frontmatter
Also changed the `generator` frontmatter credit from the full GitHub URL to just `forkleaf.vercel.app` per your request.

## Update: PDF Export Fixes
Fixed the PDF export option that was silently failing or hanging in some browsers (like Safari and Firefox).
1. Replaced the `visibility: hidden` iframe style with off-screen positioning (a known workaround for browser print-engine bugs where hidden iframes refuse to print).
2. Added fallback timeouts to the `readyState` and image-loading promises so the export won't hang indefinitely if the browser refuses to fire load events for elements inside a print frame.

## Update: Sync Error Details in Status Bar
Updated the editor status bar to display the actual error message when a sync fails, rather than a generic "Couldn't sync" label, so users can see exactly why the sync failed (e.g., rate limits, network errors) directly in the UI.