### PR TITLE
Fix the hydration mismatch on the profile page's colour swatches

### DIFF
--- a/apps/web/src/components/ProfilePanel.test.tsx
+++ b/apps/web/src/components/ProfilePanel.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+// The panel reaches for the router to sign out, and for IndexedDB to count
+// what has been written. Neither is what is under test here, and jsdom has
+// neither.
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
+vi.mock("@forkleaf/store", () => ({ openLocalDatabase: async () => null }));
+
+const { ProfilePanel } = await import("./ProfilePanel");
+
+afterEach(cleanup);
+
+/**
+ * Colour swatches, and why they must not use the `background` shorthand.
+ *
+ * React writes an inline style straight into the server HTML. With the
+ * shorthand that is `style="background:#2467db"`, which the browser parses
+ * into all eight longhands — `background-image`, `background-position-x` and
+ * the rest, each reset to `initial`. The client tree only ever set the one
+ * property, so hydration finds a tree it cannot reconcile, reports a mismatch,
+ * and stops patching that subtree.
+ *
+ * `backgroundColor` maps one-to-one onto what a swatch actually is, so there
+ * is nothing for hydration to disagree about. This asserts on the rendered
+ * attribute rather than on the computed style, because that string is exactly
+ * what gets sent to the browser and exactly what differed.
+ */
+describe("colour swatches", () => {
+  it("set a background colour, never the background shorthand", () => {
+    render(<ProfilePanel user={null} githubAvailable={false} />);
+
+    const swatches = screen
+      .getAllByRole("radio", { hidden: true })
+      .flatMap((option) => [...option.querySelectorAll<HTMLElement>("[style]")])
+      .filter((element) => (element.getAttribute("style") ?? "").includes("background"));
+
+    expect(swatches.length).toBeGreaterThan(0);
+
+    for (const swatch of swatches) {
+      const style = swatch.getAttribute("style") ?? "";
+      expect(style).toContain("background-color");
+      // `background:` with nothing between it and the colon is the shorthand;
+      // `background-color:` is not, so the check has to be on the delimiter.
+      expect(style).not.toMatch(/(^|;)\s*background\s*:/);
+    }
+  });
+});

--- a/apps/web/src/components/ProfilePanel.tsx
+++ b/apps/web/src/components/ProfilePanel.tsx
@@ -555,12 +555,24 @@ function AccentPicker({ mode, accents }: { mode: Theme; accents: ReturnType<type
   );
 }
 
-/** A colour chip. Bordered, so a swatch near the background is still a shape. */
+/**
+ * A colour chip. Bordered, so a swatch near the background is still a shape.
+ *
+ * `backgroundColor`, not the `background` shorthand. The shorthand is a
+ * hydration hazard: React writes `style="background:#2467db"` on the server,
+ * the browser parses that into all eight longhands — `background-image`,
+ * `background-position-x` and the rest, each reset to `initial` — and the
+ * client tree, which only ever set the one property, does not match. React
+ * reports a hydration mismatch and gives up on patching that subtree.
+ *
+ * The longhand maps one-to-one onto what is actually meant here, which is a
+ * solid colour, so there is nothing to reconcile.
+ */
 function Swatch({ color }: { color: string }) {
   return (
     <span
       aria-hidden="true"
-      style={{ background: color }}
+      style={{ backgroundColor: color }}
       className="block h-8 w-8 shrink-0 rounded-lg border border-[var(--fl-border-strong)]"
     />
   );

--- a/packages/editor/src/WysiwygEditor.tsx
+++ b/packages/editor/src/WysiwygEditor.tsx
@@ -597,7 +597,7 @@ function HighlightPicker({ editor }: { editor: Editor }) {
                 ? "border-[var(--fl-inverse-text)] ring-2 ring-[var(--fl-inverse-text)]/40"
                 : "border-[var(--fl-inverse-text)]/25 hover:border-[var(--fl-inverse-text)]/60"
             }`}
-            style={{ background: `var(--fl-hl-${colour.name})` }}
+            style={{ backgroundColor: `var(--fl-hl-${colour.name})` }}
           />
         );
       })}


### PR DESCRIPTION
## The error

Loading `/profile` reported:

> A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. **This won't be patched up.**
>
> ```
> + background: "#2467db"
> - background-image: "initial"
> - background-position-x: "initial"
> ```

## Why

`Swatch` set `style={{ background: color }}`. React writes that straight into the server HTML as `style="background:#2467db"`, and the browser parses the shorthand into all eight longhands — `background-image`, `background-position-x`, `background-repeat` and the rest, each reset to `initial`. The client tree only ever set the one property, so the two don't match.

The consequential part is *"This won't be patched up"*: React abandons that subtree rather than correcting it, leaving the palette picker as inert server HTML with no client behaviour attached to it.

`backgroundColor` maps one-to-one onto what a swatch actually is — a solid colour — so there is nothing for hydration to disagree about.

The editor toolbar's highlight picker carried the identical shorthand and gets the same fix. Those were the only two inline `background` declarations in the codebase; every other inline style already used a longhand.

## Verification

- `pnpm typecheck`, `pnpm test` — **799 tests across 56 files**, clean on top of `main`.
- Checked in the running app: swatches now render `style="background-color: rgb(138, 155, 184)"` rather than the shorthand.
- The new test asserts on the rendered `style` **attribute**, not the computed style, because that string is exactly what is sent to the browser and exactly what differed. **Checked against the old code first — it fails there**, so it is a real guard rather than a test that can only pass.

## Note on how this got separated

This commit was pushed to `feat/editor-polish-and-github-scopes` a few minutes after PR #33 had already been merged, so it never became part of that PR. Cherry-picked onto `main` here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)