### PR TITLE
fix(notes): keep images working when a note moves, and get them into exports

### DIFF
--- a/apps/web/src/app/api/gh/tree/route.ts
+++ b/apps/web/src/app/api/gh/tree/route.ts
@@ -1,12 +1,22 @@
 import { type NextRequest } from "next/server";
 import { handle, requireClient, readRepoRef } from "@/lib/api-helpers";
 
-/** Returns the markdown file tree for a workspace. */
+/**
+ * Returns the file tree for a workspace.
+ *
+ * Markdown only by default — that is the notebook, and a repository can hold a
+ * great deal that is not one. `all=1` asks for every file, which is what the
+ * link repair needs: it can only find the image a broken note meant if it can
+ * see the images.
+ */
 export async function GET(request: NextRequest) {
   return handle(async () => {
     const { client } = await requireClient();
-    const repo = readRepoRef(new URL(request.url).searchParams);
+    const params = new URL(request.url).searchParams;
+    const repo = readRepoRef(params);
 
-    return { tree: await client.listTree(repo) };
+    const markdownOnly = params.get("all") !== "1";
+
+    return { tree: await client.listTree(repo, { markdownOnly }) };
   });
 }

--- a/apps/web/src/app/docs/content/writing.tsx
+++ b/apps/web/src/app/docs/content/writing.tsx
@@ -125,6 +125,14 @@ export function Editor() {
         You can also link to an image already on the web. Those are stored as the URL you give,
         untouched.
       </P>
+      <P>
+        Moving a note takes its images with it. The link in the file is relative to where the note
+        sits — that is what makes it work on github.com — so ForkLeaf rewrites those links as part
+        of the move; the image files themselves stay where they are, since other notes may be using
+        them. If a note written before this still shows broken images, run{" "}
+        <strong>Find this note&rsquo;s missing images</strong> from <Code>⌘K</Code>: it searches the
+        repository for the files by name and repoints the ones it can identify with certainty.
+      </P>
 
       <H2 id="videos">YouTube videos</H2>
       <P>

--- a/apps/web/src/components/ExportDialog.tsx
+++ b/apps/web/src/components/ExportDialog.tsx
@@ -63,7 +63,11 @@ export function ExportDialog({
         const notes = await loadAllNotes();
         if (notes.length === 0) throw new Error("There are no notes to export yet.");
 
-        downloadResult(await exportWorkspace(notes, bulkFormat, options, images));
+        downloadResult(
+          await exportWorkspace(notes, bulkFormat, options, (each) =>
+            exportImageResolver(workspace, each.path, assetUrls),
+          ),
+        );
       } else if (format === "pdf") {
         // Goes through the browser's print pipeline so the PDF has real,
         // selectable text rather than a rasterised page.

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -37,6 +37,7 @@ import { BootScreen } from "@/components/BootScreen";
 import { LocalOnlyBanner } from "@/components/LocalOnlyBanner";
 import { signOut } from "@/lib/gateway";
 import { assetPathFor, relativeSrc, resolveImageSrc, uploadImage } from "@/lib/assets";
+import { repairNoteLinks } from "@/lib/repair-links";
 import { flattenTree, isMarkdown } from "@/lib/library";
 import { track } from "@/lib/firebase/analytics";
 import { upsertUserProfile } from "@/lib/firebase/users";
@@ -481,6 +482,52 @@ export function EditorWorkspace() {
     [notebook],
   );
 
+  /**
+   * Points a note's broken images back at the files they meant.
+   *
+   * Notes written before images were filed beside the note that uses them —
+   * or moved to another folder by a version of this app that did not carry
+   * their links along — refer to paths that hold nothing, and every picture in
+   * them is a broken box here and on github.com. The files are still in the
+   * repository; only the link is wrong, and that is repairable.
+   *
+   * Offered as a command rather than done silently on open: it rewrites the
+   * note, which is a commit, and a commit nobody asked for is not something an
+   * editor should be making on its own.
+   */
+  const repairImages = useCallback(async () => {
+    const note = notebook.note;
+    if (!workspace || !note) return;
+
+    if (workspace.isLocal) {
+      notebook.reportError("Connect a repository first — there is nowhere to look for the files.");
+      return;
+    }
+
+    try {
+      const result = await repairNoteLinks(workspace, note.path, note.content);
+
+      if (result.fixed.length === 0) {
+        notebook.reportError(
+          result.unresolved.length > 0
+            ? `Nothing in the repository matches ${result.unresolved.length === 1 ? "that link" : "those links"}: ${result.unresolved.slice(0, 3).join(", ")}`
+            : "Every image in this note already points at a file that exists.",
+        );
+        return;
+      }
+
+      await notebook.saveNote(result.content);
+      notebook.reportError(
+        `Repointed ${result.fixed.length} ${result.fixed.length === 1 ? "image" : "images"}` +
+          (result.unresolved.length > 0 ? `; ${result.unresolved.length} still not found.` : "."),
+      );
+    } catch (error) {
+      notebook.reportError(
+        error instanceof Error ? error.message : "Those images could not be looked up.",
+      );
+    }
+  }, [notebook, workspace]);
+
   const handleSignOut = useCallback(async () => {
     await signOut();
     router.push("/");
@@ -527,6 +574,13 @@ export function EditorWorkspace() {
         hint: "⌘S",
         keywords: "commit save upload",
         run: () => void notebook.syncNow(),
+      },
+      {
+        id: "repair-images",
+        label: "Find this note's missing images",
+        group: "Notes",
+        keywords: "broken image link repair fix missing picture",
+        run: () => void repairImages(),
       },
       {
         id: "connect",
@@ -663,6 +717,7 @@ export function EditorWorkspace() {
     currentFolder,
     handleRename,
     handleDelete,
+    repairImages,
     localFiles,
   ]);
 

--- a/apps/web/src/lib/repair-links.ts
+++ b/apps/web/src/lib/repair-links.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { flattenTree } from "@/lib/library";
+import type { TreeNode, Workspace } from "@forkleaf/types";
+import { repairRelativeLinks, type LinkRepair } from "@forkleaf/markdown-engine";
+
+/**
+ * Finding the images a note has lost track of.
+ *
+ * A note refers to its pictures by a path relative to itself. That is what
+ * makes it render on github.com — and it means a note whose links were written
+ * somewhere else, before it was moved or before images were filed beside the
+ * note that uses them, points at files that are not there. Every image in it is
+ * a broken box, in this app and on GitHub, even though the files are still in
+ * the repository a folder or two away.
+ *
+ * Repairing that needs to see the whole repository, not just the notes in it,
+ * so this asks for the full tree rather than the markdown-only one the sidebar
+ * is built from.
+ */
+export async function repairNoteLinks(
+  workspace: Workspace,
+  notePath: string,
+  content: string,
+): Promise<LinkRepair> {
+  const params = new URLSearchParams({
+    owner: workspace.repo.owner,
+    repo: workspace.repo.repo,
+    branch: workspace.repo.branch,
+    all: "1",
+  });
+  if (workspace.repo.directory) params.set("dir", workspace.repo.directory);
+
+  const response = await fetch(`/api/gh/tree?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error("Could not read the repository to find those images.");
+  }
+
+  const { tree } = (await response.json()) as { tree: TreeNode[] };
+  return repairRelativeLinks(content, notePath, flattenTree(tree));
+}

--- a/packages/exporter/src/docx-images.test.ts
+++ b/packages/exporter/src/docx-images.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { toDocx } from "./docx";
+
+/**
+ * A one-pixel PNG, and a browser that can measure it.
+ *
+ * jsdom does not load images, so `Image` is stood in for — the thing under
+ * test is what the exporter does with a picture it has, not jsdom's ability to
+ * decode one.
+ */
+const PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+function stubImage(width: number, height: number) {
+  class FakeImage {
+    naturalWidth = width;
+    naturalHeight = height;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_value: string) {
+      setTimeout(() => this.onload?.(), 0);
+    }
+  }
+  vi.stubGlobal("Image", FakeImage);
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+/** The bytes of a .docx are a zip; the image lands in it as its own part. */
+async function partNames(blob: Blob): Promise<string> {
+  return new TextDecoder("latin1").decode(await blob.arrayBuffer());
+}
+
+describe("images in a Word export", () => {
+  it("embeds the picture rather than writing its filename", async () => {
+    stubImage(1200, 600);
+
+    const blob = await toDocx("# Notes\n\n![55511.png](./assets/a.png)", "Notes", async () => PNG);
+    const contents = await partNames(blob);
+
+    // A media part exists, and the alt text is no longer standing in for it.
+    expect(contents).toContain("word/media/");
+  });
+
+  it("still writes the alt text when the bytes cannot be found", async () => {
+    stubImage(10, 10);
+
+    const blob = await toDocx("![55511.png](./assets/a.png)", "Notes", async () => null);
+    const contents = await partNames(blob);
+
+    expect(contents).not.toContain("word/media/");
+  });
+
+  it("exports without a resolver at all", async () => {
+    const blob = await toDocx("![a](./assets/a.png)", "Notes");
+    expect(blob.size).toBeGreaterThan(0);
+  });
+});

--- a/packages/exporter/src/docx.ts
+++ b/packages/exporter/src/docx.ts
@@ -10,9 +10,11 @@ import {
   WidthType,
   AlignmentType,
   ExternalHyperlink,
+  ImageRun,
 } from "docx";
 import { parseToAst } from "@forkleaf/markdown-engine";
 import type { Root, RootContent, PhrasingContent, Heading, List, Table as MdTable } from "mdast";
+import type { ImageResolver } from "./html";
 
 /**
  * Markdown → .docx, entirely in the browser.
@@ -38,12 +40,30 @@ interface InlineStyle {
   code?: boolean;
 }
 
+/** An image, decoded and measured, ready to be placed in the document. */
+interface Picture {
+  data: Uint8Array;
+  type: "png" | "jpg" | "gif" | "bmp";
+  width: number;
+  height: number;
+}
+
+/**
+ * The images found for this document, by the `src` written in the note.
+ *
+ * Word needs the bytes and the size in pixels, neither of which the markdown
+ * carries, so they are gathered before the walk begins and looked up during
+ * it — the tree walk is synchronous and fetching is not.
+ */
+type Pictures = ReadonlyMap<string, Picture>;
+
 /** Flattens inline markdown into styled runs, carrying nested emphasis down. */
 function toRuns(
   nodes: PhrasingContent[],
   style: InlineStyle = {},
-): (TextRun | ExternalHyperlink)[] {
-  const runs: (TextRun | ExternalHyperlink)[] = [];
+  pictures: Pictures = new Map(),
+): (TextRun | ImageRun | ExternalHyperlink)[] {
+  const runs: (TextRun | ImageRun | ExternalHyperlink)[] = [];
 
   for (const node of nodes) {
     switch (node.type) {
@@ -51,13 +71,13 @@ function toRuns(
         runs.push(new TextRun({ text: node.value, ...style }));
         break;
       case "strong":
-        runs.push(...toRuns(node.children, { ...style, bold: true }));
+        runs.push(...toRuns(node.children, { ...style, bold: true }, pictures));
         break;
       case "emphasis":
-        runs.push(...toRuns(node.children, { ...style, italics: true }));
+        runs.push(...toRuns(node.children, { ...style, italics: true }, pictures));
         break;
       case "delete":
-        runs.push(...toRuns(node.children, { ...style, strike: true }));
+        runs.push(...toRuns(node.children, { ...style, strike: true }, pictures));
         break;
       case "inlineCode":
         runs.push(new TextRun({ text: node.value, font: "Consolas", ...style }));
@@ -66,7 +86,7 @@ function toRuns(
         runs.push(
           new ExternalHyperlink({
             link: node.url,
-            children: toRuns(node.children, { ...style }).filter(
+            children: toRuns(node.children, { ...style }, pictures).filter(
               (r): r is TextRun => r instanceof TextRun,
             ),
           }),
@@ -75,14 +95,39 @@ function toRuns(
       case "break":
         runs.push(new TextRun({ break: 1 }));
         break;
-      case "image":
-        // Remote images cannot be fetched and embedded reliably offline, so
-        // the alt text is kept rather than leaving a silent gap.
+      case "image": {
+        /**
+         * The picture itself, when the app could find its bytes.
+         *
+         * A Word document that says "[image]" where the screenshots were is
+         * not an export of the note, it is a description of one — and the alt
+         * text a pasted screenshot carries is its filename, so what actually
+         * appeared in the document was a column of numbers.
+         *
+         * The alt text is still the fallback, for an image whose bytes are
+         * nowhere to be found. It is honest; it is just no longer the plan.
+         */
+        const picture = pictures.get(node.url);
+        if (picture) {
+          runs.push(
+            new ImageRun({
+              type: picture.type,
+              data: picture.data,
+              transformation: { width: picture.width, height: picture.height },
+              ...(node.alt
+                ? { altText: { name: node.alt, description: node.alt, title: node.alt } }
+                : {}),
+            }),
+          );
+          break;
+        }
+
         runs.push(new TextRun({ text: node.alt ?? "[image]", italics: true }));
         break;
+      }
       default:
         if ("children" in node && Array.isArray(node.children)) {
-          runs.push(...toRuns(node.children as PhrasingContent[], style));
+          runs.push(...toRuns(node.children as PhrasingContent[], style, pictures));
         }
     }
   }
@@ -90,7 +135,7 @@ function toRuns(
   return runs;
 }
 
-function listParagraphs(list: List, depth = 0): (Paragraph | Table)[] {
+function listParagraphs(list: List, pictures: Pictures, depth = 0): (Paragraph | Table)[] {
   const paragraphs: (Paragraph | Table)[] = [];
 
   for (const item of list.children) {
@@ -103,7 +148,10 @@ function listParagraphs(list: List, depth = 0): (Paragraph | Table)[] {
     if (first?.type === "paragraph") {
       paragraphs.push(
         new Paragraph({
-          children: [...(prefix ? [new TextRun({ text: prefix })] : []), ...toRuns(first.children)],
+          children: [
+            ...(prefix ? [new TextRun({ text: prefix })] : []),
+            ...toRuns(first.children, {}, pictures),
+          ],
           ...(list.ordered
             ? { numbering: { reference: "forkleaf-ordered", level: depth } }
             : { bullet: { level: depth } }),
@@ -112,15 +160,15 @@ function listParagraphs(list: List, depth = 0): (Paragraph | Table)[] {
     }
 
     for (const child of rest) {
-      if (child.type === "list") paragraphs.push(...listParagraphs(child, depth + 1));
-      else paragraphs.push(...blockToParagraphs(child));
+      if (child.type === "list") paragraphs.push(...listParagraphs(child, pictures, depth + 1));
+      else paragraphs.push(...blockToParagraphs(child, pictures));
     }
   }
 
   return paragraphs;
 }
 
-function tableToDocx(node: MdTable): Table {
+function tableToDocx(node: MdTable, pictures: Pictures): Table {
   return new Table({
     width: { size: 100, type: WidthType.PERCENTAGE },
     rows: node.children.map(
@@ -132,9 +180,11 @@ function tableToDocx(node: MdTable): Table {
               new TableCell({
                 children: [
                   new Paragraph({
-                    children: toRuns(cell.children as PhrasingContent[], {
-                      bold: rowIndex === 0,
-                    }),
+                    children: toRuns(
+                      cell.children as PhrasingContent[],
+                      { bold: rowIndex === 0 },
+                      pictures,
+                    ),
                     alignment: alignmentFor(node.align?.[cellIndex]),
                   }),
                 ],
@@ -151,24 +201,33 @@ function alignmentFor(align: string | null | undefined) {
   return AlignmentType.LEFT;
 }
 
-function blockToParagraphs(node: RootContent): (Paragraph | Table)[] {
+function blockToParagraphs(node: RootContent, pictures: Pictures): (Paragraph | Table)[] {
   switch (node.type) {
     case "heading": {
       const heading = node as Heading;
       return [
         new Paragraph({
           heading: HEADING_LEVELS[heading.depth - 1],
-          children: toRuns(heading.children),
+          children: toRuns(heading.children, {}, pictures),
           spacing: { before: 240, after: 120 },
         }),
       ];
     }
 
     case "paragraph":
-      return [new Paragraph({ children: toRuns(node.children), spacing: { after: 160 } })];
+      return [
+        new Paragraph({
+          children: toRuns(node.children, {}, pictures),
+          spacing: { after: 160 },
+          // A paragraph that is only a picture reads as a figure, and a figure
+          // belongs in the middle of the page rather than hard against the
+          // left margin.
+          ...(isPictureOnly(node.children, pictures) ? { alignment: AlignmentType.CENTER } : {}),
+        }),
+      ];
 
     case "list":
-      return listParagraphs(node);
+      return listParagraphs(node, pictures);
 
     case "code":
       // Each line becomes its own paragraph so long code does not run off the page.
@@ -183,12 +242,14 @@ function blockToParagraphs(node: RootContent): (Paragraph | Table)[] {
 
     case "blockquote":
       return node.children.flatMap((child) =>
-        blockToParagraphs(child).map((p) =>
+        blockToParagraphs(child, pictures).map((p) =>
           p instanceof Paragraph
             ? new Paragraph({
-                children: toRuns(child.type === "paragraph" ? child.children : [], {
-                  italics: true,
-                }),
+                children: toRuns(
+                  child.type === "paragraph" ? child.children : [],
+                  { italics: true },
+                  pictures,
+                ),
                 indent: { left: 480 },
                 spacing: { after: 160 },
               })
@@ -205,16 +266,35 @@ function blockToParagraphs(node: RootContent): (Paragraph | Table)[] {
       ];
 
     case "table":
-      return [tableToDocx(node)];
+      return [tableToDocx(node, pictures)];
 
     default:
       return [];
   }
 }
 
-/** Converts markdown to a .docx file as a Blob, ready to download. */
-export async function toDocx(markdown: string, title: string): Promise<Blob> {
+/** True for a paragraph holding nothing but one picture we actually have. */
+function isPictureOnly(children: PhrasingContent[], pictures: Pictures): boolean {
+  const meaningful = children.filter((child) => child.type !== "text" || child.value.trim() !== "");
+  const only = meaningful.length === 1 ? meaningful[0] : undefined;
+  return only?.type === "image" && pictures.has(only.url);
+}
+
+/**
+ * Converts markdown to a .docx file as a Blob, ready to download.
+ *
+ * `resolveImage` is how the pictures get in: the note refers to them by a path
+ * relative to itself, which means nothing outside the app, so the caller — the
+ * only part of the system that knows where the bytes live — hands them over.
+ * Without it the document still exports, with alt text where the pictures were.
+ */
+export async function toDocx(
+  markdown: string,
+  title: string,
+  resolveImage?: ImageResolver,
+): Promise<Blob> {
   const tree = parseToAst(markdown) as Root;
+  const pictures = await gatherPictures(tree, resolveImage);
 
   const children: (Paragraph | Table)[] = [
     new Paragraph({
@@ -222,7 +302,7 @@ export async function toDocx(markdown: string, title: string): Promise<Blob> {
       children: [new TextRun({ text: title })],
       spacing: { after: 320 },
     }),
-    ...tree.children.flatMap(blockToParagraphs),
+    ...tree.children.flatMap((node) => blockToParagraphs(node, pictures)),
   ];
 
   const doc = new Document({
@@ -248,4 +328,136 @@ export async function toDocx(markdown: string, title: string): Promise<Blob> {
   });
 
   return Packer.toBlob(doc);
+}
+
+// ─── Pictures ───────────────────────────────────────────────────────────────
+
+/** Widest a picture may be, in pixels: a Word page less its default margins. */
+const CONTENT_WIDTH = 624;
+
+/** Formats Word can hold directly. Anything else is converted first. */
+const NATIVE: Record<string, Picture["type"]> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/bmp": "bmp",
+};
+
+/**
+ * Finds and decodes every image in the document.
+ *
+ * Gathered up front, in parallel, and keyed by the `src` exactly as written in
+ * the note, because the tree walk that builds the document is synchronous.
+ * One unreadable image resolves to nothing and falls back to its alt text
+ * rather than failing an export somebody is waiting on.
+ */
+async function gatherPictures(tree: Root, resolve?: ImageResolver): Promise<Pictures> {
+  const pictures = new Map<string, Picture>();
+  if (!resolve) return pictures;
+
+  const urls = new Set<string>();
+  const walk = (node: RootContent | Root) => {
+    if (node.type === "image") urls.add(node.url);
+    if ("children" in node && Array.isArray(node.children)) {
+      for (const child of node.children) walk(child as RootContent);
+    }
+  };
+  walk(tree);
+  if (urls.size === 0) return pictures;
+
+  await Promise.all(
+    [...urls].map(async (url) => {
+      try {
+        const dataUrl = (await resolve(url)) ?? (url.startsWith("data:") ? url : null);
+        if (!dataUrl) return;
+
+        const picture = await decodePicture(dataUrl);
+        if (picture) pictures.set(url, picture);
+      } catch {
+        // Falls back to alt text; one missing picture is not a failed export.
+      }
+    }),
+  );
+
+  return pictures;
+}
+
+/** A `data:` URL as bytes, a format Word accepts, and a size that fits the page. */
+async function decodePicture(dataUrl: string): Promise<Picture | null> {
+  const match = /^data:([^;,]+)[^,]*,/.exec(dataUrl);
+  if (!match) return null;
+
+  const mime = match[1]!.toLowerCase();
+  // WebP and AVIF are ordinary things to paste and not things Word can read,
+  // so they are re-encoded as PNG through a canvas rather than dropped.
+  const usable = NATIVE[mime] ? dataUrl : await toPng(dataUrl);
+  if (!usable) return null;
+
+  const type = NATIVE[mime] ?? "png";
+  const size = await measure(usable);
+  if (!size) return null;
+
+  const scale = Math.min(1, CONTENT_WIDTH / size.width);
+
+  return {
+    data: bytesOf(usable),
+    type,
+    width: Math.round(size.width * scale),
+    height: Math.round(size.height * scale),
+  };
+}
+
+/** The bytes behind a base64 `data:` URL. */
+function bytesOf(dataUrl: string): Uint8Array {
+  const base64 = dataUrl.slice(dataUrl.indexOf(",") + 1);
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  return bytes;
+}
+
+/** Loads an image to learn its natural size, which the markdown never carries. */
+function measure(dataUrl: string): Promise<{ width: number; height: number } | null> {
+  if (typeof Image === "undefined") return Promise.resolve(null);
+
+  return new Promise((resolve) => {
+    const image = new Image();
+    // Capped: an image that neither loads nor errors must not hold an export
+    // open forever.
+    const fallback = setTimeout(() => resolve(null), 5000);
+    const done = (size: { width: number; height: number } | null) => {
+      clearTimeout(fallback);
+      resolve(size);
+    };
+
+    image.onload = () => done({ width: image.naturalWidth, height: image.naturalHeight });
+    image.onerror = () => done(null);
+    image.src = dataUrl;
+  });
+}
+
+/** Re-encodes an image Word cannot read — WebP, AVIF — as PNG. */
+async function toPng(dataUrl: string): Promise<string | null> {
+  if (typeof document === "undefined" || typeof Image === "undefined") return null;
+
+  const size = await measure(dataUrl);
+  if (!size) return null;
+
+  const image = new Image();
+  const loaded = new Promise<boolean>((resolve) => {
+    image.onload = () => resolve(true);
+    image.onerror = () => resolve(false);
+  });
+  image.src = dataUrl;
+  if (!(await loaded)) return null;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = size.width;
+  canvas.height = size.height;
+
+  const context = canvas.getContext("2d");
+  if (!context) return null;
+
+  context.drawImage(image, 0, 0);
+  return canvas.toDataURL("image/png");
 }

--- a/packages/exporter/src/html.ts
+++ b/packages/exporter/src/html.ts
@@ -127,7 +127,67 @@ export async function toHtml(
 
   if (resolveImage) body = await inlineImages(body, resolveImage);
 
-  return document(options.title, body, options.theme);
+  return document(
+    options.title,
+    forPrinting(withoutRepeatedTitle(body, options.title)),
+    options.theme,
+  );
+}
+
+/**
+ * Drops the note's own opening heading when it repeats the document title.
+ *
+ * Every note here begins `# Its Title`, and the exported document puts that
+ * same title in a header block of its own — because a PDF forwarded in an email
+ * has no filename left to say what it is. The two together meant every export
+ * opened with its title printed twice, one directly under the other, which is
+ * the first thing anybody notices about the file.
+ *
+ * Only an exact match is removed, and only at the very top: a note whose first
+ * heading says something else is saying something else, and keeping it is the
+ * whole point.
+ */
+function withoutRepeatedTitle(html: string, title: string): string {
+  const wanted = normaliseHeading(title);
+  if (!wanted) return html;
+
+  return html.replace(/^\s*<h1\b[^>]*>([\s\S]*?)<\/h1>/i, (whole, inner: string) =>
+    normaliseHeading(stripTags(inner)) === wanted ? "" : whole,
+  );
+}
+
+function stripTags(html: string): string {
+  return html.replace(/<[^>]*>/g, "");
+}
+
+/** Whitespace, case and entity differences are not differences in a title. */
+function normaliseHeading(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Undoes the reader-facing image loading strategy.
+ *
+ * The renderer marks every image `loading="lazy"`, which is right in the app —
+ * a note with forty screenshots should not fetch forty screenshots to show its
+ * first paragraph. It is wrong in a document that is about to be printed: a
+ * lazy image only loads when it approaches the viewport, and the print frame
+ * has no viewport worth speaking of, so every picture below the first screen
+ * stayed unloaded and the PDF came out with gaps where they should have been.
+ *
+ * `decoding="sync"` is the other half: it keeps the browser from deferring the
+ * decode past the moment the page is handed to the printer.
+ */
+function forPrinting(html: string): string {
+  return html.replace(/<img\b/gi, '<img decoding="sync"').replace(/\sloading="lazy"/gi, "");
 }
 
 /**
@@ -251,6 +311,12 @@ function document(title: string, body: string, theme: "light" | "dark"): string 
     body { padding: 0; background: #fff; color: #000; }
     h1, h2, h3 { break-after: avoid; }
     pre, blockquote, table, .diagram, figure, img { break-inside: avoid; }
+    /* An image taller than a sheet has to be allowed to shrink, or the printer
+       clips it at the page edge and the bottom half is simply gone. */
+    img { max-height: 88vh; object-fit: contain; }
+    /* Backgrounds are what tells a code block from prose; browsers drop them
+       when printing unless asked not to. */
+    * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
     a { color: inherit; text-decoration: none; }
     /* A link is worth nothing on paper unless you can see where it goes. */
     a[href^="http"]::after {

--- a/packages/exporter/src/index.test.ts
+++ b/packages/exporter/src/index.test.ts
@@ -223,3 +223,61 @@ describe("toHtml — what a printed page needs", () => {
     expect(html).toContain('a[href^="http"]::after');
   });
 });
+
+/**
+ * Exported documents are printed, and printing has its own rules.
+ *
+ * The renderer marks images lazy, which is right on screen and wrong in a
+ * print frame: a lazy image never approaches a viewport there, so it never
+ * loads, and it prints as a gap.
+ */
+describe("HTML prepared for printing", () => {
+  it("never leaves an image lazy", async () => {
+    const html = await toHtml("![shot](https://example.com/a.png)", {}, options());
+
+    expect(html).not.toContain('loading="lazy"');
+    expect(html).toContain('decoding="sync"');
+  });
+
+  it("inlines the bytes an image needs to travel with the file", async () => {
+    const html = await toHtml("![shot](./assets/a.png)", {}, options(), async (src) =>
+      src === "./assets/a.png" ? "data:image/png;base64,AAA" : null,
+    );
+
+    expect(html).toContain('src="data:image/png;base64,AAA"');
+    expect(html).not.toContain('src="./assets/a.png"');
+  });
+
+  it("keeps backgrounds and holds oversized images inside the page", async () => {
+    const html = await toHtml("# Title", {}, options());
+
+    expect(html).toContain("print-color-adjust: exact");
+    expect(html).toContain("max-height: 88vh");
+  });
+});
+
+describe("the document's title block", () => {
+  it("does not print the title twice", async () => {
+    const html = await toHtml(
+      "# Phishing attacks\n\nBody.",
+      {},
+      options({
+        title: "Phishing attacks",
+      }),
+    );
+
+    // One heading: the document's own title block. The body's copy is gone.
+    expect(html.match(/<h1\b/g)?.length).toBe(1);
+    expect(html).toContain('class="doc-title">Phishing attacks</h1>');
+  });
+
+  it("keeps a first heading that says something else", async () => {
+    const html = await toHtml(
+      "# Introduction\n\nBody.",
+      {},
+      options({ title: "Phishing attacks" }),
+    );
+
+    expect(html).toContain(">Introduction</h1>");
+  });
+});

--- a/packages/exporter/src/index.ts
+++ b/packages/exporter/src/index.ts
@@ -119,7 +119,7 @@ export async function exportNote(
     }
 
     case "docx":
-      return { blob: await toDocx(note.content, options.title), filename };
+      return { blob: await toDocx(note.content, options.title, resolveImage), filename };
 
     case "pdf": {
       // The caller should use printToPdf, which opens the print dialog. We
@@ -152,8 +152,29 @@ export async function printToPdf(
 
   const frame = document.createElement("iframe");
   frame.setAttribute("aria-hidden", "true");
-  frame.style.cssText =
-    "position:absolute;top:-10000px;left:-10000px;width:1px;height:1px;border:0;";
+  frame.setAttribute("tabindex", "-1");
+  /**
+   * A page-sized frame, parked off screen.
+   *
+   * It used to be one pixel by one pixel, which is where the ruined layout in
+   * every exported PDF came from: a document laid out in a 1px viewport has
+   * nothing to wrap against, so tables collapsed, diagrams shrank to a sliver
+   * and anything sized against the viewport came out wrong — and then that was
+   * what got printed. Giving the frame the dimensions of a sheet of paper
+   * costs nothing and lets the document lay itself out the way it will be
+   * printed. It stays invisible, and out of the tab order.
+   */
+  frame.style.cssText = [
+    "position:fixed",
+    "left:-10000px",
+    "top:0",
+    "width:210mm",
+    "height:297mm",
+    "border:0",
+    "opacity:0",
+    "pointer-events:none",
+    "z-index:-1",
+  ].join(";");
   document.body.appendChild(frame);
 
   const doc = frame.contentDocument;
@@ -166,61 +187,83 @@ export async function printToPdf(
   doc.write(html);
   doc.close();
 
-  await new Promise<void>((resolve) => {
-    // Wait for fonts and inline SVGs to settle, or the first page prints blank.
-    if (doc.readyState === "complete") {
-      resolve();
-    } else {
-      // frame.onload doesn't always fire reliably for doc.write().
-      const fallback = setTimeout(resolve, 1500);
-      frame.onload = () => {
-        clearTimeout(fallback);
-        resolve();
-      };
-      doc.addEventListener("readystatechange", () => {
-        if (doc.readyState === "complete") {
-          clearTimeout(fallback);
-          resolve();
-        }
-      });
-    }
-  });
+  try {
+    await frameReady(doc, frame);
+    await imagesReady(doc);
+    await fontsReady(doc);
+    // One more frame, so the last layout pass has run before the snapshot the
+    // print dialog takes.
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
-  // And for the images to decode. They are `data:` URLs so nothing is
-  // fetched, but decoding is still asynchronous — printing before it finishes
-  // produces a PDF with gaps where the pictures should be, which is the exact
-  // failure this export is meant to have stopped having.
-  await Promise.all(
+    frame.contentWindow?.focus();
+    frame.contentWindow?.print();
+  } finally {
+    // The print dialog is modal but not awaitable; the frame has to outlive
+    // this call or the dialog prints a document that no longer exists.
+    setTimeout(() => frame.remove(), 60_000);
+  }
+}
+
+/** Resolves once the written document has finished parsing. */
+function frameReady(doc: Document, frame: HTMLIFrameElement): Promise<void> {
+  if (doc.readyState === "complete") return Promise.resolve();
+
+  return new Promise<void>((resolve) => {
+    // `frame.onload` does not fire reliably for a document written with
+    // `doc.write`, so both signals are watched and whichever arrives first
+    // wins. The timeout is the third: printing a slightly early document beats
+    // never opening the dialog at all.
+    const fallback = setTimeout(resolve, 2000);
+    const done = () => {
+      clearTimeout(fallback);
+      resolve();
+    };
+
+    frame.onload = done;
+    doc.addEventListener("readystatechange", () => {
+      if (doc.readyState === "complete") done();
+    });
+  });
+}
+
+/**
+ * Resolves once every image has actually decoded.
+ *
+ * The pictures are `data:` URLs by the time they get here, so nothing is
+ * fetched — but decoding is asynchronous, and a print that starts first
+ * produces a PDF with holes in it. `decode()` is the exact signal; `load` is
+ * the fallback for browsers that lack it.
+ */
+function imagesReady(doc: Document): Promise<unknown> {
+  return Promise.all(
     Array.from(doc.images).map((image) => {
+      if (typeof image.decode === "function") {
+        // A broken image rejects, which must not fail the export: one missing
+        // picture is a gap, a thrown error is no PDF at all.
+        return image.decode().catch(() => undefined);
+      }
       if (image.complete) return Promise.resolve();
+
       return new Promise<void>((resolve) => {
         const fallback = setTimeout(resolve, 3000);
-        image.addEventListener(
-          "load",
-          () => {
-            clearTimeout(fallback);
-            resolve();
-          },
-          { once: true },
-        );
-        image.addEventListener(
-          "error",
-          () => {
-            clearTimeout(fallback);
-            resolve();
-          },
-          { once: true },
-        );
+        const done = () => {
+          clearTimeout(fallback);
+          resolve();
+        };
+        image.addEventListener("load", done, { once: true });
+        image.addEventListener("error", done, { once: true });
       });
     }),
   );
-  await new Promise((r) => setTimeout(r, 150));
+}
 
-  frame.contentWindow?.focus();
-  frame.contentWindow?.print();
+/** Resolves once webfonts have loaded, so nothing reflows mid-print. */
+function fontsReady(doc: Document): Promise<unknown> {
+  const fonts = (doc as Document & { fonts?: { ready?: Promise<unknown> } }).fonts;
+  if (!fonts?.ready) return Promise.resolve();
 
-  // The print dialog is modal but not awaitable; remove the frame afterwards.
-  setTimeout(() => frame.remove(), 60_000);
+  // Capped: a font that never resolves must not hold the dialog shut.
+  return Promise.race([fonts.ready, new Promise((resolve) => setTimeout(resolve, 2000))]);
 }
 
 /** Exports a single diagram as SVG or PNG. */
@@ -311,14 +354,22 @@ export async function exportWorkspace(
   notes: Note[],
   format: Extract<ExportFormat, "md" | "html" | "txt">,
   options: Omit<ExportOptions, "format" | "title">,
-  resolveImage?: ImageResolver,
+  /**
+   * How to find images, *for a given note*.
+   *
+   * A factory rather than one resolver, because a note refers to its images
+   * relative to itself: `../assets/chart.png` means a different file depending
+   * on which note it is written in. Handing the whole archive a single note's
+   * resolver was quietly wrong for every other note in it.
+   */
+  resolveImageFor?: (note: Note) => ImageResolver | undefined,
 ): Promise<ExportResult> {
   const JSZip = (await import("jszip")).default;
   const zip = new JSZip();
 
   for (const note of notes) {
     const title = (note.frontmatter.title as string) ?? note.path;
-    const result = await exportNote(note, { ...options, format, title }, resolveImage);
+    const result = await exportNote(note, { ...options, format, title }, resolveImageFor?.(note));
     // Keep the repo's folder layout so the archive mirrors what the user sees.
     const path = note.path.replace(/\.mdx?$/i, `.${extensionFor(format)}`);
     zip.file(path, result.blob);

--- a/packages/github-client/src/client.test.ts
+++ b/packages/github-client/src/client.test.ts
@@ -607,3 +607,84 @@ describe("pull requests", () => {
     expect(calls[0]!.url).toContain("head=me%3Atopic");
   });
 });
+
+/**
+ * Deleting something the repository does not have.
+ *
+ * GitHub does not shrug at a tree entry that removes a path it cannot find: it
+ * answers 422 `GitRPC::BadObjectState` and refuses the entire commit. Since a
+ * commit here carries every queued change, one stale deletion used to stop a
+ * repository syncing altogether — and keep stopping it, on every retry.
+ */
+describe("deletions of paths that are not in the repository", () => {
+  const tree = {
+    "GET /repos/octo/notes/git/trees/head-tree?recursive=1": {
+      tree: [
+        { path: "a.md", type: "blob" },
+        { path: "assets/real.png", type: "blob" },
+      ],
+      truncated: false,
+    },
+  };
+
+  it("drops the impossible deletion and commits the rest", async () => {
+    const { calls, fetchImpl } = fakeGitHub(tree);
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    await client.commitChanges(
+      repo,
+      [
+        { op: "upsert", path: "a.md", content: "a" },
+        { op: "delete", path: "assets/real.png" },
+        { op: "delete", path: "assets/never-pushed.png" },
+      ],
+      { message: "batch" },
+    );
+
+    const body = calls.find((c) => c.url.endsWith("/git/trees") && c.method === "POST")?.body as {
+      tree: { path: string; sha: string | null }[];
+    };
+
+    expect(body.tree.map((entry) => entry.path)).toEqual(["a.md", "assets/real.png"]);
+  });
+
+  it("makes no commit at all when nothing is left to write", async () => {
+    const { calls, fetchImpl } = fakeGitHub(tree);
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    const result = await client.commitChanges(
+      repo,
+      [{ op: "delete", path: "assets/never-pushed.png" }],
+      { message: "tidy up" },
+    );
+
+    // Reporting HEAD: the branch is already in the state that was asked for.
+    expect(result.sha).toBe("head-sha");
+    expect(calls.some((c) => c.method === "POST" && c.url.endsWith("/git/commits"))).toBe(false);
+  });
+
+  it("does not read the tree when there is nothing to delete", async () => {
+    const { calls, fetchImpl } = fakeGitHub(tree);
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    await client.commitChanges(repo, [{ op: "upsert", path: "a.md", content: "a" }], {
+      message: "edit",
+    });
+
+    expect(calls.some((c) => c.url.includes("recursive=1"))).toBe(false);
+  });
+
+  it("commits as asked when the tree cannot be read", async () => {
+    // No tree route: the guard cannot run, and must not become a second way
+    // for the commit to fail.
+    const { calls, fetchImpl } = fakeGitHub();
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    await client.commitChanges(repo, [{ op: "delete", path: "gone.md" }], { message: "delete" });
+
+    const body = calls.find((c) => c.url.endsWith("/git/trees") && c.method === "POST")?.body as {
+      tree: { path: string }[];
+    };
+    expect(body.tree.map((entry) => entry.path)).toEqual(["gone.md"]);
+  });
+});

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -812,7 +812,22 @@ export class GitHubClient {
       }
     }
 
-    const newTreeSha = await this.createTree(repo, baseTreeSha, treeEntries);
+    const entries = await this.withoutPhantomDeletes(repo, baseTreeSha, treeEntries);
+
+    /**
+     * Nothing left to write.
+     *
+     * Every change in this batch turned out to be the removal of something the
+     * repository does not have — an image that never reached it, a file
+     * already deleted from another device. There is no commit to make, and
+     * making an empty one would be noise in the history. Reporting HEAD is
+     * honest: the requested state is the state the branch is in.
+     */
+    if (entries.length === 0) {
+      return { sha: headSha, blobShas: {}, squashed: false };
+    }
+
+    const newTreeSha = await this.createTree(repo, baseTreeSha, entries);
 
     const commitSha = await this.createCommit(repo, {
       message: `${COMMIT_MARKER} ${options.message}`,
@@ -885,6 +900,55 @@ export class GitHubClient {
     );
     if (!data) throw new GitHubError("unknown", "Empty tree creation response");
     return data.sha;
+  }
+
+  /**
+   * Drops deletions of paths the repository does not actually have.
+   *
+   * Asking the tree API to remove a path that is not in the base tree is not
+   * ignored — GitHub answers 422 `GitRPC::BadObjectState` and refuses the
+   * whole commit. Since a commit here carries every queued change at once,
+   * one stale deletion — an image that was only ever stored on the device, a
+   * file already removed from another machine — was enough to stop a
+   * repository syncing at all, and to keep stopping it on every retry.
+   *
+   * The tree is read once, and only when there is a deletion to check.
+   */
+  private async withoutPhantomDeletes(
+    repo: RepoRef,
+    baseTree: string,
+    entries: { path: string; mode: string; type: "blob"; sha: string | null }[],
+  ): Promise<{ path: string; mode: string; type: "blob"; sha: string | null }[]> {
+    if (!entries.some((entry) => entry.sha === null)) return entries;
+
+    const existing = await this.blobPaths(repo, baseTree);
+    // Unknown — a tree too large for one response — means no filtering. A
+    // commit that might fail beats dropping a deletion the user asked for.
+    if (!existing) return entries;
+
+    return entries.filter((entry) => entry.sha !== null || existing.has(entry.path));
+  }
+
+  /**
+   * Every blob path in a tree, or null when it cannot be known.
+   *
+   * Null for a tree GitHub truncated, and null if the read itself fails: this
+   * is a guard, and a guard that cannot run must not become a second way for
+   * the commit to fail.
+   */
+  private async blobPaths(repo: RepoRef, treeSha: string): Promise<Set<string> | null> {
+    try {
+      const { data } = await this.transport.request<{
+        tree: { path: string; type: string }[];
+        truncated?: boolean;
+      }>(`/repos/${repo.owner}/${repo.repo}/git/trees/${treeSha}?recursive=1`);
+
+      if (!data || data.truncated) return null;
+
+      return new Set(data.tree.filter((entry) => entry.type === "blob").map((entry) => entry.path));
+    } catch {
+      return null;
+    }
   }
 
   private async createCommit(

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -19,6 +19,14 @@ export {
 
 export { markdownToHtml, astToMarkdown, formatMarkdown, type RenderOptions } from "./render";
 export {
+  rewriteRelativeLinks,
+  repairRelativeLinks,
+  type LinkRepair,
+  relativeFromNote,
+  resolveFromNote,
+  isRelativeLink,
+} from "./relocate";
+export {
   youtubeVideoFrom,
   youtubeEmbedUrl,
   youtubeWatchUrl,

--- a/packages/markdown-engine/src/relocate.test.ts
+++ b/packages/markdown-engine/src/relocate.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  rewriteRelativeLinks,
+  relativeFromNote,
+  resolveFromNote,
+  repairRelativeLinks,
+} from "./relocate";
+
+describe("rewriteRelativeLinks", () => {
+  it("keeps an image pointing at the same file after a move", () => {
+    const before = "![shot](./assets/a.png)";
+    const after = rewriteRelativeLinks(before, "SOC 101/Phishing/notes.md", "OSINT/notes.md");
+
+    expect(after).toBe("![shot](<../SOC 101/Phishing/assets/a.png>)");
+    // And it names the file it always named.
+    expect(resolveFromNote("OSINT/notes.md", "../SOC 101/Phishing/assets/a.png")).toBe(
+      "SOC 101/Phishing/assets/a.png",
+    );
+  });
+
+  it("moves a note up to the root", () => {
+    expect(rewriteRelativeLinks("![a](./assets/a.png)", "notes/deep/n.md", "n.md")).toBe(
+      "![a](notes/deep/assets/a.png)",
+    );
+  });
+
+  it("moves a note down into a folder", () => {
+    expect(rewriteRelativeLinks("![a](assets/a.png)", "n.md", "notes/deep/n.md")).toBe(
+      "![a](../../assets/a.png)",
+    );
+  });
+
+  it("rewrites ordinary links and reference definitions too", () => {
+    const before = "See [the other note](./other.md) and [ref].\n\n[ref]: ./assets/b.png";
+    expect(rewriteRelativeLinks(before, "a/n.md", "b/n.md")).toBe(
+      "See [the other note](../a/other.md) and [ref].\n\n[ref]: ../a/assets/b.png",
+    );
+  });
+
+  it("keeps a title and an anchor", () => {
+    expect(rewriteRelativeLinks('![a](./assets/a.png "A shot")', "a/n.md", "b/n.md")).toBe(
+      '![a](../a/assets/a.png "A shot")',
+    );
+    expect(rewriteRelativeLinks("[x](./other.md#part)", "a/n.md", "b/n.md")).toBe(
+      "[x](../a/other.md#part)",
+    );
+  });
+
+  it("leaves absolute URLs, anchors and wikilinks alone", () => {
+    const before =
+      "[web](https://example.com/a.png)\n[root](/a.png)\n[here](#section)\n[[another note]]";
+    expect(rewriteRelativeLinks(before, "a/n.md", "b/n.md")).toBe(before);
+  });
+
+  it("leaves link-shaped text inside a code fence alone", () => {
+    const before = "```md\n![a](./assets/a.png)\n```\n\n![b](./assets/b.png)";
+    expect(rewriteRelativeLinks(before, "a/n.md", "b/n.md")).toBe(
+      "```md\n![a](./assets/a.png)\n```\n\n![b](../a/assets/b.png)",
+    );
+  });
+
+  it("reads a path whose spaces were percent-encoded", () => {
+    expect(rewriteRelativeLinks("![a](./assets/my%20shot.png)", "a/n.md", "b/n.md")).toBe(
+      "![a](<../a/assets/my shot.png>)",
+    );
+  });
+
+  it("reads a destination already wrapped in angle brackets", () => {
+    expect(rewriteRelativeLinks("![a](<./assets/my shot.png>)", "a/n.md", "b/n.md")).toBe(
+      "![a](<../a/assets/my shot.png>)",
+    );
+  });
+
+  it("does nothing for a rename within the same folder", () => {
+    const before = "![a](./assets/a.png)";
+    expect(rewriteRelativeLinks(before, "a/n.md", "a/renamed.md")).toBe(before);
+  });
+});
+
+describe("relativeFromNote", () => {
+  it("keeps a sibling explicit so a colon cannot read as a scheme", () => {
+    expect(relativeFromNote("a/n.md", "a/c:d.png")).toBe("./c:d.png");
+  });
+});
+
+/**
+ * Repairing links that already point nowhere.
+ *
+ * The case this exists for is real and specific: notes written before images
+ * were committed beside the note that uses them hold `assets/shot.png` while
+ * the file itself sits in the repository root's `assets/`, so every picture in
+ * the note is a broken box in the app and on github.com.
+ */
+describe("repairRelativeLinks", () => {
+  const repo = [
+    "SOC 101/Phishing/notes.md",
+    "SOC 101/Phishing/assets/2026-08-24-later.png",
+    "assets/2026-08-24-99586.png",
+    "README.md",
+  ];
+
+  it("repoints a broken image at the file of that name", () => {
+    const result = repairRelativeLinks(
+      "![shot](assets/2026-08-24-99586.png)",
+      "SOC 101/Phishing/notes.md",
+      repo,
+    );
+
+    expect(result.content).toBe("![shot](../../assets/2026-08-24-99586.png)");
+    expect(result.fixed).toEqual([
+      { from: "assets/2026-08-24-99586.png", to: "../../assets/2026-08-24-99586.png" },
+    ]);
+  });
+
+  it("leaves a link that already resolves exactly as it is", () => {
+    const before = "![ok](./assets/2026-08-24-later.png)";
+    const result = repairRelativeLinks(before, "SOC 101/Phishing/notes.md", repo);
+
+    expect(result.content).toBe(before);
+    expect(result.fixed).toEqual([]);
+  });
+
+  it("reports a link it cannot match rather than guessing", () => {
+    const result = repairRelativeLinks(
+      "![gone](./assets/never-uploaded.png)",
+      "SOC 101/Phishing/notes.md",
+      repo,
+    );
+
+    expect(result.content).toContain("./assets/never-uploaded.png");
+    expect(result.unresolved).toEqual(["./assets/never-uploaded.png"]);
+  });
+
+  it("prefers the copy nearest the note when a name is not unique", () => {
+    const result = repairRelativeLinks("![a](shot.png)", "a/b/notes.md", [
+      "a/b/assets/shot.png",
+      "far/away/shot.png",
+    ]);
+
+    expect(result.content).toBe("![a](assets/shot.png)");
+  });
+
+  it("leaves a genuine tie for a person to settle", () => {
+    const result = repairRelativeLinks("![a](shot.png)", "notes.md", [
+      "one/shot.png",
+      "two/shot.png",
+    ]);
+
+    expect(result.fixed).toEqual([]);
+    expect(result.unresolved).toEqual(["shot.png"]);
+  });
+
+  it("leaves absolute URLs alone", () => {
+    const before = "![web](https://example.com/shot.png)";
+    expect(repairRelativeLinks(before, "a/n.md", repo).content).toBe(before);
+  });
+});

--- a/packages/markdown-engine/src/relocate.ts
+++ b/packages/markdown-engine/src/relocate.ts
@@ -1,0 +1,289 @@
+import { dirname, normalizePath } from "./paths";
+
+/**
+ * Keeping a note's links working when the note moves.
+ *
+ * Images and attachments are referenced the portable way — by a path relative
+ * to the note, `./assets/chart.png` — which is what makes a note render on
+ * github.com and in every other markdown tool. The cost of that portability is
+ * that the link's meaning depends on where the note sits: move the file one
+ * folder across and `./assets/chart.png` now names a file that does not exist,
+ * so every image in the note breaks at once, here and on GitHub.
+ *
+ * Moving a note therefore has to rewrite its relative links to keep pointing at
+ * the same files. The images themselves stay where they are: they may be shared
+ * with other notes, and rewriting a link is free where moving a file is another
+ * commit that can fail halfway.
+ */
+
+/** True for a link that names a file in the repository rather than somewhere else. */
+export function isRelativeLink(target: string): boolean {
+  if (!target) return false;
+  // A scheme, a protocol-relative URL, a root-relative path, a fragment or a
+  // query is somebody else's business.
+  return (
+    !/^[a-z][a-z0-9+.-]*:/i.test(target) &&
+    !target.startsWith("//") &&
+    !target.startsWith("/") &&
+    !target.startsWith("#") &&
+    !target.startsWith("?")
+  );
+}
+
+/** Resolves a link written in a note to the repository path it points at. */
+export function resolveFromNote(notePath: string, target: string): string {
+  return normalizePath(`${dirname(notePath)}/${decodePath(target)}`);
+}
+
+/**
+ * `notes/2026/plan.md` + `assets/chart.png` → `../../assets/chart.png`.
+ *
+ * Relative rather than absolute because that is what works everywhere: a
+ * leading-slash path resolves against the *site* root on GitHub Pages and
+ * against nothing at all in an editor, while `../assets/chart.png` means the
+ * same thing in every one of them.
+ */
+export function relativeFromNote(fromNotePath: string, toRepoPath: string): string {
+  const from = normalizePath(dirname(fromNotePath)).split("/").filter(Boolean);
+  const to = normalizePath(toRepoPath).split("/").filter(Boolean);
+
+  let shared = 0;
+  while (shared < from.length && shared < to.length - 1 && from[shared] === to[shared]) {
+    shared += 1;
+  }
+
+  const up = from.length - shared;
+  const down = to.slice(shared);
+  const steps = [...Array.from({ length: up }, () => ".."), ...down];
+
+  // A file in the same folder needs the `./`, or a name containing a colon
+  // would be read as a URL scheme.
+  return up === 0 && down.length === 1 ? `./${steps.join("/")}` : steps.join("/");
+}
+
+/** A percent-decoded path, for a link written by a tool that encoded its spaces. */
+function decodePath(target: string): string {
+  try {
+    return decodeURIComponent(target);
+  } catch {
+    // Not valid percent-encoding — a literal `%` in a filename. Take it as-is.
+    return target;
+  }
+}
+
+/**
+ * A destination safe to sit inside `(…)`.
+ *
+ * A path with a space or a bracket in it ends the link early, and folder names
+ * with spaces in them are entirely normal — `SOC 101/assets/shot.png`. Angle
+ * brackets are markdown's own way of saying "all of this is the URL", and are
+ * understood by GitHub, CommonMark and this app's own renderer alike.
+ */
+function encodeDestination(target: string): string {
+  return /[\s()<>]/.test(target) ? `<${target.replace(/[<>]/g, encodeURIComponent)}>` : target;
+}
+
+/** Ranges of the document that are fenced code, where link syntax is just text. */
+function fencedRanges(markdown: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const fence = /^[ \t]*(`{3,}|~{3,})/gm;
+
+  let open: { index: number; marker: string } | null = null;
+  let match: RegExpExecArray | null;
+
+  while ((match = fence.exec(markdown)) !== null) {
+    const marker = match[1]!;
+    if (!open) {
+      open = { index: match.index, marker: marker[0]! };
+      continue;
+    }
+    // Only a fence of the same kind closes one; a ``` inside a ~~~ block is
+    // content.
+    if (marker[0] !== open.marker) continue;
+
+    ranges.push([open.index, match.index + match[0].length]);
+    open = null;
+  }
+
+  // An unclosed fence runs to the end of the document, which is how every
+  // markdown parser reads it.
+  if (open) ranges.push([open.index, markdown.length]);
+  return ranges;
+}
+
+/**
+ * Inline links and images: `[text](target)`, `![alt](target "title")`.
+ *
+ * The title is captured separately so it survives the rewrite untouched.
+ */
+const LINK =
+  /(!?)\[((?:[^[\]\\]|\\.)*)\]\(\s*(<[^<>\n]*>|[^\s()]*)((?:\s+"[^"\n]*"|\s+'[^'\n]*')?)\s*\)/g;
+
+/** Reference definitions: `[label]: target "title"`. */
+const DEFINITION = /^([ \t]{0,3}\[(?:[^[\]\\]|\\.)+\]:[ \t]*)(<[^<>\n]*>|\S+)(.*)$/gm;
+
+/**
+ * Every relative link in a note, rewritten for the note's new home.
+ *
+ * The markdown is edited in place rather than parsed and re-printed: a round
+ * trip through a formatter would rewrite bullet markers, emphasis characters
+ * and line wrapping across the whole file, turning "moved a note" into a diff
+ * nobody can review.
+ */
+export function rewriteRelativeLinks(markdown: string, fromPath: string, toPath: string): string {
+  if (normalizePath(fromPath) === normalizePath(toPath)) return markdown;
+  if (dirname(normalizePath(fromPath)) === dirname(normalizePath(toPath))) return markdown;
+
+  const fenced = fencedRanges(markdown);
+  const inFence = (index: number) => fenced.some(([start, end]) => index >= start && index < end);
+
+  const moved = (target: string): string | null => {
+    const bare = target.startsWith("<") && target.endsWith(">") ? target.slice(1, -1) : target;
+    if (!isRelativeLink(bare)) return null;
+
+    // A link into the note's own document — `#section` — has no path part.
+    const hash = bare.indexOf("#");
+    const path = hash === -1 ? bare : bare.slice(0, hash);
+    const fragment = hash === -1 ? "" : bare.slice(hash);
+    if (!path) return null;
+
+    const repoPath = resolveFromNote(fromPath, path);
+    if (!repoPath) return null;
+
+    return encodeDestination(`${relativeFromNote(toPath, repoPath)}${fragment}`);
+  };
+
+  let result = markdown.replace(
+    LINK,
+    (whole, bang, text, target: string, title, offset: number) => {
+      if (inFence(offset)) return whole;
+      const next = moved(target);
+      return next === null ? whole : `${bang}[${text}](${next}${title})`;
+    },
+  );
+
+  result = result.replace(DEFINITION, (whole, head, target: string, tail, offset: number) => {
+    if (inFence(offset)) return whole;
+    const next = moved(target);
+    return next === null ? whole : `${head}${next}${tail}`;
+  });
+
+  return result;
+}
+
+export interface LinkRepair {
+  /** The note with its broken links repointed. */
+  content: string;
+  /** What moved, oldest form first, for telling the reader what happened. */
+  fixed: { from: string; to: string }[];
+  /** Links that point nowhere and could not be matched to a file. */
+  unresolved: string[];
+}
+
+/**
+ * Repairs links that point at files which are not there.
+ *
+ * Notes written before a move — or before this app committed images beside the
+ * note that uses them — can hold paths that resolve to nothing: the file is in
+ * the repository, at a different path, and the note has no way to know. Every
+ * image in such a note renders as a broken box here and on github.com, which
+ * looks like lost work even though nothing was lost.
+ *
+ * The repair is conservative on purpose. A link that already resolves is never
+ * touched. A broken one is matched only by filename, and only when the match is
+ * unambiguous — where several files share a name, the one sharing the most of
+ * its path with the note wins, and a genuine tie is left alone for a person to
+ * settle. Guessing wrongly here would silently point a note at somebody else's
+ * screenshot, which is worse than the broken image it replaced.
+ */
+export function repairRelativeLinks(
+  markdown: string,
+  notePath: string,
+  repoPaths: Iterable<string>,
+): LinkRepair {
+  const paths = [...repoPaths];
+  const existing = new Set(paths.map((path) => normalizePath(path)));
+
+  const byName = new Map<string, string[]>();
+  for (const path of paths) {
+    const name = path.split("/").pop() ?? path;
+    byName.set(name, [...(byName.get(name) ?? []), normalizePath(path)]);
+  }
+
+  const fixed: { from: string; to: string }[] = [];
+  const unresolved: string[] = [];
+
+  const fenced = fencedRanges(markdown);
+  const inFence = (index: number) => fenced.some(([start, end]) => index >= start && index < end);
+
+  const repaired = (target: string): string | null => {
+    const bare = target.startsWith("<") && target.endsWith(">") ? target.slice(1, -1) : target;
+    if (!isRelativeLink(bare)) return null;
+
+    const hash = bare.indexOf("#");
+    const path = hash === -1 ? bare : bare.slice(0, hash);
+    if (!path) return null;
+
+    const resolved = resolveFromNote(notePath, path);
+    if (existing.has(resolved)) return null;
+
+    const name = decodePath(path).split("/").pop() ?? "";
+    const candidates = byName.get(name) ?? [];
+
+    if (candidates.length === 0) {
+      unresolved.push(bare);
+      return null;
+    }
+
+    const best = nearest(candidates, notePath);
+    if (!best) {
+      unresolved.push(bare);
+      return null;
+    }
+
+    const next = relativeFromNote(notePath, best);
+    fixed.push({ from: bare, to: next });
+    return encodeDestination(hash === -1 ? next : `${next}${bare.slice(hash)}`);
+  };
+
+  let content = markdown.replace(
+    LINK,
+    (whole, bang, text, target: string, title, offset: number) => {
+      if (inFence(offset)) return whole;
+      const next = repaired(target);
+      return next === null ? whole : `${bang}[${text}](${next}${title})`;
+    },
+  );
+
+  content = content.replace(DEFINITION, (whole, head, target: string, tail, offset: number) => {
+    if (inFence(offset)) return whole;
+    const next = repaired(target);
+    return next === null ? whole : `${head}${next}${tail}`;
+  });
+
+  return { content, fixed, unresolved };
+}
+
+/**
+ * The candidate sharing the most of its path with the note, or null for a tie.
+ *
+ * "Nearest" is the only ordering that means anything here: a screenshot in the
+ * folder you are writing in is far more likely to be the one you meant than a
+ * file of the same name three projects away.
+ */
+function nearest(candidates: string[], notePath: string): string | null {
+  const from = normalizePath(dirname(notePath)).split("/").filter(Boolean);
+
+  const scored = candidates.map((path) => {
+    const parts = path.split("/");
+    let shared = 0;
+    while (shared < from.length && shared < parts.length - 1 && from[shared] === parts[shared]) {
+      shared += 1;
+    }
+    return { path, shared };
+  });
+
+  const best = Math.max(...scored.map((entry) => entry.shared));
+  const winners = scored.filter((entry) => entry.shared === best);
+  return winners.length === 1 ? winners[0]!.path : null;
+}

--- a/packages/store/src/note-repository.test.ts
+++ b/packages/store/src/note-repository.test.ts
@@ -112,3 +112,35 @@ describe("openNote", () => {
     expect(note.updatedAt).toBe("2025-06-01T12:00:00.000Z");
   });
 });
+
+/**
+ * Moving a note.
+ *
+ * Images are referenced relative to the note, which is what makes a note
+ * render on github.com — and what makes moving the file break every one of
+ * them unless the links move with it.
+ */
+describe("renameNote", () => {
+  it("repoints relative images at the files they already named", async () => {
+    const { notes, db } = repository({
+      "SOC 101/Phishing/notes.md": "# Notes\n\n![shot](./assets/a.png)\n",
+    });
+
+    const opened = await notes.openNote(WS, "SOC 101/Phishing/notes.md");
+    const moved = await notes.renameNote(opened, "OSINT/notes.md");
+
+    expect(moved.content).toContain("![shot](<../SOC 101/Phishing/assets/a.png>)");
+    // And the copy that gets committed says the same thing.
+    const stored = await db.getNote(`${WS}::OSINT/notes.md`);
+    expect(stored?.content).toContain("../SOC 101/Phishing/assets/a.png");
+  });
+
+  it("leaves a note renamed within its own folder untouched", async () => {
+    const { notes } = repository({ "a/notes.md": "![shot](./assets/a.png)\n" });
+
+    const opened = await notes.openNote(WS, "a/notes.md");
+    const renamed = await notes.renameNote(opened, "a/better-name.md");
+
+    expect(renamed.content).toContain("![shot](./assets/a.png)");
+  });
+});

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -6,8 +6,9 @@ import {
   joinPath,
   slugifyFilename,
   uniquePath,
-  dirname,
-  normalizePath,
+  rewriteRelativeLinks,
+  isRelativeLink,
+  resolveFromNote,
 } from "@forkleaf/markdown-engine";
 import type { LocalDatabase, RemoteGateway } from "./ports";
 import type { SyncEngine } from "./sync-engine";
@@ -267,20 +268,51 @@ export class NoteRepository {
     const matches = Array.from(target.content.matchAll(/!\[.*?\]\(([^)]+)\)/g));
     for (const match of matches) {
       const src = match[1];
-      if (!src) continue;
-      // Simple check to ensure it's a repo-relative path, not an external URL.
-      if (!/^[a-z][a-z0-9+.-]*:/i.test(src) && !src.startsWith("//") && !src.startsWith("/")) {
-        const assetPath = normalizePath(`${dirname(target.path)}/${src}`);
+      if (!src || !isRelativeLink(src)) continue;
+
+      const assetPath = resolveFromNote(target.path, src);
+      const id = `${target.workspaceId}::${assetPath}`;
+      const stored = await this.db.getAsset(id);
+
+      /**
+       * An asset that never reached GitHub must not be deleted from it.
+       *
+       * Asking git to remove a path that is not in the tree is not a no-op —
+       * GitHub rejects the whole commit with `GitRPC::BadObjectState`, and
+       * since a flush is one atomic commit, that one impossible deletion took
+       * every note queued behind it down with it. The queue then retried the
+       * same impossible commit forever, which is what "couldn't sync" that
+       * never clears actually was.
+       *
+       * No local record means the note came from the repository and its images
+       * are presumed to be there too, which is the case worth attempting.
+       */
+      if (!stored || stored.pushed) {
         await this.sync.recordAssetDelete(target.workspaceId, assetPath);
-        // Clean up from local IDB cache too.
-        await this.db.deleteAsset(`${target.workspaceId}::${assetPath}`);
       }
+
+      // Local copy goes either way: the note that used it is gone.
+      await this.db.deleteAsset(id);
     }
   }
 
+  /**
+   * Moves or renames a note, and takes its images with it.
+   *
+   * The links inside the note are relative to where the note sits — that is
+   * what makes them work on github.com — so moving the file one folder across
+   * silently repoints every image in it at a path that holds nothing. The
+   * rewrite is part of the move rather than a follow-up commit: a note that is
+   * moved but not repointed is a broken note, and there is no moment at which
+   * anyone would want to see one.
+   */
   async renameNote(note: Note, toPath: string): Promise<Note> {
     const current = await this.db.getNote(note.id);
-    const freshNote = current ?? note;
+    const stored = current ?? note;
+    const freshNote: Note = {
+      ...stored,
+      content: rewriteRelativeLinks(stored.content, stored.path, toPath),
+    };
 
     const content = serializeDocument(freshNote.content, freshNote.frontmatter);
     await this.sync.recordRename(freshNote, toPath, content);

--- a/packages/store/src/queue.ts
+++ b/packages/store/src/queue.ts
@@ -18,6 +18,18 @@ export interface CoalesceInput {
   content?: string;
   baseSha: string | null;
   now: string;
+  /**
+   * True when the path is known to exist in the repository despite our having
+   * no sha for it.
+   *
+   * A note that was created and deleted before it ever synced does not need to
+   * reach GitHub at all, and "no base sha" is how that is normally recognised.
+   * An image is the case that breaks the rule: it is committed directly rather
+   * than through this queue, so it has no sha here and yet is very much on
+   * GitHub — and the rule quietly threw away every request to remove one,
+   * leaving orphaned screenshots behind for notes that no longer exist.
+   */
+  existsRemotely?: boolean;
 }
 
 /**
@@ -92,7 +104,7 @@ function remove(
   // A note created offline and deleted before it ever synced never needs to
   // reach GitHub at all — drop it from the queue entirely.
   const neverPushed = prior ? prior.baseSha === null : input.baseSha === null;
-  if (neverPushed) return others;
+  if (neverPushed && !input.existsRemotely) return others;
 
   return [
     ...others,

--- a/packages/store/src/sync-engine.test.ts
+++ b/packages/store/src/sync-engine.test.ts
@@ -13,6 +13,8 @@ class FakeGateway implements RemoteGateway {
   files = new Map<string, { content: string; sha: string }>();
   online = true;
   failNext = 0;
+  /** Paths the fake server refuses, the way GitHub refuses a bad tree entry. */
+  rejects = new Set<string>();
   private counter = 0;
 
   async listTree(): Promise<TreeNode[]> {
@@ -29,6 +31,14 @@ class FakeGateway implements RemoteGateway {
     if (this.failNext > 0) {
       this.failNext -= 1;
       throw new Error("server error");
+    }
+
+    const refused = input.changes.find((change) => this.rejects.has(change.path));
+    if (refused) {
+      throw Object.assign(new Error(`GitRPC::BadObjectState on ${refused.path}`), {
+        code: "validation",
+        status: 422,
+      });
     }
 
     this.commits.push(structuredClone(input));
@@ -245,6 +255,19 @@ describe("queue coalescing", () => {
     expect(queue).toHaveLength(1);
     expect(queue[0]!.op).toBe("rename");
     expect(queue[0]!.content).toBe("v2");
+  });
+});
+
+describe("asset deletions", () => {
+  it("keeps the request to remove an image, which has no sha of its own", async () => {
+    const ctx = setup();
+
+    await ctx.engine.recordAssetDelete("ws", "notes/assets/shot.png");
+
+    const queued = await ctx.db.listQueue("ws");
+    expect(queued.map((item) => `${item.op} ${item.path}`)).toEqual([
+      "delete notes/assets/shot.png",
+    ]);
   });
 });
 
@@ -734,5 +757,54 @@ describe("pendingFor and discardPending", () => {
     await engine.start();
 
     await expect(engine.discardPending("nobody")).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * One change the server will never accept.
+ *
+ * A flush is a single commit, so a change GitHub refuses outright fails the
+ * commit carrying everybody else's writing too — and keeps failing it, every
+ * retry, until the whole queue is blocked and the status bar just says
+ * "couldn't sync" forever.
+ */
+describe("a change the server refuses", () => {
+  it("does not stop the rest of the queue from reaching GitHub", async () => {
+    const ctx = setup();
+    ctx.gateway.rejects.add("assets/ghost.png");
+
+    await ctx.engine.recordUpsert(makeNote({ path: "a.md", baseSha: null }), "a");
+    await ctx.engine.recordUpsert(makeNote({ id: "ws::b.md", path: "b.md", baseSha: null }), "b");
+    await ctx.engine.recordAssetDelete("ws", "assets/ghost.png");
+
+    await ctx.timers.tick();
+
+    // The two notes landed, in whatever grouping the split produced.
+    const written = ctx.gateway.commits.flatMap((commit) =>
+      commit.changes.map((change) => change.path),
+    );
+    expect(written).toContain("a.md");
+    expect(written).toContain("b.md");
+    expect(written).not.toContain("assets/ghost.png");
+
+    // And the one that failed is still queued, described by its own error.
+    const queued = await ctx.db.listQueue("ws");
+    expect(queued.map((item) => item.path)).toEqual(["assets/ghost.png"]);
+    expect(queued[0]?.lastError).toContain("BadObjectState");
+  });
+
+  it("does not split a failure that has nothing to do with the content", async () => {
+    const ctx = setup();
+    ctx.gateway.failNext = 1;
+
+    await ctx.engine.recordUpsert(makeNote({ path: "a.md", baseSha: null }), "a");
+    await ctx.engine.recordUpsert(makeNote({ id: "ws::b.md", path: "b.md", baseSha: null }), "b");
+
+    await ctx.timers.tick();
+
+    // One attempt at the batch, not one per half.
+    const queued = await ctx.db.listQueue("ws");
+    expect(queued).toHaveLength(2);
+    expect(queued.every((item) => item.attempts === 1)).toBe(true);
   });
 });

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -273,7 +273,12 @@ export class SyncEngine {
       workspaceId,
       path,
       op: "delete",
+      // Images are committed directly rather than through this queue, so there
+      // is no sha to carry — but the file is on GitHub, and saying so is what
+      // keeps the "never synced, never needs deleting" rule from discarding
+      // the request.
       baseSha: null,
+      existsRemotely: true,
       now: this.now().toISOString(),
     });
 
@@ -447,20 +452,63 @@ export class SyncEngine {
     const safe = await this.filterConflicts(workspaceId, changes);
     if (safe.length === 0) return;
 
-    let result;
+    await this.push(workspaceId, safe);
+  }
+
+  /**
+   * Pushes a batch as one commit, isolating a change the server will never
+   * accept.
+   *
+   * A flush is deliberately atomic: everything queued for a workspace lands as
+   * a single commit or none of it does. The failure mode that has is that one
+   * impossible change — a deletion of a path that is not in the repository, a
+   * file the server rejects — fails the commit that carries everybody else's
+   * writing too, and keeps failing it on every retry until the whole queue is
+   * marked blocked. "Couldn't sync, click to retry", forever, with the notes
+   * still on the device and nothing explaining which one is at fault.
+   *
+   * So a batch that fails for a reason specific to its *content* is split and
+   * retried in halves, down to single changes. Everything that can be pushed
+   * is pushed, and the one that cannot ends up alone, where its attempt count
+   * and its error message describe it rather than the queue it was standing
+   * in. Failures that are nothing to do with the content — offline, signed
+   * out, rate limited — are not split: they would fail identically in halves
+   * and cost a burst of requests to prove it.
+   */
+  private async push(workspaceId: string, changes: PendingChange[]): Promise<void> {
     try {
-      result = await this.gateway.commit({
+      const result = await this.gateway.commit({
         workspaceId,
-        message: describeChanges(safe),
+        message: describeChanges(changes),
         squashWindowMs: this.squashWindowMs,
-        changes: safe.map((c) => ({
+        changes: changes.map((c) => ({
           op: c.op,
           path: c.path,
           ...(c.toPath !== undefined ? { toPath: c.toPath } : {}),
           ...(c.content !== undefined ? { content: c.content } : {}),
         })),
       });
+
+      await this.settle(workspaceId, changes, result);
     } catch (err) {
+      if (changes.length > 1 && isContentRejection(err)) {
+        const middle = Math.ceil(changes.length / 2);
+        const failures: unknown[] = [];
+
+        for (const half of [changes.slice(0, middle), changes.slice(middle)]) {
+          try {
+            await this.push(workspaceId, half);
+          } catch (halfError) {
+            failures.push(halfError);
+          }
+        }
+
+        // The flush still failed — the status bar has to say so — but only for
+        // what actually failed.
+        if (failures.length > 0) throw failures[0];
+        return;
+      }
+
       // Count the attempt so a change that can never succeed — a deleted repo,
       // a revoked token — stops blocking everything queued behind it.
       //
@@ -473,7 +521,7 @@ export class SyncEngine {
       // dropping it costs somebody their writing.
       const message = err instanceof Error ? err.message : String(err);
 
-      for (const change of safe) {
+      for (const change of changes) {
         change.attempts += 1;
         change.lastError = message;
         if (change.attempts >= MAX_ATTEMPTS) change.blocked = true;
@@ -481,10 +529,15 @@ export class SyncEngine {
       }
       throw err;
     }
+  }
 
-    // Committed successfully: clear these from the queue and record the new
-    // blob SHAs so the next edit knows what it is based on.
-    for (const change of safe) {
+  /** Clears pushed changes from the queue and records what they were based on. */
+  private async settle(
+    workspaceId: string,
+    changes: PendingChange[],
+    result: { blobShas: Record<string, string> },
+  ): Promise<void> {
+    for (const change of changes) {
       this.queue = this.queue.filter((c) => c.id !== change.id);
       await this.db.deleteQueueItem(change.id);
 
@@ -725,4 +778,19 @@ function forkPath(path: string): string {
   const dot = path.lastIndexOf(".");
   if (dot <= path.lastIndexOf("/")) return `${path} (local copy)`;
   return `${path.slice(0, dot)} (local copy)${path.slice(dot)}`;
+}
+
+/**
+ * True when the server rejected *what* was sent rather than the fact that we
+ * sent it.
+ *
+ * A 422 is GitHub saying this particular set of paths and contents cannot be
+ * committed — a deletion of something that is not there, a path it will not
+ * accept. Splitting the batch finds the one at fault. Everything else (signed
+ * out, rate limited, offline, a conflict) applies to the whole batch equally.
+ */
+function isContentRejection(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const { code, status } = err as { code?: unknown; status?: unknown };
+  return code === "validation" || status === 422;
 }


### PR DESCRIPTION
Five bugs, one thread running through them: a note names its images by a path relative to itself, and everything that moves the note or takes it somewhere else has to respect that.

## Moving a note broke every image in it

`SOC 101/PHYSHING ANALYSIS/phishing-attacks-techniques.md` says `![99586.png](assets/2026-08-24-99586-d5d4.png)`. That resolves to `SOC 101/PHYSHING ANALYSIS/assets/…`, which holds nothing — the file is at the repository root's `assets/`. The note was written in one place and moved to another, and the move did not carry its links along. Broken pictures in the editor and on github.com, showing the filename as alt text, which is where the "images are showing as numbers" came from.

`renameNote` now rewrites relative links so they keep naming the same files (`../../assets/2026-08-24-99586-d5d4.png`). The image files stay put: other notes may be using them, and rewriting a link is free where moving a file is another commit that can fail halfway.

Existing broken notes are repaired on request — **Find this note's missing images** in ⌘K searches the repository for the files by name and repoints the ones it can identify unambiguously. Where a name is not unique the nearest copy wins; a genuine tie is left alone rather than guessed at.

## PDF export

- The print frame was `1px × 1px`. A document laid out in a one-pixel viewport has nothing to wrap against, and that is what got printed — which is the ruined layout. It is now the size of a sheet of paper, still off screen.
- Every image was marked `loading="lazy"`, right in the app and wrong in a print frame, where nothing ever approaches a viewport. They print as gaps. Exports now load eagerly and decode synchronously, and printing waits on `decode()` rather than a timer.
- The title printed twice — once in the document's own header block, once as the note's opening `# Heading`. The duplicate is dropped when it matches exactly.
- Backgrounds are kept when printing, and an image taller than a page is held inside it instead of being clipped.

## Word export never had the images

`.docx` wrote the alt text instead of the picture — and a pasted screenshot's alt text is its filename, so the document came out as a column of numbers. Pictures are now embedded, scaled to the page, with WebP and AVIF re-encoded to PNG since Word cannot read them. A picture on its own line is centred.

Bulk export was handing every note in the archive a resolver built for one note's path; it now builds one per note.

## "Couldn't sync: GitRPC::BadObjectState" that never cleared

Asking git to remove a path that is not in the tree is not a no-op — GitHub answers 422 and refuses the whole commit. A flush is one atomic commit, so a single stale deletion failed the commit carrying everything else and kept failing it on every retry, until the queue was blocked and the status bar said "couldn't sync" forever.

Three layers, so it cannot happen again:

1. A deletion is not queued for an image that never reached GitHub.
2. The client drops deletions of paths the base tree does not have; if nothing is left, no commit is made.
3. A batch the server rejects for its *content* is split and retried in halves, down to single changes. Everything that can be pushed is pushed, and the one that cannot ends up alone, described by its own error rather than by the queue it was standing in.

While testing this I found that asset deletions were being discarded before they ever reached the queue — the "created and deleted before it ever synced" rule was swallowing them, since an image is committed directly and has no sha here. Orphaned screenshots were never cleaned up. Fixed.

## Not changed: the folder row on github.com

`SOC 101/PHYSHING ANALYSIS` shows as one row because github.com's file tree collapses a folder whose only child is another folder. It is GitHub's own UI and not something this app can change. The reason `SOC 101` has only one child in the repository is the sync failure above — the other folders never got there.

## Verification

`pnpm check` passes: 696 tests, typecheck, lint, build. New coverage for link rewriting and repair, rename behaviour, phantom deletions, batch isolation, print HTML and Word images. The exported document was rendered and read end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)