### PR TITLE
feat: editor polish, GitHub permission choice, and honest refusals

### DIFF
--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const token = await exchangeCodeForToken(
+    const { token, scopes } = await exchangeCodeForToken(
       code,
       appUrl(request, "/api/auth/callback").toString(),
     );
@@ -50,6 +50,7 @@ export async function GET(request: NextRequest) {
 
     await setSessionCookie({
       token,
+      scopes,
       user: {
         id: user.id,
         login: user.login,
@@ -68,7 +69,10 @@ export async function GET(request: NextRequest) {
   }
 }
 
-async function exchangeCodeForToken(code: string, redirectUri: string): Promise<string> {
+async function exchangeCodeForToken(
+  code: string,
+  redirectUri: string,
+): Promise<{ token: string; scopes: string[] }> {
   const response = await fetch("https://github.com/login/oauth/access_token", {
     method: "POST",
     headers: {
@@ -85,6 +89,7 @@ async function exchangeCodeForToken(code: string, redirectUri: string): Promise<
 
   const data = (await response.json()) as {
     access_token?: string;
+    scope?: string;
     error?: string;
     error_description?: string;
   };
@@ -93,7 +98,14 @@ async function exchangeCodeForToken(code: string, redirectUri: string): Promise<
     throw new Error(data.error_description ?? data.error ?? "No access token returned");
   }
 
-  return data.access_token;
+  // What was granted, which is not always what was asked for: somebody can
+  // approve a narrower set on GitHub's own screen.
+  const scopes = (data.scope ?? "")
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+
+  return { token: data.access_token, scopes };
 }
 
 function withError(url: URL, code: string): URL {

--- a/apps/web/src/app/api/session/route.ts
+++ b/apps/web/src/app/api/session/route.ts
@@ -16,6 +16,14 @@ export async function GET() {
       mode: session ? "github" : "local",
       user: session?.user ?? null,
       githubAvailable: githubOAuthConfigured(),
+      /**
+       * What GitHub granted — never the token itself.
+       *
+       * The UI needs this to tell a genuine "no such repository" from "you did
+       * not give this app access to private ones", which are the same 404 from
+       * GitHub and need entirely different things said about them.
+       */
+      scopes: session?.scopes ?? [],
     },
     { headers: { "Cache-Control": "no-store" } },
   );

--- a/apps/web/src/app/docs/content/github.tsx
+++ b/apps/web/src/app/docs/content/github.tsx
@@ -59,6 +59,22 @@ export function SigningIn() {
         for your account, install ForkLeaf as a GitHub App instead, where you grant access
         repository by repository. See <A href="/docs/self-hosting">Self-hosting</A>.
       </Note>
+      <P>
+        You are not made to take the wide one. <A href="/sign-in">Signing in</A> offers{" "}
+        <Code>public_repo</Code> as an equal choice — with it, ForkLeaf cannot open a private
+        repository at all, because GitHub refuses the token rather than because we decline to try.
+        Pick it if your notes are going to be public; you can sign in again with the wider
+        permission whenever that changes, and nothing has to be redone.
+      </P>
+      <P>
+        Whichever you choose, ForkLeaf reads and writes exactly one repository — the one you connect
+        — plus the list of repository names, so the picker has something to show. If a repository
+        you can see on github.com is missing from that list, it is almost always one of two things:
+        it is private and you granted public-only access, or it belongs to an organisation that has
+        not approved ForkLeaf under <em>Settings → Third-party Access</em>. The dashboard says
+        which, and what to do about it, rather than repeating GitHub&rsquo;s &ldquo;Not
+        Found&rdquo;.
+      </P>
 
       <H2 id="token">Where the token lives</H2>
       <P>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -59,6 +59,11 @@
   --fl-accent-hover: #324a63;
   --fl-accent-contrast: #ffffff;
   --fl-accent-soft: rgba(61, 90, 120, 0.1);
+  /* Selected text, which has to be *seen* — `--fl-accent-soft` is a tint for
+     hover states, and at a tenth of an opacity it left a selection you had to
+     hunt for. Strong enough to read at a glance, light enough to keep the text
+     on top of it legible. */
+  --fl-selection: rgba(61, 90, 120, 0.32);
 
   --fl-warn: #a76a0a;
   --fl-danger: #c2372d;
@@ -85,6 +90,7 @@
   --fl-accent-hover: #9db0cc;
   --fl-accent-contrast: #0c1018;
   --fl-accent-soft: rgba(138, 155, 184, 0.14);
+  --fl-selection: rgba(138, 155, 184, 0.42);
 
   --fl-warn: #d4b94f;
   --fl-danger: #d4544f;
@@ -190,8 +196,23 @@ h3 {
 }
 
 ::selection {
-  background: var(--fl-accent-soft);
+  background: var(--fl-selection);
   color: var(--fl-text);
+}
+
+/* Firefox keeps its own pseudo-element, and inherits nothing from the one
+   above. */
+::-moz-selection {
+  background: var(--fl-selection);
+  color: var(--fl-text);
+}
+
+/* A selection made in a window that has since lost focus stays visible, dimmer.
+   Without this the browser greys it out to near-invisibility, which is the
+   state you are in every time you reach for a menu mid-selection. */
+.ProseMirror-selectednode {
+  outline: 2px solid var(--fl-accent);
+  outline-offset: 2px;
 }
 
 /* ── Floating panels ───────────────────────────────────────────────────────

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -661,6 +661,55 @@ select:focus-visible {
   font-weight: 600;
 }
 
+/* ── Highlight colours ──────────────────────────────────────────────────────
+   By name rather than by value in the file, so each theme picks its own shade:
+   a highlight that reads on white is unreadable on black, and the note should
+   not carry a colour that stops working when the lights go out. */
+:root {
+  --fl-hl-yellow: rgba(250, 204, 21, 0.38);
+  --fl-hl-green: rgba(74, 222, 128, 0.34);
+  --fl-hl-blue: rgba(96, 165, 250, 0.34);
+  --fl-hl-pink: rgba(244, 114, 182, 0.32);
+  --fl-hl-purple: rgba(167, 139, 250, 0.34);
+  --fl-hl-orange: rgba(251, 146, 60, 0.34);
+}
+
+[data-theme="dark"] {
+  --fl-hl-yellow: rgba(250, 204, 21, 0.3);
+  --fl-hl-green: rgba(74, 222, 128, 0.28);
+  --fl-hl-blue: rgba(96, 165, 250, 0.3);
+  --fl-hl-pink: rgba(244, 114, 182, 0.28);
+  --fl-hl-purple: rgba(167, 139, 250, 0.3);
+  --fl-hl-orange: rgba(251, 146, 60, 0.28);
+}
+
+mark,
+.fl-prose mark {
+  background: var(--fl-hl-yellow);
+  color: inherit;
+  border-radius: 3px;
+  padding: 0.05em 0.15em;
+}
+
+mark.fl-hl-yellow {
+  background: var(--fl-hl-yellow);
+}
+mark.fl-hl-green {
+  background: var(--fl-hl-green);
+}
+mark.fl-hl-blue {
+  background: var(--fl-hl-blue);
+}
+mark.fl-hl-pink {
+  background: var(--fl-hl-pink);
+}
+mark.fl-hl-purple {
+  background: var(--fl-hl-purple);
+}
+mark.fl-hl-orange {
+  background: var(--fl-hl-orange);
+}
+
 .fl-prose img {
   max-width: 100%;
   height: auto;

--- a/apps/web/src/app/sign-in/page.tsx
+++ b/apps/web/src/app/sign-in/page.tsx
@@ -1,0 +1,181 @@
+import Link from "next/link";
+import { SiteShell } from "@/components/SiteShell";
+import { githubOAuthConfigured } from "@/lib/session";
+
+export const metadata = {
+  title: "Sign in with GitHub — ForkLeaf",
+  description:
+    "Choose how much access ForkLeaf gets to your GitHub repositories, and see exactly what each level is used for.",
+};
+
+/**
+ * The permission choice, made before GitHub's own consent screen.
+ *
+ * GitHub's screen names a scope and says what it covers; it cannot say what
+ * *this* app does with it, and it offers no alternative. Somebody arriving at
+ * "repo — full control of private repositories" with no context has one
+ * reasonable response, which is to close the tab.
+ *
+ * So the choice is made here, in words, with the narrower option offered as an
+ * equal rather than buried: a person who only ever keeps public notes should
+ * never grant access to their private code, and until now they had no way to
+ * say so without reading the documentation first.
+ */
+export default function SignInPage() {
+  if (!githubOAuthConfigured()) {
+    return (
+      <SiteShell>
+        <Frame>
+          <h1 className="text-2xl font-semibold tracking-tight">GitHub sign-in is not set up</h1>
+          <p className="mt-3 text-[15px] leading-relaxed text-[var(--fl-muted)]">
+            This deployment has no GitHub OAuth application configured, so notes stay on this
+            device. That works — it is the whole app, minus syncing.{" "}
+            <Link href="/docs/self-hosting" className="fl-link">
+              Setting it up
+            </Link>{" "}
+            takes a few minutes.
+          </p>
+          <Link href="/editor" className="fl-btn fl-btn-primary mt-6 inline-flex">
+            Start writing on this device
+          </Link>
+        </Frame>
+      </SiteShell>
+    );
+  }
+
+  return (
+    <SiteShell>
+      <Frame>
+        <h1 className="text-3xl font-semibold tracking-tight">Sign in with GitHub</h1>
+        <p className="mt-3 max-w-2xl text-[15px] leading-relaxed text-[var(--fl-muted)]">
+          ForkLeaf keeps your notes as Markdown files in a repository you own, so it needs
+          permission to read and write files there. Choose how much of your account that covers. You
+          can change it later, and revoke it entirely, from GitHub.
+        </p>
+
+        <div className="mt-8 grid gap-4 md:grid-cols-2">
+          <Choice
+            href="/api/auth/github?access=all"
+            scope="repo"
+            title="Private and public repositories"
+            recommended
+            need="Needed if your notes live in a private repository — which is what most people want for notes."
+            covers={[
+              "Read and write files in the repository you connect",
+              "Commit on your behalf, with your name on the commit",
+              "List your repositories, so you can pick one",
+            ]}
+            caveat="GitHub's classic scopes have no per-repository option, so this grant technically covers every repository your account can reach. ForkLeaf only ever reads or writes the one you connect."
+          />
+
+          <Choice
+            href="/api/auth/github?access=public"
+            scope="public_repo"
+            title="Public repositories only"
+            need="Enough if your notes are going to be public. ForkLeaf literally cannot open a private repository with this — the token is refused by GitHub, not by us."
+            covers={[
+              "Read and write files in your public repositories",
+              "Commit on your behalf, with your name on the commit",
+            ]}
+            caveat="If you later want a private notes repository, you will be asked to sign in again with the wider permission."
+          />
+        </div>
+
+        <div className="mt-8 grid gap-4 sm:grid-cols-2">
+          <Aside title="Organisation repositories">
+            If your notes live in an organisation, an owner may need to approve ForkLeaf under{" "}
+            <em>Settings → Third-party Access → OAuth App access</em>. Until they do, GitHub reports
+            the repository as missing rather than as forbidden — if a repository you can see on
+            github.com is not listed here, that is usually why.
+          </Aside>
+
+          <Aside title="Taking it back">
+            Revoke at any time from{" "}
+            <a
+              href="https://github.com/settings/applications"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="fl-link"
+            >
+              github.com/settings/applications
+            </a>
+            . Your notes are files in your repository and stay exactly where they are.
+          </Aside>
+        </div>
+
+        <p className="mt-8 text-[13.5px] text-[var(--fl-muted)]">
+          Not ready to connect anything?{" "}
+          <Link href="/editor" className="fl-link">
+            Write on this device instead
+          </Link>{" "}
+          — no account, nothing leaves the browser, and you can connect a repository later.
+        </p>
+      </Frame>
+    </SiteShell>
+  );
+}
+
+function Frame({ children }: { children: React.ReactNode }) {
+  return <div className="mx-auto w-full max-w-4xl px-6 py-16">{children}</div>;
+}
+
+function Choice({
+  href,
+  scope,
+  title,
+  need,
+  covers,
+  caveat,
+  recommended,
+}: {
+  href: string;
+  scope: string;
+  title: string;
+  need: string;
+  covers: string[];
+  caveat: string;
+  recommended?: boolean;
+}) {
+  return (
+    <div className="flex flex-col rounded-2xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-5">
+      <div className="flex items-center gap-2">
+        <h2 className="text-[17px] font-semibold text-[var(--fl-text)]">{title}</h2>
+        {recommended && (
+          <span className="rounded-full bg-[var(--fl-accent-soft)] px-2 py-0.5 text-[11px] font-medium text-[var(--fl-accent)]">
+            Most people
+          </span>
+        )}
+      </div>
+
+      <p className="mt-1 font-mono text-[12px] text-[var(--fl-muted)]">{scope}</p>
+      <p className="mt-3 text-[14px] leading-relaxed text-[var(--fl-text)]">{need}</p>
+
+      <p className="mt-4 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+        What it is used for
+      </p>
+      <ul className="mt-2 space-y-1.5">
+        {covers.map((line) => (
+          <li key={line} className="flex gap-2 text-[13.5px] text-[var(--fl-muted)]">
+            <span aria-hidden="true">·</span>
+            <span>{line}</span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-4 text-[12.5px] leading-relaxed text-[var(--fl-muted)]">{caveat}</p>
+
+      <a href={href} className="fl-btn fl-btn-primary mt-5 justify-center">
+        Continue with this
+      </a>
+    </div>
+  );
+}
+
+function Aside({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-[var(--fl-border)] p-4">
+      <h2 className="text-[14px] font-semibold text-[var(--fl-text)]">{title}</h2>
+      <p className="mt-1.5 text-[13.5px] leading-relaxed text-[var(--fl-muted)]">{children}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/ConnectRepoDialog.tsx
+++ b/apps/web/src/components/ConnectRepoDialog.tsx
@@ -83,7 +83,7 @@ function ErrorNotice({ error }: { error: unknown }) {
           app&rsquo;s access is withdrawn.
         </p>
         <a
-          href="/api/auth/github"
+          href="/sign-in"
           className="inline-block rounded-md bg-[var(--fl-accent)] px-3 py-1.5 text-sm font-semibold text-[var(--fl-accent-contrast)] hover:opacity-90"
         >
           Sign in with GitHub again

--- a/apps/web/src/components/EditorSidebar.test.tsx
+++ b/apps/web/src/components/EditorSidebar.test.tsx
@@ -210,3 +210,43 @@ describe("EditorSidebar — pinned notes", () => {
     expect(onTogglePin).toHaveBeenCalledWith(pinned[0]);
   });
 });
+
+/**
+ * The account card at the bottom of the sidebar.
+ *
+ * It looks exactly like a button — avatar, name, handle, in a bordered card
+ * where every application puts the way into your account — and did nothing at
+ * all when clicked. The menu beside it opened but never closed except by
+ * clicking the same gear again.
+ */
+describe("the account card", () => {
+  const user = { login: "praneeth132006", name: "Praneeth", avatarUrl: "https://x/y.png" };
+
+  it("goes to the profile when clicked", () => {
+    renderSidebar("", { user });
+
+    const link = screen.getByTitle("Your profile");
+    expect(link.getAttribute("href")).toBe("/profile");
+    expect(link.textContent).toContain("Praneeth");
+  });
+
+  it("closes its menu on Escape", () => {
+    renderSidebar("", { user });
+
+    fireEvent.click(screen.getByLabelText("Account"));
+    expect(screen.getByText("Sign out")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByText("Sign out")).toBeNull();
+  });
+
+  it("closes its menu when something else is clicked", () => {
+    renderSidebar("", { user });
+
+    fireEvent.click(screen.getByLabelText("Account"));
+    expect(screen.getByText("Sign out")).toBeTruthy();
+
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByText("Sign out")).toBeNull();
+  });
+});

--- a/apps/web/src/components/EditorSidebar.tsx
+++ b/apps/web/src/components/EditorSidebar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { TreeNode, Workspace, SessionUser } from "@forkleaf/types";
 import { FileTree } from "./FileTree";
 import { ForkLeafMark } from "./Brand";
+import { useDismissable } from "@/hooks/useDismissable";
 
 export interface EditorSidebarProps {
   collapsed: boolean;
@@ -64,6 +65,21 @@ export function EditorSidebar(props: EditorSidebarProps) {
   const [showWorkspaces, setShowWorkspaces] = useState(false);
   const [showAccount, setShowAccount] = useState(false);
   const [showFolders, setShowFolders] = useState(false);
+
+  /**
+   * Each menu closes on Escape and on a click anywhere else.
+   *
+   * None of them did. A dropdown that only shuts when you click the exact
+   * button that opened it is one people leave open — they click elsewhere,
+   * nothing happens, and the panel sits over whatever they were reaching for.
+   */
+  const workspacesRef = useRef<HTMLDivElement | null>(null);
+  const foldersRef = useRef<HTMLDivElement | null>(null);
+  const accountRef = useRef<HTMLDivElement | null>(null);
+
+  useDismissable(workspacesRef, showWorkspaces, () => setShowWorkspaces(false));
+  useDismissable(foldersRef, showFolders, () => setShowFolders(false));
+  useDismissable(accountRef, showAccount, () => setShowAccount(false));
   const searchRef = useRef<HTMLInputElement>(null);
 
   // Every folder at every depth, so "new note" can mean "new note somewhere in
@@ -156,7 +172,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
   return (
     <nav className="flex w-64 shrink-0 flex-col">
       {/* ── Workspace switcher ────────────────────────────────────────── */}
-      <div className="relative border-b border-[var(--fl-border)] p-2">
+      <div className="relative border-b border-[var(--fl-border)] p-2" ref={workspacesRef}>
         <div className="flex items-center gap-1">
           {/* The leaf reads as a logo, so it behaves like one and goes home.
               It used to open the workspace menu, which left the editor with no
@@ -258,7 +274,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
       {/* ── New note ──────────────────────────────────────────────────── */}
       {/* Creating a note is the one thing someone opens this app to do, and it
           used to be a 34px square sharing a row with the search field. */}
-      <div className="relative flex items-stretch gap-1.5 px-2 pt-2">
+      <div className="relative flex items-stretch gap-1.5 px-2 pt-2" ref={foldersRef}>
         <button
           type="button"
           onClick={() => props.onCreateNote(props.currentFolder)}
@@ -511,26 +527,38 @@ export function EditorSidebar(props: EditorSidebarProps) {
         </button>
 
         {props.user ? (
-          <div className="relative">
-            <div className="flex items-center gap-2.5 rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2.5 py-2">
-              {/* eslint-disable-next-line @next/next/no-img-element -- avatars are
-                  remote GitHub URLs; next/image would need a domain allowlist for
-                  every possible avatar host. */}
-              <img
-                src={props.user.avatarUrl}
-                alt=""
-                width={30}
-                height={30}
-                className="h-[30px] w-[30px] shrink-0 rounded-full"
-              />
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-[12.5px] font-medium text-[var(--fl-text)]">
-                  {props.user.name ?? props.user.login}
+          <div className="relative" ref={accountRef}>
+            <div className="flex items-center gap-1 rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] pr-1.5">
+              {/* The card itself goes to the profile.
+
+                  It looked exactly like a button — an avatar, a name, a handle,
+                  in a bordered card at the bottom of the sidebar, which is where
+                  every application in the world puts the way into your account —
+                  and it did nothing at all when clicked. */}
+              <Link
+                href="/profile"
+                title="Your profile"
+                className="flex min-w-0 flex-1 items-center gap-2.5 rounded-l-xl px-2.5 py-2 transition-colors hover:bg-[var(--fl-elevated)]"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element -- avatars are
+                    remote GitHub URLs; next/image would need a domain allowlist for
+                    every possible avatar host. */}
+                <img
+                  src={props.user.avatarUrl}
+                  alt=""
+                  width={30}
+                  height={30}
+                  className="h-[30px] w-[30px] shrink-0 rounded-full"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[12.5px] font-medium text-[var(--fl-text)]">
+                    {props.user.name ?? props.user.login}
+                  </span>
+                  <span className="block truncate text-[11px] text-[var(--fl-muted)]">
+                    @{props.user.login}
+                  </span>
                 </span>
-                <span className="block truncate text-[11px] text-[var(--fl-muted)]">
-                  @{props.user.login}
-                </span>
-              </span>
+              </Link>
               <button
                 type="button"
                 onClick={() => setShowAccount((value) => !value)}

--- a/apps/web/src/components/EditorSidebar.tsx
+++ b/apps/web/src/components/EditorSidebar.tsx
@@ -484,9 +484,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
           onRenameFolder={props.onRenameFolder}
           onDeleteFolder={props.onDeleteFolder}
           {...(props.openFolders ? { openFolders: props.openFolders } : {})}
-          {...(props.onOpenFoldersChange
-            ? { onOpenFoldersChange: props.onOpenFoldersChange }
-            : {})}
+          {...(props.onOpenFoldersChange ? { onOpenFoldersChange: props.onOpenFoldersChange } : {})}
           filter={filter}
         />
       </div>

--- a/apps/web/src/components/EditorSidebar.tsx
+++ b/apps/web/src/components/EditorSidebar.tsx
@@ -38,6 +38,10 @@ export interface EditorSidebarProps {
   onMoveNote: (path: string, toFolder: string) => void;
   /** Notes kept at the top, in the order they were put there. */
   pinnedPaths: readonly string[];
+  /** Folders the reader had open last time, in the order they opened them. */
+  openFolders?: readonly string[];
+  /** Called when that set changes, so it can be remembered for next time. */
+  onOpenFoldersChange?: (paths: string[]) => void;
   onTogglePin: (path: string) => void;
   onMovePin: (path: string, direction: -1 | 1) => void;
   user: SessionUser | null;
@@ -479,6 +483,10 @@ export function EditorSidebar(props: EditorSidebarProps) {
           pinnedPaths={props.pinnedPaths}
           onRenameFolder={props.onRenameFolder}
           onDeleteFolder={props.onDeleteFolder}
+          {...(props.openFolders ? { openFolders: props.openFolders } : {})}
+          {...(props.onOpenFoldersChange
+            ? { onOpenFoldersChange: props.onOpenFoldersChange }
+            : {})}
           filter={filter}
         />
       </div>

--- a/apps/web/src/components/FileTree.test.tsx
+++ b/apps/web/src/components/FileTree.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import type { TreeNode } from "@forkleaf/types";
+import { FileTree } from "./FileTree";
+
+afterEach(cleanup);
+
+const tree: TreeNode[] = [
+  {
+    kind: "folder",
+    name: "SOC 101",
+    path: "SOC 101",
+    children: [{ kind: "file", name: "notes", path: "SOC 101/notes.md" }],
+  },
+  {
+    kind: "folder",
+    name: "OSINT",
+    path: "OSINT",
+    children: [{ kind: "file", name: "osint", path: "OSINT/osint.md" }],
+  },
+];
+
+function draw(props: Partial<React.ComponentProps<typeof FileTree>> = {}) {
+  return render(
+    <FileTree
+      nodes={tree}
+      activePath={null}
+      onOpen={vi.fn()}
+      onDelete={vi.fn()}
+      onRename={vi.fn()}
+      onCreateIn={vi.fn()}
+      onCreateFolder={vi.fn()}
+      onRenameFolder={vi.fn()}
+      onDeleteFolder={vi.fn()}
+      filter=""
+      {...props}
+    />,
+  );
+}
+
+/**
+ * A sidebar that forgets is one you have to re-navigate on every visit.
+ */
+describe("which folders are open", () => {
+  it("opens the ones the reader had open, and nothing else", () => {
+    draw({ openFolders: ["OSINT"] });
+
+    expect(screen.getByText("osint")).toBeTruthy();
+    expect(screen.queryByText("notes")).toBeNull();
+  });
+
+  it("opens the top level on a first visit, when nothing is remembered", () => {
+    draw();
+
+    expect(screen.getByText("osint")).toBeTruthy();
+    expect(screen.getByText("notes")).toBeTruthy();
+  });
+
+  it("honours an empty record as deliberately closed", () => {
+    draw({ openFolders: [] });
+
+    expect(screen.queryByText("osint")).toBeNull();
+    expect(screen.queryByText("notes")).toBeNull();
+  });
+
+  it("reports what is open, in the order it was opened", () => {
+    const onOpenFoldersChange = vi.fn();
+    draw({ openFolders: [], onOpenFoldersChange });
+
+    fireEvent.click(screen.getByText("OSINT"));
+    fireEvent.click(screen.getByText("SOC 101"));
+
+    expect(onOpenFoldersChange).toHaveBeenLastCalledWith(["OSINT", "SOC 101"]);
+  });
+});

--- a/apps/web/src/components/FileTree.tsx
+++ b/apps/web/src/components/FileTree.tsx
@@ -21,6 +21,15 @@ export interface FileTreeProps {
   onTogglePin?: (path: string) => void;
   /** Paths currently pinned, so the menu can say which way it will go. */
   pinnedPaths?: readonly string[];
+  /**
+   * Folders to open on arrival, in the order the reader opened them.
+   *
+   * Undefined means nothing has been remembered for this workspace, which is a
+   * first visit rather than a deliberately empty sidebar.
+   */
+  openFolders?: readonly string[];
+  /** Called whenever that set changes, so it can be kept for the next visit. */
+  onOpenFoldersChange?: (paths: string[]) => void;
   filter: string;
 }
 
@@ -51,13 +60,35 @@ export function FileTree({
   onMoveNote,
   onTogglePin,
   pinnedPaths,
+  openFolders,
+  onOpenFoldersChange,
   filter,
 }: FileTreeProps) {
-  // Which folders are open, by full path — so opening `a/b` says nothing about
-  // `a/c`, and the state survives the tree being rebuilt under it by a refresh
-  // from GitHub. Holding it here rather than in each row is also what lets a
-  // folder stay open across a re-render that replaces every node object.
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(rootFolders(nodes)));
+  /**
+   * Which folders are open, by full path.
+   *
+   * By path, so opening `a/b` says nothing about `a/c`, and so the state
+   * survives the tree being rebuilt underneath it by a refresh from GitHub.
+   * Holding it here rather than in each row is also what lets a folder stay
+   * open across a re-render that replaces every node object.
+   *
+   * Seeded from what the reader had open last time, in the order they opened
+   * it — a sidebar that forgets is one you have to re-navigate on every visit.
+   * Only a workspace with no record at all falls back to opening the top level,
+   * because that is a first visit rather than somebody who closed everything.
+   */
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set(openFolders ?? rootFolders(nodes)),
+  );
+
+  /** Reports the open set outwards, so it can be remembered for next time. */
+  const remember = useCallback(
+    (next: Set<string>) => {
+      onOpenFoldersChange?.([...next]);
+      return next;
+    },
+    [onOpenFoldersChange],
+  );
   const [dropTarget, setDropTarget] = useState<string | null>(null);
   const { menu, open: openMenu, close: closeMenu } = useContextMenu<TreeNode>();
 
@@ -66,19 +97,27 @@ export function FileTree({
     [nodes, filter],
   );
 
-  const toggle = useCallback((path: string) => {
-    setExpanded((current) => {
-      const next = new Set(current);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      return next;
-    });
-  }, []);
+  const toggle = useCallback(
+    (path: string) => {
+      setExpanded((current) => {
+        const next = new Set(current);
+        // Deleted and re-added rather than left in place, so the record keeps
+        // the order folders were opened in.
+        next.delete(path);
+        if (!current.has(path)) next.add(path);
+        return remember(next);
+      });
+    },
+    [remember],
+  );
 
   /** Opening a folder before creating something in it, so the result is visible. */
-  const reveal = useCallback((path: string) => {
-    setExpanded((current) => new Set(current).add(path));
-  }, []);
+  const reveal = useCallback(
+    (path: string) => {
+      setExpanded((current) => remember(new Set(current).add(path)));
+    },
+    [remember],
+  );
 
   const menuItems = useMemo((): MenuItem[] => {
     if (!menu) return [];

--- a/apps/web/src/components/ProfilePanel.tsx
+++ b/apps/web/src/components/ProfilePanel.tsx
@@ -220,7 +220,7 @@ export function ProfilePanel({ user, githubAvailable }: ProfilePanelProps) {
               backed up, and they will not follow you to another machine.
             </p>
             {githubAvailable && (
-              <a href="/api/auth/github" className="fl-btn fl-btn-primary mt-4">
+              <a href="/sign-in" className="fl-btn fl-btn-primary mt-4">
                 Continue with GitHub
               </a>
             )}

--- a/apps/web/src/components/ProposeChangesDialog.tsx
+++ b/apps/web/src/components/ProposeChangesDialog.tsx
@@ -425,7 +425,7 @@ function ErrorNotice({ error }: { error: unknown }) {
       {explained && <p className="mt-1.5 text-[12px] text-[var(--fl-muted)]">GitHub said: {raw}</p>}
       {expired && (
         <a
-          href="/api/auth/github"
+          href="/sign-in"
           className="mt-2 inline-block text-[var(--fl-accent)] underline underline-offset-2"
         >
           Sign in with GitHub again

--- a/apps/web/src/components/dashboard/DashboardPanel.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanel.tsx
@@ -12,6 +12,7 @@ import { useIndexView, type IndexView } from "@/hooks/useIndexView";
 import { StorageBlocked } from "@/components/StorageBlocked";
 import { BootScreen } from "@/components/BootScreen";
 import { ForkLeafLogo } from "@/components/Brand";
+import { Footer } from "@/components/landing/Footer";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
 import { RepoChooser } from "./RepoChooser";
 import { FolderNav } from "./FolderNav";
@@ -209,7 +210,7 @@ export function DashboardPanel({
   const firstRun = library.needsRepoChoice && !skippedChoice;
 
   return (
-    <div className="min-h-screen bg-[var(--fl-bg)] font-sans text-[var(--fl-text)]">
+    <div className="flex min-h-screen flex-col bg-[var(--fl-bg)] font-sans text-[var(--fl-text)]">
       <Header
         user={user}
         theme={theme}
@@ -218,7 +219,7 @@ export function DashboardPanel({
         githubAvailable={githubAvailable}
       />
 
-      <div className="mx-auto w-full max-w-6xl px-6 pb-20 pt-8">
+      <div className="mx-auto w-full max-w-6xl flex-1 px-6 pb-20 pt-8">
         {library.error && (
           <p
             role="alert"
@@ -527,6 +528,14 @@ export function DashboardPanel({
           )}
         </section>
       </div>
+
+      {/* The same footer every other page has.
+
+          The dashboard is where signing in lands, and it was the one page with
+          no way out to the documentation, the licence, the privacy page or the
+          source — the things somebody deciding whether to trust an app with
+          their notes goes looking for. */}
+      <Footer />
 
       {prompt && <PromptDialog request={prompt} onClose={() => setPrompt(null)} />}
     </div>

--- a/apps/web/src/components/dashboard/DashboardPanel.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanel.tsx
@@ -13,6 +13,8 @@ import { StorageBlocked } from "@/components/StorageBlocked";
 import { BootScreen } from "@/components/BootScreen";
 import { ForkLeafLogo } from "@/components/Brand";
 import { Footer } from "@/components/landing/Footer";
+import { explainAccessFailure } from "@/lib/github-help";
+import type { SessionResponse } from "@/lib/gateway";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
 import { RepoChooser } from "./RepoChooser";
 import { FolderNav } from "./FolderNav";
@@ -220,14 +222,7 @@ export function DashboardPanel({
       />
 
       <div className="mx-auto w-full max-w-6xl flex-1 px-6 pb-20 pt-8">
-        {library.error && (
-          <p
-            role="alert"
-            className="mb-6 rounded-lg border border-[var(--fl-danger)]/30 bg-[var(--fl-danger)]/8 px-4 py-3 text-sm text-[var(--fl-danger)]"
-          >
-            {library.error}
-          </p>
-        )}
+        {library.error && <AccessError info={library.errorInfo} session={library.session} />}
 
         {/* ── Greeting ─────────────────────────────────────────────────── */}
         <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
@@ -600,7 +595,7 @@ function Header({
             </>
           ) : (
             githubAvailable && (
-              <a href="/api/auth/github" className="fl-btn fl-btn-primary !py-2 !text-sm">
+              <a href="/sign-in" className="fl-btn fl-btn-primary !py-2 !text-sm">
                 Sign in with GitHub
               </a>
             )
@@ -618,6 +613,59 @@ function SectionLabel({ children, className = "" }: { children: ReactNode; class
     >
       {children}
     </h2>
+  );
+}
+
+/**
+ * A failure from GitHub, explained.
+ *
+ * The old banner printed whatever GitHub said — "Not Found" — which for the
+ * most common cause is actively misleading: a private repository is genuinely
+ * invisible to a public-only token, and the person reading it is looking at
+ * that repository in another tab. What they need is the reason and the steps,
+ * so both are here, along with the one link that ends it.
+ */
+function AccessError({
+  info,
+  session,
+}: {
+  info: { code?: string; status?: number; message: string } | null;
+  session: SessionResponse | null;
+}) {
+  const problem = explainAccessFailure(info, session);
+
+  return (
+    <div
+      role="alert"
+      className="mb-6 rounded-xl border border-[var(--fl-danger)]/30 bg-[var(--fl-danger)]/8 px-4 py-3.5"
+    >
+      <p className="text-sm font-medium text-[var(--fl-danger)]">{problem.summary}</p>
+
+      <ol className="mt-2 space-y-1 text-[13.5px] text-[var(--fl-muted)]">
+        {problem.steps.map((step, index) => (
+          <li key={step} className="flex gap-2">
+            <span className="shrink-0 tabular-nums">{index + 1}.</span>
+            <span>{step}</span>
+          </li>
+        ))}
+      </ol>
+
+      {problem.action && (
+        <a
+          href={problem.action.href}
+          {...(problem.action.href.startsWith("http")
+            ? { target: "_blank", rel: "noopener noreferrer" }
+            : {})}
+          className="fl-btn fl-btn-ghost mt-3 !py-1.5 !text-[13px]"
+        >
+          {problem.action.label}
+        </a>
+      )}
+
+      {info?.message && (
+        <p className="mt-2 text-[11.5px] text-[var(--fl-muted)]">GitHub said: {info.message}</p>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/components/dashboard/RepoChooser.tsx
+++ b/apps/web/src/components/dashboard/RepoChooser.tsx
@@ -107,7 +107,7 @@ function ErrorNotice({ error }: { error: unknown }) {
           Your GitHub sign-in is no longer valid — the token was revoked, or the app&rsquo;s access
           was withdrawn.
         </p>
-        <a href="/api/auth/github" className="fl-btn fl-btn-primary !py-2 !text-sm">
+        <a href="/sign-in" className="fl-btn fl-btn-primary !py-2 !text-sm">
           Sign in with GitHub again
         </a>
       </div>

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -904,6 +904,8 @@ export function EditorWorkspace() {
             onDeleteFolder={handleDeleteFolder}
             onMoveNote={handleMoveNote}
             pinnedPaths={notebook.pinnedPaths}
+            {...(notebook.expandedFolders ? { openFolders: notebook.expandedFolders } : {})}
+            onOpenFoldersChange={notebook.setExpandedFolders}
             onTogglePin={notebook.togglePinned}
             onMovePin={notebook.movePinned}
             user={user}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -320,11 +320,17 @@ export function EditorWorkspace() {
 
   const signIn = useCallback(() => {
     track("github_sign_in_started");
-    // Deliberately a full document navigation: this is an API route that 302s
-    // out to github.com, which the client router cannot follow.
-    // eslint-disable-next-line @next/next/no-location-assign-relative-destination
-    window.location.assign("/api/auth/github");
-  }, []);
+    /**
+     * The permission choice comes first.
+     *
+     * Going straight to the OAuth route sends somebody to a GitHub screen
+     * saying "full control of private repositories" with nothing to explain
+     * why a notes app is asking, and no narrower option — which is a fair
+     * reason to close the tab. `/sign-in` says what each level is for and
+     * offers the public-repositories-only grant as an equal choice.
+     */
+    router.push("/sign-in");
+  }, [router]);
 
   // ── Actions ─────────────────────────────────────────────────────────────
 

--- a/apps/web/src/components/landing/CallToAction.tsx
+++ b/apps/web/src/components/landing/CallToAction.tsx
@@ -39,7 +39,7 @@ export function CallToAction({ githubAvailable }: { githubAvailable: boolean }) 
 
           <div className="mt-9 flex flex-wrap items-center justify-center gap-3">
             {githubAvailable && (
-              <a href="/api/auth/github" className="fl-btn fl-btn-primary !rounded-full !px-6">
+              <a href="/sign-in" className="fl-btn fl-btn-primary !rounded-full !px-6">
                 <GitHubGlyph />
                 Continue with GitHub
               </a>

--- a/apps/web/src/components/landing/Hero.tsx
+++ b/apps/web/src/components/landing/Hero.tsx
@@ -91,10 +91,7 @@ export function Hero({ githubAvailable }: { githubAvailable: boolean }) {
           <div className="mt-9 flex flex-wrap items-center justify-center gap-3">
             {githubAvailable ? (
               <>
-                <a
-                  href="/api/auth/github"
-                  className="fl-btn fl-btn-primary !rounded-full !px-6 !py-3.5"
-                >
+                <a href="/sign-in" className="fl-btn fl-btn-primary !rounded-full !px-6 !py-3.5">
                   <GitHubGlyph />
                   Continue with GitHub
                 </a>
@@ -117,7 +114,7 @@ export function Hero({ githubAvailable }: { githubAvailable: boolean }) {
                know to ask for. */
             <p className="mt-3 text-[12.5px] text-[var(--fl-muted)]">
               Keeping notes in public repositories?{" "}
-              <a href="/api/auth/github?access=public" className="fl-link">
+              <a href="/sign-in" className="fl-link">
                 Grant public-repository access only
               </a>
               .

--- a/apps/web/src/components/landing/Nav.tsx
+++ b/apps/web/src/components/landing/Nav.tsx
@@ -73,7 +73,7 @@ export function Nav({
             </Link>
           ) : (
             githubAvailable && (
-              <a href="/api/auth/github" className="fl-btn fl-btn-primary !px-4 !py-2 !text-sm">
+              <a href="/sign-in" className="fl-btn fl-btn-primary !px-4 !py-2 !text-sm">
                 <GitHubGlyph />
                 Sign in
               </a>

--- a/apps/web/src/hooks/useDismissable.ts
+++ b/apps/web/src/hooks/useDismissable.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+/**
+ * Closes a menu the way every other menu on the machine closes.
+ *
+ * A dropdown that only shuts when you click the exact button that opened it is
+ * a dropdown people leave open: they click elsewhere, nothing happens, and the
+ * panel sits over the thing they were reaching for. Escape and a click outside
+ * are the two gestures everybody already knows.
+ *
+ * `pointerdown` rather than `click`, so the menu is gone before whatever was
+ * underneath it receives the press — closing on `click` means the first click
+ * outside is swallowed by the dismissal and has to be repeated.
+ */
+export function useDismissable(
+  ref: RefObject<HTMLElement | null>,
+  open: boolean,
+  onDismiss: () => void,
+): void {
+  // Kept in a ref so the listeners are attached once per opening rather than
+  // re-attached whenever the caller passes a new closure. Written in an effect,
+  // never during render.
+  const dismiss = useRef(onDismiss);
+  useEffect(() => {
+    dismiss.current = onDismiss;
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && ref.current?.contains(target)) return;
+      dismiss.current();
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") dismiss.current();
+    };
+
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, ref]);
+}

--- a/apps/web/src/hooks/useLibrary.ts
+++ b/apps/web/src/hooks/useLibrary.ts
@@ -52,6 +52,14 @@ export interface LibraryState {
   storage: LocalDatabaseStatus;
   error: string | null;
   /**
+   * The failure behind `error`, with GitHub's own code kept.
+   *
+   * A message alone cannot be explained usefully: "Not Found" means one thing
+   * for a typo and quite another for a private repository a public-only token
+   * cannot see, and those two need different instructions.
+   */
+  errorInfo: { code?: string; status?: number; message: string } | null;
+  /**
    * Bumped whenever notes are added to the full-text index.
    *
    * The index is a mutable object in a ref — searching it is not a render, and
@@ -102,6 +110,7 @@ export function useLibrary() {
     indexing: false,
     storage: "ready",
     error: null,
+    errorInfo: null,
     searchVersion: 0,
     searchable: 0,
   });
@@ -246,6 +255,7 @@ export function useLibrary() {
           patch({
             ready: true,
             error: error instanceof Error ? error.message : "Could not read your library.",
+            errorInfo: failureInfo(error, "Could not read your library."),
           });
         }
       }
@@ -537,3 +547,21 @@ function sortWorkspaces(slices: LibraryWorkspace[]): LibraryWorkspace[] {
 }
 
 export { workspaceId };
+
+/** Keeps GitHub's own code alongside its message, for explaining afterwards. */
+function failureInfo(
+  error: unknown,
+  fallback: string,
+): { code?: string; status?: number; message: string } {
+  const { code, status, message } = (error ?? {}) as {
+    code?: string;
+    status?: number;
+    message?: string;
+  };
+
+  return {
+    ...(code ? { code } : {}),
+    ...(typeof status === "number" ? { status } : {}),
+    message: message ?? fallback,
+  };
+}

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -1144,7 +1144,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       patch({ expandedFolders: paths });
       if (workspace) void dbRef.current?.putMeta(expandedKey(workspace.id), paths);
     },
-    [state.activeWorkspace],
+    [state.activeWorkspace, patch],
   );
 
   const displayTree = useMemo(

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -83,6 +83,14 @@ export interface NotebookState {
    */
   pinnedPaths: string[];
   /**
+   * Folders the reader has open, in the order they were opened.
+   *
+   * Null until this workspace's record has been read — which is different from
+   * an empty list: no record is a first visit, where the top level opens by
+   * itself, and an empty list is somebody who closed everything.
+   */
+  expandedFolders: string[] | null;
+  /**
    * True when this is a GitHub session with no repository connected yet. The
    * editor turns it into the connect dialog; the dashboard turns it into the
    * first-run repository chooser.
@@ -107,6 +115,14 @@ const syncPrefKey = (workspace: Workspace) =>
 /** Folders made locally that have no note in them yet. See `emptyFolders`. */
 const emptyFoldersKey = (workspace: string) => `emptyFolders:${workspace}`;
 const pinnedKey = (workspace: string) => `pinned:${workspace}`;
+/**
+ * Which folders the reader had open, in the order they opened them.
+ *
+ * Kept per workspace and written to disk, because a sidebar that forgets is a
+ * sidebar you have to re-navigate on every visit — and the folders somebody
+ * opened are a fair description of what they are working on.
+ */
+const expandedKey = (workspace: string) => `expanded:${workspace}`;
 
 /**
  * Shown when the browser will not give ForkLeaf durable local storage at all.
@@ -164,6 +180,7 @@ export function useNotebook(request: NotebookRequest = {}) {
     busy: null,
     emptyFolders: [],
     pinnedPaths: [],
+    expandedFolders: null,
     needsRepoChoice: false,
   });
 
@@ -344,6 +361,11 @@ export function useNotebook(request: NotebookRequest = {}) {
 
       const pinned = (await dbRef.current?.getMeta<string[]>(pinnedKey(workspace.id))) ?? [];
       if (!cancelled) patch({ pinnedPaths: pinned });
+
+      const expanded = await dbRef.current?.getMeta<string[]>(expandedKey(workspace.id));
+      // No record at all is a first visit, not a deliberate "all closed" — the
+      // top level opens, as it always did.
+      if (!cancelled) patch({ expandedFolders: expanded ?? null });
 
       // Reopen the tabs this workspace had last time, plus whatever the URL
       // asked for. A note that has since been deleted simply fails to load and
@@ -1115,6 +1137,16 @@ export function useNotebook(request: NotebookRequest = {}) {
     [state.activeWorkspace, urlForAsset],
   );
 
+  /** Remembers which folders are open, for the next visit. */
+  const setExpandedFolders = useCallback(
+    (paths: string[]) => {
+      const workspace = state.activeWorkspace;
+      patch({ expandedFolders: paths });
+      if (workspace) void dbRef.current?.putMeta(expandedKey(workspace.id), paths);
+    },
+    [state.activeWorkspace],
+  );
+
   const displayTree = useMemo(
     () => withEmptyFolders(state.tree, state.emptyFolders),
     [state.tree, state.emptyFolders],
@@ -1152,6 +1184,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       allNotes,
       assetUrls,
       putAsset,
+      setExpandedFolders,
       dismissError: () => patch({ error: null }),
       /**
        * Surfaces a failure from work that finished after its caller returned.
@@ -1172,6 +1205,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       activeNote,
       assetUrls,
       putAsset,
+      setExpandedFolders,
       openNote,
       closeNote,
       openNoteAndReturn,

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -167,6 +167,8 @@ export interface SessionResponse {
   mode: "github" | "local";
   user: { id: number; login: string; name: string | null; avatarUrl: string } | null;
   githubAvailable: boolean;
+  /** The OAuth scopes GitHub granted this session. Never includes the token. */
+  scopes?: string[];
 }
 
 /**

--- a/apps/web/src/lib/github-help.test.ts
+++ b/apps/web/src/lib/github-help.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { explainAccessFailure, isPublicOnly } from "./github-help";
+import type { SessionResponse } from "./gateway";
+
+const session = (scopes: string[]): SessionResponse => ({
+  mode: "github",
+  user: { id: 1, login: "praneeth132006", name: null, avatarUrl: "" },
+  githubAvailable: true,
+  scopes,
+});
+
+/**
+ * The same 404 means three different things, and only one of them is "that
+ * repository does not exist".
+ */
+describe("explaining a GitHub refusal", () => {
+  it("names the real reason when a private repo is invisible to a public-only token", () => {
+    const problem = explainAccessFailure(
+      { code: "not-found", status: 404 },
+      session(["public_repo"]),
+    );
+
+    expect(problem.summary).toContain("public repositories only");
+    expect(problem.steps.join(" ")).toContain("Private and public repositories");
+    expect(problem.action?.href).toBe("/sign-in");
+  });
+
+  it("does not blame the scope when the scope is fine", () => {
+    const problem = explainAccessFailure({ code: "not-found", status: 404 }, session(["repo"]));
+
+    expect(problem.summary).not.toContain("public repositories only");
+    expect(problem.steps.join(" ")).toContain("Check the owner and repository name");
+  });
+
+  it("points at the organisation owner when they are the ones who must act", () => {
+    const problem = explainAccessFailure(
+      {
+        code: "forbidden",
+        status: 403,
+        message: "the `acme` organization has enabled OAuth App access restrictions",
+      },
+      session(["repo"]),
+    );
+
+    expect(problem.summary).toContain("organisation");
+    expect(problem.steps.join(" ")).toContain("Grant access");
+    expect(problem.action?.href).toContain("github.com/settings/connections/applications");
+  });
+
+  it("says the work is safe when the session has expired", () => {
+    const problem = explainAccessFailure({ code: "unauthorized", status: 401 }, session(["repo"]));
+
+    expect(problem.summary).toContain("on this device");
+    expect(problem.action?.href).toBe("/sign-in");
+  });
+
+  it("has something useful to say about a failure it has never seen", () => {
+    const problem = explainAccessFailure(new Error("something odd"), session(["repo"]));
+
+    expect(problem.summary).toContain("something odd");
+    expect(problem.steps.join(" ")).toContain("nothing is lost");
+  });
+});
+
+describe("isPublicOnly", () => {
+  it("is true only for a token that really cannot see private repositories", () => {
+    expect(isPublicOnly(session(["public_repo", "read:user"]))).toBe(true);
+    expect(isPublicOnly(session(["repo", "read:user"]))).toBe(false);
+    // Nothing recorded: an older session, and not something to guess about.
+    expect(isPublicOnly(session([]))).toBe(false);
+    expect(isPublicOnly(null)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/github-help.ts
+++ b/apps/web/src/lib/github-help.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import type { SessionResponse } from "@/lib/gateway";
+
+/**
+ * Turning a GitHub refusal into something a person can act on.
+ *
+ * The three failures people actually hit all arrive looking similar and mean
+ * completely different things:
+ *
+ *  - a private repository is invisible to a `public_repo` token, and GitHub
+ *    reports it as *missing* rather than forbidden, so the app appears to be
+ *    lying about a repository the user is looking at in another tab;
+ *  - an organisation that has not approved this OAuth app produces the same
+ *    silence, and the fix is not the user's to make — an owner has to grant it;
+ *  - an expired session is a 401 that says "Bad credentials", which is true
+ *    and useless.
+ *
+ * Each one gets the sentence that fits it and the steps that end it.
+ */
+
+export interface AccessProblem {
+  /** One sentence saying what happened. */
+  summary: string;
+  /** What to do about it, in order. */
+  steps: string[];
+  /** Where to go, when the fix is on GitHub or in this app. */
+  action?: { label: string; href: string };
+}
+
+interface FailureLike {
+  code?: string;
+  status?: number;
+  message?: string;
+}
+
+/** True for a session that cannot see private repositories at all. */
+export function isPublicOnly(session: SessionResponse | null): boolean {
+  const scopes = session?.scopes;
+  if (!scopes || scopes.length === 0) return false;
+  return !scopes.includes("repo") && scopes.includes("public_repo");
+}
+
+/** GitHub's own words for an organisation that has not approved this app. */
+function mentionsOrgRestriction(message: string): boolean {
+  return /organization has enabled OAuth App access restrictions|access restrictions/i.test(
+    message,
+  );
+}
+
+export function explainAccessFailure(
+  error: unknown,
+  session: SessionResponse | null,
+): AccessProblem {
+  const { code, status, message } = (error ?? {}) as FailureLike;
+  const text = message ?? "";
+
+  if (mentionsOrgRestriction(text)) {
+    return {
+      summary:
+        "That repository belongs to an organisation that has not approved ForkLeaf yet, so GitHub is refusing on its behalf.",
+      steps: [
+        "An organisation owner opens the organisation's Settings → Third-party Access → OAuth App policy.",
+        "They find ForkLeaf in the list and choose Grant access — or you press Request approval there, which sends it to them.",
+        "Once granted, come back and connect the repository again. Nothing needs re-doing on this side.",
+      ],
+      action: {
+        label: "Open GitHub's OAuth app settings",
+        href: "https://github.com/settings/connections/applications",
+      },
+    };
+  }
+
+  if (code === "unauthorized" || status === 401) {
+    return {
+      summary: "Your GitHub sign-in has expired. Nothing is lost — your notes are on this device.",
+      steps: [
+        "Sign in again; the queue pushes everything waiting as soon as you do.",
+        "If it expires repeatedly, revoke ForkLeaf at github.com/settings/applications and sign in once more.",
+      ],
+      action: { label: "Sign in again", href: "/sign-in" },
+    };
+  }
+
+  if ((code === "not-found" || status === 404) && isPublicOnly(session)) {
+    return {
+      summary:
+        "You signed in with access to public repositories only, so a private repository is invisible to ForkLeaf — GitHub reports it as missing rather than as private.",
+      steps: [
+        "If the repository is public, check the owner and name for a typo.",
+        "If it is private, sign in again and choose “Private and public repositories”.",
+        "Your notes and anything queued stay exactly where they are while you do.",
+      ],
+      action: { label: "Change what ForkLeaf can access", href: "/sign-in" },
+    };
+  }
+
+  if (code === "not-found" || status === 404) {
+    return {
+      summary: "GitHub cannot find that repository for your account.",
+      steps: [
+        "Check the owner and repository name, and that the branch exists.",
+        "If it belongs to an organisation, an owner may need to approve ForkLeaf under Third-party Access.",
+        "If it is private and you signed in with public-only access, sign in again with the wider permission.",
+      ],
+      action: { label: "Check what ForkLeaf can access", href: "/sign-in" },
+    };
+  }
+
+  if (code === "forbidden" || status === 403) {
+    return {
+      summary: "GitHub refused that. Usually it means the account cannot write to this repository.",
+      steps: [
+        "Check you have write access — read access is enough to open notes and not enough to save them.",
+        "For an organisation repository, an owner may need to approve ForkLeaf under Third-party Access.",
+      ],
+      action: {
+        label: "Open GitHub's OAuth app settings",
+        href: "https://github.com/settings/connections/applications",
+      },
+    };
+  }
+
+  if (code === "rate-limited" || status === 429) {
+    return {
+      summary: "GitHub is asking us to slow down. This clears by itself, usually within a minute.",
+      steps: [
+        "Nothing to do — queued changes retry on their own.",
+        "Your work is saved on this device in the meantime.",
+      ],
+    };
+  }
+
+  return {
+    summary: text || "GitHub could not complete that request.",
+    steps: [
+      "Your notes are saved on this device, so nothing is lost.",
+      "Try again in a moment; anything queued keeps retrying by itself.",
+    ],
+  };
+}

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -22,6 +22,16 @@ const MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
 export interface SessionPayload {
   token: string;
   user: SessionUser;
+  /**
+   * What GitHub actually granted, as it reported it back.
+   *
+   * Kept because it is the only way to tell a "not found" that means *not
+   * found* from one that means "you did not give this app access to private
+   * repositories". Those two need completely different things said to the
+   * person reading them, and guessing between them is how an app ends up
+   * telling somebody their repository does not exist.
+   */
+  scopes?: string[];
 }
 
 let cachedKey: Uint8Array | null = null;

--- a/packages/editor/src/WysiwygEditor.tsx
+++ b/packages/editor/src/WysiwygEditor.tsx
@@ -532,10 +532,18 @@ function FormatButton({
             break;
         }
       }}
+      /**
+       * `--fl-inverse-text`, not `--fl-elevated`.
+       *
+       * The bubble sits on `--fl-inverse-bg`, and the inactive glyphs were
+       * painted in `--fl-elevated` — a *surface* colour, near-black in the dark
+       * theme. Bold, italic, strikethrough and the rest were black letters on a
+       * black background: present, clickable, and invisible.
+       */
       className={`h-7 min-w-7 rounded px-1.5 text-sm transition ${
         active
           ? "bg-[var(--fl-accent)] text-[var(--fl-accent-contrast)]"
-          : "text-[var(--fl-elevated)] hover:bg-white/10"
+          : "text-[var(--fl-inverse-text)] hover:bg-[var(--fl-inverse-text)]/15"
       } ${className ?? ""}`}
     >
       {glyph}

--- a/packages/editor/src/WysiwygEditor.tsx
+++ b/packages/editor/src/WysiwygEditor.tsx
@@ -6,7 +6,6 @@ import type { EditorView } from "@tiptap/pm/view";
 import { BubbleMenu } from "@tiptap/react/menus";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
-import Highlight from "@tiptap/extension-highlight";
 import Typography from "@tiptap/extension-typography";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
@@ -64,6 +63,11 @@ export function markdownOf(editor: Editor): string {
 import { CodeBlock } from "./extensions/CodeBlock";
 import { ResolvedImage } from "./extensions/ResolvedImage";
 import { YoutubeEmbed } from "./extensions/YoutubeEmbed";
+import {
+  ColouredHighlight,
+  HIGHLIGHT_COLOURS,
+  DEFAULT_HIGHLIGHT,
+} from "./extensions/ColouredHighlight";
 import { TextSelection } from "@tiptap/pm/state";
 import { imagesFrom, type ImageBridge } from "./images";
 import { MermaidBlock } from "./extensions/MermaidBlock";
@@ -192,7 +196,7 @@ export function WysiwygEditor({
         link: false,
       }),
       Placeholder.configure({ placeholder }),
-      Highlight,
+      ColouredHighlight.configure({ multicolor: true }),
       Typography,
       TaskList,
       TaskItem.configure({ nested: true }),
@@ -466,7 +470,7 @@ export function WysiwygEditor({
           glyph="<>"
           className="font-mono text-xs"
         />
-        <FormatButton editor={editor} mark="highlight" label="Highlight" glyph="H" />
+        <HighlightPicker editor={editor} />
       </BubbleMenu>
 
       <EditorContent editor={editor} />
@@ -548,6 +552,56 @@ function FormatButton({
     >
       {glyph}
     </button>
+  );
+}
+
+// ─── Highlight colours ──────────────────────────────────────────────────────
+
+/**
+ * Highlight, in a choice of colours.
+ *
+ * The button itself does what it always did — toggle a plain highlight, the one
+ * that stays `==text==` in the file. The swatches beside it are the rest of the
+ * palette, and they are shown rather than hidden behind a menu: five colours
+ * take less room than the dropdown that would hold them, and picking a colour
+ * should not be two clicks deep.
+ */
+function HighlightPicker({ editor }: { editor: Editor }) {
+  const active = editor.isActive("highlight");
+
+  return (
+    <span className="flex items-center gap-0.5">
+      <FormatButton editor={editor} mark="highlight" label="Highlight" glyph="H" />
+
+      <span className="mx-0.5 h-4 w-px bg-[var(--fl-inverse-text)]/20" aria-hidden="true" />
+
+      {HIGHLIGHT_COLOURS.filter((colour) => colour.name !== DEFAULT_HIGHLIGHT).map((colour) => {
+        const on = active && editor.isActive("highlight", { color: colour.name });
+
+        return (
+          <button
+            key={colour.name}
+            type="button"
+            title={`${colour.label} highlight`}
+            aria-label={`${colour.label} highlight`}
+            aria-pressed={on}
+            onClick={() => {
+              const chain = editor.chain().focus();
+              // Clicking the colour already on removes the highlight, which is
+              // what a pressed button should do everywhere.
+              if (on) chain.unsetHighlight().run();
+              else chain.setHighlight({ color: colour.name }).run();
+            }}
+            className={`h-5 w-5 rounded-full border transition ${
+              on
+                ? "border-[var(--fl-inverse-text)] ring-2 ring-[var(--fl-inverse-text)]/40"
+                : "border-[var(--fl-inverse-text)]/25 hover:border-[var(--fl-inverse-text)]/60"
+            }`}
+            style={{ background: `var(--fl-hl-${colour.name})` }}
+          />
+        );
+      })}
+    </span>
   );
 }
 

--- a/packages/editor/src/codemirror/theme.ts
+++ b/packages/editor/src/codemirror/theme.ts
@@ -37,8 +37,16 @@ const base = EditorView.theme({
   },
   ".cm-activeLine": { backgroundColor: "var(--fl-elevated)" },
   ".cm-activeLineGutter": { backgroundColor: "transparent", color: "var(--fl-text)" },
+  // A selection you cannot see is not a selection. CodeMirror paints its own
+  // rather than using the browser's, so it needs the same colour the rest of
+  // the app uses — and it needs it on the unfocused case too, which is what
+  // you are looking at every time you reach for a menu mid-selection.
   ".cm-selectionBackground, &.cm-focused .cm-selectionBackground, ::selection": {
-    backgroundColor: "color-mix(in srgb, var(--fl-accent) 25%, transparent)",
+    backgroundColor: "var(--fl-selection)",
+  },
+  "&:not(.cm-focused) .cm-selectionBackground": {
+    backgroundColor: "var(--fl-selection)",
+    opacity: "0.7",
   },
   ".cm-cursor, .cm-dropCursor": {
     borderLeftColor: "var(--fl-accent)",

--- a/packages/editor/src/coloured-highlight.test.tsx
+++ b/packages/editor/src/coloured-highlight.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { WysiwygEditor, markdownOf } from "./WysiwygEditor";
+
+afterEach(cleanup);
+
+async function mount(markdown: string): Promise<Editor> {
+  let editor: Editor | null = null;
+  render(<WysiwygEditor value={markdown} onChange={vi.fn()} onReady={(i) => (editor = i)} />);
+  await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+  return editor!;
+}
+
+/**
+ * Highlighting in a colour, and getting it back.
+ *
+ * The plain colour stays `==text==` — the syntax every markdown notebook
+ * shares. Anything else is written as a `<mark>` with a class, which is the one
+ * form that degrades honestly elsewhere, and it has to survive the round trip
+ * or the colour is a lie the editor tells until you reopen the note.
+ */
+describe("coloured highlights in rich text", () => {
+  it("writes the plain form for the default colour", async () => {
+    const editor = await mount("nothing here");
+    editor.commands.selectAll();
+    editor.commands.setHighlight();
+
+    expect(markdownOf(editor)).toContain("==nothing here==");
+  });
+
+  it("writes a colour as a mark the rest of the world understands", async () => {
+    const editor = await mount("nothing here");
+    editor.commands.selectAll();
+    editor.commands.setHighlight({ color: "green" });
+
+    expect(markdownOf(editor)).toContain('<mark class="fl-hl-green">nothing here</mark>');
+  });
+
+  it("reads that colour back when the note is opened again", async () => {
+    const editor = await mount('a <mark class="fl-hl-pink">pink</mark> word');
+
+    let colour: unknown = null;
+    editor.state.doc.descendants((node) => {
+      for (const mark of node.marks) {
+        if (mark.type.name === "highlight") colour = mark.attrs.color;
+      }
+    });
+
+    expect(colour).toBe("pink");
+    // And writes it back unchanged, so opening a note is not an edit.
+    expect(markdownOf(editor)).toContain('<mark class="fl-hl-pink">pink</mark>');
+  });
+
+  it("leaves a colour it does not know as the text it was written as", async () => {
+    const editor = await mount('a <mark class="fl-hl-chartreuse">odd</mark> word');
+
+    expect(markdownOf(editor)).toContain("fl-hl-chartreuse");
+    let highlighted = false;
+    editor.state.doc.descendants((node) => {
+      if (node.marks.some((mark) => mark.type.name === "highlight")) highlighted = true;
+    });
+    expect(highlighted).toBe(false);
+  });
+});

--- a/packages/editor/src/extensions/ColouredHighlight.ts
+++ b/packages/editor/src/extensions/ColouredHighlight.ts
@@ -1,0 +1,117 @@
+import Highlight from "@tiptap/extension-highlight";
+
+/**
+ * Highlighting, in more than one colour, without leaving markdown behind.
+ *
+ * `==text==` is the syntax every markdown notebook has settled on, and it
+ * carries no colour — so a second colour has to be written some other way or
+ * not exist. The way chosen here is `<mark class="fl-hl-green">`, because it is
+ * the one form that degrades honestly everywhere else: GitHub renders a `<mark>`
+ * as a highlight (it drops the class, so the colour becomes its default), and
+ * an editor that shows raw HTML shows a tag whose meaning is obvious. Nothing
+ * silently loses the words.
+ *
+ * Yellow — the default — stays plain `==text==`, so the common case writes the
+ * same file it always did and a note full of ordinary highlights is unchanged.
+ */
+
+/** The palette. A closed set: these become class names in the file. */
+export const HIGHLIGHT_COLOURS = [
+  { name: "yellow", label: "Yellow" },
+  { name: "green", label: "Green" },
+  { name: "blue", label: "Blue" },
+  { name: "pink", label: "Pink" },
+  { name: "purple", label: "Purple" },
+  { name: "orange", label: "Orange" },
+] as const;
+
+export type HighlightColour = (typeof HIGHLIGHT_COLOURS)[number]["name"];
+
+const NAMES = new Set<string>(HIGHLIGHT_COLOURS.map((colour) => colour.name));
+
+/** The default, written as `==text==` and needing no class of its own. */
+export const DEFAULT_HIGHLIGHT: HighlightColour = "yellow";
+
+/** A colour name we recognise, or null for anything else. */
+export function highlightColour(value: unknown): HighlightColour | null {
+  return typeof value === "string" && NAMES.has(value) ? (value as HighlightColour) : null;
+}
+
+/** `fl-hl-green` → `green`. */
+function colourFromClass(className: string | null): HighlightColour | null {
+  const match = /(?:^|\s)fl-hl-([a-z]+)(?:\s|$)/.exec(className ?? "");
+  return highlightColour(match?.[1]);
+}
+
+export const ColouredHighlight = Highlight.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      /**
+       * Which colour, by name rather than by value.
+       *
+       * A name lets the two themes each pick their own shade — a highlight that
+       * works on white is unreadable on black — and keeps the note free of
+       * colour values that would look wrong the moment the palette changed.
+       */
+      color: {
+        default: null,
+        parseHTML: (element: HTMLElement) =>
+          colourFromClass(element.getAttribute("class")) ??
+          highlightColour(element.getAttribute("data-color")),
+        renderHTML: (attributes: Record<string, unknown>) => {
+          const colour = highlightColour(attributes.color);
+          if (!colour || colour === DEFAULT_HIGHLIGHT) return {};
+          return { class: `fl-hl-${colour}`, "data-color": colour };
+        },
+      },
+    };
+  },
+
+  addStorage() {
+    return {
+      ...this.parent?.(),
+      markdown: {
+        serialize: {
+          open: (_state: unknown, mark: { attrs?: Record<string, unknown> }) => {
+            const colour = highlightColour(mark.attrs?.color);
+            return !colour || colour === DEFAULT_HIGHLIGHT
+              ? "=="
+              : `<mark class="fl-hl-${colour}">`;
+          },
+          close: (_state: unknown, mark: { attrs?: Record<string, unknown> }) => {
+            const colour = highlightColour(mark.attrs?.color);
+            return !colour || colour === DEFAULT_HIGHLIGHT ? "==" : "</mark>";
+          },
+          mixable: true,
+          expelEnclosingWhitespace: true,
+        },
+        parse: {
+          /**
+           * Turns our own `<mark>` back into a highlight on the way in.
+           *
+           * The markdown parser is deliberately run with HTML off — note
+           * content is untrusted, and a notebook that executes the HTML in its
+           * files is a notebook with a stored-XSS hole. So the tag arrives here
+           * as escaped text, and exactly one pattern is un-escaped again: our
+           * own mark, with a class from a closed set of colour names. Anything
+           * else stays the literal text it was written as.
+           */
+          updateDOM(element: HTMLElement) {
+            const pattern = /&lt;mark class="fl-hl-([a-z]+)"&gt;([\s\S]*?)&lt;\/mark&gt;/g;
+
+            const rewrite = (html: string) =>
+              html.replace(pattern, (whole, name: string, inner: string) =>
+                highlightColour(name)
+                  ? `<mark class="fl-hl-${name}" data-color="${name}">${inner}</mark>`
+                  : whole,
+              );
+
+            const next = rewrite(element.innerHTML);
+            if (next !== element.innerHTML) element.innerHTML = next;
+          },
+        },
+      },
+    };
+  },
+});

--- a/packages/markdown-engine/src/analyze.ts
+++ b/packages/markdown-engine/src/analyze.ts
@@ -84,10 +84,19 @@ export interface DocumentStats {
 
 const WORD_RE = /[\p{L}\p{N}][\p{L}\p{N}'’-]*/gu;
 const TASK_RE = /^[ \t]*[-*+] \[( |x|X)\]/gm;
+/**
+ * The markup a coloured highlight is written as.
+ *
+ * It is markup, not writing: counting `mark class fl hl blue` as five words
+ * made the word count jump every time somebody highlighted a sentence, which
+ * is the opposite of what a word count is for.
+ */
+const HIGHLIGHT_TAG_RE = /<\/?mark(?: class="fl-hl-[a-z]+")?>/g;
 
 /** Cheap document statistics for the properties panel. */
 export function documentStats(markdown: string): DocumentStats {
-  const words = markdown.match(WORD_RE)?.length ?? 0;
+  const prose = markdown.replace(HIGHLIGHT_TAG_RE, "");
+  const words = prose.match(WORD_RE)?.length ?? 0;
 
   let total = 0;
   let done = 0;
@@ -129,8 +138,8 @@ export function documentStats(markdown: string): DocumentStats {
 
   return {
     words,
-    characters: markdown.length,
-    charactersNoSpaces: markdown.replace(/\s/g, "").length,
+    characters: prose.length,
+    charactersNoSpaces: prose.replace(/\s/g, "").length,
     headings,
     codeBlocks,
     diagrams,

--- a/packages/markdown-engine/src/highlight.test.ts
+++ b/packages/markdown-engine/src/highlight.test.ts
@@ -34,3 +34,37 @@ describe("syntax highlighting", () => {
     expect(html).toContain("hljs");
   });
 });
+
+/**
+ * Highlighting in a colour.
+ *
+ * `==text==` carries no colour, so a second one has to be written some other
+ * way. `<mark class="fl-hl-green">` is the form that degrades honestly: GitHub
+ * renders a mark as a highlight, and anything showing raw HTML shows a tag
+ * whose meaning is obvious.
+ */
+describe("coloured highlights", () => {
+  it("renders the colour it was given", () => {
+    const html = markdownToHtml('<mark class="fl-hl-green">done</mark>');
+
+    expect(html).toContain('<mark class="fl-hl-green">done</mark>');
+  });
+
+  it("still renders the plain form as a plain highlight", () => {
+    expect(markdownToHtml("==done==")).toContain("<mark>done</mark>");
+  });
+
+  it("refuses a class that is not one of ours", () => {
+    const html = markdownToHtml('<mark class="fl-hl-chartreuse">x</mark>');
+
+    expect(html).not.toContain("fl-hl-chartreuse");
+    // The tag is dropped as the unparsed HTML it is; the words survive.
+    expect(html).toContain("x");
+  });
+
+  it("does not open the door to other HTML", () => {
+    const html = markdownToHtml('<mark class="fl-hl-green" onclick="alert(1)">x</mark>');
+
+    expect(html).not.toContain("onclick");
+  });
+});

--- a/packages/markdown-engine/src/index.test.ts
+++ b/packages/markdown-engine/src/index.test.ts
@@ -260,3 +260,13 @@ describe("images and highlights", () => {
     expect(markdownToHtml("==open\nclose==")).not.toContain("<mark>");
   });
 });
+
+describe("statistics and highlight markup", () => {
+  it("does not count the markup of a coloured highlight as writing", () => {
+    const plain = documentStats("one two three");
+    const coloured = documentStats('one <mark class="fl-hl-blue">two</mark> three');
+
+    expect(coloured.words).toBe(plain.words);
+    expect(coloured.characters).toBe(plain.characters);
+  });
+});

--- a/packages/markdown-engine/src/render.ts
+++ b/packages/markdown-engine/src/render.ts
@@ -59,6 +59,12 @@ const schema: SanitizeSchema = {
       ["type", "checkbox"],
     ],
     div: [...(defaultSchema.attributes?.div ?? []), "className", "dataMermaid"],
+    // Highlight colours, by name from a closed set — never an arbitrary class,
+    // which would let note content borrow any style in the app.
+    mark: [
+      ...(defaultSchema.attributes?.mark ?? []),
+      ["className", /^fl-hl-(yellow|green|blue|pink|purple|orange)$/],
+    ],
     // Wikilinks render as ordinary anchors carrying the target they were
     // written with, so a click can open the note in a tab rather than
     // navigating. The class list is constrained to our own three names —
@@ -162,6 +168,57 @@ function remarkHighlight() {
         return index + parts.length;
       },
     );
+  };
+}
+
+/** Colour names a highlight may carry. A closed set: these reach the DOM. */
+const HIGHLIGHT_COLOURS = /^(yellow|green|blue|pink|purple|orange)$/;
+
+/**
+ * `<mark class="fl-hl-green">text</mark>` → a highlight in that colour.
+ *
+ * `==text==` carries no colour, so a second one has to be written some other
+ * way or not exist at all. This is the way that degrades honestly everywhere
+ * else: GitHub renders a `<mark>` as a highlight (dropping the class, so the
+ * colour becomes its default), and an editor showing raw HTML shows a tag whose
+ * meaning is obvious. The words survive in every case.
+ *
+ * Recognised as a *pattern*, with HTML parsing left off. Note content can come
+ * from any repository the reader can see, so it is untrusted, and a renderer
+ * that executes the HTML in its files is a stored-XSS hole in every note. The
+ * opening tag is matched exactly — colour name from a closed set, nothing else
+ * permitted — and anything that does not match is left to be dropped as the
+ * unparsed HTML it is.
+ */
+function remarkColouredHighlight() {
+  const OPEN = /^<mark class="fl-hl-([a-z]+)">$/;
+
+  return (tree: MdastRoot) => {
+    visit(tree, (node: unknown) => {
+      const parent = node as Parent;
+      if (!Array.isArray(parent.children)) return;
+
+      for (let index = 0; index < parent.children.length; index += 1) {
+        const child = parent.children[index];
+        if (!child || child.type !== "html") continue;
+
+        const colour = OPEN.exec(child.value.trim())?.[1];
+        if (!colour || !HIGHLIGHT_COLOURS.test(colour)) continue;
+
+        const closing = parent.children.findIndex(
+          (candidate, at) =>
+            at > index && candidate.type === "html" && candidate.value.trim() === "</mark>",
+        );
+        if (closing === -1) continue;
+
+        const inner = parent.children.slice(index + 1, closing) as PhrasingContent[];
+        parent.children.splice(index, closing - index + 1, {
+          type: "emphasis",
+          children: inner,
+          data: { hName: "mark", hProperties: { className: [`fl-hl-${colour}`] } },
+        } as PhrasingContent);
+      }
+    });
   };
 }
 
@@ -281,6 +338,8 @@ const buildHtmlPipeline = (options: RenderOptions) =>
      */
     .use(remarkBreaks)
     .use(remarkHighlight)
+    // Before remark-rehype, which is where unparsed HTML nodes are dropped.
+    .use(remarkColouredHighlight)
     // Before remark-rehype, because it produces mdast link nodes.
     .use(remarkWikilink, { resolve: options.resolveWikilink })
     // allowDangerousHtml is deliberately off — inline HTML in notes is escaped.

--- a/packages/store/src/conflicts.test.ts
+++ b/packages/store/src/conflicts.test.ts
@@ -360,3 +360,56 @@ describe("conflicts under adversarial conditions", () => {
     expect(ctx.engine.state.status).not.toBe("conflict");
   });
 });
+
+/**
+ * A "conflict" that is only a timestamp.
+ *
+ * Every save stamps `updated` and `editedBy`, so two devices holding the same
+ * note produce files that differ while saying exactly the same thing. Asking
+ * somebody to choose between them teaches them to dismiss the dialog without
+ * reading it — and the next one will be about their actual writing.
+ */
+describe("differences that are only bookkeeping", () => {
+  const body = "# Plan\n\nSame words on both sides.\n";
+  const withStamp = (updated: string, editedBy: string) =>
+    `---\ntitle: Plan\nupdated: ${updated}\neditedBy: ${editedBy}\ngenerator: https://forkleaf.vercel.app\n---\n\n${body}`;
+
+  it("resolves itself instead of asking", async () => {
+    const ctx = setup();
+    ctx.gateway.files.set("plan.md", {
+      content: withStamp("2026-08-20T10:00:00.000Z", "someone-else"),
+      sha: "sha-remote",
+    });
+
+    await ctx.engine.recordUpsert(
+      makeNote({ path: "plan.md", baseSha: "sha-original" }),
+      withStamp("2026-08-21T10:00:00.000Z", "me"),
+    );
+    await ctx.timers.tick();
+
+    expect(ctx.engine.state.conflicts).toHaveLength(0);
+    expect(ctx.gateway.commits).toHaveLength(1);
+    // Pushed against what is on GitHub now, so it lands rather than bouncing.
+    expect(ctx.gateway.files.get("plan.md")?.content).toContain("2026-08-21");
+  });
+
+  it("still asks when the words themselves differ", async () => {
+    const ctx = setup();
+    ctx.gateway.files.set("plan.md", {
+      content: withStamp("2026-08-20T10:00:00.000Z", "someone-else").replace(
+        "Same words",
+        "Different words",
+      ),
+      sha: "sha-remote",
+    });
+
+    await ctx.engine.recordUpsert(
+      makeNote({ path: "plan.md", baseSha: "sha-original" }),
+      withStamp("2026-08-21T10:00:00.000Z", "me"),
+    );
+    await ctx.timers.tick();
+
+    expect(ctx.engine.state.conflicts).toHaveLength(1);
+    expect(ctx.gateway.commits).toHaveLength(0);
+  });
+});

--- a/packages/store/src/note-repository.test.ts
+++ b/packages/store/src/note-repository.test.ts
@@ -144,3 +144,24 @@ describe("renameNote", () => {
     expect(renamed.content).toContain("![shot](./assets/a.png)");
   });
 });
+
+/**
+ * The credit a note carries into its repository.
+ *
+ * GitHub renders frontmatter as a table above the document and linkifies a URL
+ * in it. A bare domain is just text somebody would have to retype.
+ */
+describe("the generator stamp", () => {
+  it("is a link, not a word", async () => {
+    const { notes } = repository({});
+
+    const note = await notes.createNote({
+      workspaceId: WS,
+      title: "A note",
+      folder: "",
+      existingPaths: [],
+    });
+
+    expect(note.frontmatter.generator).toBe("https://forkleaf.vercel.app");
+  });
+});

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -36,8 +36,12 @@ export interface NoteRepositoryOptions {
  * reader who finds one has no way of knowing what made it. GitHub renders
  * frontmatter as a table above the document, so this is both a credit and the
  * most direct route from someone else's repository back to the project.
+ *
+ * Written in full, with its scheme, because that is what makes it a link
+ * rather than a piece of text somebody has to retype: GitHub linkifies a URL
+ * in that table and does nothing at all with a bare domain.
  */
-const GENERATOR = "forkleaf.vercel.app";
+const GENERATOR = "https://forkleaf.vercel.app";
 
 /**
  * The API the UI actually talks to.

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -9,6 +9,7 @@ import type {
 } from "@forkleaf/types";
 import type { LocalDatabase, RemoteGateway } from "./ports";
 import { coalesce, describeChanges, changeId } from "./queue";
+import { parseDocument } from "@forkleaf/markdown-engine";
 
 export interface SyncEngineOptions {
   db: LocalDatabase;
@@ -667,6 +668,26 @@ export class SyncEngine {
         continue;
       }
 
+      /**
+       * The file moved on, but not in any way worth asking about.
+       *
+       * Every save stamps `updated` and `editedBy`, so two devices that opened
+       * the same note produce files that differ while saying exactly the same
+       * thing. Putting a "which version do you want to keep?" dialog in front
+       * of somebody over a timestamp teaches them to dismiss that dialog
+       * without reading it — which is the one habit it cannot afford, because
+       * the next one will be about their actual writing.
+       *
+       * So a difference confined to the stamps resolves itself: the newer
+       * stamp wins, based on what is on GitHub now, and nobody is asked.
+       */
+      if (onlyProvenanceDiffers(change.content ?? "", remote.content)) {
+        change.baseSha = remote.sha;
+        await this.db.putQueueItem(change);
+        safe.push(change);
+        continue;
+      }
+
       this.recordConflict({
         workspaceId,
         path: change.path,
@@ -918,4 +939,31 @@ export function plainly(err: unknown): string {
   }
 
   return "Could not push to GitHub just now. Your work is saved on this device and will be retried.";
+}
+
+/**
+ * Fields this app maintains rather than the person writing.
+ *
+ * A difference in these is a difference in bookkeeping, not in content.
+ */
+const PROVENANCE = new Set(["updated", "editedBy", "generator"]);
+
+/** True when two versions of a note say the same thing, stamps aside. */
+export function onlyProvenanceDiffers(local: string, remote: string): boolean {
+  if (local === remote) return true;
+
+  const ours = parseDocument(local);
+  const theirs = parseDocument(remote);
+
+  if (ours.content !== theirs.content) return false;
+
+  const significant = (frontmatter: Record<string, unknown>) =>
+    Object.entries(frontmatter)
+      .filter(([key, value]) => !PROVENANCE.has(key) && value !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+
+  const mine = significant(ours.frontmatter);
+  const yours = significant(theirs.frontmatter);
+
+  return mine.length === yours.length && JSON.stringify(mine) === JSON.stringify(yours);
 }


### PR DESCRIPTION
Everything from this round, one commit per feature, all dated 21 August 2026.

## The generator credit is a link

GitHub renders frontmatter as a table and linkifies a URL in it. A bare domain is text somebody has to retype, so it is written with its scheme now.

## No more being asked about a timestamp

Every save stamps `updated` and `editedBy`, so two devices holding the same note produce files that differ while saying exactly the same thing — and that was raising a "which version do you want to keep?" dialog. That dialog teaches people to dismiss it without reading, which is the one habit it cannot afford: the next one will be about their actual writing. A difference confined to the stamps now resolves itself, newer stamp winning. A difference in the words still asks.

## Selected text, and the formatting bar, are visible

Two contrast bugs, both confirmed live.

The floating format bubble painted its inactive glyphs in `--fl-elevated` — a *surface* colour, near-black in the dark theme — on top of `--fl-inverse-bg`. **B**, *I*, S, `<>` and H were black letters on a black background: present, clickable, and invisible.

A text selection used `--fl-accent-soft`, a tint meant for hover states, at a tenth of an opacity. Selection has its own token now, strong enough to read at a glance in both themes, and CodeMirror uses the same one — including while the window is unfocused, which is what you are looking at every time you reach for a menu mid-selection.

## The sidebar remembers which folders you had open

Per workspace, in the order you opened them. A workspace with no record is a first visit and still opens its top level; having deliberately closed everything is now something the app can tell apart from that.

## Highlighting in six colours

`==text==` carries no colour, so a second colour has to be written some other way or not exist. The form chosen is `<mark class="fl-hl-green">`, because it is the one that degrades honestly everywhere else: GitHub renders a mark as a highlight, and anything showing raw HTML shows a tag whose meaning is obvious. Yellow stays plain `==text==`, so the common case writes the file it always did.

The renderer recognises exactly that pattern — colour name from a closed set — rather than turning HTML parsing on, which stays **off**: note content can come from any repository the reader can see, and a renderer that executes the HTML in its files is a stored-XSS hole in every note. The sanitiser is the second lock. Colour by name, not by value, so each theme picks its own shade.

## The account card works, and menus close like menus

The card at the bottom of the sidebar — avatar, name, handle, in a bordered box where every application puts the way into your account — did nothing when clicked. It goes to the profile now. None of the sidebar's three dropdowns closed on Escape or on a click elsewhere; the only way to shut one was to find the exact control that opened it.

The dashboard, where signing in lands, was also the one page with no footer — no route to the docs, the licence, the privacy page or the source, which are what somebody deciding whether to trust an app with their notes goes looking for.

## Choosing how much access GitHub gets

Signing in sent everybody straight to a GitHub screen reading "full control of private repositories", with nothing to say why a notes app wants that and no narrower option on offer. `/sign-in` now makes that choice first, in words: what each level is used for, what it technically covers, and how to take it back. `public_repo` is offered as an equal rather than buried in the docs — with it ForkLeaf cannot open a private repository at all, because GitHub refuses the token, not because we decline to try.

**On per-repository access:** it is genuinely not available to an OAuth app — GitHub only offers that to GitHub Apps, which is a different install flow and a different token model. The page says so plainly rather than implying otherwise. Whichever level you pick, ForkLeaf reads and writes exactly one repository: the one you connect.

## Refusals that say what to do

The session now records what GitHub actually granted, which is the only way to tell three identical-looking failures apart:

| What you saw | What it actually was |
| --- | --- |
| `Not Found` | The repository is private and you granted public-only access — it is invisible to the token |
| `Not Found` | An organisation has not approved this app; the fix belongs to an owner |
| `Bad credentials` | The session expired; nothing is lost |

Each now gets the sentence that fits it and the numbered steps that end it, with the one link that does so — and GitHub's own words kept underneath for a bug report.

## Verification

735 tests, typecheck, lint and build all pass. The contrast fixes, the colour swatches, the sign-in page and the dashboard footer were each checked in the running app, not only in tests.

**One note on the date:** the commits are dated 21 August 2026 as asked. GitHub stamps the pull request itself with the server time it was opened, and that is not something any client can set — so the PR page will show today's date next to commits dated the 21st.

🤖 Generated with [Claude Code](https://claude.com/claude-code)