### PR TITLE
Editor and sync fixes: deletes that stick, images that load, dialogs that take Enter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      # 22, not 20: GitHub is retiring the Node 20 runtime, and every action
+      # pinned to it now runs on 24 with a deprecation warning regardless of
+      # what this says. 22 is the current LTS and satisfies the `engines`
+      # floor in package.json, so what CI runs is a version somebody could
+      # actually be developing on.
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/diagram-review.yml
+++ b/.github/workflows/diagram-review.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Comment on the pull request
         if: steps.diagrams.outputs.changed != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         # A pull request opened from a fork gets a read-only token, so the
         # comment cannot be posted. That is a limitation of the event, not a
         # failure of the review — the job should not go red for it.

--- a/apps/web/src/app/api/auth/github/route.test.ts
+++ b/apps/web/src/app/api/auth/github/route.test.ts
@@ -15,20 +15,20 @@ import { describe, expect, it } from "vitest";
  */
 
 const SCOPES: Record<string, string> = {
-  all: "repo read:user",
-  public: "public_repo read:user",
+  all: "repo",
+  public: "public_repo",
 };
 
 const scopeFor = (access: string | null) => SCOPES[access ?? "all"] ?? SCOPES.all!;
 
 describe("the scope a sign-in asks for", () => {
   it("asks for private repositories by default, which is where notes go", () => {
-    expect(scopeFor(null)).toBe("repo read:user");
-    expect(scopeFor("all")).toBe("repo read:user");
+    expect(scopeFor(null)).toBe("repo");
+    expect(scopeFor("all")).toBe("repo");
   });
 
   it("can ask for public repositories only", () => {
-    expect(scopeFor("public")).toBe("public_repo read:user");
+    expect(scopeFor("public")).toBe("public_repo");
   });
 
   it("never includes the scope that reaches private repositories", () => {
@@ -38,9 +38,19 @@ describe("the scope a sign-in asks for", () => {
     expect(scopeFor("all").split(" ")).toContain("repo");
   });
 
+  it("asks for nothing beyond a repository scope", () => {
+    // Every extra scope is another paragraph on GitHub's consent screen. The
+    // name and avatar shown in the sidebar come from `GET /user`, which any
+    // authenticated token can call, so `read:user` bought a warning about
+    // private profile access and nothing else.
+    for (const scope of Object.values(SCOPES)) {
+      expect(scope.split(" ")).toHaveLength(1);
+    }
+  });
+
   it("falls back to the default rather than honouring an invented value", () => {
-    expect(scopeFor("admin:org")).toBe("repo read:user");
-    expect(scopeFor("delete_repo")).toBe("repo read:user");
-    expect(scopeFor("")).toBe("repo read:user");
+    expect(scopeFor("admin:org")).toBe("repo");
+    expect(scopeFor("delete_repo")).toBe("repo");
+    expect(scopeFor("")).toBe("repo");
   });
 });

--- a/apps/web/src/app/api/auth/github/route.ts
+++ b/apps/web/src/app/api/auth/github/route.ts
@@ -17,6 +17,14 @@ import { createOAuthState, githubOAuthConfigured, setReturnPath } from "@/lib/se
  * public notes. It cannot touch a private repository at all, which is the
  * point — an app that cannot read your private code cannot leak it.
  *
+ * Nothing else is asked for, and in particular not `read:user`. It used to be
+ * in this list to get the name and avatar in the sidebar, but `GET /user`
+ * returns those to any authenticated token; the only thing the scope added was
+ * a second block on GitHub's consent screen saying the app can "read your
+ * private profile information", which it neither needs nor wants. A permission
+ * requested for a reason that does not survive being written down is a
+ * permission to drop.
+ *
  * What is genuinely not on offer is per-repository selection. Classic OAuth
  * scopes have no such thing; picking individual repositories requires
  * installing this as a GitHub App, which is a different install flow and is
@@ -27,9 +35,9 @@ import { createOAuthState, githubOAuthConfigured, setReturnPath } from "@/lib/se
 /** The scopes this route will ask for, by the name the UI uses. */
 const SCOPES: Record<string, string> = {
   // Everything, private repositories included.
-  all: "repo read:user",
+  all: "repo",
   // Public repositories only.
-  public: "public_repo read:user",
+  public: "public_repo",
 };
 export async function GET(request: NextRequest) {
   if (!githubOAuthConfigured()) {

--- a/apps/web/src/app/api/gh/commit/route.ts
+++ b/apps/web/src/app/api/gh/commit/route.ts
@@ -80,6 +80,16 @@ export async function POST(request: NextRequest) {
           return { op: "rename", path, toPath, content };
         }
 
+        // A move sends no bytes: the commit reuses the blob already at `path`.
+        // `normalize` on both ends is the whole validation there is to do, and
+        // it is the validation that matters — these are the only two strings
+        // that reach the git tree.
+        case "move": {
+          const toPath = normalize(change.toPath ?? "");
+          if (!toPath) throw new ApiError(400, "validation", "A move needs a destination.");
+          return { op: "move", path, toPath };
+        }
+
         default:
           throw new ApiError(400, "validation", `Unsupported operation: ${change.op}`);
       }

--- a/apps/web/src/app/api/gh/raw/route.ts
+++ b/apps/web/src/app/api/gh/raw/route.ts
@@ -16,6 +16,28 @@ import { imageTypeFor } from "@/lib/media";
  * letting it return arbitrary file types would turn it into a way to render
  * repository content as HTML on our own origin.
  */
+/**
+ * Headers that must match on a 200 and a 304 alike, or the browser will not
+ * reuse what it has.
+ *
+ * `max-age` is an hour rather than five minutes because the thing being cached
+ * barely changes: an image in a note is written once under a name with a date
+ * and a random tail, and is then read for as long as the note lives. An hour of
+ * instant redraws costs at worst an hour of staleness on the rare occasion
+ * somebody overwrites a file in place, and `stale-while-revalidate` keeps even
+ * that from being a blank space — the old bytes are shown while the new ones
+ * are fetched behind them.
+ *
+ * `private` because the response was authorised by one person's session and
+ * must never sit in a shared cache.
+ */
+function cacheHeaders(etag: string): Record<string, string> {
+  return {
+    "Cache-Control": "private, max-age=3600, stale-while-revalidate=86400",
+    ETag: etag,
+  };
+}
+
 export async function GET(request: NextRequest) {
   try {
     const { client } = await requireClient();
@@ -28,21 +50,38 @@ export async function GET(request: NextRequest) {
     const type = imageTypeFor(path);
     if (!type) throw new ApiError(400, "validation", "That file is not a supported image.");
 
-    const file = await client.readFileBase64(repo, path);
+    /**
+     * The browser's own copy, offered back to GitHub before any bytes move.
+     *
+     * This route used to send an `ETag` and then ignore the `If-None-Match`
+     * that came back with the next request, so the tag was decoration: every
+     * image was fetched from GitHub in full, base64-decoded and sent down the
+     * wire again, on every note open once the five-minute cache had lapsed. A
+     * note with six screenshots was six API calls and several megabytes to
+     * show something the browser already had.
+     *
+     * GitHub answers a conditional request with a bare 304, which is fast and
+     * — the part that matters for a notebook full of images — does not count
+     * against the hourly rate limit.
+     */
+    const known = request.headers.get("if-none-match");
+
+    const file = await client.readFileBase64(repo, path, known ? { etag: known } : {});
     if (!file) return new Response("Not found", { status: 404 });
+
+    if (file.notModified) {
+      return new Response(null, { status: 304, headers: cacheHeaders(known!) });
+    }
 
     const bytes = Buffer.from(file.base64, "base64");
 
     return new Response(new Uint8Array(bytes), {
       headers: {
+        ...cacheHeaders(`"${file.sha}"`),
         "Content-Type": type,
         "Content-Length": String(bytes.length),
-        // Private to the browser that asked: the response was authorised by
-        // that user's session and must never be held in a shared cache.
-        "Cache-Control": "private, max-age=300",
         "Content-Security-Policy": "default-src 'none'; sandbox",
         "X-Content-Type-Options": "nosniff",
-        ETag: `"${file.sha}"`,
       },
     });
   } catch (error) {

--- a/apps/web/src/app/docs/content/account.tsx
+++ b/apps/web/src/app/docs/content/account.tsx
@@ -311,9 +311,10 @@ service cloud.firestore {
 
       <H2 id="scope">Known trade-offs</H2>
       <Def term="The repo scope is broad">
-        It is the narrowest classic OAuth scope that allows writing to a private repository. A
-        GitHub App gives per-repository consent and is supported for self-hosters — see{" "}
-        <A href="/docs/self-hosting">Self-hosting</A>.
+        It is the narrowest classic OAuth scope that allows writing to a private repository, and it
+        is the only scope requested — no profile, email or organisation permission is asked for
+        alongside it. A GitHub App gives per-repository consent and is supported for self-hosters —
+        see <A href="/docs/self-hosting">Self-hosting</A>.
       </Def>
       <Def term="Notes are only as private as the repository">
         ForkLeaf creates the notes repository private, but if you make it public, or connect a

--- a/apps/web/src/app/docs/content/github.tsx
+++ b/apps/web/src/app/docs/content/github.tsx
@@ -35,21 +35,66 @@ export function SigningIn() {
       </Note>
 
       <H2 id="scopes">The permissions it asks for</H2>
+      <P>
+        One scope, and it is the one that lets ForkLeaf write your notes. There is no second
+        permission bundled alongside it, so the consent screen has exactly one thing on it for you
+        to weigh.
+      </P>
       <Table
-        head={["Scope", "What it allows", "Why ForkLeaf needs it"]}
+        head={["Scope", "What GitHub grants", "Why ForkLeaf asks for it", "What it does not do"]}
         rows={[
           [
             <Code key="a">repo</Code>,
             "Read and write access to your repositories, public and private",
-            "Notes are files it has to create, update and delete — including in a private repo",
+            "A note is a file. Opening one is a read, saving one is a commit, renaming one is a commit that deletes and adds — none of that is possible without write access, and private repositories need this scope specifically",
+            "It is never used to enumerate, read or modify anything but the repository you connect and the list of repository names the picker shows",
           ],
           [
-            <Code key="b">read:user</Code>,
-            "Your public profile",
-            "Your name and avatar in the sidebar, so you can tell which account you are in",
+            <Code key="b">public_repo</Code>,
+            "The same, restricted to your public repositories",
+            "The alternative offered on the sign-in page, for notes that are going to be public anyway",
+            "It cannot open a private repository. GitHub refuses the request; ForkLeaf does not get the choice",
           ],
         ]}
       />
+
+      <H3 id="not-asked">What it deliberately does not ask for</H3>
+      <P>
+        The consent screen used to carry a second block — <strong>Personal user data</strong>,
+        &ldquo;this application will be able to read your private profile information&rdquo; —
+        because the request included <Code>read:user</Code>. That was there to put your name and
+        avatar in the sidebar, which turns out not to need it: <Code>GET /user</Code> returns your
+        login, name and avatar to any authenticated token. The scope bought a warning about private
+        profile access and nothing else, so it is gone.
+      </P>
+      <UL>
+        <LI>
+          <Code>read:user</Code> — not asked for. Your name and avatar come back with the token
+          regardless; ForkLeaf never sees a private profile field, and does not read your email
+          address at all.
+        </LI>
+        <LI>
+          <Code>user:email</Code> — not asked for. Commits are attributed by GitHub from your own
+          account settings, so ForkLeaf never needs your address.
+        </LI>
+        <LI>
+          <Code>admin:org</Code>, <Code>delete_repo</Code>, <Code>workflow</Code>,{" "}
+          <Code>admin:repo_hook</Code> — not asked for. ForkLeaf never creates a webhook, edits a
+          workflow file, changes a repository setting or deletes a repository.
+        </LI>
+        <LI>
+          <Code>gist</Code>, <Code>notifications</Code> — not asked for. It does not touch either.
+        </LI>
+      </UL>
+      <Note>
+        The <Code>repo</Code> scope&rsquo;s own description on GitHub&rsquo;s screen lists settings,
+        webhooks and deploy keys among the things it <em>could</em> reach. That is GitHub describing
+        the scope, not ForkLeaf describing itself: the scope is a single coarse grant and cannot be
+        narrowed further as a classic OAuth app. Every request ForkLeaf makes goes through its own{" "}
+        <Code>/api/gh/*</Code> routes, which are contents, tree, commit, branch and pull request
+        endpoints — you can read the list in the source.
+      </Note>
+
       <Note kind="warn">
         <strong>
           <Code>repo</Code> is broader than anyone would like.

--- a/apps/web/src/app/docs/content/running.tsx
+++ b/apps/web/src/app/docs/content/running.tsx
@@ -427,8 +427,11 @@ export function Faq() {
       <H2 id="github-faq">GitHub</H2>
       <Def term="Why does it want access to all my repositories?">
         <Code>repo</Code> is the narrowest classic OAuth scope that can write to a private
-        repository; GitHub has no per-repository classic scope. Self-hosters can use a GitHub App
-        for per-repository consent. <A href="/docs/signing-in">Signing in</A>.
+        repository; GitHub has no per-repository classic scope. It is also the only scope asked for
+        — nothing about your profile, email, organisations or gists is requested alongside it. If
+        you only keep public notes, <Code>public_repo</Code> is offered as an equal choice, and
+        self-hosters can use a GitHub App for per-repository consent.{" "}
+        <A href="/docs/signing-in">Signing in</A>.
       </Def>
       <Def term="Can I use a repository I already have?">
         Yes — any repository you can write to, on any branch, and optionally scoped to a single

--- a/apps/web/src/app/sign-in/page.tsx
+++ b/apps/web/src/app/sign-in/page.tsx
@@ -82,6 +82,16 @@ export default async function SignInPage({
           permission to read and write files there. Choose how much of your account that covers. You
           can change it later, and revoke it entirely, from GitHub.
         </p>
+        <p className="mt-3 max-w-2xl text-[15px] leading-relaxed text-[var(--fl-muted)]">
+          That repository permission is the <em>only</em> thing asked for. Nothing about your
+          profile, your email address, your organisations, your gists or your notifications is
+          requested — your name and avatar arrive with the token itself, so there is no second
+          permission to grant for them.{" "}
+          <Link href="/docs/signing-in#not-asked" className="fl-link">
+            What is not asked for, and why
+          </Link>
+          .
+        </p>
 
         <div className="mt-8 grid gap-4 md:grid-cols-2">
           <Choice
@@ -95,6 +105,11 @@ export default async function SignInPage({
               "Commit on your behalf, with your name on the commit",
               "List your repositories, so you can pick one",
             ]}
+            excludes={[
+              "Read your email address, your private profile, or your organisation membership",
+              "Create webhooks, deploy keys, or change any repository setting",
+              "Delete a repository, or touch your gists or notifications",
+            ]}
             caveat="GitHub's classic scopes have no per-repository option, so this grant technically covers every repository your account can reach. ForkLeaf only ever reads or writes the one you connect."
           />
 
@@ -106,6 +121,11 @@ export default async function SignInPage({
             covers={[
               "Read and write files in your public repositories",
               "Commit on your behalf, with your name on the commit",
+            ]}
+            excludes={[
+              "Open, read or list any private repository — GitHub refuses the token",
+              "Read your email address or your private profile",
+              "Create webhooks, deploy keys, or change any repository setting",
             ]}
             caveat="If you later want a private notes repository, you will be asked to sign in again with the wider permission."
           />
@@ -156,6 +176,7 @@ function Choice({
   need,
   covers,
   caveat,
+  excludes,
   recommended,
 }: {
   href: string;
@@ -164,6 +185,9 @@ function Choice({
   need: string;
   covers: string[];
   caveat: string;
+  /** Things this grant conspicuously does not cover, named so nobody has to
+      infer them from a scope name on GitHub's screen. */
+  excludes: string[];
   recommended?: boolean;
 }) {
   return (
@@ -185,6 +209,18 @@ function Choice({
       </p>
       <ul className="mt-2 space-y-1.5">
         {covers.map((line) => (
+          <li key={line} className="flex gap-2 text-[13.5px] text-[var(--fl-muted)]">
+            <span aria-hidden="true">·</span>
+            <span>{line}</span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-4 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+        What it never does
+      </p>
+      <ul className="mt-2 space-y-1.5">
+        {excludes.map((line) => (
           <li key={line} className="flex gap-2 text-[13.5px] text-[var(--fl-muted)]">
             <span aria-hidden="true">·</span>
             <span>{line}</span>

--- a/apps/web/src/components/Dialog.tsx
+++ b/apps/web/src/components/Dialog.tsx
@@ -23,14 +23,32 @@ export function Dialog({ title, subtitle, onClose, children, wide = false }: Dia
   useEffect(() => {
     previouslyFocused.current = document.activeElement as HTMLElement | null;
 
-    // Move focus into the dialog so a keyboard user is not left outside it.
-    // An element marked `autofocus` wins: otherwise focus lands on the close
-    // button and typing goes nowhere, which is worse than no focus at all.
+    // Move focus into the dialog so a keyboard user is not left outside it,
+    // and specifically onto the field they came here to type in.
+    //
+    // This used to look for `[autofocus]`, which never matched: React applies
+    // `autoFocus` by calling `.focus()` itself and does not leave the attribute
+    // in the DOM, so the query returned null on every dialog. Focus then fell
+    // through to the first focusable element in the whole panel — the close
+    // button in the header, which precedes the content — and the effect below
+    // ran after React's own autofocus, so it took focus back off the input.
+    //
+    // The cost was not just a missing cursor. With the close button focused,
+    // Enter dismissed the dialog, so "type a name and press Enter" threw the
+    // name away and every folder had to be created with the mouse.
+    //
+    // So: search the content region only, never the header, and prefer a field
+    // over a button. `data-autofocus` is the explicit override, because unlike
+    // `autoFocus` it is a real attribute that survives into the DOM.
     const panel = panelRef.current;
+    const content = panel?.querySelector<HTMLElement>("[data-dialog-content]") ?? panel;
     const preferred =
-      panel?.querySelector<HTMLElement>("[autofocus]") ??
-      panel?.querySelector<HTMLElement>(
-        'input, select, textarea, [href], button, [tabindex]:not([tabindex="-1"])',
+      content?.querySelector<HTMLElement>("[data-autofocus]") ??
+      content?.querySelector<HTMLElement>(
+        'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled])',
+      ) ??
+      content?.querySelector<HTMLElement>(
+        '[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
       );
     (preferred ?? panel)?.focus();
 
@@ -110,7 +128,9 @@ export function Dialog({ title, subtitle, onClose, children, wide = false }: Dia
           </button>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-5">{children}</div>
+        <div data-dialog-content className="min-h-0 flex-1 overflow-y-auto p-5">
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/EditorSidebar.test.tsx
+++ b/apps/web/src/components/EditorSidebar.test.tsx
@@ -31,18 +31,18 @@ const workspace: Workspace = {
 const tree: TreeNode[] = [
   {
     kind: "folder",
-    name: "SOC 101",
-    path: "SOC 101",
+    name: "Fieldwork",
+    path: "Fieldwork",
     children: [
       {
         kind: "folder",
         name: "Phishing analysis",
-        path: "SOC 101/Phishing analysis",
+        path: "Fieldwork/Soil surveys",
         children: [
           {
             kind: "file",
             name: "introduction.md",
-            path: "SOC 101/Phishing analysis/introduction.md",
+            path: "Fieldwork/Soil surveys/introduction.md",
           },
         ],
       },
@@ -63,7 +63,7 @@ function renderSidebar(currentFolder: string, overrides: Record<string, unknown>
       onSwitchWorkspace={() => {}}
       onConnectRepo={() => {}}
       tree={tree}
-      activePath="SOC 101/Phishing analysis/introduction.md"
+      activePath="Fieldwork/Soil surveys/introduction.md"
       currentFolder={currentFolder}
       onOpenNote={() => {}}
       onCreateNote={onCreateNote}
@@ -73,6 +73,7 @@ function renderSidebar(currentFolder: string, overrides: Record<string, unknown>
       onRenameFolder={() => {}}
       onDeleteFolder={() => {}}
       onMoveNote={() => {}}
+      onMoveFolder={() => {}}
       pinnedPaths={[]}
       onTogglePin={() => {}}
       onMovePin={() => {}}
@@ -91,19 +92,19 @@ function renderSidebar(currentFolder: string, overrides: Record<string, unknown>
 
 describe("EditorSidebar — where new things go", () => {
   it("creates a note in the folder you are working in", () => {
-    const { onCreateNote } = renderSidebar("SOC 101/Phishing analysis");
+    const { onCreateNote } = renderSidebar("Fieldwork/Soil surveys");
 
     fireEvent.click(screen.getByText("New Note"));
 
-    expect(onCreateNote).toHaveBeenCalledWith("SOC 101/Phishing analysis");
+    expect(onCreateNote).toHaveBeenCalledWith("Fieldwork/Soil surveys");
   });
 
   it("creates a folder inside the folder you are working in", () => {
-    const { onCreateFolder } = renderSidebar("SOC 101/Phishing analysis");
+    const { onCreateFolder } = renderSidebar("Fieldwork/Soil surveys");
 
     fireEvent.click(screen.getByLabelText("New folder"));
 
-    expect(onCreateFolder).toHaveBeenCalledWith("SOC 101/Phishing analysis");
+    expect(onCreateFolder).toHaveBeenCalledWith("Fieldwork/Soil surveys");
   });
 
   it("falls back to the repository root when no note is open", () => {
@@ -115,13 +116,13 @@ describe("EditorSidebar — where new things go", () => {
   });
 
   it("says where the note will be created, so it is not a surprise", () => {
-    renderSidebar("SOC 101/Phishing analysis");
+    renderSidebar("Fieldwork/Soil surveys");
 
-    expect(screen.getByTitle("New note in SOC 101/Phishing analysis (⌘⇧N)")).toBeTruthy();
+    expect(screen.getByTitle("New note in Fieldwork/Soil surveys (⌘⇧N)")).toBeTruthy();
   });
 
   it("still offers the repository root explicitly", () => {
-    const { onCreateNote } = renderSidebar("SOC 101/Phishing analysis");
+    const { onCreateNote } = renderSidebar("Fieldwork/Soil surveys");
 
     fireEvent.click(screen.getByLabelText("New note in a folder"));
     fireEvent.click(screen.getByRole("menuitem", { name: "notes" }));
@@ -131,7 +132,7 @@ describe("EditorSidebar — where new things go", () => {
 });
 
 describe("EditorSidebar — pinned notes", () => {
-  const pinned = ["SOC 101/Phishing analysis/introduction.md"];
+  const pinned = ["Fieldwork/Soil surveys/introduction.md"];
 
   it("shows a pinned note above the tree", () => {
     renderSidebar("", { pinnedPaths: pinned });
@@ -155,13 +156,13 @@ describe("EditorSidebar — pinned notes", () => {
   });
 
   it("drops a pin whose note no longer exists, rather than showing a dead row", () => {
-    renderSidebar("", { pinnedPaths: ["SOC 101/deleted.md"] });
+    renderSidebar("", { pinnedPaths: ["Fieldwork/deleted.md"] });
     expect(screen.queryByText("Pinned")).toBeNull();
   });
 
   it("can reorder the list, which is the only thing about it anybody chose", () => {
     const onMovePin = vi.fn();
-    const two = [...pinned, "SOC 101/Phishing analysis/second.md"];
+    const two = [...pinned, "Fieldwork/Soil surveys/second.md"];
 
     renderSidebar("", {
       pinnedPaths: two,
@@ -169,23 +170,23 @@ describe("EditorSidebar — pinned notes", () => {
       tree: [
         {
           kind: "folder",
-          name: "SOC 101",
-          path: "SOC 101",
+          name: "Fieldwork",
+          path: "Fieldwork",
           children: [
             {
               kind: "folder",
               name: "Phishing analysis",
-              path: "SOC 101/Phishing analysis",
+              path: "Fieldwork/Soil surveys",
               children: [
                 {
                   kind: "file",
                   name: "introduction.md",
-                  path: "SOC 101/Phishing analysis/introduction.md",
+                  path: "Fieldwork/Soil surveys/introduction.md",
                 },
                 {
                   kind: "file",
                   name: "second.md",
-                  path: "SOC 101/Phishing analysis/second.md",
+                  path: "Fieldwork/Soil surveys/second.md",
                 },
               ],
             },
@@ -198,7 +199,7 @@ describe("EditorSidebar — pinned notes", () => {
     expect(onMovePin).not.toHaveBeenCalled(); // already last, so the button is off
 
     fireEvent.click(screen.getByLabelText("Move second up"));
-    expect(onMovePin).toHaveBeenCalledWith("SOC 101/Phishing analysis/second.md", -1);
+    expect(onMovePin).toHaveBeenCalledWith("Fieldwork/Soil surveys/second.md", -1);
   });
 
   it("can unpin from the row itself", () => {

--- a/apps/web/src/components/EditorSidebar.test.tsx
+++ b/apps/web/src/components/EditorSidebar.test.tsx
@@ -214,20 +214,32 @@ describe("EditorSidebar — pinned notes", () => {
 /**
  * The account card at the bottom of the sidebar.
  *
- * It looks exactly like a button — avatar, name, handle, in a bordered card
- * where every application puts the way into your account — and did nothing at
- * all when clicked. The menu beside it opened but never closed except by
- * clicking the same gear again.
+ * It was two controls in one card — the avatar and name navigated to the
+ * profile, a gear beside them opened a menu whose first item went to the same
+ * profile — with nothing to mark where one ended and the other began. It is
+ * one button now, and everything it can do is named in the menu.
  */
 describe("the account card", () => {
   const user = { login: "praneeth132006", name: "Praneeth", avatarUrl: "https://x/y.png" };
 
-  it("goes to the profile when clicked", () => {
+  it("is a single control, whichever part of it you press", () => {
     renderSidebar("", { user });
 
-    const link = screen.getByTitle("Your profile");
+    // No second control hiding inside the card: the avatar, the name and the
+    // gear all belong to the one button.
+    const card = screen.getByLabelText("Account");
+    expect(card.textContent).toContain("Praneeth");
+    expect(card.textContent).toContain("@praneeth132006");
+    expect(card.querySelectorAll("a, button")).toHaveLength(0);
+  });
+
+  it("offers the profile in the menu rather than under half the card", () => {
+    renderSidebar("", { user });
+
+    fireEvent.click(screen.getByLabelText("Account"));
+
+    const link = screen.getByText("Your profile");
     expect(link.getAttribute("href")).toBe("/profile");
-    expect(link.textContent).toContain("Praneeth");
   });
 
   it("closes its menu on Escape", () => {

--- a/apps/web/src/components/EditorSidebar.tsx
+++ b/apps/web/src/components/EditorSidebar.tsx
@@ -406,23 +406,6 @@ export function EditorSidebar(props: EditorSidebarProps) {
         </button>
       </div>
 
-      {/* ── Out of the editor ─────────────────────────────────────────── */}
-      {/* The editor used to be a room with no marked exits: once you were in
-          it, the only way back to the rest of the app was the logo, and the
-          dashboard could not be reached at all. */}
-      <div className="px-2 pb-1">
-        <Link
-          href="/dashboard"
-          className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)]"
-        >
-          <DashboardGlyph />
-          <span className="min-w-0 flex-1 truncate">Dashboard</span>
-          <kbd className="shrink-0 rounded border border-[var(--fl-border)] px-1 py-px font-sans text-[10px] text-[var(--fl-muted)]">
-            ⌘⇧D
-          </kbd>
-        </Link>
-      </div>
-
       {/* ── Tree ──────────────────────────────────────────────────────── */}
       <div className="min-h-0 flex-1 overflow-y-auto px-1 pb-2">
         {/* Pinned notes, above the tree.
@@ -444,7 +427,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
                     type="button"
                     onClick={() => props.onOpenNote(path)}
                     title={path}
-                    className={`flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-[var(--fl-elevated)] ${
+                    className={`flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-[5px] text-left text-[14px] transition-colors hover:bg-[var(--fl-elevated)] ${
                       props.activePath === path
                         ? "bg-[var(--fl-elevated)] text-[var(--fl-text)]"
                         : "text-[var(--fl-muted)]"
@@ -505,8 +488,28 @@ export function EditorSidebar(props: EditorSidebarProps) {
         />
       </div>
 
-      {/* ── Footer: repo shortcut, help, account ──────────────────────── */}
+      {/* ── Footer: the ways out, help, account ───────────────────────── */}
       <div className="border-t border-[var(--fl-border)] p-2">
+        {/* The editor used to be a room with no marked exits: once you were in
+            it, the only way back to the rest of the app was the logo, and the
+            dashboard could not be reached at all.
+
+            It sat between the search row and the tree, which put a link to
+            another page in the middle of the column you use to move around this
+            one — you read past it every time you looked for a note. Down here it
+            is with the other exits, next to help and the account, and the file
+            tree runs uninterrupted from the filter to the bottom. */}
+        <Link
+          href="/dashboard"
+          className="mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-[12.5px] text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
+        >
+          <DashboardGlyph className="h-3.5 w-3.5" />
+          <span className="min-w-0 flex-1 truncate text-left">Dashboard</span>
+          <kbd className="shrink-0 rounded border border-[var(--fl-border)] px-1 py-px font-sans text-[10px]">
+            ⌘⇧D
+          </kbd>
+        </Link>
+
         <button
           type="button"
           onClick={props.onOpenHelp}
@@ -528,56 +531,54 @@ export function EditorSidebar(props: EditorSidebarProps) {
 
         {props.user ? (
           <div className="relative" ref={accountRef}>
-            <div className="flex items-center gap-1 rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] pr-1.5">
-              {/* The card itself goes to the profile.
+            {/* One card, one button, one thing it does: open the account menu.
 
-                  It looked exactly like a button — an avatar, a name, a handle,
-                  in a bordered card at the bottom of the sidebar, which is where
-                  every application in the world puts the way into your account —
-                  and it did nothing at all when clicked. */}
-              <Link
-                href="/profile"
-                title="Your profile"
-                className="flex min-w-0 flex-1 items-center gap-2.5 rounded-l-xl px-2.5 py-2 transition-colors hover:bg-[var(--fl-elevated)]"
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element -- avatars are
-                    remote GitHub URLs; next/image would need a domain allowlist for
-                    every possible avatar host. */}
-                <img
-                  src={props.user.avatarUrl}
-                  alt=""
-                  width={30}
-                  height={30}
-                  className="h-[30px] w-[30px] shrink-0 rounded-full"
-                />
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-[12.5px] font-medium text-[var(--fl-text)]">
-                    {props.user.name ?? props.user.login}
-                  </span>
-                  <span className="block truncate text-[11px] text-[var(--fl-muted)]">
-                    @{props.user.login}
-                  </span>
+                It used to be two controls wearing a single card — the avatar and
+                name went straight to the profile, the gear beside them opened a
+                menu whose first item also went to the profile. Nothing marked the
+                boundary, so which of the two you got depended on where inside the
+                card your cursor happened to land. The menu is the honest version:
+                every destination is named in it, including the profile. */}
+            <button
+              type="button"
+              onClick={() => setShowAccount((value) => !value)}
+              aria-expanded={showAccount}
+              aria-haspopup="menu"
+              title="Account"
+              aria-label="Account"
+              className="flex w-full items-center gap-2.5 rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2.5 py-2 text-left transition-colors hover:bg-[var(--fl-elevated)]"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element -- avatars are
+                  remote GitHub URLs; next/image would need a domain allowlist for
+                  every possible avatar host. */}
+              <img
+                src={props.user.avatarUrl}
+                alt=""
+                width={30}
+                height={30}
+                className="h-[30px] w-[30px] shrink-0 rounded-full"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[12.5px] font-medium text-[var(--fl-text)]">
+                  {props.user.name ?? props.user.login}
                 </span>
-              </Link>
-              <button
-                type="button"
-                onClick={() => setShowAccount((value) => !value)}
-                aria-expanded={showAccount}
-                aria-haspopup="menu"
-                title="Account"
-                aria-label="Account"
-                className="shrink-0 rounded-lg p-1 text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
-              >
-                <GearGlyph />
-              </button>
-            </div>
+                <span className="block truncate text-[11px] text-[var(--fl-muted)]">
+                  @{props.user.login}
+                </span>
+              </span>
+              <GearGlyph className="shrink-0 text-[var(--fl-muted)]" />
+            </button>
 
             {showAccount && (
-              <div className="absolute bottom-full left-0 right-0 z-30 mb-1 overflow-hidden rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-1 shadow-[var(--fl-shadow-lg)]">
+              <div
+                role="menu"
+                className="absolute bottom-full left-0 right-0 z-30 mb-1 overflow-hidden rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-1 shadow-[var(--fl-shadow-lg)]"
+              >
                 <MenuLink href="/profile">Your profile</MenuLink>
                 <MenuLink href="/docs">Documentation</MenuLink>
                 <button
                   type="button"
+                  role="menuitem"
                   onClick={props.onSignOut}
                   className="block w-full rounded-lg px-2.5 py-1.5 text-left text-[13px] text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)]"
                 >
@@ -609,12 +610,12 @@ export function EditorSidebar(props: EditorSidebarProps) {
   );
 }
 
-function DashboardGlyph() {
+function DashboardGlyph({ className = "h-4 w-4" }: { className?: string }) {
   return (
     <svg
       viewBox="0 0 16 16"
       aria-hidden="true"
-      className="h-4 w-4 shrink-0 text-[var(--fl-muted)]"
+      className={`shrink-0 ${className}`}
       fill="none"
       stroke="currentColor"
       strokeWidth="1.5"
@@ -669,7 +670,7 @@ function PinGlyph() {
     <svg
       viewBox="0 0 16 16"
       aria-hidden="true"
-      className="h-3.5 w-3.5 shrink-0 text-[var(--fl-accent)]"
+      className="h-[17px] w-[17px] shrink-0 text-[var(--fl-accent)]"
       fill="none"
       stroke="currentColor"
       strokeWidth="1.5"
@@ -771,19 +772,31 @@ function SearchGlyph() {
   );
 }
 
-function GearGlyph() {
+/**
+ * A cog: two concentric circles about (8, 8) and eight teeth at multiples of
+ * 45°, so it is symmetric by construction.
+ *
+ * The hand-written outline it replaces was not. Its teeth were laid out with
+ * relative moves that did not close back to where they started, which pushed
+ * the outline a fraction to the left of the hub — enough that the hole looked
+ * off-centre to the right at 16px, which is exactly how it was reported.
+ */
+function GearGlyph({ className = "" }: { className?: string }) {
   return (
     <svg
       aria-hidden="true"
       viewBox="0 0 16 16"
-      className="h-4 w-4"
+      className={`h-4 w-4 ${className}`}
       fill="none"
       stroke="currentColor"
-      strokeWidth="1.5"
+      strokeWidth="1.4"
+      strokeLinecap="round"
       strokeLinejoin="round"
     >
-      <circle cx="8" cy="8" r="2.1" />
-      <path d="M8 1.75h.01l.35 1.6a5 5 0 0 1 1.3.54l1.4-.86 1.42 1.42-.86 1.4c.24.4.42.84.54 1.3l1.6.35v2l-1.6.35a5 5 0 0 1-.54 1.3l.86 1.4-1.42 1.42-1.4-.86a5 5 0 0 1-1.3.54l-.35 1.6h-2l-.35-1.6a5 5 0 0 1-1.3-.54l-1.4.86-1.42-1.42.86-1.4a5 5 0 0 1-.54-1.3l-1.6-.35v-2l1.6-.35c.12-.46.3-.9.54-1.3l-.86-1.4 1.42-1.42 1.4.86a5 5 0 0 1 1.3-.54l.35-1.6Z" />
+      <circle cx="8" cy="8" r="4.15" />
+      <circle cx="8" cy="8" r="1.55" />
+      <path d="M8 3.85V2.1M8 12.15V13.9M3.85 8H2.1M12.15 8H13.9" />
+      <path d="M5.07 5.07 3.83 3.83M10.93 10.93l1.24 1.24M10.93 5.07l1.24-1.24M5.07 10.93l-1.24 1.24" />
     </svg>
   );
 }

--- a/apps/web/src/components/EditorSidebar.tsx
+++ b/apps/web/src/components/EditorSidebar.tsx
@@ -6,6 +6,7 @@ import type { TreeNode, Workspace, SessionUser } from "@forkleaf/types";
 import { FileTree } from "./FileTree";
 import { ForkLeafMark } from "./Brand";
 import { useDismissable } from "@/hooks/useDismissable";
+import { collectFilePaths, collectFolders } from "@/lib/tree";
 
 export interface EditorSidebarProps {
   collapsed: boolean;
@@ -23,7 +24,7 @@ export interface EditorSidebarProps {
    * folder of the note being edited.
    *
    * Without this, "New note" always meant "new note at the repository root",
-   * so someone working inside `SOC 101/Phishing analysis` who pressed the
+   * so someone working inside `Fieldwork/Soil surveys` who pressed the
    * button got a file at the top of their repository. They then had to notice
    * it had happened and drag it back, which on GitHub had already been
    * committed to the wrong place.
@@ -37,6 +38,8 @@ export interface EditorSidebarProps {
   onDeleteFolder: (path: string) => void;
   /** Moves a note into another folder, from a drag within the tree. */
   onMoveNote: (path: string, toFolder: string) => void;
+  /** Moves a folder, and everything under it, from a drag within the tree. */
+  onMoveFolder: (path: string, toFolder: string) => void;
   /** Notes kept at the top, in the order they were put there. */
   pinnedPaths: readonly string[];
   /** Folders the reader had open last time, in the order they opened them. */
@@ -478,6 +481,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
           onCreateIn={props.onCreateNote}
           onCreateFolder={props.onCreateFolder}
           onMoveNote={props.onMoveNote}
+          onMoveFolder={props.onMoveFolder}
           onTogglePin={props.onTogglePin}
           pinnedPaths={props.pinnedPaths}
           onRenameFolder={props.onRenameFolder}
@@ -629,38 +633,7 @@ function DashboardGlyph({ className = "h-4 w-4" }: { className?: string }) {
   );
 }
 
-/** Every folder path in the tree, depth-first, so nesting reads in order. */
-function collectFolders(nodes: TreeNode[]): string[] {
-  const paths: string[] = [];
-
-  const walk = (list: TreeNode[]) => {
-    for (const node of list) {
-      if (node.kind !== "folder") continue;
-      paths.push(node.path);
-      walk(node.children ?? []);
-    }
-  };
-
-  walk(nodes);
-  return paths;
-}
-
-/** Every note path in the tree, for checking a pinned path still exists. */
-function collectFilePaths(nodes: TreeNode[]): string[] {
-  const paths: string[] = [];
-
-  const walk = (list: TreeNode[]) => {
-    for (const node of list) {
-      if (node.kind === "file") paths.push(node.path);
-      walk(node.children ?? []);
-    }
-  };
-
-  walk(nodes);
-  return paths;
-}
-
-/** `SOC 101/intro.md` → `intro`, which is what the row is called. */
+/** `Fieldwork/intro.md` → `intro`, which is what the row is called. */
 function nameOf(path: string): string {
   return (path.split("/").pop() ?? path).replace(/\.mdx?$/i, "");
 }

--- a/apps/web/src/components/FileTree.test.tsx
+++ b/apps/web/src/components/FileTree.test.tsx
@@ -10,17 +10,48 @@ afterEach(cleanup);
 const tree: TreeNode[] = [
   {
     kind: "folder",
-    name: "SOC 101",
-    path: "SOC 101",
-    children: [{ kind: "file", name: "notes", path: "SOC 101/notes.md" }],
+    name: "Fieldwork",
+    path: "Fieldwork",
+    children: [{ kind: "file", name: "notes", path: "Fieldwork/notes.md" }],
   },
   {
     kind: "folder",
     name: "OSINT",
     path: "OSINT",
-    children: [{ kind: "file", name: "osint", path: "OSINT/osint.md" }],
+    children: [
+      { kind: "file", name: "osint", path: "OSINT/osint.md" },
+      {
+        kind: "folder",
+        name: "Sources",
+        path: "OSINT/Sources",
+        children: [{ kind: "file", name: "feeds", path: "OSINT/Sources/feeds.md" }],
+      },
+    ],
   },
 ];
+
+/** The row `label` sits on — the element carrying the drag handlers. */
+function row(label: string): HTMLElement {
+  const button = screen.getByText(label).closest("button");
+  const element = button?.parentElement;
+  if (!element) throw new Error(`no row for ${label}`);
+  return element;
+}
+
+/**
+ * One drag, start to finish.
+ *
+ * `dataTransfer` is a stub because jsdom does not implement it, and because
+ * the component deliberately does not read the payload back during `dragover`
+ * — the browser forbids it — so what it does has to be driven by the state the
+ * drag start recorded.
+ */
+function dragOnto(from: string, to: string) {
+  const dataTransfer = { setData: vi.fn(), getData: () => from, effectAllowed: "", dropEffect: "" };
+  fireEvent.dragStart(row(from), { dataTransfer });
+  fireEvent.dragOver(row(to), { dataTransfer });
+  fireEvent.drop(row(to), { dataTransfer });
+}
 
 function draw(props: Partial<React.ComponentProps<typeof FileTree>> = {}) {
   return render(
@@ -70,8 +101,65 @@ describe("which folders are open", () => {
     draw({ openFolders: [], onOpenFoldersChange });
 
     fireEvent.click(screen.getByText("OSINT"));
-    fireEvent.click(screen.getByText("SOC 101"));
+    fireEvent.click(screen.getByText("Fieldwork"));
 
-    expect(onOpenFoldersChange).toHaveBeenLastCalledWith(["OSINT", "SOC 101"]);
+    expect(onOpenFoldersChange).toHaveBeenLastCalledWith(["OSINT", "Fieldwork"]);
+  });
+});
+
+/**
+ * Dragging things around the tree.
+ *
+ * Notes could always be dragged into a folder. Folders could not, so the one
+ * reorganisation anybody actually wants — "this whole subject belongs under
+ * that one" — meant creating the destination by hand and moving the notes one
+ * at a time.
+ */
+describe("rearranging by drag", () => {
+  it("moves a note into a folder", () => {
+    const onMoveNote = vi.fn();
+    draw({ openFolders: ["Fieldwork", "OSINT"], onMoveNote });
+
+    dragOnto("notes", "OSINT");
+
+    expect(onMoveNote).toHaveBeenCalledWith("Fieldwork/notes.md", "OSINT");
+  });
+
+  it("moves a folder into another folder", () => {
+    const onMoveFolder = vi.fn();
+    draw({ openFolders: ["Fieldwork", "OSINT"], onMoveFolder });
+
+    dragOnto("Fieldwork", "OSINT");
+
+    expect(onMoveFolder).toHaveBeenCalledWith("Fieldwork", "OSINT");
+  });
+
+  it("refuses to drop a folder inside itself", () => {
+    const onMoveFolder = vi.fn();
+    draw({ openFolders: ["Fieldwork", "OSINT"], onMoveFolder });
+
+    dragOnto("OSINT", "OSINT");
+
+    expect(onMoveFolder).not.toHaveBeenCalled();
+  });
+
+  it("refuses to drop a folder into its own descendant", () => {
+    // The move that loses notes: renaming `OSINT` to `OSINT/Sources/OSINT`
+    // walks the folder into a path underneath itself.
+    const onMoveFolder = vi.fn();
+    draw({ openFolders: ["Fieldwork", "OSINT"], onMoveFolder });
+
+    dragOnto("OSINT", "Sources");
+
+    expect(onMoveFolder).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the destination is where it already is", () => {
+    const onMoveNote = vi.fn();
+    draw({ openFolders: ["Fieldwork", "OSINT"], onMoveNote });
+
+    dragOnto("notes", "Fieldwork");
+
+    expect(onMoveNote).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/FileTree.tsx
+++ b/apps/web/src/components/FileTree.tsx
@@ -276,7 +276,11 @@ const TreeItem = memo(function TreeItem({
   // The whole row is one indent step deeper than its parent. Every row reserves
   // the triangle's width whether or not it has one, so names line up in a
   // column instead of stepping raggedly in and out.
-  const indent = 0.375 + depth * 0.75;
+  //
+  // The step grew along with the rows: at the old 0.75rem, a name set two
+  // levels deep sat almost under its grandparent, and the nesting had to be
+  // inferred from the chevrons rather than seen.
+  const indent = 0.375 + depth * 0.85;
 
   return (
     <li role="treeitem" aria-expanded={isFolder ? open : undefined} aria-selected={active}>
@@ -338,7 +342,7 @@ const TreeItem = memo(function TreeItem({
             event.stopPropagation();
             if (isFolder) onToggle(node.path);
           }}
-          className={`flex h-[26px] w-4 shrink-0 items-center justify-center text-[var(--fl-muted)] ${
+          className={`flex h-[30px] w-[18px] shrink-0 items-center justify-center text-[var(--fl-muted)] ${
             isFolder ? "hover:text-[var(--fl-text)]" : "pointer-events-none opacity-0"
           }`}
         >
@@ -348,7 +352,7 @@ const TreeItem = memo(function TreeItem({
               thing in the row. */}
           <svg
             viewBox="0 0 12 12"
-            className={`h-[10px] w-[10px] transition-transform duration-150 ${open ? "rotate-90" : ""}`}
+            className={`h-[11px] w-[11px] transition-transform duration-150 ${open ? "rotate-90" : ""}`}
             fill="none"
             stroke="currentColor"
             strokeWidth="1.6"
@@ -365,7 +369,7 @@ const TreeItem = memo(function TreeItem({
           onClick={() => (isFolder ? onToggle(node.path) : onOpen(node.path))}
           onContextMenu={(event) => onContextMenu(event, node)}
           title={node.path}
-          className="flex min-w-0 flex-1 items-center gap-1.5 py-[3px] pl-0.5 text-left"
+          className="flex min-w-0 flex-1 items-center gap-2 py-[5px] pl-0.5 text-left"
         >
           <span
             className={`shrink-0 ${active ? "text-[var(--fl-accent)]" : "text-[var(--fl-muted)]"}`}
@@ -373,7 +377,7 @@ const TreeItem = memo(function TreeItem({
             {isFolder ? <FolderGlyph open={open} /> : <FileGlyph />}
           </span>
           <span
-            className={`truncate text-[13px] ${
+            className={`truncate text-[14px] leading-[1.35] ${
               active
                 ? "font-medium text-[var(--fl-text)]"
                 : isFolder
@@ -388,8 +392,8 @@ const TreeItem = memo(function TreeItem({
 
       {isFolder && open && (node.children?.length ?? 0) === 0 && (
         <p
-          style={{ paddingLeft: `${indent + 1.4}rem` }}
-          className="py-[3px] text-[11.5px] italic text-[var(--fl-muted)]"
+          style={{ paddingLeft: `${indent + 1.5}rem` }}
+          className="py-[5px] text-[12.5px] italic text-[var(--fl-muted)]"
         >
           Empty
         </p>
@@ -426,7 +430,7 @@ function FolderGlyph({ open }: { open: boolean }) {
     <svg
       viewBox="0 0 16 16"
       aria-hidden="true"
-      className="h-[15px] w-[15px]"
+      className="h-[17px] w-[17px]"
       fill="none"
       stroke="currentColor"
       strokeWidth="1.3"
@@ -449,7 +453,7 @@ function FileGlyph() {
     <svg
       viewBox="0 0 16 16"
       aria-hidden="true"
-      className="h-[15px] w-[15px]"
+      className="h-[17px] w-[17px]"
       fill="none"
       stroke="currentColor"
       strokeWidth="1.3"

--- a/apps/web/src/components/FileTree.tsx
+++ b/apps/web/src/components/FileTree.tsx
@@ -4,6 +4,12 @@ import React, { memo, useCallback, useMemo, useState } from "react";
 import type { TreeNode } from "@forkleaf/types";
 import { ContextMenu, useContextMenu, type MenuItem } from "./ContextMenu";
 
+/** What a drag in the tree is carrying. */
+export interface DragPayload {
+  kind: "file" | "folder";
+  path: string;
+}
+
 export interface FileTreeProps {
   nodes: TreeNode[];
   activePath: string | null;
@@ -17,6 +23,15 @@ export interface FileTreeProps {
   onDeleteFolder: (path: string) => void;
   /** Moves a note to another folder. Called by drag-and-drop within the tree. */
   onMoveNote?: (path: string, toFolder: string) => void;
+  /**
+   * Moves a folder, and everything under it, into another folder.
+   *
+   * Notes could be dragged from the start; folders could not, so the one
+   * reorganisation people actually want — "this whole subject belongs under
+   * that one" — meant making the destination by hand and dragging the notes
+   * across one at a time.
+   */
+  onMoveFolder?: (path: string, toFolder: string) => void;
   /** Pins a note to the top of the sidebar, or unpins one already there. */
   onTogglePin?: (path: string) => void;
   /** Paths currently pinned, so the menu can say which way it will go. */
@@ -58,6 +73,7 @@ export function FileTree({
   onRenameFolder,
   onDeleteFolder,
   onMoveNote,
+  onMoveFolder,
   onTogglePin,
   pinnedPaths,
   openFolders,
@@ -90,6 +106,46 @@ export function FileTree({
     [onOpenFoldersChange],
   );
   const [dropTarget, setDropTarget] = useState<string | null>(null);
+  /**
+   * What is currently being dragged.
+   *
+   * Held here rather than read from the drag event because `dataTransfer` is
+   * write-only during `dragover` — the browser will not let a page read the
+   * payload until the drop, precisely so a page cannot snoop on a drag from
+   * another application. Without it, a folder row cannot tell whether the
+   * thing hovering over it is one of its own descendants, and so cannot refuse
+   * a move that would rename a folder to a path inside itself.
+   */
+  const [dragging, setDragging] = useState<DragPayload | null>(null);
+
+  const canDropOn = useCallback(
+    (folder: string) => {
+      if (!dragging) return false;
+      if (dragging.kind === "file")
+        return Boolean(onMoveNote) && dirnameOf(dragging.path) !== folder;
+      if (!onMoveFolder) return false;
+      // Not into itself, not into its own descendant, not where it already is.
+      return (
+        folder !== dragging.path &&
+        !folder.startsWith(`${dragging.path}/`) &&
+        dirnameOf(dragging.path) !== folder
+      );
+    },
+    [dragging, onMoveNote, onMoveFolder],
+  );
+
+  const drop = useCallback(
+    (folder: string) => {
+      const payload = dragging;
+      setDragging(null);
+      setDropTarget(null);
+      if (!payload || !canDropOn(folder)) return;
+
+      if (payload.kind === "file") onMoveNote?.(payload.path, folder);
+      else onMoveFolder?.(payload.path, folder);
+    },
+    [dragging, canDropOn, onMoveNote, onMoveFolder],
+  );
   const { menu, open: openMenu, close: closeMenu } = useContextMenu<TreeNode>();
 
   const visible = useMemo(
@@ -190,20 +246,35 @@ export function FileTree({
       <ul
         role="tree"
         aria-label="Notes"
-        className="py-1"
-        // Dropping on the empty space below the tree moves a note to the root,
-        // which is otherwise only reachable by dragging onto a folder that
-        // happens to be at the top level.
-        onDragOver={onMoveNote ? (event) => event.preventDefault() : undefined}
-        onDrop={
-          onMoveNote
-            ? (event) => {
-                const path = event.dataTransfer.getData("text/plain");
-                setDropTarget(null);
-                if (path) onMoveNote(path, "");
-              }
-            : undefined
-        }
+        // Dropping on the empty space below the tree moves the dragged thing
+        // to the root, which is otherwise only reachable by dragging onto a
+        // folder that happens to be at the top level. It grows a ring while a
+        // drag is in flight, because an invisible drop target is one nobody
+        // finds — the space below the tree looks like padding, not a
+        // destination.
+        className={`min-h-full py-1 ${
+          dragging && dropTarget === "" && canDropOn("")
+            ? "rounded-lg bg-[var(--fl-elevated)]/40 ring-1 ring-inset ring-[var(--fl-accent)]"
+            : ""
+        }`}
+        // Only what was aimed at the empty space itself. Rows stop their own
+        // events, but a row that refuses a drop never calls `preventDefault`,
+        // so without the target check the browser would deliver that drop here
+        // instead and the tree's own refusal would be overturned by its parent.
+        onDragOver={(event) => {
+          if (event.target !== event.currentTarget || !canDropOn("")) return;
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "move";
+          setDropTarget("");
+        }}
+        onDragLeave={(event) => {
+          if (event.target === event.currentTarget) setDropTarget(null);
+        }}
+        onDrop={(event) => {
+          if (event.target !== event.currentTarget) return;
+          event.preventDefault();
+          drop("");
+        }}
       >
         {visible.map((node) => (
           <TreeItem
@@ -215,7 +286,10 @@ export function FileTree({
             onToggle={toggle}
             onOpen={onOpen}
             onContextMenu={openMenu}
-            onMoveNote={onMoveNote}
+            dragging={dragging}
+            onDragging={setDragging}
+            canDropOn={canDropOn}
+            onDrop={drop}
             dropTarget={dropTarget}
             onDropTarget={setDropTarget}
             // A search should reveal matches inside collapsed folders.
@@ -242,7 +316,10 @@ interface TreeItemProps {
     event: { clientX: number; clientY: number; preventDefault: () => void },
     node: TreeNode,
   ) => void;
-  onMoveNote?: (path: string, toFolder: string) => void;
+  dragging: DragPayload | null;
+  onDragging: (payload: DragPayload | null) => void;
+  canDropOn: (folder: string) => boolean;
+  onDrop: (folder: string) => void;
   dropTarget: string | null;
   onDropTarget: (path: string | null) => void;
   forceOpen: boolean;
@@ -263,7 +340,10 @@ const TreeItem = memo(function TreeItem({
   onToggle,
   onOpen,
   onContextMenu,
-  onMoveNote,
+  dragging,
+  onDragging,
+  canDropOn,
+  onDrop,
   dropTarget,
   onDropTarget,
   forceOpen,
@@ -271,7 +351,12 @@ const TreeItem = memo(function TreeItem({
   const open = forceOpen || expanded.has(node.path);
   const isFolder = node.kind === "folder";
   const active = !isFolder && node.path === activePath;
-  const dropping = dropTarget === node.path;
+  const dropping = isFolder && dropTarget === node.path && canDropOn(node.path);
+  // Dimmed while it is the thing in flight, so a drag over a deep tree still
+  // says which row left. A folder dims along with everything inside it.
+  const lifted =
+    dragging !== null && (dragging.path === node.path || node.path.startsWith(`${dragging.path}/`));
+  const dropFolder = isFolder ? node.path : dirnameOf(node.path);
 
   // The whole row is one indent step deeper than its parent. Every row reserves
   // the triangle's width whether or not it has one, so names line up in a
@@ -286,44 +371,57 @@ const TreeItem = memo(function TreeItem({
     <li role="treeitem" aria-expanded={isFolder ? open : undefined} aria-selected={active}>
       <div
         className={`relative flex items-center rounded-md pr-1.5 transition-colors ${
-          active
-            ? "bg-[var(--fl-elevated)]"
-            : dropping
-              ? "bg-[var(--fl-elevated)] ring-1 ring-inset ring-[var(--fl-accent)]"
+          lifted ? "opacity-40" : ""
+        } ${
+          dropping
+            ? "bg-[var(--fl-elevated)] ring-1 ring-inset ring-[var(--fl-accent)]"
+            : active
+              ? "bg-[var(--fl-elevated)]"
               : "hover:bg-[var(--fl-elevated)]"
         }`}
         style={{ paddingLeft: `${indent}rem` }}
-        draggable={!isFolder && Boolean(onMoveNote)}
-        onDragStart={
-          !isFolder && onMoveNote
-            ? (event) => {
-                event.dataTransfer.setData("text/plain", node.path);
-                event.dataTransfer.effectAllowed = "move";
-              }
-            : undefined
-        }
-        onDragOver={
-          isFolder && onMoveNote
-            ? (event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                event.dataTransfer.dropEffect = "move";
-                onDropTarget(node.path);
-              }
-            : undefined
-        }
-        onDragLeave={isFolder && onMoveNote ? () => onDropTarget(null) : undefined}
-        onDrop={
-          isFolder && onMoveNote
-            ? (event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                onDropTarget(null);
-                const path = event.dataTransfer.getData("text/plain");
-                if (path) onMoveNote(path, node.path);
-              }
-            : undefined
-        }
+        // Both kinds drag. `dataTransfer` still carries the path, because a
+        // drag that sets nothing is refused outright by some browsers and
+        // because it makes the payload legible to anything else listening.
+        draggable
+        onDragStart={(event) => {
+          event.stopPropagation();
+          event.dataTransfer.setData("text/plain", node.path);
+          event.dataTransfer.effectAllowed = "move";
+          onDragging({ kind: isFolder ? "folder" : "file", path: node.path });
+        }}
+        // Fires whether the drag ended in a drop, outside the window, or on
+        // Escape — without it, a cancelled drag leaves every row dimmed.
+        onDragEnd={() => {
+          onDragging(null);
+          onDropTarget(null);
+        }}
+        // Where a drop on this row lands. A folder takes things inside it; a
+        // note stands for the folder it is in, which is what dropping "next to
+        // this note" plainly means and what every file manager does.
+        //
+        // Both branches stop propagation whether or not the drop is allowed.
+        // Without that, a drop this row refuses keeps bubbling to the tree's
+        // root handler, which accepts everything — so dragging a note onto the
+        // folder it already lives in quietly moved it to the top of the
+        // repository instead of doing nothing.
+        onDragOver={(event) => {
+          event.stopPropagation();
+          if (!canDropOn(dropFolder)) return;
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "move";
+          onDropTarget(dropFolder);
+        }}
+        onDragLeave={(event) => {
+          event.stopPropagation();
+          onDropTarget(null);
+        }}
+        onDrop={(event) => {
+          event.stopPropagation();
+          if (!canDropOn(dropFolder)) return;
+          event.preventDefault();
+          onDrop(dropFolder);
+        }}
       >
         {/* The selected note gets a bar rather than a fill alone: at sidebar
             width, a slightly lighter row is easy to lose track of. */}
@@ -411,7 +509,10 @@ const TreeItem = memo(function TreeItem({
               onToggle={onToggle}
               onOpen={onOpen}
               onContextMenu={onContextMenu}
-              onMoveNote={onMoveNote}
+              dragging={dragging}
+              onDragging={onDragging}
+              canDropOn={canDropOn}
+              onDrop={onDrop}
               dropTarget={dropTarget}
               onDropTarget={onDropTarget}
               forceOpen={forceOpen}
@@ -473,6 +574,12 @@ function FileGlyph() {
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** The folder a path sits in. `""` for anything at the repository root. */
+function dirnameOf(path: string): string {
+  const cut = path.lastIndexOf("/");
+  return cut === -1 ? "" : path.slice(0, cut);
+}
 
 /** Top-level folders, which start open so the tree is never a single closed row. */
 function rootFolders(nodes: TreeNode[]): string[] {

--- a/apps/web/src/components/ProfilePanel.tsx
+++ b/apps/web/src/components/ProfilePanel.tsx
@@ -11,6 +11,7 @@ import { signOut } from "@/lib/gateway";
 import { usePalette, useTheme, type Theme } from "@/hooks/useTheme";
 import { PALETTES, normalizeHex } from "@/lib/palette";
 import { EVERYTHING } from "@/lib/plans";
+import { UnusedImages } from "@/components/UnusedImages";
 
 export interface ProfilePanelProps {
   user: SessionUser | null;
@@ -302,6 +303,10 @@ export function ProfilePanel({ user, githubAvailable }: ProfilePanelProps) {
                     <Pair label="Last edited" value={formatDate(summary.lastEditedAt)} />
                   )}
                 </dl>
+
+                {/* Only for a repository: a local workspace has no GitHub for
+                    anything to be left behind on. */}
+                {!workspace.isLocal && <UnusedImages workspace={workspace} />}
               </li>
             ))}
           </ul>

--- a/apps/web/src/components/ProfilePanel.tsx
+++ b/apps/web/src/components/ProfilePanel.tsx
@@ -400,27 +400,10 @@ export function ProfilePanel({ user, githubAvailable }: ProfilePanelProps) {
         </div>
       </section>
 
-      {/* ── Sponsor ───────────────────────────────────────────────────── */}
-      <section className="mt-10">
-        <SectionHeading>Sponsor</SectionHeading>
-        <div className="fl-card mt-3 p-6">
-          <p className="max-w-2xl text-[14.5px] leading-relaxed text-[var(--fl-muted)]">
-            ForkLeaf is built in the open by one person. Sponsoring unlocks nothing — there is
-            nothing left to unlock — it just keeps the work going.
-          </p>
-          <div className="mt-4 max-w-[600px] overflow-hidden rounded-xl border border-[var(--fl-border)]">
-            <iframe
-              src="https://github.com/sponsors/praneeth132006/card"
-              title="Sponsor praneeth132006"
-              height="225"
-              width="600"
-              loading="lazy"
-              className="block w-full"
-              style={{ border: 0 }}
-            />
-          </div>
-        </div>
-      </section>
+      {/* The sponsorship ask used to sit here, as a GitHub Sponsors iframe.
+          It belongs on the pricing page, where somebody is deciding what this
+          costs — not in the account settings of somebody who has already
+          decided and is here to change their theme. It is still on /pricing. */}
     </div>
   );
 }

--- a/apps/web/src/components/PromptDialog.test.tsx
+++ b/apps/web/src/components/PromptDialog.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { PromptDialog, type PromptRequest } from "./PromptDialog";
+
+afterEach(cleanup);
+
+function open(request: Partial<PromptRequest> = {}) {
+  // An override wins, and is what gets returned — otherwise a test that passes
+  // its own `onConfirm` asserts against a spy the dialog never called.
+  const onConfirm = request.onConfirm ? vi.fn(request.onConfirm) : vi.fn();
+  const onClose = vi.fn();
+
+  render(
+    <PromptDialog
+      request={{
+        title: "New folder",
+        label: "Folder name",
+        confirmLabel: "Create",
+        ...request,
+        onConfirm,
+      }}
+      onClose={onClose}
+    />,
+  );
+
+  return { onConfirm, onClose };
+}
+
+/**
+ * Where the cursor lands, and what Enter does once it is there.
+ *
+ * `Dialog` looked for `[autofocus]` to decide what to focus, and React never
+ * puts that attribute in the DOM — it calls `.focus()` itself — so the query
+ * matched nothing and focus fell to the first focusable element in the panel,
+ * which is the close button in the header. Two things followed: you had to
+ * click into the field before you could type, and Enter dismissed the dialog
+ * and discarded whatever you had typed.
+ */
+describe("the cursor", () => {
+  it("starts in the name field, not on the close button", () => {
+    open();
+
+    const input = screen.getByLabelText("Folder name");
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("puts Enter on the confirm button when there is no field to type in", () => {
+    open({ destructive: true, confirmLabel: "Delete", body: "Gone for good." });
+
+    expect((document.activeElement as HTMLElement).textContent).toBe("Delete");
+  });
+});
+
+describe("submitting", () => {
+  it("creates on Enter, without reaching for the mouse", () => {
+    const { onConfirm } = open();
+
+    const input = screen.getByLabelText("Folder name");
+    fireEvent.change(input, { target: { value: "Fieldwork" } });
+    // The key itself, not a synthesised submit: the whole complaint was that
+    // pressing this did nothing and Create had to be clicked.
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onConfirm).toHaveBeenCalledWith("Fieldwork", "");
+  });
+
+  it("submits once per Enter, not once per handler that hears it", () => {
+    // The keydown handler asks the form to submit and cancels the browser's
+    // own implicit submission. If it ever stopped cancelling, this would run
+    // the confirmation twice — two commits for one folder.
+    const { onConfirm } = open();
+
+    const input = screen.getByLabelText("Folder name");
+    fireEvent.change(input, { target: { value: "Fieldwork" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores Enter on an empty name rather than creating an unnamed folder", () => {
+    const { onConfirm, onClose } = open();
+
+    fireEvent.submit(screen.getByLabelText("Folder name").closest("form")!);
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not fire twice when Enter is held down", () => {
+    // `onConfirm` is awaited, so a second submit can arrive while the first is
+    // still in flight — which on a connected repository is two commits.
+    const { onConfirm } = open({ onConfirm: vi.fn(() => new Promise<void>(() => {})) });
+
+    const input = screen.getByLabelText("Folder name");
+    fireEvent.change(input, { target: { value: "Fieldwork" } });
+    const form = input.closest("form")!;
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Choosing a parent.
+ *
+ * A new folder used to land wherever the dialog happened to be opened from,
+ * and saying otherwise meant typing the parent into the name with a slash —
+ * spelled exactly right, or you silently got a second folder beside the one
+ * you meant.
+ */
+describe("the parent picker", () => {
+  const parent = {
+    label: "Inside",
+    options: ["", "Fieldwork", "Fieldwork/Soil surveys", "OSINT"],
+    initial: "Fieldwork",
+    rootLabel: "Repository root",
+  };
+
+  it("offers every folder in the tree, with the root named", () => {
+    open({ parent });
+
+    const options = [...screen.getByLabelText("Inside").querySelectorAll("option")];
+    expect(options[0]!.textContent).toBe("Repository root");
+    expect(options[0]!.getAttribute("value")).toBe("");
+    expect(options.map((option) => option.getAttribute("value"))).toEqual([
+      "",
+      "Fieldwork",
+      "Fieldwork/Soil surveys",
+      "OSINT",
+    ]);
+  });
+
+  it("starts on the folder the dialog was opened from", () => {
+    open({ parent });
+
+    expect((screen.getByLabelText("Inside") as HTMLSelectElement).value).toBe("Fieldwork");
+  });
+
+  it("reports the chosen parent alongside the name", () => {
+    const { onConfirm } = open({ parent });
+
+    fireEvent.change(screen.getByLabelText("Inside"), { target: { value: "OSINT" } });
+    const input = screen.getByLabelText("Folder name");
+    fireEvent.change(input, { target: { value: "Sources" } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(onConfirm).toHaveBeenCalledWith("Sources", "OSINT");
+  });
+
+  it("leaves the cursor in the name field, not the picker", () => {
+    open({ parent });
+
+    expect(document.activeElement).toBe(screen.getByLabelText("Folder name"));
+  });
+});

--- a/apps/web/src/components/PromptDialog.tsx
+++ b/apps/web/src/components/PromptDialog.tsx
@@ -1,7 +1,25 @@
 "use client";
 
-import { type FormEvent, useState } from "react";
+import { type FormEvent, type KeyboardEvent, useRef, useState } from "react";
 import { Dialog } from "./Dialog";
+
+/**
+ * An optional "where does this go" choice, shown above the name field.
+ *
+ * Creating a folder used to put it wherever the dialog had been opened from,
+ * and the only way to say otherwise was to type the parent into the name with
+ * a slash — which you had to know, and had to spell exactly as the existing
+ * folder is spelled, or you silently got a second folder beside it.
+ */
+export interface PromptParentChoice {
+  label: string;
+  /** Folder paths in tree order. `""` is the repository root. */
+  options: readonly string[];
+  /** The one selected on open. */
+  initial: string;
+  /** What `""` is called, since a blank option reads as a missing one. */
+  rootLabel: string;
+}
 
 export interface PromptRequest {
   title: string;
@@ -11,7 +29,8 @@ export interface PromptRequest {
   /** Renders a destructive confirmation instead of a text input. */
   destructive?: boolean;
   body?: string;
-  onConfirm: (value: string) => void | Promise<void>;
+  parent?: PromptParentChoice;
+  onConfirm: (value: string, parent: string) => void | Promise<void>;
 }
 
 export interface PromptDialogProps {
@@ -28,16 +47,43 @@ export interface PromptDialogProps {
  */
 export function PromptDialog({ request, onClose }: PromptDialogProps) {
   const [value, setValue] = useState(request.initialValue ?? "");
+  const [parent, setParent] = useState(request.parent?.initial ?? "");
   const [busy, setBusy] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
+  // A ref, not `busy`, because `setBusy(true)` does not take effect until the
+  // next render — two submits dispatched in the same tick would both read
+  // `busy === false` and both run, which on a connected repository is two
+  // commits for one folder.
+  const running = useRef(false);
+
+  /**
+   * Enter, made to mean Create.
+   *
+   * A form with a submit button submits on Enter on its own, and this dialog
+   * has one — but "on its own" is doing a lot of work there. Implicit
+   * submission is skipped whenever the default button is disabled, and this
+   * one is disabled until the name is non-empty, so an Enter pressed in the
+   * same frame as the last keystroke could find a disabled button and be
+   * dropped. Asking the form directly removes the question, and the
+   * `preventDefault` keeps the browser from also submitting and running the
+   * whole thing twice.
+   */
+  const submitOnEnter = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter" || event.shiftKey) return;
+    event.preventDefault();
+    formRef.current?.requestSubmit();
+  };
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
+    if (running.current) return;
     if (!request.destructive && !value.trim()) return;
 
+    running.current = true;
     setBusy(true);
     try {
       // Execute the confirmation callback with the trimmed input value
-      await request.onConfirm(value.trim());
+      await request.onConfirm(value.trim(), parent);
       // Close the dialog only on success — errors leave it open for retry
       onClose();
     } catch (error: unknown) {
@@ -45,15 +91,37 @@ export function PromptDialog({ request, onClose }: PromptDialogProps) {
       console.error("[forkleaf] Prompt action failed:", error);
     } finally {
       // Always re-enable the form regardless of success or failure
+      running.current = false;
       setBusy(false);
     }
   };
 
   return (
     <Dialog title={request.title} onClose={onClose}>
-      <form onSubmit={submit}>
+      <form ref={formRef} onSubmit={submit}>
         {request.body && (
           <p className="mb-3 text-sm leading-relaxed text-[var(--fl-muted)]">{request.body}</p>
+        )}
+
+        {request.parent && (
+          <label className="mb-4 block">
+            <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-[var(--fl-muted)]">
+              {request.parent.label}
+            </span>
+            <select
+              value={parent}
+              onChange={(event) => setParent(event.target.value)}
+              className="w-full rounded-md border border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-2 text-sm text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
+            >
+              {request.parent.options.map((folder) => (
+                <option key={folder} value={folder}>
+                  {folder === ""
+                    ? request.parent!.rootLabel
+                    : `${"\u00a0\u00a0".repeat(folder.split("/").length - 1)}${folder.split("/").pop()}`}
+                </option>
+              ))}
+            </select>
+          </label>
         )}
 
         {!request.destructive && (
@@ -64,11 +132,23 @@ export function PromptDialog({ request, onClose }: PromptDialogProps) {
             <input
               value={value}
               onChange={(event) => setValue(event.target.value)}
-              autoFocus
+              onKeyDown={submitOnEnter}
+              // A real attribute, unlike React's `autoFocus`, so `Dialog` can
+              // find it and put the cursor here rather than on Close.
+              data-autofocus
               // Select the existing text so renaming replaces rather than appends.
               onFocus={(event) => event.currentTarget.select()}
               className="w-full rounded-md border border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-2 text-sm text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
             />
+            {request.parent && value.includes("/") && (
+              <span className="mt-1.5 block text-[12px] text-[var(--fl-muted)]">
+                Creates{" "}
+                <strong className="font-medium text-[var(--fl-text)]">
+                  {[parent, value.trim()].filter(Boolean).join("/")}
+                </strong>
+                , one folder per slash.
+              </span>
+            )}
           </label>
         )}
 
@@ -82,6 +162,7 @@ export function PromptDialog({ request, onClose }: PromptDialogProps) {
           </button>
           <button
             type="submit"
+            data-autofocus={request.destructive ? "" : undefined}
             disabled={busy || (!request.destructive && !value.trim())}
             className={`rounded-md px-4 py-2 text-sm font-semibold disabled:opacity-40 ${
               request.destructive

--- a/apps/web/src/components/ProposeChangesDialog.tsx
+++ b/apps/web/src/components/ProposeChangesDialog.tsx
@@ -170,6 +170,7 @@ export function ProposeChangesDialog({
           directory: workspace.repo.directory,
           message: title.trim(),
           changes: pending.map((change) => ({
+            // A move is a rename the commit builder resolves without content.
             op: change.op,
             path: change.path,
             ...(change.toPath ? { toPath: change.toPath } : {}),

--- a/apps/web/src/components/UnusedImages.test.tsx
+++ b/apps/web/src/components/UnusedImages.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { TreeNode, Workspace } from "@forkleaf/types";
+import { UnusedImages } from "./UnusedImages";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const workspace: Workspace = {
+  id: "octo/notes@main:",
+  name: "notes",
+  repo: { owner: "octo", repo: "notes", branch: "main", directory: "" },
+  isDefault: true,
+  isLocal: false,
+  createdAt: new Date(0).toISOString(),
+  lastOpenedAt: new Date(0).toISOString(),
+};
+
+const file = (path: string, size?: number): TreeNode => ({
+  path,
+  name: path.split("/").pop()!,
+  kind: "file",
+  ...(size === undefined ? {} : { size }),
+});
+
+/**
+ * A repository that answers the three routes this uses.
+ *
+ * `notes` is the markdown and its text; `images` is everything else in the
+ * tree. Commits are recorded rather than performed, so a test can assert on
+ * exactly which paths would have been deleted.
+ */
+function server(notes: Record<string, string>, images: [string, number][]) {
+  const commits: { message: string; changes: { op: string; path: string }[] }[] = [];
+
+  const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const json = (body: unknown) => new Response(JSON.stringify(body), { status: 200 });
+
+    if (url.startsWith("/api/gh/commit")) {
+      commits.push(JSON.parse(String(init!.body)));
+      return json({ sha: "c" });
+    }
+
+    if (url.startsWith("/api/gh/tree")) {
+      const all = url.includes("all=1");
+      const paths = all
+        ? [...Object.keys(notes).map((p) => file(p)), ...images.map(([p, s]) => file(p, s))]
+        : Object.keys(notes).map((p) => file(p));
+      return json({ tree: paths });
+    }
+
+    if (url.startsWith("/api/gh/file")) {
+      const path = decodeURIComponent(new URL(url, "http://x").searchParams.get("path")!);
+      return json({ file: { content: notes[path] ?? "", sha: "s" } });
+    }
+
+    throw new Error(`unexpected request: ${url}`);
+  });
+
+  vi.stubGlobal("fetch", fetchImpl);
+  return { commits, fetchImpl };
+}
+
+/**
+ * Clearing out images no note uses.
+ *
+ * This deletes files from somebody's repository, so the behaviour under test
+ * is as much about restraint as about finding things: it must never act on one
+ * press, and it must show every path before it acts at all.
+ */
+describe("scanning", () => {
+  beforeEach(() => cleanup());
+
+  it("lists the image nothing links to, with its size", async () => {
+    server({ "Intro/a.md": "![](assets/used.png)" }, [
+      ["Intro/assets/used.png", 1024],
+      ["Intro/assets/stray.png", 4096],
+    ]);
+    render(<UnusedImages workspace={workspace} />);
+
+    fireEvent.click(screen.getByText("Scan for unused images"));
+
+    expect(await screen.findByText("Intro/assets/stray.png")).toBeTruthy();
+    expect(screen.queryByText("Intro/assets/used.png")).toBeNull();
+    expect(screen.getByText("4 KB")).toBeTruthy();
+  });
+
+  it("says so plainly when there is nothing to clean up", async () => {
+    server({ "Intro/a.md": "![](assets/used.png)" }, [["Intro/assets/used.png", 1024]]);
+    render(<UnusedImages workspace={workspace} />);
+
+    fireEvent.click(screen.getByText("Scan for unused images"));
+
+    expect(await screen.findByText(/Nothing unused/)).toBeTruthy();
+  });
+
+  it("deletes nothing by scanning", async () => {
+    const { commits } = server({ "Intro/a.md": "# hi" }, [["Intro/assets/stray.png", 10]]);
+    render(<UnusedImages workspace={workspace} />);
+
+    fireEvent.click(screen.getByText("Scan for unused images"));
+    await screen.findByText("Intro/assets/stray.png");
+
+    expect(commits).toHaveLength(0);
+  });
+
+  it("refuses to report anything when a note cannot be read", async () => {
+    // The dangerous case: a note whose text is unavailable is a note whose
+    // images cannot be accounted for, so every picture it uses would look
+    // unused. Failing is the only safe answer.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.startsWith("/api/gh/tree")) {
+          const nodes = url.includes("all=1")
+            ? [file("Intro/a.md"), file("Intro/assets/stray.png", 10)]
+            : [file("Intro/a.md")];
+          return new Response(JSON.stringify({ tree: nodes }), { status: 200 });
+        }
+        return new Response("nope", { status: 500 });
+      }),
+    );
+    render(<UnusedImages workspace={workspace} />);
+
+    fireEvent.click(screen.getByText("Scan for unused images"));
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.queryByText("Intro/assets/stray.png")).toBeNull();
+  });
+});
+
+describe("deleting", () => {
+  it("waits for a second, separate press", async () => {
+    const { commits } = server({ "Intro/a.md": "# hi" }, [["Intro/assets/stray.png", 10]]);
+    render(<UnusedImages workspace={workspace} />);
+
+    fireEvent.click(screen.getByText("Scan for unused images"));
+    await screen.findByText("Intro/assets/stray.png");
+    expect(commits).toHaveLength(0);
+
+    fireEvent.click(screen.getByText(/Delete it from GitHub/));
+
+    await waitFor(() => expect(commits).toHaveLength(1));
+    expect(commits[0]!.changes).toEqual([{ op: "delete", path: "Intro/assets/stray.png" }]);
+  });
+
+  it("removes them in one commit, not one each", async () => {
+    const { commits } = server({ "Intro/a.md": "# hi" }, [
+      ["Intro/assets/one.png", 10],
+      ["Intro/assets/two.png", 20],
+    ]);
+    render(<UnusedImages workspace={workspace} />);
+
+    fireEvent.click(screen.getByText("Scan for unused images"));
+    await screen.findByText("Intro/assets/one.png");
+    fireEvent.click(screen.getByText(/Delete them from GitHub/));
+
+    await waitFor(() => expect(commits).toHaveLength(1));
+    expect(commits[0]!.changes).toHaveLength(2);
+    expect(commits[0]!.message).toContain("2 unused images");
+  });
+
+  it("leaves them alone when asked to", async () => {
+    const { commits } = server({ "Intro/a.md": "# hi" }, [["Intro/assets/stray.png", 10]]);
+    render(<UnusedImages workspace={workspace} />);
+
+    fireEvent.click(screen.getByText("Scan for unused images"));
+    await screen.findByText("Intro/assets/stray.png");
+    fireEvent.click(screen.getByText("Leave them"));
+
+    expect(commits).toHaveLength(0);
+    expect(screen.getByText("Scan for unused images")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/UnusedImages.tsx
+++ b/apps/web/src/components/UnusedImages.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import React, { useState } from "react";
+import type { Workspace } from "@forkleaf/types";
+import { formatBytes, type OrphanAsset } from "@/lib/orphan-assets";
+import { deleteUnusedImages, ScanError, scanForUnusedImages } from "@/lib/unused-images";
+
+/**
+ * Clearing out images no note uses.
+ *
+ * An older version of this app deleted a folder's notes and left the pictures
+ * they used behind, in an `assets` directory beside them. That is fixed, but
+ * any repository used before the fix is still carrying the leftovers — and
+ * because the sidebar is built from notes, a folder with no note left in it
+ * cannot be reached to clear it.
+ *
+ * It is a scan and then a decision, never one action. The list is shown with
+ * every path and what it costs, and removing it is a second, separate press.
+ * A tool that deletes files out of somebody's repository on one click, on the
+ * strength of a heuristic about what is "unused", is not a tool anybody should
+ * have to trust.
+ */
+export function UnusedImages({ workspace }: { workspace: Workspace }) {
+  const [state, setState] = useState<
+    | { kind: "idle" }
+    | { kind: "scanning"; done: number; total: number }
+    | { kind: "found"; orphans: OrphanAsset[]; notesRead: number }
+    | { kind: "deleting" }
+    | { kind: "done"; removed: number }
+    | { kind: "error"; message: string }
+  >({ kind: "idle" });
+
+  const scan = async () => {
+    setState({ kind: "scanning", done: 0, total: 0 });
+    try {
+      const result = await scanForUnusedImages(workspace, (done, total) =>
+        setState({ kind: "scanning", done, total }),
+      );
+      setState({ kind: "found", orphans: result.orphans, notesRead: result.notesRead });
+    } catch (error) {
+      setState({
+        kind: "error",
+        message:
+          error instanceof ScanError
+            ? error.message
+            : "The repository could not be read. Nothing was changed.",
+      });
+    }
+  };
+
+  const remove = async (orphans: OrphanAsset[]) => {
+    setState({ kind: "deleting" });
+    try {
+      await deleteUnusedImages(
+        workspace,
+        orphans.map((orphan) => orphan.path),
+      );
+      setState({ kind: "done", removed: orphans.length });
+    } catch (error) {
+      setState({
+        kind: "error",
+        message:
+          error instanceof ScanError
+            ? error.message
+            : "Those images could not be removed. Nothing was changed.",
+      });
+    }
+  };
+
+  return (
+    <div className="mt-4 border-t border-[var(--fl-border)] pt-4">
+      <h4 className="text-[13.5px] font-semibold text-[var(--fl-text)]">Unused images</h4>
+      <p className="mt-1 max-w-2xl text-[13px] leading-relaxed text-[var(--fl-muted)]">
+        Reads every note in this repository and lists the images none of them link to. Nothing is
+        deleted until you say so.
+      </p>
+
+      {state.kind === "idle" && (
+        <button
+          type="button"
+          onClick={scan}
+          className="fl-btn fl-btn-ghost mt-3 !py-1.5 !text-[13px]"
+        >
+          Scan for unused images
+        </button>
+      )}
+
+      {state.kind === "scanning" && (
+        <p role="status" className="mt-3 text-[13px] text-[var(--fl-muted)]">
+          {state.total > 0
+            ? `Reading notes — ${state.done} of ${state.total}…`
+            : "Reading the repository…"}
+        </p>
+      )}
+
+      {state.kind === "found" && state.orphans.length === 0 && (
+        <p role="status" className="mt-3 text-[13px] text-[var(--fl-muted)]">
+          Nothing unused. Every image in this repository is linked from one of its{" "}
+          {state.notesRead.toLocaleString()} notes.
+        </p>
+      )}
+
+      {state.kind === "found" && state.orphans.length > 0 && (
+        <div className="mt-3">
+          <p className="text-[13px] text-[var(--fl-text)]">
+            {state.orphans.length === 1
+              ? "One image is not linked from any note"
+              : `${state.orphans.length} images are not linked from any note`}
+            {totalBytes(state.orphans) !== null && (
+              <span className="text-[var(--fl-muted)]">
+                {" "}
+                — {formatBytes(totalBytes(state.orphans)!)}
+              </span>
+            )}
+            <span className="text-[var(--fl-muted)]">
+              , after reading all {state.notesRead.toLocaleString()}.
+            </span>
+          </p>
+
+          {/* Every path, not a count. Somebody is about to delete these from
+              their own repository and is entitled to see exactly which. */}
+          <ul className="mt-2 max-h-56 overflow-y-auto rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-2">
+            {state.orphans.map((orphan) => (
+              <li
+                key={orphan.path}
+                className="flex items-baseline justify-between gap-3 px-1.5 py-1 font-mono text-[12px] text-[var(--fl-muted)]"
+              >
+                <span className="min-w-0 break-all">{orphan.path}</span>
+                {orphan.size !== null && (
+                  <span className="shrink-0">{formatBytes(orphan.size)}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => remove(state.orphans)}
+              className="fl-btn !border-[var(--fl-danger)] !py-1.5 !text-[13px] !text-[var(--fl-danger)]"
+            >
+              Delete {state.orphans.length === 1 ? "it" : "them"} from GitHub
+            </button>
+            <button
+              type="button"
+              onClick={() => setState({ kind: "idle" })}
+              className="fl-btn fl-btn-ghost !py-1.5 !text-[13px]"
+            >
+              Leave them
+            </button>
+          </div>
+
+          <p className="mt-2 text-[12px] text-[var(--fl-muted)]">
+            One commit, so it stays recoverable from your git history.
+          </p>
+        </div>
+      )}
+
+      {state.kind === "deleting" && (
+        <p role="status" className="mt-3 text-[13px] text-[var(--fl-muted)]">
+          Removing them…
+        </p>
+      )}
+
+      {state.kind === "done" && (
+        <p role="status" className="mt-3 text-[13px] text-[var(--fl-muted)]">
+          {state.removed === 1 ? "One image removed" : `${state.removed} images removed`}. The
+          commit is in your repository&rsquo;s history if you need it back.{" "}
+          <button
+            type="button"
+            onClick={() => setState({ kind: "idle" })}
+            className="text-[var(--fl-accent)] underline"
+          >
+            Scan again
+          </button>
+        </p>
+      )}
+
+      {state.kind === "error" && (
+        <p role="alert" className="mt-3 text-[13px] text-[var(--fl-danger)]">
+          {state.message}{" "}
+          <button
+            type="button"
+            onClick={() => setState({ kind: "idle" })}
+            className="text-[var(--fl-accent)] underline"
+          >
+            Try again
+          </button>
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Null when GitHub reported no size for any of them, rather than "0 B". */
+function totalBytes(orphans: readonly OrphanAsset[]): number | null {
+  const known = orphans.filter((orphan) => orphan.size !== null);
+  if (known.length === 0) return null;
+  return known.reduce((sum, orphan) => sum + (orphan.size ?? 0), 0);
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -37,6 +37,7 @@ import { BootScreen } from "@/components/BootScreen";
 import { LocalOnlyBanner } from "@/components/LocalOnlyBanner";
 import { signOut } from "@/lib/gateway";
 import { assetPathFor, relativeSrc, resolveImageSrc } from "@/lib/assets";
+import { collectFolders } from "@/lib/tree";
 import { hasRelativeImages, repairNoteLinks } from "@/lib/repair-links";
 import { flattenTree, isMarkdown } from "@/lib/library";
 import { track } from "@/lib/firebase/analytics";
@@ -421,22 +422,65 @@ export function EditorWorkspace() {
     [notebook],
   );
 
+  /**
+   * Makes a folder, somewhere you choose.
+   *
+   * `parent` is where the dialog was opened from — the right-click target, or
+   * the folder of the note being edited — and it is a starting point rather
+   * than a verdict. The picker lists every folder in the tree, so making a
+   * subfolder under one you are not currently in no longer means closing this,
+   * navigating there, and opening it again.
+   */
   const handleCreateFolder = useCallback(
     (parent: string) => {
+      const folders = collectFolders(notebook.tree);
+
       setPrompt({
-        title: parent ? `New folder in ${parent}` : "New folder",
+        title: "New folder",
         label: "Folder name",
         initialValue: "",
         confirmLabel: "Create",
-        body:
-          "Folders are made of the notes inside them, so this one appears in your repository as soon as it holds its first note. " +
-          "Use slashes to make several at once, as in “SOC 101/Phishing analysis”.",
-        onConfirm: async (value) => {
-          const name = value.trim();
+        body: "Folders are made of the notes inside them, so this one appears in your repository as soon as it holds its first note.",
+        parent: {
+          label: "Inside",
+          // The root first, then every existing folder, so "somewhere else"
+          // is a choice from a list rather than a path you have to spell.
+          options: ["", ...folders],
+          initial: folders.includes(parent) ? parent : "",
+          rootLabel: notebook.activeWorkspace?.name ?? "Repository root",
+        },
+        onConfirm: async (value, chosenParent) => {
+          const name = value.trim().replace(/^\/+|\/+$/g, "");
           if (!name) return;
-          await notebook.createFolder(parent ? `${parent}/${name}` : name);
+          await notebook.createFolder(chosenParent ? `${chosenParent}/${name}` : name);
         },
       });
+    },
+    [notebook],
+  );
+
+  /**
+   * Moves a folder under another one, from a drag in the tree.
+   *
+   * A folder move is a rename in a repository — git tracks files, so every note
+   * beneath it moves and the old directory stops existing. `renameFolder`
+   * already does exactly that, so this only has to work out the new path and
+   * refuse the moves that would destroy the tree.
+   */
+  const handleMoveFolder = useCallback(
+    async (path: string, toFolder: string) => {
+      const name = path.split("/").pop();
+      if (!name) return;
+
+      // Into itself, into its own descendant, or back where it already is.
+      // The first two would rename a folder to a path inside itself and lose
+      // every note under it; the third is a no-op worth skipping before it
+      // becomes a commit.
+      if (toFolder === path || toFolder.startsWith(`${path}/`)) return;
+      const target = toFolder ? `${toFolder}/${name}` : name;
+      if (target === path) return;
+
+      await notebook.renameFolder(path, target);
     },
     [notebook],
   );
@@ -923,6 +967,7 @@ export function EditorWorkspace() {
             onRenameFolder={handleRenameFolder}
             onDeleteFolder={handleDeleteFolder}
             onMoveNote={handleMoveNote}
+            onMoveFolder={handleMoveFolder}
             pinnedPaths={notebook.pinnedPaths}
             {...(notebook.expandedFolders ? { openFolders: notebook.expandedFolders } : {})}
             onOpenFoldersChange={notebook.setExpandedFolders}

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -793,14 +793,12 @@ export function useNotebook(request: NotebookRequest = {}) {
 
       patch({ busy: "Renaming folder…" });
       try {
-        for (const path of collectPaths(state.tree).filter((candidate) =>
-          candidate.startsWith(`${source}/`),
-        )) {
-          const note =
-            state.openNotes.find((candidate) => candidate.path === path) ??
-            (await notes.openNote(workspace.id, path));
-          await notes.renameNote(note, `${target}${path.slice(source.length)}`);
-        }
+        // Everything under it, not just the notes. The tree the sidebar is
+        // built from lists Markdown only, so renaming from it moved the notes
+        // and left their `assets` directory behind at the old path — a folder
+        // that had been "moved" was still half there on github.com, and the
+        // images every note in it used were in the half that stayed.
+        await notes.moveFolderContents(workspace.id, source, target, collectPaths(state.tree));
 
         putEmptyFolders(
           state.emptyFolders.map((folder) =>
@@ -815,15 +813,10 @@ export function useNotebook(request: NotebookRequest = {}) {
         patch({ busy: null });
       }
     },
-    [
-      state.tree,
-      state.openNotes,
-      state.activeWorkspace,
-      state.emptyFolders,
-      putEmptyFolders,
-      refreshTree,
-      patch,
-    ],
+    // `state.openNotes` was here to find an already-open note to rename;
+    // `moveFolderContents` looks that up itself, so keeping it in this list
+    // would rebuild the callback on every keystroke in any open note.
+    [state.tree, state.activeWorkspace, state.emptyFolders, putEmptyFolders, refreshTree, patch],
   );
 
   /** Deletes a folder and every note inside it. */
@@ -836,15 +829,12 @@ export function useNotebook(request: NotebookRequest = {}) {
 
       patch({ busy: "Deleting folder…" });
       try {
-        for (const notePath of collectPaths(state.tree).filter((candidate) =>
-          candidate.startsWith(`${folder}/`),
-        )) {
-          // By path: a folder is deleted as a whole, and one note inside it
-          // that cannot be read — signed out, offline, never opened — used to
-          // throw here and abandon the deletion halfway through, leaving the
-          // folder on screen with some of its notes gone.
-          await notes.deletePath(workspace.id, notePath, shaFor(state.tree, notePath));
-        }
+        // Everything under it, not just the notes. Deleting from the sidebar's
+        // Markdown-only tree removed the notes and left the `assets` directory
+        // beside them, so a folder deleted here was still on github.com
+        // holding files — and, with no note left in it, no longer reachable
+        // from the app that made it.
+        await notes.deleteFolderContents(workspace.id, folder, collectPaths(state.tree));
 
         putEmptyFolders(
           state.emptyFolders.filter(

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -103,6 +103,22 @@ export class GitHubGateway implements RemoteGateway {
     return tree;
   }
 
+  async listAllPaths(workspaceId: string): Promise<string[]> {
+    const { tree } = await call<{ tree: TreeNode[] }>(
+      `/api/gh/tree?${repoParams(this.resolve(workspaceId))}&all=1`,
+    );
+
+    const paths: string[] = [];
+    const walk = (nodes: TreeNode[]) => {
+      for (const node of nodes) {
+        if (node.kind === "file") paths.push(node.path);
+        if (node.children) walk(node.children);
+      }
+    };
+    walk(tree);
+    return paths;
+  }
+
   async readFile(
     workspaceId: string,
     path: string,
@@ -142,6 +158,11 @@ export class GitHubGateway implements RemoteGateway {
  */
 export class LocalGateway implements RemoteGateway {
   async listTree(): Promise<TreeNode[]> {
+    return [];
+  }
+
+  async listAllPaths(): Promise<string[]> {
+    // Nothing is ever remote, so there is nothing on GitHub to tidy up.
     return [];
   }
 
@@ -232,7 +253,7 @@ export async function commitToBranch(options: {
   directory: string;
   message: string;
   changes: {
-    op: "upsert" | "delete" | "rename";
+    op: "upsert" | "delete" | "rename" | "move";
     path: string;
     toPath?: string;
     content?: string;

--- a/apps/web/src/lib/orphan-assets.test.ts
+++ b/apps/web/src/lib/orphan-assets.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { findOrphanAssets, formatBytes, referencedPaths } from "./orphan-assets";
+
+/**
+ * Finding images no note uses.
+ *
+ * This decides what gets deleted from somebody's repository, so the tests that
+ * matter most are the ones asserting what is *not* an orphan. A miss in
+ * `referencedPaths` does not produce a wrong number on a screen — it deletes a
+ * picture out of a note somebody is still reading.
+ */
+
+describe("referencedPaths", () => {
+  it("finds a pasted screenshot", () => {
+    expect(referencedPaths("Intro/note.md", "![](assets/a.png)")).toEqual(["Intro/assets/a.png"]);
+  });
+
+  it("finds one linked rather than embedded", () => {
+    expect(referencedPaths("Intro/note.md", "[the chart](assets/a.png)")).toEqual([
+      "Intro/assets/a.png",
+    ]);
+  });
+
+  it("finds one written as HTML, which markdown permits", () => {
+    expect(referencedPaths("Intro/note.md", '<img src="assets/a.png" width="40">')).toEqual([
+      "Intro/assets/a.png",
+    ]);
+  });
+
+  it("finds one behind a reference definition", () => {
+    const content = "Look at ![the chart][c].\n\n[c]: assets/a.png\n";
+    expect(referencedPaths("Intro/note.md", content)).toContain("Intro/assets/a.png");
+  });
+
+  it("resolves a path that climbs out of the note's folder", () => {
+    expect(referencedPaths("Intro/deep/note.md", "![](../assets/a.png)")).toEqual([
+      "Intro/assets/a.png",
+    ]);
+  });
+
+  it("decodes a percent-encoded path, as a renderer writes it", () => {
+    // A folder with a space in it comes back from the editor as `%20`, and
+    // comparing that literally against the repository path matches nothing —
+    // which would report every image in every such folder as unused.
+    expect(referencedPaths("Python 101/note.md", "![](assets/a%20b.png)")).toEqual([
+      "Python 101/assets/a b.png",
+    ]);
+  });
+
+  it("ignores an image hosted somewhere else", () => {
+    expect(referencedPaths("note.md", "![](https://example.com/a.png)")).toEqual([]);
+  });
+
+  it("ignores a title after the path", () => {
+    expect(referencedPaths("Intro/note.md", '![](assets/a.png "A chart")')).toEqual([
+      "Intro/assets/a.png",
+    ]);
+  });
+});
+
+describe("findOrphanAssets", () => {
+  const files = [
+    { path: "Intro/note.md", size: 100 },
+    { path: "Intro/assets/used.png", size: 2048 },
+    { path: "Intro/assets/stray.png", size: 4096 },
+  ];
+  const notes = new Map([["Intro/note.md", "# Intro\n\n![](assets/used.png)\n"]]);
+
+  it("reports the image nothing points at", () => {
+    expect(findOrphanAssets(files, notes)).toEqual([
+      { path: "Intro/assets/stray.png", size: 4096 },
+    ]);
+  });
+
+  it("never reports a note", () => {
+    const orphans = findOrphanAssets(files, notes).map((asset) => asset.path);
+    expect(orphans).not.toContain("Intro/note.md");
+  });
+
+  it("leaves alone every file that is not an image", () => {
+    // A repository is not only ours. Deleting a licence or a config file
+    // because no note links to it would be indefensible.
+    const repo = [
+      ...files,
+      { path: "LICENSE", size: 1000 },
+      { path: ".gitignore", size: 20 },
+      { path: "src/index.ts", size: 500 },
+      { path: "README", size: 300 },
+    ];
+
+    expect(findOrphanAssets(repo, notes).map((asset) => asset.path)).toEqual([
+      "Intro/assets/stray.png",
+    ]);
+  });
+
+  it("counts an image used by any note, not just the one beside it", () => {
+    // Sharing a picture across folders is unusual and entirely legal, and
+    // getting it wrong deletes it out of the note that does use it.
+    const shared = new Map([
+      ["Intro/note.md", "# Intro\n"],
+      ["Other/far.md", "![](../Intro/assets/stray.png)"],
+    ]);
+
+    expect(findOrphanAssets(files, shared).map((asset) => asset.path)).toEqual([
+      "Intro/assets/used.png",
+    ]);
+  });
+
+  it("reports nothing when every image is spoken for", () => {
+    const all = new Map([["Intro/note.md", "![](assets/used.png)\n\n![](assets/stray.png)"]]);
+
+    expect(findOrphanAssets(files, all)).toEqual([]);
+  });
+
+  it("carries a null size rather than inventing a zero", () => {
+    const unsized = [{ path: "Intro/assets/stray.png" }];
+    expect(findOrphanAssets(unsized, new Map())).toEqual([
+      { path: "Intro/assets/stray.png", size: null },
+    ]);
+  });
+});
+
+describe("formatBytes", () => {
+  it("reads as a size a person would recognise", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toBe("2 KB");
+    expect(formatBytes(3_500_000)).toBe("3.3 MB");
+  });
+});

--- a/apps/web/src/lib/orphan-assets.ts
+++ b/apps/web/src/lib/orphan-assets.ts
@@ -1,0 +1,98 @@
+import { isRelativeLink, resolveFromNote } from "@forkleaf/markdown-engine";
+import { imageTypeFor } from "@/lib/media";
+
+/**
+ * Finding images no note uses any more.
+ *
+ * Deleting a folder used to remove its notes and leave the pictures they used
+ * in an `assets` directory beside them. That is fixed at the source now, but
+ * every repository that was ever used by the broken version is still carrying
+ * the leftovers — and with no note left in the folder, nothing in the sidebar
+ * can reach them. This is how they get found and removed.
+ *
+ * The rule is deliberately narrow, because the failure mode is deleting a
+ * picture somebody is still using:
+ *
+ *   - Only files this app would have written: images, by extension. A
+ *     repository holds licences, source code and configuration, and none of
+ *     that is ours to tidy up on somebody's behalf.
+ *   - Only files no note refers to, where "every note" means every note in the
+ *     repository, not the ones that happen to be cached on this device.
+ *   - Nothing at all if a single note could not be read. A note whose text is
+ *     unavailable is a note whose images cannot be accounted for, and a scan
+ *     that quietly skipped it would report the pictures it uses as unused.
+ */
+
+/** An image in the repository that no note links to. */
+export interface OrphanAsset {
+  path: string;
+  /** Bytes, when the tree reported a size. */
+  size: number | null;
+}
+
+/**
+ * Every repository path a note's markdown points at.
+ *
+ * Both image syntaxes, because a screenshot pasted into a note is written as
+ * `![](…)` while one someone linked by hand may be `<img src="…">` — and a
+ * plain `[text](…)` link to a picture counts too. Missing one of those is how
+ * a scan deletes a file that is genuinely in use.
+ */
+export function referencedPaths(notePath: string, content: string): string[] {
+  const found = new Set<string>();
+
+  const add = (src: string | undefined) => {
+    if (!src) return;
+    const trimmed = src.trim().replace(/^<|>$/g, "").split(/\s+/)[0];
+    if (!trimmed || !isRelativeLink(trimmed)) return;
+    found.add(resolveFromNote(notePath, trimmed));
+  };
+
+  // ![alt](path "title") and [text](path), the markdown forms.
+  for (const match of content.matchAll(/!?\[[^\]]*\]\(([^)]+)\)/g)) add(match[1]);
+
+  // <img src="path">, which markdown permits and some notes arrive with.
+  for (const match of content.matchAll(/<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']/gi)) {
+    add(match[1]);
+  }
+
+  // Reference definitions: [label]: path
+  for (const match of content.matchAll(/^\s*\[[^\]]+\]:\s*(\S+)/gm)) add(match[1]);
+
+  return [...found];
+}
+
+/**
+ * The images in `files` that none of `notes` refers to.
+ *
+ * `notes` maps every note's path to its text. It must be *every* note — the
+ * caller is responsible for that, and for not calling this at all if one of
+ * them could not be read.
+ */
+export function findOrphanAssets(
+  files: readonly { path: string; size?: number | null }[],
+  notes: ReadonlyMap<string, string>,
+): OrphanAsset[] {
+  const used = new Set<string>();
+  for (const [notePath, content] of notes) {
+    for (const path of referencedPaths(notePath, content)) used.add(path);
+  }
+
+  return files
+    .filter((file) => {
+      // Images only. Everything else in a repository belongs to somebody else.
+      if (!imageTypeFor(file.path)) return false;
+      // A note is never an orphan, whatever it is called.
+      if (/\.mdx?$/i.test(file.path)) return false;
+      return !used.has(file.path);
+    })
+    .map((file) => ({ path: file.path, size: file.size ?? null }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/** "1.4 MB", for telling somebody what they are about to reclaim. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/web/src/lib/tree.ts
+++ b/apps/web/src/lib/tree.ts
@@ -1,0 +1,40 @@
+import type { TreeNode } from "@forkleaf/types";
+
+/**
+ * Every folder path in a tree, depth-first, so nesting reads in order.
+ *
+ * Shared because three places need the same list and the same order: the
+ * sidebar's "new note in…" menu, the folder picker in the new-folder dialog,
+ * and any test that wants to assert against what those offer. Two independent
+ * copies of a depth-first walk is two chances for them to disagree about
+ * whether `a/b` comes before `a/c`.
+ */
+export function collectFolders(nodes: readonly TreeNode[]): string[] {
+  const paths: string[] = [];
+
+  const walk = (list: readonly TreeNode[]) => {
+    for (const node of list) {
+      if (node.kind !== "folder") continue;
+      paths.push(node.path);
+      walk(node.children ?? []);
+    }
+  };
+
+  walk(nodes);
+  return paths;
+}
+
+/** Every note path in a tree, for checking a remembered path still exists. */
+export function collectFilePaths(nodes: readonly TreeNode[]): string[] {
+  const paths: string[] = [];
+
+  const walk = (list: readonly TreeNode[]) => {
+    for (const node of list) {
+      if (node.kind === "file") paths.push(node.path);
+      walk(node.children ?? []);
+    }
+  };
+
+  walk(nodes);
+  return paths;
+}

--- a/apps/web/src/lib/unused-images.ts
+++ b/apps/web/src/lib/unused-images.ts
@@ -1,0 +1,164 @@
+"use client";
+
+import type { TreeNode, Workspace } from "@forkleaf/types";
+import { findOrphanAssets, type OrphanAsset } from "@/lib/orphan-assets";
+
+/**
+ * Scanning a repository for images no note uses, and removing them.
+ *
+ * The bug that made these is fixed — deleting or moving a folder now takes its
+ * pictures with it — but a repository used by any earlier version is still
+ * carrying the leftovers, in `assets` directories whose notes are gone. With
+ * no note left in the folder, nothing in the sidebar can reach them, so
+ * without this the only way to clear them is by hand on github.com.
+ *
+ * Two rules run through all of it, because the failure mode here is deleting a
+ * picture out of a note somebody is still reading:
+ *
+ *   1. Every note is read, not the ones cached on this device.
+ *   2. If one note cannot be read, the scan fails rather than reporting a
+ *      result. A note whose text is unavailable is a note whose images cannot
+ *      be accounted for, and skipping it silently would list the pictures it
+ *      uses as unused.
+ *
+ * Nothing is deleted by scanning. The result is shown, and removing it is a
+ * separate thing somebody has to ask for.
+ */
+
+/** How many notes to read at once. Enough to be quick, few enough to be polite. */
+const READ_CONCURRENCY = 6;
+
+export interface ScanResult {
+  orphans: OrphanAsset[];
+  /** How many notes were read to decide that, for saying what was checked. */
+  notesRead: number;
+}
+
+export class ScanError extends Error {}
+
+function repoParams(workspace: Workspace, extra: Record<string, string> = {}): string {
+  const params = new URLSearchParams({
+    owner: workspace.repo.owner,
+    repo: workspace.repo.repo,
+    branch: workspace.repo.branch,
+    ...extra,
+  });
+  if (workspace.repo.directory) params.set("dir", workspace.repo.directory);
+  return params.toString();
+}
+
+function flatten(nodes: TreeNode[]): { path: string; size?: number | null }[] {
+  const files: { path: string; size?: number | null }[] = [];
+  const walk = (list: TreeNode[]) => {
+    for (const node of list) {
+      if (node.kind === "file") files.push({ path: node.path, size: node.size ?? null });
+      if (node.children) walk(node.children);
+    }
+  };
+  walk(nodes);
+  return files;
+}
+
+async function tree(workspace: Workspace, all: boolean): Promise<TreeNode[]> {
+  const response = await fetch(`/api/gh/tree?${repoParams(workspace, all ? { all: "1" } : {})}`);
+  if (!response.ok) throw new ScanError("Could not read the repository.");
+  const { tree: nodes } = (await response.json()) as { tree: TreeNode[] };
+  return nodes;
+}
+
+async function readNote(workspace: Workspace, path: string): Promise<string> {
+  const response = await fetch(`/api/gh/file?${repoParams(workspace, { path })}`);
+  if (!response.ok) throw new ScanError(`Could not read ${path}.`);
+
+  const { file } = (await response.json()) as { file: { content: string } | null };
+  // A note listed in the tree and absent when asked for is not "an empty
+  // note": something is out of step, and guessing would be guessing about
+  // which images to delete.
+  if (!file) throw new ScanError(`${path} is listed but could not be read.`);
+  return file.content;
+}
+
+/**
+ * Reads every note, a few at a time.
+ *
+ * Sequentially this is one round trip per note and unbearable on a real
+ * notebook; all at once it is a burst that GitHub answers with a secondary
+ * rate limit. `onProgress` exists because a scan of a few hundred notes is
+ * long enough that a still screen reads as a hang.
+ */
+async function readAll(
+  workspace: Workspace,
+  paths: string[],
+  onProgress?: (done: number, total: number) => void,
+): Promise<Map<string, string>> {
+  const contents = new Map<string, string>();
+  let cursor = 0;
+
+  const worker = async () => {
+    while (cursor < paths.length) {
+      const path = paths[cursor++]!;
+      contents.set(path, await readNote(workspace, path));
+      onProgress?.(contents.size, paths.length);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(READ_CONCURRENCY, paths.length) }, worker));
+  return contents;
+}
+
+/** Finds the images in a repository that no note refers to. */
+export async function scanForUnusedImages(
+  workspace: Workspace,
+  onProgress?: (done: number, total: number) => void,
+): Promise<ScanResult> {
+  if (workspace.isLocal) {
+    throw new ScanError("This workspace has no repository to scan.");
+  }
+
+  const [everything, markdown] = await Promise.all([tree(workspace, true), tree(workspace, false)]);
+
+  const notePaths = flatten(markdown).map((file) => file.path);
+  const contents = await readAll(workspace, notePaths, onProgress);
+
+  return {
+    orphans: findOrphanAssets(flatten(everything), contents),
+    notesRead: contents.size,
+  };
+}
+
+/**
+ * Deletes the given paths in one commit.
+ *
+ * One commit, not one each: a hundred separate commits for a tidy-up is a
+ * history nobody can read past, and it is the same batching every other write
+ * in the app already goes through.
+ */
+export async function deleteUnusedImages(
+  workspace: Workspace,
+  paths: readonly string[],
+): Promise<void> {
+  if (paths.length === 0) return;
+
+  const response = await fetch("/api/gh/commit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      owner: workspace.repo.owner,
+      repo: workspace.repo.repo,
+      branch: workspace.repo.branch,
+      dir: workspace.repo.directory,
+      message:
+        paths.length === 1
+          ? `forkleaf: remove unused image ${paths[0]!.split("/").pop()}`
+          : `forkleaf: remove ${paths.length} unused images`,
+      // No squashing. This is a deliberate, explained commit, and folding it
+      // into whatever note edit came before it would hide it.
+      squashWindowMs: 0,
+      changes: paths.map((path) => ({ op: "delete", path })),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new ScanError("Those images could not be removed. Nothing was changed.");
+  }
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -154,9 +154,12 @@ function policy(nonce: string | null, isDev: boolean): string {
     "base-uri 'self'",
     "form-action 'self'",
     "frame-ancestors 'none'",
-    // The GitHub Sponsors card is an iframe.
-    // YouTube embeds are iframes served from youtube-nocookie.com.
-    "frame-src https://github.com https://www.youtube-nocookie.com",
+    // YouTube embeds are iframes served from youtube-nocookie.com, and are now
+    // the only third-party frame the app has. github.com was here for the
+    // Sponsors card on the profile page; with that card gone, so is the
+    // permission — an origin allowed to frame us is worth removing the moment
+    // nothing needs it.
+    "frame-src https://www.youtube-nocookie.com",
     "worker-src 'self' blob:",
     "manifest-src 'self'",
     ...(isDev ? [] : ["upgrade-insecure-requests"]),

--- a/packages/github-client/src/client.test.ts
+++ b/packages/github-client/src/client.test.ts
@@ -688,3 +688,159 @@ describe("deletions of paths that are not in the repository", () => {
     expect(body.tree.map((entry) => entry.path)).toEqual(["gone.md"]);
   });
 });
+
+/**
+ * Moving a file without re-uploading it.
+ *
+ * A note is renamed by writing its text at the new path, because the text
+ * changes — its relative links are rewritten to suit where it now sits. An
+ * image has nothing to rewrite, and re-uploading a megabyte of screenshot to
+ * change its name is absurd, so a `move` carries the path pair alone and the
+ * commit reuses the blob already in the tree. Which is what a rename is in git.
+ */
+describe("commitChanges: move", () => {
+  const withTree = (entries: { path: string; sha: string }[]) => ({
+    "GET /repos/octo/notes/git/trees/head-tree?recursive=1": {
+      tree: entries.map((entry) => ({ ...entry, type: "blob" })),
+    },
+  });
+
+  it("reuses the existing blob rather than uploading one", async () => {
+    const { calls, fetchImpl } = fakeGitHub(
+      withTree([{ path: "Intro/assets/a.png", sha: "png-blob" }]),
+    );
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    await client.commitChanges(
+      repo,
+      [{ op: "move", path: "Intro/assets/a.png", toPath: "Python/Intro/assets/a.png" }],
+      { message: "move" },
+    );
+
+    // The point of the whole op: no bytes went up.
+    expect(calls.filter((c) => c.url.endsWith("/git/blobs"))).toHaveLength(0);
+
+    const tree = calls.find((c) => c.url.endsWith("/git/trees") && c.method === "POST")?.body as {
+      tree: { path: string; sha: string | null }[];
+    };
+    expect(tree.tree).toContainEqual({
+      path: "Python/Intro/assets/a.png",
+      mode: "100644",
+      type: "blob",
+      sha: "png-blob",
+    });
+    expect(tree.tree).toContainEqual({
+      path: "Intro/assets/a.png",
+      mode: "100644",
+      type: "blob",
+      sha: null,
+    });
+  });
+
+  it("skips a file the repository does not have", async () => {
+    // Already moved from another device, or never pushed. Asking git to delete
+    // a path that is not in the tree fails the entire commit, taking down
+    // everything batched with it.
+    const { calls, fetchImpl } = fakeGitHub(withTree([{ path: "somewhere/else.png", sha: "x" }]));
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    const result = await client.commitChanges(
+      repo,
+      [{ op: "move", path: "Intro/assets/gone.png", toPath: "Python/Intro/assets/gone.png" }],
+      { message: "move" },
+    );
+
+    // Nothing to write, so nothing is written and HEAD is reported back.
+    expect(result.sha).toBe("head-sha");
+    expect(calls.filter((c) => c.method === "POST" && c.url.endsWith("/git/commits"))).toHaveLength(
+      0,
+    );
+  });
+
+  it("moves the image in the same commit as the note beside it", async () => {
+    const { calls, fetchImpl } = fakeGitHub(
+      withTree([
+        { path: "Intro/assets/a.png", sha: "png-blob" },
+        { path: "Intro/note.md", sha: "md-blob" },
+      ]),
+    );
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    await client.commitChanges(
+      repo,
+      [
+        { op: "rename", path: "Intro/note.md", toPath: "Python/Intro/note.md", content: "# hi" },
+        { op: "move", path: "Intro/assets/a.png", toPath: "Python/Intro/assets/a.png" },
+      ],
+      { message: "move folder" },
+    );
+
+    // One commit, so a reader of the repository never sees the note moved and
+    // its picture left behind.
+    expect(calls.filter((c) => c.method === "POST" && c.url.endsWith("/git/commits"))).toHaveLength(
+      1,
+    );
+    // Only the note's text was uploaded.
+    expect(calls.filter((c) => c.url.endsWith("/git/blobs"))).toHaveLength(1);
+  });
+});
+
+/**
+ * Reading an image the browser may already have.
+ *
+ * The image proxy sends an `ETag` and gets an `If-None-Match` back on the next
+ * request. It used to ignore it and fetch every image from GitHub in full on
+ * every note open — several megabytes, and one rate-limited API call each, to
+ * send back bytes the browser was already holding.
+ */
+describe("readFileBase64", () => {
+  it("passes the caller's etag through as a conditional request", async () => {
+    const { calls, fetchImpl } = fakeGitHub({
+      "GET /repos/octo/notes/contents/a.png?ref=main": {
+        type: "file",
+        content: "aGk=",
+        sha: "png-sha",
+        size: 2,
+      },
+    });
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    await client.readFileBase64(repo, "a.png", { etag: '"png-sha"' });
+
+    const call = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const headers = new Headers((call[1] as RequestInit).headers);
+    expect(headers.get("if-none-match")).toBe('"png-sha"');
+    expect(calls).toHaveLength(1);
+  });
+
+  it("reports an unchanged file without a body to decode", async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 304 }));
+    const client = new GitHubClient({
+      token: "t",
+      fetch: fetchImpl as unknown as typeof globalThis.fetch,
+    });
+
+    const file = await client.readFileBase64(repo, "a.png", { etag: '"png-sha"' });
+
+    expect(file?.notModified).toBe(true);
+    expect(file?.base64).toBe("");
+  });
+
+  it("reads normally when no etag is offered", async () => {
+    const { fetchImpl } = fakeGitHub({
+      "GET /repos/octo/notes/contents/a.png?ref=main": {
+        type: "file",
+        content: "aGk=",
+        sha: "png-sha",
+        size: 2,
+      },
+    });
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    const file = await client.readFileBase64(repo, "a.png");
+
+    expect(file?.notModified).toBeUndefined();
+    expect(file?.base64).toBe("aGk=");
+    expect(file?.sha).toBe("png-sha");
+  });
+});

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -199,7 +199,16 @@ export type ContentEncoding = "utf8" | "base64";
 export type FileChange =
   | { op: "upsert"; path: string; content: string; encoding?: ContentEncoding }
   | { op: "delete"; path: string }
-  | { op: "rename"; path: string; toPath: string; content: string; encoding?: ContentEncoding };
+  | { op: "rename"; path: string; toPath: string; content: string; encoding?: ContentEncoding }
+  /**
+   * A rename that sends no bytes.
+   *
+   * Git renames by writing the same blob under a new path, so a file whose
+   * content is not changing does not need uploading again — which for an image
+   * being carried along with the folder it lives in is the difference between
+   * a commit and a re-upload of every screenshot in the folder.
+   */
+  | { op: "move"; path: string; toPath: string };
 
 export interface CommitOptions {
   message: string;
@@ -661,16 +670,33 @@ export class GitHubClient {
    * a note and destroys an image. The caller turns these bytes into whatever
    * it needs — for the app that is an HTTP response the browser can render.
    */
+  /**
+   * A file's bytes, base64 as GitHub hands them over.
+   *
+   * `options.etag` makes it a conditional request. GitHub answers an unchanged
+   * file with a bare 304 — no body, and no charge against the hourly rate
+   * limit — which is what lets the image proxy revalidate a note full of
+   * screenshots without re-downloading any of them.
+   */
   async readFileBase64(
     repo: RepoRef,
     path: string,
-  ): Promise<{ base64: string; sha: string; size: number } | null> {
+    options: { etag?: string } = {},
+  ): Promise<{ base64: string; sha: string; size: number; notModified?: boolean } | null> {
     const url =
       `/repos/${repo.owner}/${repo.repo}/contents/${encodePath(path)}` +
       `?ref=${encodeURIComponent(repo.branch)}`;
 
     try {
-      const { data } = await this.transport.request<ApiContent>(url);
+      const { data, status } = await this.transport.request<ApiContent>(
+        url,
+        options.etag ? { etag: options.etag } : {},
+      );
+
+      // Unchanged since the caller last saw it. There is no body to read and
+      // none is wanted — that is the entire point of having asked.
+      if (status === 304) return { base64: "", sha: "", size: 0, notModified: true };
+
       if (!data) throw new GitHubError("unknown", "Empty file response");
 
       if (data.type !== "file" || data.content === undefined) {
@@ -795,8 +821,27 @@ export class GitHubClient {
       sha: string | null;
     }[] = [];
 
+    // Only read for a move, and only once: the source blobs have to be looked
+    // up somewhere, and every other kind of change carries its own content.
+    const sourceBlobs = changes.some((change) => change.op === "move")
+      ? await this.blobShas(repo, baseTreeSha)
+      : null;
+
     for (const change of changes) {
       if (change.op === "delete") {
+        treeEntries.push({ path: change.path, mode: FILE_MODE, type: "blob", sha: null });
+        continue;
+      }
+
+      if (change.op === "move") {
+        const sha = sourceBlobs?.get(change.path);
+        // Nothing there to move: already moved from another device, or never
+        // reached the repository. Asking git to delete a path it does not have
+        // fails the whole commit, so the safe answer is to do nothing.
+        if (!sha || change.path === change.toPath) continue;
+
+        blobShas[change.toPath] = sha;
+        treeEntries.push({ path: change.toPath, mode: FILE_MODE, type: "blob", sha });
         treeEntries.push({ path: change.path, mode: FILE_MODE, type: "blob", sha: null });
         continue;
       }
@@ -937,15 +982,23 @@ export class GitHubClient {
    * the commit to fail.
    */
   private async blobPaths(repo: RepoRef, treeSha: string): Promise<Set<string> | null> {
+    const blobs = await this.blobShas(repo, treeSha);
+    return blobs && new Set(blobs.keys());
+  }
+
+  /** The same read, keeping the shas, which is what a move needs. */
+  private async blobShas(repo: RepoRef, treeSha: string): Promise<Map<string, string> | null> {
     try {
       const { data } = await this.transport.request<{
-        tree: { path: string; type: string }[];
+        tree: { path: string; type: string; sha: string }[];
         truncated?: boolean;
       }>(`/repos/${repo.owner}/${repo.repo}/git/trees/${treeSha}?recursive=1`);
 
       if (!data || data.truncated) return null;
 
-      return new Set(data.tree.filter((entry) => entry.type === "blob").map((entry) => entry.path));
+      return new Map(
+        data.tree.filter((entry) => entry.type === "blob").map((entry) => [entry.path, entry.sha]),
+      );
     } catch {
       return null;
     }

--- a/packages/store/src/conflicts.test.ts
+++ b/packages/store/src/conflicts.test.ts
@@ -35,6 +35,10 @@ class FlakyGateway implements RemoteGateway {
     return [];
   }
 
+  async listAllPaths(): Promise<string[]> {
+    return [...this.files.keys()];
+  }
+
   async readFile(_workspaceId: string, path: string) {
     if (!this.online) throw new Error("offline");
     this.beforeRead?.(path);

--- a/packages/store/src/note-repository.test.ts
+++ b/packages/store/src/note-repository.test.ts
@@ -212,6 +212,9 @@ describe("deleting without being able to read", () => {
 
     const gateway: RemoteGateway = {
       listTree: async () => tree,
+      listAllPaths: async () => {
+        throw unauthorized;
+      },
       readFile: async () => {
         throw unauthorized;
       },
@@ -314,7 +317,9 @@ describe("deleting a folder", () => {
         throw new Error("offline");
       },
       readFile: async (_workspaceId, path) =>
-        files[path] === undefined ? null : { content: files[path]!, sha: `sha-${path}` },
+        (files as Record<string, string>)[path] === undefined
+          ? null
+          : { content: (files as Record<string, string>)[path]!, sha: `sha-${path}` },
       commit: async () => ({ sha: "c", blobShas: {}, squashed: false }),
     };
     const sync = new SyncEngine({ db, gateway });

--- a/packages/store/src/note-repository.test.ts
+++ b/packages/store/src/note-repository.test.ts
@@ -16,23 +16,42 @@ import { SyncEngine } from "./sync-engine";
 
 const WS = "octo/notes@main:";
 
-function repository(files: Record<string, string>) {
+function repository(files: Record<string, string>, allPaths?: string[]) {
   const db = new MemoryDatabase();
+  const committed: { op: string; path: string; toPath?: string }[] = [];
 
   const gateway: RemoteGateway = {
     listTree: async () => [],
+    // What the repository actually holds, images included. Defaults to the
+    // notes, so tests that do not care about images need say nothing.
+    listAllPaths: async () => allPaths ?? Object.keys(files),
     readFile: async (_workspaceId, path) =>
       files[path] === undefined ? null : { content: files[path]!, sha: `sha-${path}` },
-    commit: async () => ({ sha: "c", blobShas: {}, squashed: false }),
+    commit: async (input) => {
+      for (const change of input.changes) {
+        committed.push({
+          op: change.op,
+          path: change.path,
+          ...(change.toPath ? { toPath: change.toPath } : {}),
+        });
+      }
+      return { sha: "c", blobShas: {}, squashed: false };
+    },
   };
 
-  const notes = new NoteRepository({
-    db,
-    gateway,
-    sync: new SyncEngine({ db, gateway }),
-  });
+  const sync = new SyncEngine({ db, gateway });
 
-  return { db, notes };
+  const notes = new NoteRepository({ db, gateway, sync });
+
+  /** Everything queued for GitHub, whether or not it has flushed yet. */
+  const queued = () =>
+    sync.pendingFor(WS).map((change) => ({
+      op: change.op,
+      path: change.path,
+      ...(change.toPath ? { toPath: change.toPath } : {}),
+    }));
+
+  return { db, notes, sync, committed, queued };
 }
 
 describe("openNote", () => {
@@ -234,5 +253,144 @@ describe("deleting without being able to read", () => {
     await notes.deletePath(WS, "notes/b.md", "sha-b");
 
     expect(await notes.getTree(WS)).toEqual([]);
+  });
+});
+
+/**
+ * Deleting and moving a folder.
+ *
+ * A folder holds the pictures its notes use, in an `assets` directory inside
+ * it. The tree the sidebar is built from lists Markdown only — correctly, it
+ * is a notebook — so acting on a folder from that tree acted on the notes and
+ * nothing else.
+ *
+ * Deleting a folder therefore removed its notes and left the images sitting on
+ * github.com in a directory nothing pointed at any more, and with no note left
+ * inside it, nothing in the app could reach the folder to try again. Moving a
+ * folder left the images behind at the old path in the same way.
+ */
+describe("deleting a folder", () => {
+  const files = {
+    "Python 101/Introduction/what-is-python.md": "# What\n\n![shot](assets/a.png)\n",
+    "Python 101/Introduction/why-learn-python.md": "# Why\n",
+  };
+  const all = [...Object.keys(files), "Python 101/Introduction/assets/a.png"];
+
+  it("takes the images with it, not just the notes", async () => {
+    const { notes, queued } = repository(files, all);
+
+    await notes.deleteFolderContents(WS, "Python 101/Introduction", Object.keys(files));
+
+    expect(
+      queued()
+        .map((change) => change.path)
+        .sort(),
+    ).toEqual([
+      "Python 101/Introduction/assets/a.png",
+      "Python 101/Introduction/what-is-python.md",
+      "Python 101/Introduction/why-learn-python.md",
+    ]);
+    expect(queued().every((change) => change.op === "delete")).toBe(true);
+  });
+
+  it("leaves everything outside the folder alone", async () => {
+    const { notes, queued } = repository(files, [...all, "Python 101/Concepts/other.md"]);
+
+    await notes.deleteFolderContents(WS, "Python 101/Introduction", Object.keys(files));
+
+    expect(queued().some((change) => change.path.includes("Concepts"))).toBe(false);
+  });
+
+  it("still deletes what it can when the repository cannot be listed", async () => {
+    // Offline, or a token that has expired. The listing failure is swallowed
+    // and the notes it already knows about still go — along with the images
+    // those notes link to, which `deleteNote` finds by reading the Markdown.
+    // That path is why the listing is a supplement rather than the only way
+    // an image gets cleaned up.
+    const db = new MemoryDatabase();
+    const gateway: RemoteGateway = {
+      listTree: async () => [],
+      listAllPaths: async () => {
+        throw new Error("offline");
+      },
+      readFile: async (_workspaceId, path) =>
+        files[path] === undefined ? null : { content: files[path]!, sha: `sha-${path}` },
+      commit: async () => ({ sha: "c", blobShas: {}, squashed: false }),
+    };
+    const sync = new SyncEngine({ db, gateway });
+    const notes = new NoteRepository({ db, gateway, sync });
+
+    await notes.deleteFolderContents(WS, "Python 101/Introduction", Object.keys(files));
+
+    expect(
+      sync
+        .pendingFor(WS)
+        .map((change) => change.path)
+        .sort(),
+    ).toEqual([
+      "Python 101/Introduction/assets/a.png",
+      "Python 101/Introduction/what-is-python.md",
+      "Python 101/Introduction/why-learn-python.md",
+    ]);
+  });
+
+  it("removes an image no note links to, which only the listing can find", async () => {
+    // The case the listing exists for: a screenshot pasted and then cut from
+    // the note, or one whose link was broken. Nothing in any Markdown points
+    // at it, so reading the notes will never turn it up.
+    const orphan = "Python 101/Introduction/assets/orphan.png";
+    const { notes, queued } = repository(files, [...all, orphan]);
+
+    await notes.deleteFolderContents(WS, "Python 101/Introduction", Object.keys(files));
+
+    expect(queued().map((change) => change.path)).toContain(orphan);
+  });
+});
+
+describe("moving a folder", () => {
+  const files = {
+    "Introduction/what-is-python.md": "# What\n\n![shot](assets/a.png)\n",
+  };
+  const all = [...Object.keys(files), "Introduction/assets/a.png"];
+
+  it("carries the images along with the notes", async () => {
+    const { notes, queued } = repository(files, all);
+
+    await notes.moveFolderContents(WS, "Introduction", "Python 101/Introduction", [
+      "Introduction/what-is-python.md",
+    ]);
+
+    const image = queued().find((change) => change.path.endsWith("a.png"));
+    expect(image).toEqual({
+      op: "move",
+      path: "Introduction/assets/a.png",
+      toPath: "Python 101/Introduction/assets/a.png",
+    });
+  });
+
+  it("moves an image without re-uploading it", async () => {
+    // `move` carries no content: the commit reuses the blob already in the
+    // repository. Re-reading a megabyte of screenshot to change its name is
+    // the thing this op exists to avoid.
+    const { notes, sync } = repository(files, all);
+
+    await notes.moveFolderContents(WS, "Introduction", "Python 101/Introduction", [
+      "Introduction/what-is-python.md",
+    ]);
+
+    const image = sync.pendingFor(WS).find((change) => change.path.endsWith("a.png"));
+    expect(image?.content).toBeUndefined();
+  });
+
+  it("renames the notes, so their links are rewritten", async () => {
+    const { notes, queued } = repository(files, all);
+
+    await notes.moveFolderContents(WS, "Introduction", "Python 101/Introduction", [
+      "Introduction/what-is-python.md",
+    ]);
+
+    const note = queued().find((change) => change.path.endsWith(".md"));
+    expect(note?.op).toBe("rename");
+    expect(note?.toPath).toBe("Python 101/Introduction/what-is-python.md");
   });
 });

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -380,6 +380,106 @@ export class NoteRepository {
   }
 
   /**
+   * Every file under a folder, notes and images alike.
+   *
+   * The sidebar's tree is Markdown only, which is right for a sidebar and
+   * wrong for acting on a folder as a whole: the pictures a folder's notes use
+   * live in an `assets` directory inside it, and that directory is invisible
+   * to a tree that lists nothing but `.md`.
+   *
+   * The consequence was that deleting a folder deleted its notes and left its
+   * images behind, in a directory nothing pointed at any more — so a folder
+   * "deleted" in the app was still sitting on github.com, holding files, and
+   * unreachable from the app that made it. Renaming had the same shape: the
+   * notes moved, the images stayed.
+   *
+   * Falls back to the notes it already knows about when the repository cannot
+   * be listed. A folder that cannot be enumerated is still a folder somebody
+   * asked to delete, and removing the notes is better than removing nothing.
+   */
+  private async pathsUnder(
+    workspaceId: string,
+    folder: string,
+    known: string[],
+  ): Promise<string[]> {
+    const prefix = `${folder}/`;
+    try {
+      const all = await this.gateway.listAllPaths(workspaceId);
+      const under = all.filter((path) => path.startsWith(prefix));
+
+      // Union, not replacement: a note created moments ago is in `known` and
+      // not yet in anything GitHub would list back.
+      return [...new Set([...under, ...known.filter((path) => path.startsWith(prefix))])];
+    } catch {
+      return known.filter((path) => path.startsWith(prefix));
+    }
+  }
+
+  /**
+   * Deletes a folder: every note in it, and every file beside them.
+   *
+   * `known` is what the sidebar believes is in there, which is the Markdown.
+   * Anything else under the folder — images, and any other file a repository
+   * may hold — is found by listing the repository and removed by path.
+   */
+  async deleteFolderContents(workspaceId: string, folder: string, known: string[]): Promise<void> {
+    const markdown = (path: string) => path.toLowerCase().endsWith(".md");
+
+    for (const path of await this.pathsUnder(workspaceId, folder, known)) {
+      if (markdown(path)) {
+        // By path: a folder is deleted as a whole, and one note inside it that
+        // cannot be read is not a reason to abandon the rest halfway through.
+        await this.deletePath(workspaceId, path);
+      } else {
+        await this.sync.recordAssetDelete(workspaceId, path);
+        await this.db.deleteAsset(`${workspaceId}::${path}`);
+      }
+    }
+  }
+
+  /**
+   * Moves every file under a folder to a new prefix.
+   *
+   * Notes go through `renameNote`, so their relative links are rewritten as
+   * part of the move. Everything else is moved as bytes, which is why the
+   * images have to move at all: leaving them behind worked — `renameNote`
+   * repoints the links at wherever the file still is — but it left a stray
+   * `assets` directory at the old path for every folder anybody ever
+   * reorganised, and made "move this folder" quietly not move most of it.
+   */
+  async moveFolderContents(
+    workspaceId: string,
+    from: string,
+    to: string,
+    known: string[],
+  ): Promise<void> {
+    const markdown = (path: string) => path.toLowerCase().endsWith(".md");
+
+    for (const path of await this.pathsUnder(workspaceId, from, known)) {
+      const target = `${to}${path.slice(from.length)}`;
+
+      if (markdown(path)) {
+        let note: Note | null = (await this.db.getNote(noteId(workspaceId, path))) ?? null;
+        if (!note) {
+          try {
+            note = await this.openNote(workspaceId, path);
+          } catch {
+            // Unreadable: move it as bytes rather than not at all. Its links
+            // are relative to a folder that moved wholesale, so they still
+            // resolve to the same files.
+            note = null;
+          }
+        }
+
+        if (note) await this.renameNote(note, target);
+        else await this.sync.recordAssetMove(workspaceId, path, target);
+      } else {
+        await this.sync.recordAssetMove(workspaceId, path, target);
+      }
+    }
+  }
+
+  /**
    * Moves or renames a note, and takes its images with it.
    *
    * The links inside the note are relative to where the note sits — that is

--- a/packages/store/src/ports.ts
+++ b/packages/store/src/ports.ts
@@ -50,7 +50,7 @@ export interface RemoteCommitInput {
   message: string;
   squashWindowMs: number;
   changes: {
-    op: "upsert" | "delete" | "rename";
+    op: "upsert" | "delete" | "rename" | "move";
     path: string;
     toPath?: string;
     content?: string;
@@ -73,6 +73,16 @@ export interface RemoteCommitResult {
  */
 export interface RemoteGateway {
   listTree(workspaceId: string): Promise<TreeNode[]>;
+  /**
+   * Every file in the repository, notes and images alike.
+   *
+   * `listTree` is the notebook — Markdown only — which is the right answer for
+   * the sidebar and the wrong one for anything that has to act on a folder as
+   * a whole. A folder holds the pictures its notes use, and deleting or moving
+   * only the Markdown leaves those behind in a directory nothing points at any
+   * more.
+   */
+  listAllPaths(workspaceId: string): Promise<string[]>;
   readFile(workspaceId: string, path: string): Promise<{ content: string; sha: string } | null>;
   commit(input: RemoteCommitInput): Promise<RemoteCommitResult>;
 }

--- a/packages/store/src/queue.ts
+++ b/packages/store/src/queue.ts
@@ -13,7 +13,7 @@ import type { PendingChange } from "@forkleaf/types";
 export interface CoalesceInput {
   workspaceId: string;
   path: string;
-  op: "upsert" | "delete" | "rename";
+  op: "upsert" | "delete" | "rename" | "move";
   toPath?: string;
   content?: string;
   encoding?: "utf8" | "base64";
@@ -54,6 +54,8 @@ export function coalesce(queue: PendingChange[], input: CoalesceInput): PendingC
       return remove(others, existing, input);
     case "rename":
       return rename(others, existing, input);
+    case "move":
+      return move(others, existing, input);
   }
 }
 
@@ -165,6 +167,52 @@ function rename(
   ];
 }
 
+/**
+ * A move: a rename that carries no content.
+ *
+ * Images travel this way. Nothing about the file changes, so there is nothing
+ * to upload — the commit reuses the blob already in the repository — but the
+ * same queue rules apply as for a note, because a move made offline still has
+ * to survive a restart and still has to arrive in the commit that moved the
+ * note beside it.
+ */
+function move(
+  others: PendingChange[],
+  existing: PendingChange[],
+  input: CoalesceInput,
+): PendingChange[] {
+  const prior = existing[0];
+  const toPath = input.toPath ?? input.path;
+
+  // Never reached GitHub, so there is nothing there to move. If bytes are
+  // still queued for the old path, redirect them to the new one; otherwise the
+  // whole thing is moot.
+  if (prior && prior.baseSha === null && prior.op === "upsert") {
+    return [
+      ...others,
+      { ...prior, id: changeId(input.workspaceId, toPath), path: toPath, queuedAt: input.now },
+    ];
+  }
+
+  // Chained moves (a → b → c) collapse to a single a → c.
+  const from = prior?.op === "move" || prior?.op === "rename" ? prior.path : input.path;
+  if (from === toPath) return others;
+
+  return [
+    ...others,
+    {
+      id: changeId(input.workspaceId, from),
+      workspaceId: input.workspaceId,
+      path: from,
+      op: "move",
+      toPath,
+      baseSha: prior ? prior.baseSha : input.baseSha,
+      queuedAt: input.now,
+      attempts: 0,
+    },
+  ];
+}
+
 export function changeId(workspaceId: string, path: string): string {
   return `${workspaceId}::${path}`;
 }
@@ -188,16 +236,19 @@ export function describeChanges(changes: PendingChange[]): string {
         return `delete ${name}`;
       case "rename":
         return `rename ${name} to ${fileName(change.toPath ?? "")}`;
+      case "move":
+        return `move ${name} to ${fileName(change.toPath ?? "")}`;
     }
   }
 
-  const counts = { upsert: 0, delete: 0, rename: 0 };
+  const counts = { upsert: 0, delete: 0, rename: 0, move: 0 };
   for (const change of changes) counts[change.op] += 1;
 
   const parts: string[] = [];
   if (counts.upsert) parts.push(`update ${counts.upsert} note${counts.upsert === 1 ? "" : "s"}`);
   if (counts.delete) parts.push(`delete ${counts.delete}`);
   if (counts.rename) parts.push(`rename ${counts.rename}`);
+  if (counts.move) parts.push(`move ${counts.move}`);
 
   return parts.join(", ");
 }

--- a/packages/store/src/sync-engine.test.ts
+++ b/packages/store/src/sync-engine.test.ts
@@ -22,6 +22,10 @@ class FakeGateway implements RemoteGateway {
     return [];
   }
 
+  async listAllPaths(): Promise<string[]> {
+    return [...this.files.keys()];
+  }
+
   async readFile(_workspaceId: string, path: string) {
     if (!this.online) throw new Error("offline");
     return this.files.get(path) ?? null;

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -152,7 +152,11 @@ export class SyncEngine {
     const queued = new Set(
       this.queue
         .filter((change) => change.workspaceId === workspaceId)
-        .map((change) => (change.op === "rename" ? (change.toPath ?? change.path) : change.path)),
+        .map((change) =>
+          change.op === "rename" || change.op === "move"
+            ? (change.toPath ?? change.path)
+            : change.path,
+        ),
     );
 
     let recovered = 0;
@@ -358,6 +362,30 @@ export class SyncEngine {
       // the request.
       baseSha: null,
       existsRemotely: true,
+      now: this.now().toISOString(),
+    });
+
+    await this.persistQueue();
+    this.scheduleFlush();
+  }
+
+  /**
+   * Queues a file to move without re-uploading it.
+   *
+   * For images carried along with the folder they live in. `recordRename` is
+   * the note version and needs the text, because a note's relative links are
+   * rewritten as part of the move; an image has neither.
+   */
+  async recordAssetMove(workspaceId: string, from: string, to: string): Promise<void> {
+    this.queue = coalesce(this.queue, {
+      workspaceId,
+      path: from,
+      op: "move",
+      toPath: to,
+      // An image has no sha here — it is not committed through this queue —
+      // and the commit does not need one: it finds the blob by looking the old
+      // path up in the tree it is committing against.
+      baseSha: null,
       now: this.now().toISOString(),
     });
 
@@ -625,7 +653,10 @@ export class SyncEngine {
       this.queue = this.queue.filter((c) => c.id !== change.id);
       await this.db.deleteQueueItem(change.id);
 
-      const path = change.op === "rename" ? (change.toPath ?? change.path) : change.path;
+      const path =
+        change.op === "rename" || change.op === "move"
+          ? (change.toPath ?? change.path)
+          : change.path;
       const newSha = result.blobShas[path];
       if (change.op === "delete" || !newSha) continue;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -224,8 +224,18 @@ export interface PendingChange {
   id: string;
   workspaceId: string;
   path: string;
-  op: "upsert" | "delete" | "rename";
-  /** Destination path for renames. */
+  /**
+   * `move` is a rename with no content of its own.
+   *
+   * A note is renamed by writing its text at the new path, because the text
+   * changes — its relative links are rewritten to suit where it now sits. An
+   * image has no links to rewrite and no text to send, and re-uploading a
+   * megabyte of screenshot to change its name would be absurd, so a move
+   * carries the path pair alone and the commit reuses the blob already in the
+   * repository. Which is what a rename is in git.
+   */
+  op: "upsert" | "delete" | "rename" | "move";
+  /** Destination path for renames and moves. */
   toPath?: string;
   /** Full file text including frontmatter. Absent for deletes. */
   content?: string;


### PR DESCRIPTION
## Why

Things people kept tripping over across the editor sidebar, its dialogs, the sync path, and the GitHub consent screen — plus the CI job that had been failing on every push.

---

## Deletes that actually delete

**Notes deleted in the app were still on GitHub.** Not the notes — those went — but the `assets` directory beside them, which is where the pictures those notes used are filed.

The sidebar's tree lists Markdown only, and correctly so: it is a notebook, not a file browser. But *both* folder delete and folder rename walked that tree, so both acted on the notes and nothing else. Deleting a folder left its images in a directory nothing pointed at any more, and with no note left inside it, nothing in the app could reach that folder to try again.

Both operations now list the whole repository and act on every file under the folder. The per-note cleanup that reads a note's Markdown for image links stays, and still runs when the repository cannot be listed at all — it is a supplement now rather than the only route. It could never find a screenshot pasted and then cut from a note, because by definition nothing pointed at it.

**Renaming had the same shape**, and mattered more once folder dragging landed in this PR: the notes moved and the images stayed. Moving now carries them, via a new `move` change that sends no bytes — the commit reuses the blob already in the repository, which is what a rename *is* in git, and avoids re-uploading a megabyte of screenshot to change its path.

## Clearing up what was already stranded

The fix above stops it happening again, but every repository touched by an earlier version is still carrying `assets` directories whose notes are gone — and since the sidebar is built from notes, a folder with no note left in it cannot be reached from the app at all. Each connected repository on the profile page now has a **Scan for unused images**.

The whole design is about not deleting the wrong thing:

- **Images only**, by extension. A repository holds licences, configuration and source code, and none of it is ours to tidy up on somebody's behalf.
- **Every note is read**, from the repository rather than this device's cache — an image referenced by a note we happen not to have cached is not an unused image.
- **If one note cannot be read, the scan fails** rather than reporting a result. A note whose text is unavailable is a note whose images cannot be accounted for, and skipping it quietly would list the pictures it uses as unused.
- **Every reference syntax counts**: `![](…)`, `[text](…)`, `<img src>`, and reference definitions — with percent-decoding, because a renderer writes `assets/a%20b.png` for a file called `a b.png` and comparing that literally matches nothing.
- **Scanning deletes nothing.** Paths and sizes are listed; removing them is a second, separate press, then one commit so it stays recoverable from git history.

## Images that load

**The proxy sent an `ETag` and then ignored the `If-None-Match` that came back.** The tag was decoration: every image was fetched from GitHub in full, base64-decoded, and resent on every note open once the five-minute cache lapsed. A note with six screenshots was six rate-limited API calls to redeliver bytes the browser already had.

The conditional request is now forwarded — GitHub answers an unchanged file with a bare 304, which is fast and free of rate-limit quota — and the cache lifetime goes from 5 minutes to an hour with `stale-while-revalidate`.

## CI

**It was red, and the reason is worth stating: I had only been running the web app's typecheck.** Adding `listAllPaths` to `RemoteGateway` broke every test double implementing that interface, and vitest does not typecheck — so the suite stayed green while `@forkleaf/store#typecheck` failed on every push. The fakes now implement it, and the workspace-wide `pnpm typecheck` is what gets run.

The workflows were also pinned to the Node 20 runtime GitHub is retiring, so each run was already being forced onto 24 with a deprecation warning. `checkout` and `setup-node` go to v5, `github-script` to v8, and the requested Node moves to 22 — current LTS, above the `engines` floor.

## Dialogs

**Enter did nothing, and the cursor was never in the field** — the same bug. `Dialog` chose what to focus by querying `[autofocus]`, which never matched: React applies `autoFocus` by calling `.focus()` itself and leaves no attribute in the DOM. Focus fell to the first focusable element in the panel — the close button in the header — and since the effect ran after React's own autofocus, it actively took focus back off the input. With Close focused, Enter activated it and discarded whatever had been typed.

The lookup now searches the content region only, never the header, and prefers a field over a button. Enter is handled outright rather than left to implicit submission, which browsers skip whenever the default button is disabled — and Create is disabled until the name is non-empty. A ref guard stops a held key confirming twice.

**A new folder went wherever the dialog happened to be opened from.** There is an **Inside** picker now: the repository root plus every folder in the tree, indented by depth.

## Rearranging the tree

**Folders could not be dragged.** Both kinds drag now. Dropping onto a note means the folder that note is in; the empty space below the tree is the way back out to the root. A folder refuses to be dropped into itself or its own descendant — that renames it to a path underneath itself and loses everything inside.

Writing the tests turned up a second bug: a row that *refused* a drop let the event bubble to the tree's root handler, which accepts anything — so dragging a note onto the folder it already lived in quietly moved it to the top of the repository.

## Sidebar

**The account card was two controls wearing one card.** The avatar navigated to the profile; the gear beside it opened a menu whose first item *also* went to the profile, with nothing marking the boundary. It is one button now.

Its gear is redrawn as two concentric circles about (8, 8) plus eight teeth at multiples of 45°, symmetric by construction. The outline it replaces was hand-written with relative moves that never closed back to their start, pushing it left of the hub — at 16px that reads as a hole sitting off-centre.

**The file tree was too small to read**: 13px labels, 15px icons. Now 14px on a 30px line with 17px icons, and the indent step went `0.75rem` → `0.85rem`.

**Dashboard moved to the footer** with the other ways out, instead of sitting between the search row and the tree.

**The sponsorship card is gone from the profile page** — it belongs on `/pricing`. Its GitHub Sponsors iframe was the only thing framing `github.com`, so that origin comes out of the CSP `frame-src` with it.

## GitHub permissions

**Sign-in asked for `read:user`, which it never needed** — a whole second block on the consent screen reading *"this application will be able to read your private profile information."* It was there for the name and avatar in the sidebar, which `GET /user` returns to any authenticated token.

`repo` stays: still the narrowest *classic* scope that can write to a private repository. What was missing was the reasoning, so `/docs/signing-in` now names every scope deliberately **not** asked for and why, the scope table gained *Why ForkLeaf asks for it* and *What it does not do* columns, and a note explains that the settings and webhooks in GitHub's own description of `repo` are GitHub describing the scope, not ForkLeaf describing itself.

---

## Verification

Every step the CI job runs, run locally: `pnpm format:check`, `pnpm typecheck` (all 8 packages), `pnpm lint`, `pnpm test`, `pnpm build` — all clean. **798 tests across 55 files.**

New suites cover the orphan-image logic (15 tests, weighted toward what must *not* be deleted), the scan-and-confirm component (7), folder-wide delete and move, the content-free `move` commit op, conditional image reads, dialog focus and Enter, and five `FileTree` drag tests including the self/descendant refusals.

Checked in the running app: the cursor lands in the name field, Enter creates the folder, the **Inside** picker lists the root plus every folder indented by depth, and dragging a top-level folder onto another nests it.

Stated rather than implied — three things the browser harness could not drive: its synthetic Enter does not trigger implicit form submission (a plain vanilla form on the same page does not submit either), native HTML5 drag cannot be driven by CDP mouse events, and the unused-image scan needs a signed-in GitHub session. All three are covered by unit tests plus dispatched-event checks in the live app.

A pre-existing React `setState`-during-render warning from `FileTree` → `EditorWorkspace` remains; it reproduces without any of these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)