### PR TITLE
Make the expired-sign-in message a way out, and let deletes stick

### DIFF
--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { GitHubClient } from "@forkleaf/github-client";
-import { appUrl } from "@/lib/app-url";
-import { consumeOAuthState, setSessionCookie, githubOAuthConfigured } from "@/lib/session";
+import { appUrl, safeReturnPath } from "@/lib/app-url";
+import {
+  consumeOAuthState,
+  consumeReturnPath,
+  setSessionCookie,
+  githubOAuthConfigured,
+} from "@/lib/session";
 
 /**
  * Completes the GitHub OAuth flow.
@@ -59,10 +64,18 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // The dashboard, not the editor: a fresh sign-in has no repository chosen
-    // yet, and dropping someone into an empty editor is how the repo choice
-    // used to get made silently on their behalf.
-    return NextResponse.redirect(appUrl(request, "/dashboard"));
+    // Back where the sign-in was started from, when it was started somewhere
+    // specific — signing in again because a token expired should return to the
+    // note that was open, not to a dashboard.
+    //
+    // Otherwise the dashboard, not the editor: a fresh sign-in has no
+    // repository chosen yet, and dropping someone into an empty editor is how
+    // the repo choice used to get made silently on their behalf.
+    //
+    // Re-checked on the way out as well as on the way in: a cookie is not a
+    // safer source of a redirect target than a query string is.
+    const back = safeReturnPath(await consumeReturnPath());
+    return NextResponse.redirect(appUrl(request, back ?? "/dashboard"));
   } catch (error) {
     console.error("[forkleaf] OAuth callback failed:", error);
     return NextResponse.redirect(withError(home, "exchange_failed"));

--- a/apps/web/src/app/api/auth/github/route.ts
+++ b/apps/web/src/app/api/auth/github/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { appUrl } from "@/lib/app-url";
+import { appUrl, safeReturnPath } from "@/lib/app-url";
 import { clientKey } from "@/lib/rate-limit";
-import { createOAuthState, githubOAuthConfigured } from "@/lib/session";
+import { createOAuthState, githubOAuthConfigured, setReturnPath } from "@/lib/session";
 
 /**
  * Starts the GitHub OAuth flow.
@@ -44,6 +44,12 @@ export async function GET(request: NextRequest) {
   }
 
   const state = await createOAuthState();
+
+  // Where to land afterwards. Somebody whose token expired mid-sentence is
+  // signing in *from* the editor, and finishing on the dashboard with their
+  // note nowhere in sight reads as though the sign-in went somewhere else.
+  // Validated here, so nothing but a path on this deployment can be stored.
+  await setReturnPath(safeReturnPath(new URL(request.url).searchParams.get("next")));
 
   const authorize = new URL("https://github.com/login/oauth/authorize");
   authorize.searchParams.set("client_id", process.env.GITHUB_OAUTH_CLIENT_ID!);

--- a/apps/web/src/app/sign-in/page.tsx
+++ b/apps/web/src/app/sign-in/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { SiteShell } from "@/components/SiteShell";
+import { safeReturnPath } from "@/lib/app-url";
 import { githubOAuthConfigured } from "@/lib/session";
 
 export const metadata = {
@@ -21,7 +22,23 @@ export const metadata = {
  * never grant access to their private code, and until now they had no way to
  * say so without reading the documentation first.
  */
-export default function SignInPage() {
+export default async function SignInPage({
+  searchParams,
+}: {
+  /**
+   * `next` is where to return to afterwards, and `expired` says this is a
+   * sign-in that interrupted something rather than a first one. Both arrive
+   * from the editor, which is the only place that knows either.
+   */
+  searchParams: Promise<{ next?: string; expired?: string }>;
+}) {
+  const params = await searchParams;
+  const back = safeReturnPath(params.next);
+  const expired = params.expired === "1";
+  // Appended to both grant links, so whichever level is chosen ends up in the
+  // same place. Encoded once, here, rather than in each href.
+  const next = back ? `&next=${encodeURIComponent(back)}` : "";
+
   if (!githubOAuthConfigured()) {
     return (
       <SiteShell>
@@ -35,7 +52,7 @@ export default function SignInPage() {
             </Link>{" "}
             takes a few minutes.
           </p>
-          <Link href="/editor" className="fl-btn fl-btn-primary mt-6 inline-flex">
+          <Link href={back ?? "/editor"} className="fl-btn fl-btn-primary mt-6 inline-flex">
             Start writing on this device
           </Link>
         </Frame>
@@ -46,7 +63,20 @@ export default function SignInPage() {
   return (
     <SiteShell>
       <Frame>
-        <h1 className="text-3xl font-semibold tracking-tight">Sign in with GitHub</h1>
+        <h1 className="text-3xl font-semibold tracking-tight">
+          {expired ? "Sign in to GitHub again" : "Sign in with GitHub"}
+        </h1>
+
+        {expired && (
+          <p
+            role="status"
+            className="mt-4 max-w-2xl rounded-lg border border-[var(--fl-warn)]/40 bg-[var(--fl-warn)]/10 px-4 py-3 text-sm text-[var(--fl-text)]"
+          >
+            Your previous sign-in expired, which is why pushing stopped. Nothing was lost — every
+            change is saved on this device and goes to GitHub as soon as you are back in.
+          </p>
+        )}
+
         <p className="mt-3 max-w-2xl text-[15px] leading-relaxed text-[var(--fl-muted)]">
           ForkLeaf keeps your notes as Markdown files in a repository you own, so it needs
           permission to read and write files there. Choose how much of your account that covers. You
@@ -55,7 +85,7 @@ export default function SignInPage() {
 
         <div className="mt-8 grid gap-4 md:grid-cols-2">
           <Choice
-            href="/api/auth/github?access=all"
+            href={`/api/auth/github?access=all${next}`}
             scope="repo"
             title="Private and public repositories"
             recommended
@@ -69,7 +99,7 @@ export default function SignInPage() {
           />
 
           <Choice
-            href="/api/auth/github?access=public"
+            href={`/api/auth/github?access=public${next}`}
             scope="public_repo"
             title="Public repositories only"
             need="Enough if your notes are going to be public. ForkLeaf literally cannot open a private repository with this — the token is refused by GitHub, not by us."

--- a/apps/web/src/components/EditorStatusBar.tsx
+++ b/apps/web/src/components/EditorStatusBar.tsx
@@ -31,6 +31,15 @@ export interface EditorStatusBarProps {
   onSwitchBranch: (branch: string) => void | Promise<void>;
   /** Opens the pull-request flow for the current work. */
   onPropose: () => void;
+  /**
+   * Starts signing in again, and comes back here afterwards.
+   *
+   * Needed because "retry" is the wrong offer for an expired token: the queue
+   * would push into the same 401 it just failed on, and the status bar would
+   * report the same sentence again with nothing having moved. When the reason
+   * is the sign-in, the button has to be the sign-in.
+   */
+  onSignIn: () => void;
 }
 
 /**
@@ -53,20 +62,45 @@ export function EditorStatusBar({
   onShowConflicts,
   onSwitchBranch,
   onPropose,
+  onSignIn,
 }: EditorStatusBarProps) {
-  const status = describe(sync);
+  /**
+   * An expired sign-in is the one failure retrying cannot fix, so it takes
+   * over the whole status control rather than sitting behind it.
+   */
+  const expired = sync.lastErrorCode === "unauthorized";
+  const status = describe(sync, expired);
 
   return (
     <footer className="flex h-8 shrink-0 items-center gap-3 px-4 text-[0.7rem] text-[var(--fl-muted)]">
       <button
         type="button"
-        onClick={sync.conflicts.length > 0 ? onShowConflicts : onSyncNow}
-        title={sync.conflicts.length > 0 ? "Resolve conflicts" : "Sync now"}
+        onClick={sync.conflicts.length > 0 ? onShowConflicts : expired ? onSignIn : onSyncNow}
+        title={
+          sync.conflicts.length > 0
+            ? "Resolve conflicts"
+            : expired
+              ? "Sign in to GitHub again"
+              : "Sync now"
+        }
         className="flex items-center gap-1.5 rounded px-1.5 py-0.5 hover:bg-[var(--fl-elevated)]"
       >
         <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${status.dot}`} />
         <span className={status.className}>{status.label}</span>
       </button>
+
+      {/* The way out, drawn as a button rather than left as advice inside a
+          sentence. Somebody reading "sign in again" in red text has no reason
+          to guess that the red text is clickable. */}
+      {expired && (
+        <button
+          type="button"
+          onClick={onSignIn}
+          className="shrink-0 rounded bg-[var(--fl-accent)] px-2 py-0.5 text-[0.7rem] font-semibold text-[var(--fl-accent-contrast)] transition-colors hover:bg-[var(--fl-accent-hover)]"
+        >
+          Sign in again
+        </button>
+      )}
 
       {workspace?.isLocal && <span className="hidden truncate sm:inline">Local storage</span>}
 
@@ -99,7 +133,9 @@ export function EditorStatusBar({
         </>
       )}
 
-      {sync.lastError && (
+      {/* Only when the status control is not already saying it: the same
+          sentence printed twice across one bar reads as two problems. */}
+      {sync.lastError && sync.status !== "error" && sync.status !== "blocked" && (
         <span
           className="ml-auto truncate text-[var(--fl-danger)]"
           title={sync.lastErrorDetail ?? sync.lastError}
@@ -146,7 +182,10 @@ export function EditorStatusBar({
   );
 }
 
-function describe(sync: SyncState): { label: string; className: string; dot: string } {
+function describe(
+  sync: SyncState,
+  expired: boolean,
+): { label: string; className: string; dot: string } {
   if (sync.conflicts.length > 0) {
     return {
       label: `${sync.conflicts.length} conflict${sync.conflicts.length === 1 ? "" : "s"} — click to resolve`,
@@ -186,8 +225,12 @@ function describe(sync: SyncState): { label: string; className: string; dot: str
     case "error":
       return {
         // The message already says what happened and that the work is safe;
-        // "click to retry" is the only thing left to add.
-        label: `${sync.lastError ?? "Could not push to GitHub."} Click to retry.`,
+        // what to press is the only thing left to add — and for an expired
+        // token that is not "retry", which is what made the old label a dead
+        // end for the one failure people actually hit.
+        label: expired
+          ? `${sync.lastError ?? "Your GitHub sign-in has expired."} Click to sign in.`
+          : `${sync.lastError ?? "Could not push to GitHub."} Click to retry.`,
         className: "text-[var(--fl-danger)] truncate max-w-[500px]",
         dot: "bg-[var(--fl-danger)]",
       };
@@ -197,7 +240,9 @@ function describe(sync: SyncState): { label: string; className: string; dot: str
       // have stopped retrying and will not move until somebody asks them to,
       // so the label says what is true and what to do about it.
       return {
-        label: `${sync.blockedCount} change${sync.blockedCount === 1 ? "" : "s"} not on GitHub — click to retry`,
+        label: expired
+          ? `${sync.blockedCount} change${sync.blockedCount === 1 ? "" : "s"} not on GitHub — click to sign in again`
+          : `${sync.blockedCount} change${sync.blockedCount === 1 ? "" : "s"} not on GitHub — click to retry`,
         className: "text-[var(--fl-danger)] font-medium",
         dot: "bg-[var(--fl-danger)]",
       };

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -332,6 +332,20 @@ export function EditorWorkspace() {
     router.push("/sign-in");
   }, [router]);
 
+  /**
+   * Signing in again after a token expired, which is a different errand.
+   *
+   * It interrupted something: there is a note open and a queue waiting behind
+   * a 401. So it says so on the sign-in page, and it comes back here rather
+   * than to the dashboard — being bounced to a repository picker after fixing
+   * a sign-in reads as having lost the note you were writing.
+   */
+  const signInAgain = useCallback(() => {
+    track("github_sign_in_started");
+    const here = `${window.location.pathname}${window.location.search}`;
+    router.push(`/sign-in?expired=1&next=${encodeURIComponent(here)}`);
+  }, [router]);
+
   // ── Actions ─────────────────────────────────────────────────────────────
 
   const handleCreate = useCallback(
@@ -474,10 +488,10 @@ export function EditorWorkspace() {
         confirmLabel: "Delete",
         body: `“${path}” will be deleted. On a connected repository this is committed to GitHub, so it stays recoverable from your git history.`,
         onConfirm: async () => {
-          // Load it first so the sync engine knows the base SHA to delete against.
-          const target =
-            notebook.note?.path === path ? notebook.note : await notebook.openNoteAndReturn(path);
-          if (target) await notebook.deleteNote(target);
+          // By path, not by opening it first: reading the note reaches for
+          // GitHub, and a note GitHub will not hand over — expired sign-in, no
+          // connection — used to make Delete do nothing at all.
+          await notebook.deleteNoteAt(path);
         },
       });
     },
@@ -1110,6 +1124,34 @@ export function EditorWorkspace() {
               </div>
             ))}
 
+          {/* An expired sign-in gets a banner rather than only a line in the
+              status bar. It stops every push until it is dealt with, and the
+              fix is one button — so the button is where the reader is looking,
+              not eight point type at the bottom of the window. */}
+          {notebook.sync.lastErrorCode === "unauthorized" && (
+            <div
+              role="alert"
+              className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-[var(--fl-danger)]/30 bg-[var(--fl-danger)]/8 px-4 py-2.5 text-[13px]"
+            >
+              <p className="w-full min-w-0 text-[var(--fl-text)] sm:w-auto sm:flex-1">
+                <strong className="font-semibold">Your GitHub sign-in has expired.</strong>{" "}
+                <span className="text-[var(--fl-muted)]">
+                  {notebook.sync.pendingCount > 0
+                    ? `${notebook.sync.pendingCount} change${notebook.sync.pendingCount === 1 ? "" : "s"} are saved on this device and will push as soon as you are back in.`
+                    : "Your notes are saved on this device. Signing in again resumes pushing to GitHub."}
+                </span>
+              </p>
+
+              <button
+                type="button"
+                onClick={signInAgain}
+                className="shrink-0 rounded-lg bg-[var(--fl-accent)] px-3 py-1.5 text-[12.5px] font-semibold text-[var(--fl-accent-contrast)] transition-colors hover:bg-[var(--fl-accent-hover)]"
+              >
+                Sign in again
+              </button>
+            </div>
+          )}
+
           {!user && (
             <LocalOnlyBanner
               githubAvailable={notebook.session?.githubAvailable ?? false}
@@ -1208,6 +1250,7 @@ export function EditorWorkspace() {
         onSyncModeChange={notebook.setSyncMode}
         onSyncNow={() => void saveEverything()}
         onShowConflicts={() => setConflictsDismissed(false)}
+        onSignIn={signInAgain}
       />
 
       {/* ── Dialogs ────────────────────────────────────────────────────── */}

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -172,6 +172,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       lastSyncedAt: null,
       lastError: null,
       lastErrorDetail: null,
+      lastErrorCode: null,
       conflicts: [],
     },
     syncPreference: DEFAULT_SYNC_PREFERENCE,
@@ -630,22 +631,32 @@ export function useNotebook(request: NotebookRequest = {}) {
     [state.activeWorkspace, state.tree, state.openNotes, state.emptyFolders, patch, rememberTabs],
   );
 
-  const deleteNote = useCallback(
-    async (note: Note) => {
+  /**
+   * Deletes whatever is at a path, opened or not.
+   *
+   * By path rather than by note, because requiring the note first meant a
+   * delete could only happen for something the app had managed to read — and
+   * an unreadable note (signed out, offline, never opened) is precisely the
+   * one somebody is trying to get rid of. The repository handles the rest.
+   */
+  const deleteNoteAt = useCallback(
+    async (path: string) => {
       const notes = repoRef.current;
-      if (!notes) return;
+      const workspace = state.activeWorkspace;
+      if (!notes || !workspace) return;
 
-      await notes.deleteNote(note);
+      await notes.deletePath(workspace.id, path, shaFor(state.tree, path));
 
-      const open = state.openNotes.filter((candidate) => candidate.path !== note.path);
-      const activePath =
-        state.activePath === note.path ? (open[0]?.path ?? null) : state.activePath;
+      const open = state.openNotes.filter((candidate) => candidate.path !== path);
+      const activePath = state.activePath === path ? (open[0]?.path ?? null) : state.activePath;
 
-      patch({ tree: removeFromTree(state.tree, note.path), openNotes: open, activePath });
-      if (state.activeWorkspace) rememberTabs(state.activeWorkspace.id, open, activePath);
+      patch({ tree: removeFromTree(state.tree, path), openNotes: open, activePath });
+      rememberTabs(workspace.id, open, activePath);
     },
     [state.tree, state.openNotes, state.activePath, state.activeWorkspace, patch, rememberTabs],
   );
+
+  const deleteNote = useCallback(async (note: Note) => deleteNoteAt(note.path), [deleteNoteAt]);
 
   const renameNote = useCallback(
     async (note: Note, toPath: string) => {
@@ -828,10 +839,11 @@ export function useNotebook(request: NotebookRequest = {}) {
         for (const notePath of collectPaths(state.tree).filter((candidate) =>
           candidate.startsWith(`${folder}/`),
         )) {
-          const note =
-            state.openNotes.find((candidate) => candidate.path === notePath) ??
-            (await notes.openNote(workspace.id, notePath));
-          await notes.deleteNote(note);
+          // By path: a folder is deleted as a whole, and one note inside it
+          // that cannot be read — signed out, offline, never opened — used to
+          // throw here and abandon the deletion halfway through, leaving the
+          // folder on screen with some of its notes gone.
+          await notes.deletePath(workspace.id, notePath, shaFor(state.tree, notePath));
         }
 
         putEmptyFolders(
@@ -1165,6 +1177,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       updateFrontmatter,
       createNote,
       deleteNote,
+      deleteNoteAt,
       renameNote,
       createFolder,
       togglePinned,
@@ -1214,6 +1227,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       updateFrontmatter,
       createNote,
       deleteNote,
+      deleteNoteAt,
       renameNote,
       createFolder,
       togglePinned,
@@ -1369,4 +1383,16 @@ function sortNodes(nodes: TreeNode[]): TreeNode[] {
     if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
     return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
   });
+}
+
+/** The blob SHA the tree reported for a path, when it reported one. */
+function shaFor(tree: TreeNode[], path: string): string | undefined {
+  for (const node of tree) {
+    if (node.path === path) return node.sha;
+    if (node.children) {
+      const found = shaFor(node.children, path);
+      if (found) return found;
+    }
+  }
+  return undefined;
 }

--- a/apps/web/src/lib/app-url.test.ts
+++ b/apps/web/src/lib/app-url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { safeReturnPath } from "./app-url";
+
+/**
+ * Where a sign-in is allowed to end.
+ *
+ * Signing in again from the editor carries a destination through the OAuth
+ * round trip, which is exactly the shape of an open redirect: a value from a
+ * query string that a browser is later told to follow. Everything that is not
+ * plainly a path on this deployment has to be refused rather than repaired.
+ */
+describe("safeReturnPath", () => {
+  it("keeps a path on this deployment, query string and all", () => {
+    expect(safeReturnPath("/editor")).toBe("/editor");
+    expect(safeReturnPath("/editor?path=notes%2Fa.md")).toBe("/editor?path=notes%2Fa.md");
+  });
+
+  it("refuses another origin, however it is spelled", () => {
+    expect(safeReturnPath("https://evil.example/steal")).toBeNull();
+    // Protocol-relative: a browser reads this as another host entirely.
+    expect(safeReturnPath("//evil.example/steal")).toBeNull();
+    expect(safeReturnPath("/\\evil.example/steal")).toBeNull();
+    expect(safeReturnPath("javascript:alert(1)")).toBeNull();
+  });
+
+  it("refuses anything that could split a header", () => {
+    expect(safeReturnPath("/editor\r\nSet-Cookie: a=b")).toBeNull();
+  });
+
+  it("refuses nothing at all", () => {
+    expect(safeReturnPath(null)).toBeNull();
+    expect(safeReturnPath("")).toBeNull();
+    expect(safeReturnPath(`/${"a".repeat(600)}`)).toBeNull();
+  });
+
+  it("drops a fragment, which the server has no use for", () => {
+    expect(safeReturnPath("/editor#section")).toBe("/editor");
+  });
+});

--- a/apps/web/src/lib/app-url.ts
+++ b/apps/web/src/lib/app-url.ts
@@ -47,3 +47,33 @@ export function appBaseUrl(request: NextRequest): URL {
 export function appUrl(request: NextRequest, path: string): URL {
   return new URL(path, appBaseUrl(request));
 }
+
+/**
+ * A place on this deployment it is safe to send somebody after signing in.
+ *
+ * Signing in again from the editor should end in the editor. Doing that means
+ * carrying a destination through the OAuth round trip, and a destination taken
+ * from a query string and used unchecked is an open redirect: `?next=//evil`
+ * is a protocol-relative URL, and a browser follows it off this origin
+ * entirely. So only a plain, single-slash, same-origin path is accepted, and
+ * anything else falls back to the default rather than being repaired.
+ */
+export function safeReturnPath(value: string | null | undefined): string | null {
+  if (!value) return null;
+  if (value.length > 512) return null;
+  // Must be rooted here, and must not be `//host` or `/\host`, both of which
+  // browsers read as another origin.
+  if (!value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) return null;
+  // A newline or a NUL in a `Location` header is a header-splitting attempt.
+  if (/[\u0000-\u001f\u007f]/.test(value)) return null;
+
+  try {
+    // Parsed against a throwaway origin purely to reject anything that is not
+    // a path once escapes are resolved.
+    const url = new URL(value, "https://forkleaf.invalid");
+    if (url.origin !== "https://forkleaf.invalid") return null;
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -17,6 +17,7 @@ import type { SessionUser } from "@forkleaf/types";
 
 const COOKIE_NAME = "forkleaf_session";
 const STATE_COOKIE = "forkleaf_oauth_state";
+const RETURN_COOKIE = "forkleaf_return_to";
 const MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
 
 export interface SessionPayload {
@@ -136,6 +137,31 @@ export async function createOAuthState(): Promise<string> {
   store.set(STATE_COOKIE, state, { ...cookieOptions, maxAge: 600 });
 
   return state;
+}
+
+/**
+ * Remembers where to go once GitHub has answered.
+ *
+ * In a cookie rather than in the `state` parameter or GitHub's `redirect_uri`:
+ * the redirect URI has to match what is registered on the OAuth app exactly,
+ * and `state` is compared byte for byte as a CSRF token. A cookie keeps the
+ * destination on this origin, where it was already checked.
+ */
+export async function setReturnPath(path: string | null): Promise<void> {
+  const store = await cookies();
+  if (!path) {
+    store.delete(RETURN_COOKIE);
+    return;
+  }
+  store.set(RETURN_COOKIE, path, { ...cookieOptions, maxAge: 600 });
+}
+
+/** Reads and clears the remembered destination. Single use, like the state. */
+export async function consumeReturnPath(): Promise<string | null> {
+  const store = await cookies();
+  const value = store.get(RETURN_COOKIE)?.value ?? null;
+  store.delete(RETURN_COOKIE);
+  return value;
 }
 
 /** Verifies and consumes the state parameter. Single use. */

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,7 +1,7 @@
 export type { LocalDatabase, RemoteGateway, RemoteCommitInput, RemoteCommitResult } from "./ports";
 
 export { coalesce, describeChanges, changeId, type CoalesceInput } from "./queue";
-export { SyncEngine, type SyncEngineOptions } from "./sync-engine";
+export { SyncEngine, plainly, codeOf, type SyncEngineOptions } from "./sync-engine";
 export { MemoryDatabase } from "./memory-db";
 export {
   IndexedDbDatabase,

--- a/packages/store/src/note-repository.test.ts
+++ b/packages/store/src/note-repository.test.ts
@@ -165,3 +165,74 @@ describe("the generator stamp", () => {
     expect(note.frontmatter.generator).toBe("https://forkleaf.vercel.app");
   });
 });
+
+/**
+ * Deleting, when GitHub will not answer.
+ *
+ * The failure this covers is the one people hit: a sign-in expires, the queue
+ * stops draining, and from then on deleting a note did nothing whatsoever —
+ * the delete needed to read the note first, the read was refused, and the
+ * refusal was swallowed. Then the tree refreshed and put everything back.
+ */
+describe("deleting without being able to read", () => {
+  const tree = [
+    {
+      path: "notes",
+      name: "notes",
+      kind: "folder" as const,
+      children: [
+        { path: "notes/a.md", name: "a.md", kind: "file" as const, sha: "sha-a" },
+        { path: "notes/b.md", name: "b.md", kind: "file" as const, sha: "sha-b" },
+      ],
+    },
+  ];
+
+  function signedOut() {
+    const db = new MemoryDatabase();
+    const unauthorized = Object.assign(new Error("Bad credentials"), { code: "unauthorized" });
+
+    const gateway: RemoteGateway = {
+      listTree: async () => tree,
+      readFile: async () => {
+        throw unauthorized;
+      },
+      commit: async () => {
+        throw unauthorized;
+      },
+    };
+
+    const sync = new SyncEngine({ db, gateway, isOnline: () => false });
+    return { db, sync, notes: new NoteRepository({ db, gateway, sync }) };
+  }
+
+  it("deletes a note it was never able to open", async () => {
+    const { notes, sync } = signedOut();
+
+    await notes.deletePath(WS, "notes/a.md", "sha-a");
+
+    const queued = sync.pendingFor(WS);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]!.op).toBe("delete");
+    expect(queued[0]!.path).toBe("notes/a.md");
+    expect(queued[0]!.baseSha).toBe("sha-a");
+  });
+
+  it("keeps the deleted note out of the tree until the deletion is pushed", async () => {
+    const { notes } = signedOut();
+
+    await notes.deletePath(WS, "notes/a.md", "sha-a");
+
+    const shown = await notes.getTree(WS);
+    const paths = shown.flatMap((node) => node.children ?? []).map((node) => node.path);
+    expect(paths).toEqual(["notes/b.md"]);
+  });
+
+  it("drops a folder once every note in it is gone", async () => {
+    const { notes } = signedOut();
+
+    await notes.deletePath(WS, "notes/a.md", "sha-a");
+    await notes.deletePath(WS, "notes/b.md", "sha-b");
+
+    expect(await notes.getTree(WS)).toEqual([]);
+  });
+});

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -135,7 +135,7 @@ export class NoteRepository {
       try {
         const fresh = await this.gateway.listTree(workspaceId);
         await this.db.putTreeCache(workspaceId, fresh);
-        onUpdate?.(fresh);
+        onUpdate?.(this.withPending(workspaceId, fresh));
       } catch {
         // Offline or rate limited: the cached tree stays on screen.
       }
@@ -146,14 +146,51 @@ export class NoteRepository {
       try {
         const fresh = await this.gateway.listTree(workspaceId);
         await this.db.putTreeCache(workspaceId, fresh);
-        return fresh;
+        return this.withPending(workspaceId, fresh);
       } catch {
-        return cached;
+        return this.withPending(workspaceId, cached);
       }
     }
 
     void refresh();
-    return cached;
+    return this.withPending(workspaceId, cached);
+  }
+
+  /**
+   * The repository's tree, corrected by what has not been pushed yet.
+   *
+   * Both trees this method is handed describe GitHub: the cache is the last
+   * answer GitHub gave, and a refresh is the current one. Neither knows about
+   * a note deleted thirty seconds ago and still sitting in the queue — so the
+   * sidebar used to put deleted notes and deleted folders straight back on
+   * screen the moment anything refreshed the tree, which is indistinguishable
+   * from delete not working. With a queue that cannot drain — an expired
+   * sign-in, no connection — they came back and stayed.
+   *
+   * Applying the queue on top makes the sidebar agree with what the person
+   * did, and it stops agreeing the moment the deletion is really committed and
+   * GitHub stops listing the path.
+   */
+  private withPending(workspaceId: string, tree: TreeNode[]): TreeNode[] {
+    const pending = this.sync.pendingFor(workspaceId);
+    if (pending.length === 0) return tree;
+
+    // Images go through the same queue and are not part of the notebook; the
+    // tree only ever lists Markdown.
+    const markdown = (path: string) => path.toLowerCase().endsWith(".md");
+
+    let next = tree;
+    for (const change of pending) {
+      if (change.op === "delete") {
+        next = withoutPath(next, change.path);
+      } else if (change.op === "rename") {
+        next = withoutPath(next, change.path);
+        if (change.toPath && markdown(change.toPath)) next = withPath(next, change.toPath);
+      } else if (markdown(change.path)) {
+        next = withPath(next, change.path);
+      }
+    }
+    return next;
   }
 
   // ─── Notes ────────────────────────────────────────────────────────────────
@@ -263,6 +300,48 @@ export class NoteRepository {
     return note;
   }
 
+  /**
+   * Deletes a note by path, whether or not it can be read first.
+   *
+   * Deleting used to require opening the note, because the delete is recorded
+   * against the note's own base SHA. But opening reaches for GitHub, and when
+   * GitHub will not answer — an expired token, no connection, a file that was
+   * only ever listed in the tree and never opened — the read threw and the
+   * delete never happened. Nothing was removed and nothing said why, which is
+   * exactly the state where somebody most wants to be able to tidy up.
+   *
+   * So a note we cannot read is deleted on the strength of its path and the
+   * SHA the tree already reported. That is all the commit needs.
+   */
+  async deletePath(workspaceId: string, path: string, sha?: string): Promise<void> {
+    const id = noteId(workspaceId, path);
+    const stored = await this.db.getNote(id);
+    if (stored) {
+      await this.deleteNote(stored);
+      return;
+    }
+
+    let note: Note | null = null;
+    try {
+      note = await this.openNote(workspaceId, path);
+    } catch {
+      // Unreadable, which is not a reason to refuse to delete it.
+    }
+
+    await this.deleteNote(
+      note ?? {
+        id,
+        workspaceId,
+        path,
+        content: "",
+        frontmatter: {},
+        baseSha: sha ?? null,
+        updatedAt: null,
+        dirty: false,
+      },
+    );
+  }
+
   async deleteNote(note: Note): Promise<void> {
     const current = await this.db.getNote(note.id);
     const target = current ?? note;
@@ -341,4 +420,65 @@ export class NoteRepository {
 
 export function noteId(workspaceId: string, path: string): string {
   return `${workspaceId}::${path}`;
+}
+
+/**
+ * The tree without one path, and without any folder that path was the last
+ * thing in.
+ *
+ * Leaving an empty folder behind would be a lie in the other direction: git
+ * has no empty directories, so a folder whose every note has been deleted does
+ * not exist in the repository either.
+ */
+function withoutPath(tree: TreeNode[], path: string): TreeNode[] {
+  return tree
+    .filter((node) => node.path !== path)
+    .map((node) => (node.children ? { ...node, children: withoutPath(node.children, path) } : node))
+    .filter((node) => node.kind !== "folder" || (node.children?.length ?? 0) > 0);
+}
+
+/** The tree with one path added, creating the folders on the way to it. */
+function withPath(tree: TreeNode[], path: string): TreeNode[] {
+  const segments = path.split("/");
+  const name = segments.pop();
+  if (!name) return tree;
+
+  const insert = (nodes: TreeNode[], depth: number, prefix: string): TreeNode[] => {
+    if (depth === segments.length) {
+      if (nodes.some((node) => node.path === path)) return nodes;
+      return sortNodes([...nodes, { path, name, kind: "file" as const }]);
+    }
+
+    const folderName = segments[depth]!;
+    const folderPath = prefix ? `${prefix}/${folderName}` : folderName;
+    const existing = nodes.find((node) => node.path === folderPath && node.kind === "folder");
+
+    if (existing) {
+      return nodes.map((node) =>
+        node === existing
+          ? { ...node, children: insert(node.children ?? [], depth + 1, folderPath) }
+          : node,
+      );
+    }
+
+    return sortNodes([
+      ...nodes,
+      {
+        path: folderPath,
+        name: folderName,
+        kind: "folder" as const,
+        children: insert([], depth + 1, folderPath),
+      },
+    ]);
+  };
+
+  return insert(tree, 0, "");
+}
+
+/** Folders first, then by name — the order the tree already arrives in. */
+function sortNodes(nodes: TreeNode[]): TreeNode[] {
+  return [...nodes].sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
 }

--- a/packages/store/src/sync-engine.test.ts
+++ b/packages/store/src/sync-engine.test.ts
@@ -3,7 +3,7 @@ import type { Note, SyncMode, TreeNode } from "@forkleaf/types";
 import { SyncEngine } from "./sync-engine";
 import { MemoryDatabase } from "./memory-db";
 import { coalesce, describeChanges } from "./queue";
-import { plainly } from "./sync-engine";
+import { plainly, codeOf } from "./sync-engine";
 import type { RemoteCommitInput, RemoteGateway } from "./ports";
 
 // ─── Test doubles ───────────────────────────────────────────────────────────
@@ -286,6 +286,41 @@ describe("a failure reported to the reader", () => {
 
   it("has something useful to say about an error it has never seen", () => {
     expect(plainly(new Error("something nobody predicted"))).toContain("saved on this device");
+  });
+
+  /**
+   * The message alone left the UI with one offer — retry — which for an
+   * expired token retries into the same 401 forever. The code is what lets the
+   * status bar offer the sign-in instead.
+   */
+  it("reports the kind of failure, not only the sentence", async () => {
+    const ctx = setup();
+    ctx.gateway.rejects.add("a.md");
+
+    await ctx.engine.recordUpsert(makeNote({ path: "a.md", baseSha: null }), "a");
+    await ctx.timers.tick();
+
+    expect(ctx.engine.state.lastErrorCode).toBe("validation");
+  });
+
+  it("recognises a signed-out failure however GitHub phrases it", () => {
+    expect(codeOf({ code: "unauthorized" })).toBe("unauthorized");
+    expect(codeOf({ status: 401 })).toBe("unauthorized");
+    expect(codeOf({ status: 503 })).toBe("server");
+    expect(codeOf(new Error("who knows"))).toBe("unknown");
+  });
+
+  it("forgets the failure once a push succeeds", async () => {
+    const ctx = setup();
+    ctx.gateway.failNext = 1;
+
+    await ctx.engine.recordUpsert(makeNote({ path: "a.md", baseSha: null }), "a");
+    await ctx.timers.tick();
+    expect(ctx.engine.state.lastErrorCode).not.toBeNull();
+
+    ctx.engine.retryNow();
+    await ctx.timers.tick();
+    expect(ctx.engine.state.lastErrorCode).toBeNull();
   });
 });
 

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -3,6 +3,7 @@ import type {
   ConflictResolution,
   Note,
   PendingChange,
+  SyncErrorCode,
   SyncMode,
   SyncState,
   SyncStatus,
@@ -74,6 +75,7 @@ export class SyncEngine {
   private lastSyncedAt: string | null = null;
   private lastError: string | null = null;
   private lastErrorDetail: string | null = null;
+  private lastErrorCode: SyncErrorCode | null = null;
   private readonly listeners = new Set<Listener>();
 
   constructor(options: SyncEngineOptions) {
@@ -235,6 +237,7 @@ export class SyncEngine {
       lastSyncedAt: this.lastSyncedAt,
       lastError: this.lastError,
       lastErrorDetail: this.lastErrorDetail,
+      lastErrorCode: this.lastErrorCode,
       conflicts: this.conflicts,
     };
   }
@@ -458,11 +461,13 @@ export class SyncEngine {
       this.lastSyncedAt = this.now().toISOString();
       this.lastError = null;
       this.lastErrorDetail = null;
+      this.lastErrorCode = null;
       this.retryDelay = 0;
       this.setStatus(this.restingStatus());
     } catch (err) {
       this.lastError = plainly(err);
       this.lastErrorDetail = err instanceof Error ? err.message : String(err);
+      this.lastErrorCode = codeOf(err);
       // "error" means a push failed and will be tried again by itself. Once
       // nothing is left that *will* be tried again, that reading is wrong and
       // the honest word is "blocked" — it has stopped, and it needs asking.
@@ -914,6 +919,40 @@ function isContentRejection(err: unknown): boolean {
  * writing is safe. It always is; that is the whole point of saving locally
  * first, and it is the first thing anybody wants to know.
  */
+/**
+ * The same failure, in a form the UI can branch on.
+ *
+ * `plainly` says what happened; this says what *kind* of thing happened, which
+ * is what decides whether the honest offer is "try again" or "sign in again".
+ * Kept beside it so the two can never drift into disagreeing about one error.
+ */
+export function codeOf(err: unknown): SyncErrorCode {
+  const { code, status } = (err ?? {}) as { code?: unknown; status?: unknown };
+
+  switch (code) {
+    case "unauthorized":
+    case "forbidden":
+    case "not-found":
+    case "rate-limited":
+    case "conflict":
+    case "validation":
+    case "network":
+      return code;
+  }
+
+  if (typeof status === "number") {
+    if (status === 401) return "unauthorized";
+    if (status === 403) return "forbidden";
+    if (status === 404) return "not-found";
+    if (status === 409) return "conflict";
+    if (status === 422) return "validation";
+    if (status === 429) return "rate-limited";
+    if (status >= 500) return "server";
+  }
+
+  return "unknown";
+}
+
 export function plainly(err: unknown): string {
   const { code, status } = (err ?? {}) as { code?: unknown; status?: unknown };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -168,6 +168,18 @@ export const DEFAULT_SYNC_PREFERENCE: SyncPreference = {
   intervalMinutes: 15,
 };
 
+/** The failure kinds a push can end in, as the UI needs to tell them apart. */
+export type SyncErrorCode =
+  | "unauthorized"
+  | "forbidden"
+  | "not-found"
+  | "rate-limited"
+  | "conflict"
+  | "validation"
+  | "network"
+  | "server"
+  | "unknown";
+
 export interface SyncState {
   status: SyncStatus;
   /** How this workspace is configured to push. */
@@ -193,6 +205,17 @@ export interface SyncState {
   lastError: string | null;
   /** The underlying message, for a tooltip and for bug reports. */
   lastErrorDetail: string | null;
+  /**
+   * What kind of failure it was, so the UI can offer the fix rather than
+   * describe it.
+   *
+   * A message alone leaves every failure looking the same: one button that
+   * says "retry", which for an expired sign-in retries into the same 401
+   * forever. Carrying the code lets the status bar put "Sign in again" where
+   * the retry would have been — the difference between a dead end and a way
+   * out.
+   */
+  lastErrorCode: SyncErrorCode | null;
   conflicts: Conflict[];
 }
 


### PR DESCRIPTION
Two bugs that both read as the app ignoring you.

## The expired sign-in went nowhere

The status bar said *"Your GitHub sign-in has expired. Sign in again to push these changes"* — and clicking it called retry, which pushed into the same 401 and printed the same sentence. No sign-in page ever opened. The same message was also printed twice across one bar.

- `SyncState` now carries `lastErrorCode` beside `lastError`, so the UI can branch on the *kind* of failure rather than parse its wording.
- When that code is `unauthorized`, the status control becomes the sign-in — plus a **Sign in again** button in the bar and a banner at the top of the editor, where the reader is actually looking. It says how many changes are waiting and that they are safe on this device.
- `/sign-in` accepts `?expired=1&next=…`: it explains that the previous sign-in expired and returns to the note that was open instead of dropping you on the dashboard.
- The destination is carried in a short-lived cookie, and validated by `safeReturnPath` both on the way in and on the way out — only a single-slash, same-origin path with no control characters is accepted, so `?next=//evil.example` is dropped rather than repaired.

## Deleting notes and folders did nothing

Deleting needed to *read* the note first, to record the delete against its base SHA. When GitHub would not answer — expired token, offline, a note only ever listed in the tree — the read threw, the failure was swallowed, and nothing was deleted. Folder deletes threw on the first unreadable note and abandoned the rest halfway through. And even a successful delete came back: the sidebar's tree describes GitHub, so the next refresh listed the file again.

- `NoteRepository.deletePath()` deletes by path, using the SHA the tree already reported, whether or not the note can be read.
- `getTree()` now applies the unpushed queue on top of both the cached and the freshly fetched tree, so a deleted note stays deleted until the deletion is genuinely committed — and a folder disappears once the last note in it is gone.
- The folder delete no longer opens each note, so one unreadable note cannot strand the rest.

## Checks

`pnpm check` passes (format, typecheck, lint, 746 tests, build). New tests cover `safeReturnPath`, `codeOf`, and deleting/tree behaviour against a gateway that refuses everything with a 401. Verified in the browser: `/sign-in?expired=1&next=/editor` renders the notice and carries `next` into both grant links, an off-origin `next` is dropped, and deleting a note removes it from the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)