### PR TITLE
fix: stale dashboard index, repository removal, and published-page visibility

### DIFF
--- a/apps/web/src/app/api/gh/publish/route.ts
+++ b/apps/web/src/app/api/gh/publish/route.ts
@@ -1,6 +1,12 @@
 import { type NextRequest } from "next/server";
-import { handle, requireClient, readRepoRefFromBody, ApiError } from "@/lib/api-helpers";
-import { PUBLISH_DIR, pagePath, pageUrl } from "@/lib/publish";
+import {
+  handle,
+  requireClient,
+  readRepoRef,
+  readRepoRefFromBody,
+  ApiError,
+} from "@/lib/api-helpers";
+import { PUBLISH_DIR, pagePath, pageUrl, slugOfPage } from "@/lib/publish";
 import { enforceRateLimit } from "@/lib/rate-limit";
 
 /**
@@ -42,6 +48,53 @@ interface PublishBody {
   html?: string;
   /** The note's title, for the commit message. */
   title?: string;
+}
+
+/**
+ * What this repository currently has published.
+ *
+ * Publishing used to be something that happened once and was then forgotten:
+ * the URL lived in the dialog's own state, and closing it was the end of any
+ * record that a note was public at all. Reopening the dialog offered to
+ * publish, as though it never had been — so there was no way to find the
+ * address again, and no way to reach Unpublish.
+ *
+ * The answer is not stored here, because it does not need to be: what is
+ * published is exactly what is in `docs/`, in the user's own repository. One
+ * listing answers it for every note at once, which is what lets the editor
+ * mark the open note and the dashboard show the whole set.
+ */
+export async function GET(request: NextRequest) {
+  return handle(async () => {
+    const { client } = await requireClient();
+    const params = new URL(request.url).searchParams;
+    const repo = readRepoRef(params);
+
+    const [entries, site] = await Promise.all([
+      client.listDirectory(repo.owner, repo.repo, repo.branch, PUBLISH_DIR),
+      // Pages being off is not an error. The pages are still committed and
+      // still listed; they just have no address yet, which the caller says.
+      client.getPages(repo.owner, repo.repo).catch(() => null),
+    ]);
+
+    const pages = entries
+      .map((entry) => ({ entry, slug: slugOfPage(entry.name) }))
+      .filter(
+        (item): item is { entry: (typeof entries)[number]; slug: string } => item.slug !== null,
+      )
+      .map(({ entry, slug }) => ({
+        slug,
+        path: entry.path,
+        size: entry.size,
+        sha: entry.sha,
+        url: site ? pageUrl(site.url, slug) : null,
+      }));
+
+    return {
+      pages,
+      site: site ? { url: site.url, status: site.status, isPublic: site.isPublic } : null,
+    };
+  });
 }
 
 export async function POST(request: NextRequest) {

--- a/apps/web/src/app/docs/content/github.tsx
+++ b/apps/web/src/app/docs/content/github.tsx
@@ -237,6 +237,33 @@ export function Repositories() {
         be worse than saying so.
       </Note>
 
+      <H2 id="publishing">Publishing a note as a page</H2>
+      <P>
+        <strong>Publish as a page</strong> in the right-hand panel renders the open note to one
+        self-contained HTML file, commits it to <Code>docs/</Code> in the same repository, and
+        switches GitHub Pages on. Nothing is uploaded to ForkLeaf — the page is a file in your
+        repository, served by GitHub, and it outlives this app entirely.
+      </P>
+      <P>
+        A published note is marked as such wherever you look at it afterwards. The right-hand panel
+        gains a <strong>Published</strong> section with the address, and the dashboard lists every
+        page the repository is serving under <strong>Published pages</strong>, each with its link
+        and an <strong>Unpublish</strong> button. That list is read back from <Code>docs/</Code>
+        rather than remembered here, so deleting a page on GitHub directly unpublishes it as
+        completely as the button does.
+      </P>
+      <P>
+        Unpublishing deletes the file — one commit, recoverable from your git history — and leaves
+        the note alone. GitHub Pages stays switched on, because it is a repository-wide setting you
+        may have had before ForkLeaf ever touched it.
+      </P>
+      <Note kind="warn">
+        Anyone with the link can read a published page, whether or not the repository is private.
+        Publishing from a private repository needs a paid GitHub plan; GitHub says so if that
+        applies to yours, and the page is committed either way, so turning Pages on later publishes
+        it as it stands.
+      </Note>
+
       <H2 id="branches">Branches and protection rules</H2>
       <P>
         ForkLeaf commits directly to the configured branch. If that branch has protection rules

--- a/apps/web/src/app/docs/nav.ts
+++ b/apps/web/src/app/docs/nav.ts
@@ -79,7 +79,7 @@ export const DOC_SECTIONS: DocSection[] = [
         slug: "repositories",
         title: "Repositories & workspaces",
         summary:
-          "The notes repo, connecting your own repositories, branches, subdirectories and switching between them.",
+          "The notes repo, connecting and disconnecting repositories, publishing a note as a page, branches, subdirectories and switching between them.",
       },
       {
         slug: "sync",

--- a/apps/web/src/components/EditorRightPanel.tsx
+++ b/apps/web/src/components/EditorRightPanel.tsx
@@ -19,6 +19,15 @@ export interface EditorRightPanelProps {
   onShowHistory: () => void;
   /** Opens the publish dialog. Absent for a workspace with no repository. */
   onPublish?: (() => void) | undefined;
+  /**
+   * Where this note is published, or null if it is not.
+   *
+   * The panel is where somebody looks to find out what is true about the note
+   * they have open, and "this one is public, at this address" belongs in that
+   * list. Before this, publishing left no trace anywhere in the app once the
+   * dialog was closed.
+   */
+  published?: { url: string | null } | undefined;
   /** Drives the auto-save indicator in the panel header. */
   syncMode: SyncMode;
   onSyncNow: () => void;
@@ -75,6 +84,7 @@ export function EditorRightPanel({
   onExport,
   onShowHistory,
   onPublish,
+  published,
   syncMode,
   onSyncNow,
   links,
@@ -346,6 +356,49 @@ export function EditorRightPanel({
               </Section>
             )}
 
+            {/* ── Published ─────────────────────────────────────────────── */}
+            {/* Only when the note is public. A row saying "not published" on
+                every one of a thousand private notes would be noise about
+                nothing; this section appearing at all is the signal. */}
+            {published && (
+              <Section title="Published">
+                <div className="space-y-2">
+                  <p className="flex items-center gap-1.5 text-[12.5px] text-[var(--fl-text)]">
+                    <span
+                      aria-hidden="true"
+                      className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--fl-accent)]"
+                    />
+                    This note is a public page.
+                  </p>
+
+                  {published.url ? (
+                    <a
+                      href={published.url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="block break-all font-mono text-[11.5px] text-[var(--fl-accent)] underline underline-offset-2"
+                    >
+                      {published.url}
+                    </a>
+                  ) : (
+                    /* The page is committed, and GitHub Pages is not serving
+                       the repository — so there is a file and no address.
+                       Saying which of the two is missing is the difference
+                       between a fixable state and a broken one. */
+                    <p className="text-[12px] leading-relaxed text-[var(--fl-muted)]">
+                      The page is committed, but GitHub Pages is switched off for this repository,
+                      so it has no address yet.
+                    </p>
+                  )}
+
+                  <p className="text-[12px] leading-relaxed text-[var(--fl-muted)]">
+                    Publishing again updates it. Unpublishing deletes the page and leaves the note
+                    alone.
+                  </p>
+                </div>
+              </Section>
+            )}
+
             {/* ── Actions ───────────────────────────────────────────────── */}
             <Section title="Actions">
               <div className="space-y-1.5">
@@ -368,7 +421,7 @@ export function EditorRightPanel({
                 </PanelButton>
                 {hasHistory && onPublish && (
                   <PanelButton onClick={onPublish} icon={<ShareGlyph />}>
-                    Publish as a page
+                    {published ? "Published as a page" : "Publish as a page"}
                   </PanelButton>
                 )}
                 {/* Named for the thing it shows. "Version history" is accurate

--- a/apps/web/src/components/EditorSidebar.test.tsx
+++ b/apps/web/src/components/EditorSidebar.test.tsx
@@ -62,6 +62,7 @@ function renderSidebar(currentFolder: string, overrides: Record<string, unknown>
       activeWorkspace={workspace}
       onSwitchWorkspace={() => {}}
       onConnectRepo={() => {}}
+      onDisconnectRepo={() => {}}
       tree={tree}
       activePath="Fieldwork/Soil surveys/introduction.md"
       currentFolder={currentFolder}
@@ -261,5 +262,54 @@ describe("the account card", () => {
 
     fireEvent.pointerDown(document.body);
     expect(screen.queryByText("Sign out")).toBeNull();
+  });
+});
+
+/**
+ * Getting a repository back out of the list.
+ *
+ * The switcher only ever grew. Anything opened once stayed in it forever — a
+ * fork tried and abandoned, someone else's repo read for an afternoon — and
+ * the only way to be rid of it was to clear the browser's site data.
+ */
+describe("EditorSidebar — disconnecting a repository", () => {
+  const local: Workspace = {
+    ...workspace,
+    id: "local",
+    name: "On this device",
+    isLocal: true,
+  };
+
+  it("offers to disconnect a connected repository", () => {
+    const onDisconnectRepo = vi.fn();
+    renderSidebar("", { onDisconnectRepo });
+
+    fireEvent.click(screen.getByText("notes"));
+    fireEvent.click(screen.getByLabelText("Disconnect notes"));
+
+    expect(onDisconnectRepo).toHaveBeenCalledWith(workspace);
+  });
+
+  it("leaves the on-device workspace alone", () => {
+    // There is nothing to disconnect it from, and it is where notes go when
+    // there is nowhere else.
+    renderSidebar("", {
+      workspaces: [workspace, local],
+      onDisconnectRepo: () => {},
+    });
+
+    fireEvent.click(screen.getByText("notes"));
+
+    expect(screen.queryByLabelText("Disconnect On this device")).toBeNull();
+    expect(screen.getByLabelText("Disconnect notes")).toBeTruthy();
+  });
+
+  it("closes the menu once a repository has been sent for disconnection", () => {
+    renderSidebar("", { onDisconnectRepo: () => {} });
+
+    fireEvent.click(screen.getByText("notes"));
+    fireEvent.click(screen.getByLabelText("Disconnect notes"));
+
+    expect(screen.queryByLabelText("Disconnect notes")).toBeNull();
   });
 });

--- a/apps/web/src/components/EditorSidebar.tsx
+++ b/apps/web/src/components/EditorSidebar.tsx
@@ -15,6 +15,14 @@ export interface EditorSidebarProps {
   activeWorkspace: Workspace | null;
   onSwitchWorkspace: (workspace: Workspace) => void;
   onConnectRepo: () => void;
+  /**
+   * Disconnects a repository from this device.
+   *
+   * The list only ever grew. Every repository ever opened stayed in this menu
+   * — a fork tried once, a colleague's repo read for an afternoon — with no
+   * way to say "not that one" short of clearing the browser's site data.
+   */
+  onDisconnectRepo: (workspace: Workspace) => void;
   tree: TreeNode[];
   activePath: string | null;
   onOpenNote: (path: string) => void;
@@ -193,7 +201,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
             type="button"
             onClick={() => setShowWorkspaces((value) => !value)}
             aria-expanded={showWorkspaces}
-            aria-haspopup="listbox"
+            aria-haspopup="true"
             className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-[var(--fl-elevated)]"
           >
             <span className="min-w-0 flex-1">
@@ -226,32 +234,62 @@ export function EditorSidebar(props: EditorSidebarProps) {
 
         {showWorkspaces && (
           <div
-            role="listbox"
+            aria-label="Connected repositories"
             className="absolute left-2 right-2 top-full z-30 mt-1 overflow-hidden rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-1 shadow-[var(--fl-shadow-lg)]"
           >
             {props.workspaces.map((workspace) => (
-              <button
-                key={workspace.id}
-                type="button"
-                role="option"
-                aria-selected={workspace.id === props.activeWorkspace?.id}
-                onClick={() => {
-                  props.onSwitchWorkspace(workspace);
-                  setShowWorkspaces(false);
-                }}
-                className={`block w-full rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--fl-elevated)] ${
-                  workspace.id === props.activeWorkspace?.id
-                    ? "text-[var(--fl-accent)]"
-                    : "text-[var(--fl-text)]"
-                }`}
-              >
-                <span className="block truncate text-[13px] font-medium">{workspace.name}</span>
-                <span className="block truncate text-[11px] text-[var(--fl-muted)]">
-                  {workspace.isLocal
-                    ? "This device only"
-                    : `${workspace.repo.owner}/${workspace.repo.repo} · ${workspace.repo.branch}`}
-                </span>
-              </button>
+              /* Two buttons, so the row is a group rather than an option: a
+                 listbox option cannot contain a control of its own, and
+                 disconnecting is not a way of choosing. */
+              <div key={workspace.id} className="flex items-center gap-0.5">
+                <button
+                  type="button"
+                  aria-current={workspace.id === props.activeWorkspace?.id}
+                  onClick={() => {
+                    props.onSwitchWorkspace(workspace);
+                    setShowWorkspaces(false);
+                  }}
+                  className={`block min-w-0 flex-1 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--fl-elevated)] ${
+                    workspace.id === props.activeWorkspace?.id
+                      ? "text-[var(--fl-accent)]"
+                      : "text-[var(--fl-text)]"
+                  }`}
+                >
+                  <span className="block truncate text-[13px] font-medium">{workspace.name}</span>
+                  <span className="block truncate text-[11px] text-[var(--fl-muted)]">
+                    {workspace.isLocal
+                      ? "This device only"
+                      : `${workspace.repo.owner}/${workspace.repo.repo} · ${workspace.repo.branch}`}
+                  </span>
+                </button>
+
+                {/* Not offered for the on-device workspace: it is where notes
+                    go when there is nowhere else, and there would be nothing
+                    left to disconnect it to. */}
+                {!workspace.isLocal && (
+                  <button
+                    type="button"
+                    aria-label={`Disconnect ${workspace.name}`}
+                    title={`Disconnect ${workspace.name} from this device`}
+                    onClick={() => {
+                      props.onDisconnectRepo(workspace);
+                      setShowWorkspaces(false);
+                    }}
+                    className="shrink-0 rounded-lg p-1.5 text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-danger)]"
+                  >
+                    <svg
+                      viewBox="0 0 16 16"
+                      className="h-3.5 w-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.6"
+                      strokeLinecap="round"
+                    >
+                      <path d="M4 4l8 8M12 4l-8 8" />
+                    </svg>
+                  </button>
+                )}
+              </div>
             ))}
 
             {props.user ? (

--- a/apps/web/src/components/PublishDialog.tsx
+++ b/apps/web/src/components/PublishDialog.tsx
@@ -10,10 +10,27 @@ import { Dialog } from "./Dialog";
 export interface PublishDialogProps {
   note: Note;
   workspace: Workspace;
+  /**
+   * Where this note is already published, if it is.
+   *
+   * Passed in rather than discovered here. The dialog used to know only what
+   * it had done itself in the current session, so a note published last week
+   * opened on the "Publish" screen as though it were not public at all — no
+   * address to copy, and Unpublish behind a screen there was no way to reach.
+   *
+   * Mount this dialog with `key={note.id}` — switching notes underneath it
+   * must not leave the last note's address on screen as though it were this
+   * one's, and a fresh mount is a cleaner reset than an effect that fights
+   * whatever the reader is in the middle of.
+   */
+  published?: { url: string | null } | undefined;
+  /** Re-reads the published listing, so the rest of the app agrees. */
+  onChanged?: (() => void | Promise<void>) | undefined;
   onClose: () => void;
 }
 
-type Stage = "form" | "working" | "done";
+/** The dialog is either waiting for the reader, or waiting on GitHub. */
+type Stage = "idle" | "working";
 
 /**
  * Share this note as a public web page.
@@ -29,18 +46,42 @@ type Stage = "form" | "working" | "done";
  * two names drift apart is how a note quietly stops being reachable at the
  * address it was shared under.
  */
-export function PublishDialog({ note, workspace, onClose }: PublishDialogProps) {
+export function PublishDialog({
+  note,
+  workspace,
+  published,
+  onChanged,
+  onClose,
+}: PublishDialogProps) {
   const title = useMemo(() => deriveTitle(note.content, note.frontmatter.title, note.path), [note]);
   const slug = useMemo(
     () => slugifyFilename(stripExtension(note.path.split("/").pop() ?? "note")),
     [note.path],
   );
 
-  const [stage, setStage] = useState<Stage>("form");
+  const [stage, setStage] = useState<Stage>("idle");
   const [step, setStep] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<{ url: string; status: string | null } | null>(null);
+  const [result, setResult] = useState<{ url: string | null; status: string | null } | null>(null);
   const [copied, setCopied] = useState(false);
+
+  /**
+   * What to show: what this dialog just did, else what was already true.
+   *
+   * Derived rather than copied into state on open. `published` is rebuilt by
+   * the parent on every render, so mirroring it in an effect would reset this
+   * dialog underneath whatever the reader was doing — including wiping the
+   * address it had just handed them, in the moment between publishing and the
+   * listing catching up.
+   *
+   * A page that is already published is `built` by definition: it has been
+   * sitting in the repository since some earlier commit, so there is no build
+   * in progress to warn about.
+   */
+  const page = useMemo(
+    () => result ?? (published ? { url: published.url, status: "built" as string | null } : null),
+    [result, published],
+  );
 
   const publish = useCallback(async () => {
     setStage("working");
@@ -57,15 +98,16 @@ export function PublishDialog({ note, workspace, onClose }: PublishDialogProps) 
       });
 
       setStep("Committing it to your repository…");
-      const published = await publishNote({ repo: workspace.repo, slug, html, title });
+      const result = await publishNote({ repo: workspace.repo, slug, html, title });
 
-      setResult({ url: published.url, status: published.status });
-      setStage("done");
+      setResult({ url: result.url, status: result.status });
+      setStage("idle");
+      await onChanged?.();
     } catch (problem) {
       setError(messageFor(problem));
-      setStage("form");
+      setStage("idle");
     }
-  }, [note, title, slug, workspace.repo]);
+  }, [note, title, slug, workspace.repo, onChanged]);
 
   const unpublish = useCallback(async () => {
     setStage("working");
@@ -74,42 +116,55 @@ export function PublishDialog({ note, workspace, onClose }: PublishDialogProps) 
 
     try {
       await unpublishNote(workspace.repo, slug);
+      await onChanged?.();
       onClose();
     } catch (problem) {
       setError(messageFor(problem));
-      setStage("done");
+      setStage("idle");
     }
-  }, [workspace.repo, slug, onClose]);
+  }, [workspace.repo, slug, onChanged, onClose]);
 
   const copy = useCallback(async () => {
-    if (!result) return;
-    await navigator.clipboard.writeText(result.url);
+    if (!page?.url) return;
+    await navigator.clipboard.writeText(page.url);
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1600);
-  }, [result]);
+  }, [page]);
 
   // ── Published ───────────────────────────────────────────────────────────
 
-  if (stage === "done" && result) {
+  if (page) {
     return (
-      <Dialog title="Published" onClose={onClose}>
+      <Dialog title="Published" subtitle={`${title} is a public page`} onClose={onClose}>
         <div className="space-y-4">
-          <div className="rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-3">
-            <a
-              href={result.url}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="block break-all font-mono text-[12.5px] text-[var(--fl-accent)] underline underline-offset-2"
-            >
-              {result.url}
-            </a>
-          </div>
+          {page.url ? (
+            <div className="rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-3">
+              <a
+                href={page.url}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="block break-all font-mono text-[12.5px] text-[var(--fl-accent)] underline underline-offset-2"
+              >
+                {page.url}
+              </a>
+            </div>
+          ) : (
+            /* Committed, but the repository is not being served. There is a
+               file and no address, and which of the two is missing is what
+               separates a fixable state from a broken one. */
+            <p className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+              The page is committed to{" "}
+              <code className="font-mono text-[12px]">docs/{slug}.html</code>, but GitHub Pages is
+              switched off for this repository, so it has no public address yet. Turning Pages on in
+              the repository&rsquo;s settings publishes it as it stands.
+            </p>
+          )}
 
           {/* GitHub takes up to a minute to build a site for the first time.
               Handing over a link and saying nothing means the first person to
               click it — usually the author, immediately — gets a 404 and
               concludes it did not work. */}
-          {result.status !== "built" && (
+          {page.url && page.status !== "built" && (
             <p className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
               GitHub is building the site now. The first publish of a repository can take a minute
               or so before the address answers; every one after that is quick.
@@ -118,18 +173,41 @@ export function PublishDialog({ note, workspace, onClose }: PublishDialogProps) 
 
           <p className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
             The page is a file in {workspace.repo.owner}/{workspace.repo.repo}, served by GitHub
-            Pages. Publishing again updates it. Anyone with the link can read it.
+            Pages. Anyone with the link can read it.
           </p>
+
+          {error && (
+            <p role="alert" className="text-[13px] leading-relaxed text-[var(--fl-danger)]">
+              {error}
+            </p>
+          )}
 
           <div className="flex flex-wrap items-center justify-end gap-2">
             <button
               type="button"
               onClick={() => void unpublish()}
-              className="fl-btn fl-btn-ghost !text-[var(--fl-danger)]"
+              disabled={stage === "working"}
+              className="fl-btn fl-btn-ghost !text-[var(--fl-danger)] disabled:opacity-50"
             >
               Unpublish
             </button>
-            <button type="button" onClick={() => void copy()} className="fl-btn fl-btn-ghost">
+            {/* Re-publishing is what pushes the note's current text to the
+                page. It was only ever reachable by closing the dialog and
+                opening it again, which showed no sign the note was public. */}
+            <button
+              type="button"
+              onClick={() => void publish()}
+              disabled={stage === "working"}
+              className="fl-btn fl-btn-ghost disabled:opacity-50"
+            >
+              {stage === "working" ? step || "Working…" : "Update page"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void copy()}
+              disabled={!page.url || stage === "working"}
+              className="fl-btn fl-btn-ghost disabled:opacity-40"
+            >
               {copied ? "Copied" : "Copy link"}
             </button>
             <button type="button" onClick={onClose} className="fl-btn fl-btn-primary">

--- a/apps/web/src/components/dashboard/DashboardPanel.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanel.tsx
@@ -21,6 +21,8 @@ import { FolderNav } from "./FolderNav";
 import { NoteList, formatWhen } from "./NoteList";
 import { NoteTree } from "./NoteTree";
 import { NoteGrid } from "./NoteGrid";
+import { PublishedPages } from "./PublishedPages";
+import { usePublishedPages } from "@/hooks/usePublishedPages";
 
 /**
  * The dashboard.
@@ -92,6 +94,11 @@ export function DashboardPanel({
   // Memoised so the derived indexes below do not recompute on every render:
   // `active?.entries ?? []` is a fresh array each time.
   const entries = useMemo(() => active?.entries ?? [], [active]);
+
+  // Which of this repository's notes are public. Read here rather than in the
+  // editor alone: "which of my notes have I published" is a question about the
+  // library, and the dashboard is where the library is.
+  const published = usePublishedPages(active?.workspace ?? null);
 
   /**
    * Full-text hits for the current query.
@@ -433,6 +440,24 @@ export function DashboardPanel({
             </div>
           )}
         </section>
+
+        {/* ── Published pages ──────────────────────────────────────────── */}
+        {active && !active.workspace.isLocal && (
+          <PublishedPages
+            workspace={active.workspace}
+            state={published}
+            confirm={(request) =>
+              setPrompt({
+                title: request.title,
+                label: "",
+                destructive: true,
+                confirmLabel: "Unpublish",
+                body: request.body,
+                onConfirm: request.onConfirm,
+              })
+            }
+          />
+        )}
 
         {/* ── Recent ───────────────────────────────────────────────────── */}
         {recent.length > 0 && (

--- a/apps/web/src/components/dashboard/DashboardPanel.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { SessionUser, Workspace } from "@forkleaf/types";
@@ -58,6 +58,15 @@ export function DashboardPanel({
   const library = useLibrary();
   const router = useRouter();
   const [theme, , toggleTheme] = useTheme();
+
+  /**
+   * The index section, so choosing a repository can bring you to it.
+   *
+   * Clicking a repository card did select it, and the list below did change —
+   * three screens further down, past the stats, the other repositories and the
+   * recent notes. From where the card is, nothing appeared to happen at all.
+   */
+  const indexRef = useRef<HTMLElement | null>(null);
 
   const [activeId, setActiveId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
@@ -145,12 +154,18 @@ export function DashboardPanel({
     [],
   );
 
-  const selectWorkspace = useCallback((workspace: Workspace) => {
+  const selectWorkspace = useCallback((workspace: Workspace, reveal = false) => {
     setActiveId(workspace.id);
     setFolder(null);
     setTag(null);
     setQuery("");
     setVisible(PAGE_SIZE);
+
+    // Only when a person picked it. Connecting a repository already moves the
+    // page around enough without also throwing it down to the bottom.
+    if (reveal) {
+      indexRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
   }, []);
 
   const browseFolder = useCallback((next: string | null) => {
@@ -170,6 +185,34 @@ export function DashboardPanel({
       setAddingRepo(false);
     },
     [library, selectWorkspace],
+  );
+
+  const disconnect = useCallback(
+    (slice: (typeof library.workspaces)[number]) => {
+      const unpushed = slice.pending;
+
+      setPrompt({
+        title: "Disconnect repository",
+        label: "",
+        destructive: true,
+        confirmLabel: "Disconnect",
+        body:
+          `“${slice.workspace.name}” will be removed from this device. The repository on GitHub is ` +
+          `not touched — everything pushed to it stays there, and connecting it again brings it all back.` +
+          (unpushed > 0
+            ? ` ${unpushed} change${unpushed === 1 ? "" : "s"} here ${
+                unpushed === 1 ? "has" : "have"
+              } not been pushed yet, and will be lost.`
+            : ""),
+        onConfirm: async () => {
+          await library.removeWorkspace(slice.workspace.id);
+          // The card that was selected is gone; fall back to whatever is left
+          // rather than leaving the index pointed at nothing.
+          setActiveId((current) => (current === slice.workspace.id ? null : current));
+        },
+      });
+    },
+    [library],
   );
 
   const newNote = useCallback(() => {
@@ -292,48 +335,79 @@ export function DashboardPanel({
               const words = slice.entries.reduce((total, entry) => total + entry.words, 0);
 
               return (
-                <button
+                /* The card is a group, not one big button: it holds the
+                   disconnect control, and a button cannot contain a button. */
+                <div
                   key={slice.workspace.id}
-                  type="button"
-                  aria-pressed={selected}
-                  onClick={() => selectWorkspace(slice.workspace)}
-                  className={`rounded-xl border p-4 text-left transition ${
+                  className={`relative rounded-xl border transition ${
                     selected
                       ? "border-[var(--fl-accent)] bg-[var(--fl-accent-soft)]"
                       : "border-[var(--fl-border)] bg-[var(--fl-surface)] hover:border-[var(--fl-border-strong)]"
                   }`}
                 >
-                  <span className="mb-1 flex items-center gap-2">
-                    <span className="truncate font-semibold text-[var(--fl-text)]">
-                      {slice.workspace.name}
+                  <button
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => selectWorkspace(slice.workspace, true)}
+                    className="block w-full rounded-xl p-4 pr-11 text-left"
+                  >
+                    <span className="mb-1 flex items-center gap-2">
+                      <span className="truncate font-semibold text-[var(--fl-text)]">
+                        {slice.workspace.name}
+                      </span>
+                      {slice.workspace.isLocal && (
+                        <span className="shrink-0 rounded bg-[var(--fl-elevated)] px-1.5 py-0.5 text-[10.5px] uppercase tracking-wide text-[var(--fl-muted)]">
+                          this device
+                        </span>
+                      )}
                     </span>
-                    {slice.workspace.isLocal && (
-                      <span className="shrink-0 rounded bg-[var(--fl-elevated)] px-1.5 py-0.5 text-[10.5px] uppercase tracking-wide text-[var(--fl-muted)]">
-                        this device
+
+                    <span className="block truncate font-mono text-[11.5px] text-[var(--fl-muted)]">
+                      {slice.workspace.isLocal
+                        ? "Not backed by a repository"
+                        : `${slice.workspace.repo.owner}/${slice.workspace.repo.repo}@${slice.workspace.repo.branch}${
+                            slice.workspace.repo.directory
+                              ? `/${slice.workspace.repo.directory}`
+                              : ""
+                          }`}
+                    </span>
+
+                    <span className="mt-2 block text-[12.5px] text-[var(--fl-muted)]">
+                      {slice.entries.length} note{slice.entries.length === 1 ? "" : "s"} ·{" "}
+                      {words.toLocaleString()} words
+                      {slice.pending > 0 && ` · ${slice.pending} waiting`}
+                    </span>
+
+                    {slice.error && (
+                      <span className="mt-1.5 block text-[12px] text-[var(--fl-danger)]">
+                        {slice.error}
                       </span>
                     )}
-                  </span>
+                  </button>
 
-                  <span className="block truncate font-mono text-[11.5px] text-[var(--fl-muted)]">
-                    {slice.workspace.isLocal
-                      ? "Not backed by a repository"
-                      : `${slice.workspace.repo.owner}/${slice.workspace.repo.repo}@${slice.workspace.repo.branch}${
-                          slice.workspace.repo.directory ? `/${slice.workspace.repo.directory}` : ""
-                        }`}
-                  </span>
-
-                  <span className="mt-2 block text-[12.5px] text-[var(--fl-muted)]">
-                    {slice.entries.length} note{slice.entries.length === 1 ? "" : "s"} ·{" "}
-                    {words.toLocaleString()} words
-                    {slice.pending > 0 && ` · ${slice.pending} waiting`}
-                  </span>
-
-                  {slice.error && (
-                    <span className="mt-1.5 block text-[12px] text-[var(--fl-danger)]">
-                      {slice.error}
-                    </span>
+                  {/* The on-device workspace has no repository to disconnect
+                      from, and is where notes go when there is nowhere else. */}
+                  {!slice.workspace.isLocal && (
+                    <button
+                      type="button"
+                      aria-label={`Disconnect ${slice.workspace.name}`}
+                      title={`Disconnect ${slice.workspace.name} from this device`}
+                      onClick={() => disconnect(slice)}
+                      className="absolute right-2 top-2 rounded-lg p-1.5 text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-danger)]"
+                    >
+                      <svg
+                        viewBox="0 0 16 16"
+                        className="h-3.5 w-3.5"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                      >
+                        <path d="M4 4l8 8M12 4l-8 8" />
+                      </svg>
+                    </button>
                   )}
-                </button>
+                </div>
               );
             })}
 
@@ -389,7 +463,7 @@ export function DashboardPanel({
         )}
 
         {/* ── The index ────────────────────────────────────────────────── */}
-        <section>
+        <section ref={indexRef} className="scroll-mt-20">
           <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
             <SectionLabel className="!mb-0">
               {/* The on-device workspace is already named as a place, so

--- a/apps/web/src/components/dashboard/PublishedPages.tsx
+++ b/apps/web/src/components/dashboard/PublishedPages.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { Workspace } from "@forkleaf/types";
+import { unpublishNote } from "@/lib/gateway";
+import type { PublishedState } from "@/hooks/usePublishedPages";
+
+/**
+ * Every note this repository is serving as a public page.
+ *
+ * The one question publishing never answered: which of my notes are public?
+ * The address came back once, in a dialog, and closing it was the end of the
+ * record — so the only way to find out later was to browse the repository on
+ * GitHub and read the `docs/` folder yourself.
+ *
+ * The list is not a list of things ForkLeaf remembers publishing. It is the
+ * contents of that folder, read back, which is the only version of the answer
+ * that stays true when a page is deleted from GitHub directly.
+ */
+
+export function PublishedPages({
+  workspace,
+  state,
+  confirm,
+}: {
+  workspace: Workspace;
+  state: PublishedState;
+  /**
+   * Asks before taking a page down.
+   *
+   * Unpublishing is a commit that deletes a file somebody else may have a link
+   * to, so it goes through the same confirmation every other destructive
+   * action in the app does rather than happening on one stray click.
+   */
+  confirm: (request: { title: string; body: string; onConfirm: () => Promise<void> }) => void;
+}) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const copy = useCallback(async (slug: string, url: string) => {
+    await navigator.clipboard.writeText(url);
+    setCopied(slug);
+    window.setTimeout(() => setCopied((current) => (current === slug ? null : current)), 1600);
+  }, []);
+
+  const unpublish = useCallback(
+    (slug: string) => {
+      confirm({
+        title: "Unpublish page",
+        body: `“${slug}” will stop being a public page, and any link to it will stop working. The note itself is untouched, and the deletion is a commit, so it stays recoverable from your git history.`,
+        onConfirm: async () => {
+          setBusy(slug);
+          setError(null);
+
+          try {
+            await unpublishNote(workspace.repo, slug);
+            await state.refresh();
+          } catch (problem) {
+            setError(
+              problem instanceof Error ? problem.message : "That page could not be unpublished.",
+            );
+          } finally {
+            setBusy(null);
+          }
+        },
+      });
+    },
+    [workspace.repo, state, confirm],
+  );
+
+  // Nothing published and nothing to say. A repository with no public pages
+  // does not need a section explaining that it has none.
+  if (state.pages.size === 0) return null;
+
+  const pages = [...state.pages.values()].sort((a, b) => a.slug.localeCompare(b.slug));
+
+  return (
+    <section className="mb-8">
+      <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+        Published pages
+      </h2>
+
+      <div className="overflow-hidden rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)]">
+        <p className="border-b border-[var(--fl-border)] px-4 py-2.5 text-[12.5px] text-[var(--fl-muted)]">
+          {state.site
+            ? `Served by GitHub Pages from docs/ in ${workspace.repo.owner}/${workspace.repo.repo}. Anyone with a link can read these.`
+            : /* The files are committed and the site is off, which is a real
+                 state with a real fix, and not the same as "not published". */
+              `These pages are committed to docs/ in ${workspace.repo.owner}/${workspace.repo.repo}, but GitHub Pages is switched off for this repository, so they have no public address yet.`}
+        </p>
+
+        <ul>
+          {pages.map((page) => (
+            <li
+              key={page.slug}
+              className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-[var(--fl-border)] px-4 py-3 last:border-b-0"
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[13.5px] font-medium text-[var(--fl-text)]">
+                  {page.slug}
+                </span>
+                {page.url ? (
+                  <a
+                    href={page.url}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="block truncate font-mono text-[11.5px] text-[var(--fl-accent)] underline underline-offset-2"
+                  >
+                    {page.url}
+                  </a>
+                ) : (
+                  <span className="block truncate font-mono text-[11.5px] text-[var(--fl-muted)]">
+                    {page.path}
+                  </span>
+                )}
+              </span>
+
+              {page.url && (
+                <button
+                  type="button"
+                  onClick={() => void copy(page.slug, page.url!)}
+                  className="fl-btn fl-btn-ghost !py-1.5 !text-[12.5px]"
+                >
+                  {copied === page.slug ? "Copied" : "Copy link"}
+                </button>
+              )}
+
+              <button
+                type="button"
+                onClick={() => unpublish(page.slug)}
+                disabled={busy === page.slug}
+                className="fl-btn fl-btn-ghost !py-1.5 !text-[12.5px] !text-[var(--fl-danger)] disabled:opacity-50"
+              >
+                {busy === page.slug ? "Unpublishing…" : "Unpublish"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {error && (
+        <p role="alert" className="mt-2 text-[12.5px] text-[var(--fl-danger)]">
+          {error}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import type { CursorPosition, ImageBridge, LinkBridge } from "@forkleaf/editor";
-import type { EditorViewMode } from "@forkleaf/types";
+import type { EditorViewMode, Workspace } from "@forkleaf/types";
 import {
   deriveTitle,
   dirname,
@@ -523,6 +523,41 @@ export function EditorWorkspace() {
     [notebook],
   );
 
+  /**
+   * Disconnects a repository from this device.
+   *
+   * Worth spelling out in the dialog what this is not: no commit is made, and
+   * nothing on GitHub is touched. What goes is this device's copy — the notes
+   * cached here, the cached tree, and any queued change that never made it
+   * out, which is the one part that is not recoverable and so is counted in
+   * the warning rather than left as a surprise.
+   */
+  const handleDisconnectRepo = useCallback(
+    (workspace: Workspace) => {
+      const unpushed = notebook.sync.pendingCount;
+      const isOpen = workspace.id === notebook.activeWorkspace?.id;
+
+      setPrompt({
+        title: "Disconnect repository",
+        label: "",
+        destructive: true,
+        confirmLabel: "Disconnect",
+        body:
+          `“${workspace.name}” will be removed from this device. The repository on GitHub is not touched — ` +
+          `everything pushed to it stays there, and connecting it again brings it all back.` +
+          (isOpen && unpushed > 0
+            ? ` ${unpushed} change${unpushed === 1 ? "" : "s"} here ${
+                unpushed === 1 ? "has" : "have"
+              } not been pushed yet, and will be lost.`
+            : ""),
+        onConfirm: async () => {
+          await notebook.removeWorkspace(workspace.id);
+        },
+      });
+    },
+    [notebook],
+  );
+
   const handleDelete = useCallback(
     (path: string) => {
       setPrompt({
@@ -952,6 +987,7 @@ export function EditorWorkspace() {
             activeWorkspace={workspace}
             onSwitchWorkspace={notebook.switchWorkspace}
             onConnectRepo={() => setDialog("connect")}
+            onDisconnectRepo={handleDisconnectRepo}
             tree={notebook.tree}
             activePath={note?.path ?? null}
             onOpenNote={(path) => {

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -15,6 +15,7 @@ import {
   stripExtension,
 } from "@forkleaf/markdown-engine";
 import { useNotebook } from "@/hooks/useNotebook";
+import { usePublishedPages } from "@/hooks/usePublishedPages";
 import { useLinks } from "@/hooks/useLinks";
 import { useLocalFiles } from "@/hooks/useLocalFiles";
 import type { LocalFile } from "@/lib/local-files";
@@ -532,6 +533,24 @@ export function EditorWorkspace() {
    * out, which is the one part that is not recoverable and so is counted in
    * the warning rather than left as a surprise.
    */
+  /**
+   * What this repository has published, and whether the open note is one.
+   *
+   * Read once per workspace and shared by the panel and the dialog, so both
+   * agree — and so publishing leaves a mark somewhere other than the dialog
+   * that did it.
+   */
+  const publishedPages = usePublishedPages(workspace);
+
+  const publishedNote = useMemo(() => {
+    if (!note) return undefined;
+
+    const slug = slugifyFilename(stripExtension(note.path.split("/").pop() ?? "note"));
+    const page = publishedPages.pages.get(slug);
+
+    return page ? { url: page.url } : undefined;
+  }, [note, publishedPages.pages]);
+
   const handleDisconnectRepo = useCallback(
     (workspace: Workspace) => {
       const unpushed = notebook.sync.pendingCount;
@@ -1302,6 +1321,7 @@ export function EditorWorkspace() {
                     }
                   : undefined
               }
+              published={publishedNote}
               syncMode={notebook.syncPreference.mode}
               onSyncNow={() => void saveEverything()}
               assetUrls={notebook.assetUrls}
@@ -1387,7 +1407,16 @@ export function EditorWorkspace() {
       )}
 
       {openDialog === "publish" && workspace && !workspace.isLocal && note && (
-        <PublishDialog workspace={workspace} note={note} onClose={() => setDialog(null)} />
+        <PublishDialog
+          // A fresh dialog per note: switching notes underneath it must not
+          // leave the last one's address on screen as this one's.
+          key={note.id}
+          workspace={workspace}
+          note={note}
+          published={publishedNote}
+          onChanged={publishedPages.refresh}
+          onClose={() => setDialog(null)}
+        />
       )}
 
       {openDialog === "propose" && workspace && !workspace.isLocal && user && (

--- a/apps/web/src/hooks/useLibrary.ts
+++ b/apps/web/src/hooks/useLibrary.ts
@@ -13,7 +13,7 @@ import {
 } from "@forkleaf/store";
 import { workspaceId, type Note, type PendingChange, type Workspace } from "@forkleaf/types";
 import { GitHubGateway, LocalGateway, fetchSession, type SessionResponse } from "@/lib/gateway";
-import { buildIndex, flattenTree, isMarkdown, type IndexEntry } from "@/lib/library";
+import { buildIndex, flattenTree, isMarkdown, orphanedNotes, type IndexEntry } from "@/lib/library";
 import { deriveTitle, extractTags } from "@forkleaf/markdown-engine";
 import { LOCAL_WORKSPACE } from "@/lib/workspaces";
 
@@ -144,6 +144,26 @@ export function useLibrary() {
     }));
   }, []);
 
+  /**
+   * Drops notes from the full-text index.
+   *
+   * The counterpart to `indexNotes`, and needed for the same reason: the index
+   * is a ref, so nothing else would ever take a deleted note back out of it.
+   * Without this, a note deleted on GitHub kept answering searches for the
+   * rest of the session, from the pass that indexed it before the tree said it
+   * was gone.
+   */
+  const forgetNotes = useCallback((ids: string[]) => {
+    if (ids.length === 0) return;
+    for (const id of ids) searchRef.current.remove(id);
+
+    setState((current) => ({
+      ...current,
+      searchVersion: current.searchVersion + 1,
+      searchable: searchRef.current.size,
+    }));
+  }, []);
+
   /** Replaces one workspace's slice of the state, leaving the others alone. */
   const patchWorkspace = useCallback((id: string, updates: Partial<LibraryWorkspace>) => {
     setState((current) => ({
@@ -239,6 +259,7 @@ export function useLibrary() {
             const fresh = await refreshWorkspace(db, gateway, slice);
             if (cancelled) return slice;
 
+            forgetNotes(fresh.dropped);
             const merged = { ...slice, entries: fresh.entries, error: fresh.error };
             patchWorkspace(slice.workspace.id, {
               entries: fresh.entries,
@@ -313,7 +334,7 @@ export function useLibrary() {
     return () => {
       cancelled = true;
     };
-  }, [patch, patchWorkspace, indexNotes]);
+  }, [patch, patchWorkspace, indexNotes, forgetNotes]);
 
   // ── Actions ─────────────────────────────────────────────────────────────
 
@@ -343,23 +364,41 @@ export function useLibrary() {
       // A repository just connected has nothing cached, so the network pass is
       // the only one that will put anything in it.
       const fresh = await refreshWorkspace(db, gateway, slice);
+      forgetNotes(fresh.dropped);
       patchWorkspace(workspace.id, { entries: fresh.entries, error: fresh.error });
     },
-    [patchWorkspace],
+    [patchWorkspace, forgetNotes],
   );
 
-  const removeWorkspace = useCallback(async (id: string) => {
-    const notes = repoRef.current;
-    if (!notes) return;
+  /**
+   * Disconnects a repository from this device.
+   *
+   * Local only, always: the notes, the queued changes and the cached tree go,
+   * and the repository on GitHub is untouched. Everything that was pushed is
+   * still in it, and connecting it again brings the lot back.
+   */
+  const removeWorkspace = useCallback(
+    async (id: string) => {
+      const db = dbRef.current;
+      const notes = repoRef.current;
+      if (!db || !notes) return;
 
-    await notes.removeWorkspace(id);
-    if (gatewayRef.current instanceof GitHubGateway) gatewayRef.current.unregister(id);
+      // Read before the delete: `removeWorkspace` takes the notes with it, and
+      // afterwards there is no way left to know what to unindex.
+      const stored = await db.listNotes(id).catch((): Note[] => []);
 
-    setState((current) => ({
-      ...current,
-      workspaces: current.workspaces.filter((entry) => entry.workspace.id !== id),
-    }));
-  }, []);
+      await notes.removeWorkspace(id);
+      if (gatewayRef.current instanceof GitHubGateway) gatewayRef.current.unregister(id);
+
+      forgetNotes(stored.map((note) => note.id));
+
+      setState((current) => ({
+        ...current,
+        workspaces: current.workspaces.filter((entry) => entry.workspace.id !== id),
+      }));
+    },
+    [forgetNotes],
+  );
 
   /**
    * Creates a note and hands back where it lives, so the dashboard can send
@@ -459,12 +498,24 @@ async function readWorkspace(
 
   const cached = await db.getTreeCache(workspace.id);
 
+  // A cached tree is a real listing, so it is authoritative here too: last
+  // visit's deletions must not reappear for as long as it takes GitHub to
+  // answer. No cache at all is not a listing, and everything stored is shown.
+  const entries = buildIndex(workspace, markdownOnly(flattenTree(cached ?? [])), notes, {
+    treeKnown: cached != null,
+  });
+
+  // Only what the index kept is handed on to be searched. A note the cached
+  // tree has already ruled out would otherwise be missing from the list and
+  // findable by searching for it, which is a worse state than either.
+  const listed = new Set(entries.map((entry) => entry.path));
+
   return {
     workspace,
-    entries: buildIndex(workspace, markdownOnly(flattenTree(cached ?? [])), notes),
+    entries,
     pending,
     error: null,
-    notes,
+    notes: notes.filter((note) => listed.has(note.path)),
   };
 }
 
@@ -479,20 +530,38 @@ async function refreshWorkspace(
   db: LocalDatabase,
   gateway: GitHubGateway | LocalGateway,
   slice: LibraryWorkspace,
-): Promise<{ entries: IndexEntry[]; error: string | null }> {
+): Promise<{ entries: IndexEntry[]; error: string | null; dropped: string[] }> {
   try {
     const tree = await gateway.listTree(slice.workspace.id);
     await db.putTreeCache(slice.workspace.id, tree);
 
-    const notes = await db.listNotes(slice.workspace.id);
+    const paths = markdownOnly(flattenTree(tree));
+    const stored = await db.listNotes(slice.workspace.id);
+
+    /**
+     * The copies of notes that no longer exist, forgotten.
+     *
+     * Leaving them in IndexedDB is not harmless. Dropping them from the index
+     * fixes what is on screen, but the next visit would read them back out of
+     * storage and the full-text index would go on answering searches with
+     * notes the repository does not have — findable, and opening nothing.
+     */
+    const orphans = orphanedNotes(paths, stored);
+    for (const orphan of orphans) await db.deleteNote(orphan.id);
+
+    const gone = new Set(orphans.map((orphan) => orphan.id));
+    const notes = stored.filter((note) => !gone.has(note.id));
+
     return {
-      entries: buildIndex(slice.workspace, markdownOnly(flattenTree(tree)), notes),
+      entries: buildIndex(slice.workspace, paths, notes, { treeKnown: true }),
       error: null,
+      dropped: [...gone],
     };
   } catch (error) {
     return {
       entries: slice.entries,
       error: error instanceof Error ? error.message : "Could not reach this repository.",
+      dropped: [],
     };
   }
 }

--- a/apps/web/src/hooks/usePublishedPages.ts
+++ b/apps/web/src/hooks/usePublishedPages.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { RepoRef, Workspace } from "@forkleaf/types";
+import { listPublishedPages, type PublishedPage } from "@/lib/gateway";
+
+/**
+ * Which of this repository's notes are published as public pages.
+ *
+ * Publishing had no memory. The address came back from the commit, was shown
+ * once, and lived in the dialog's own state — so closing it was the end of any
+ * record that the note was public. Reopening the dialog offered to publish, as
+ * though it never had been: there was no way to find the link again, and the
+ * Unpublish button behind that screen could not be reached at all.
+ *
+ * Nothing new is stored to fix that. What is published is exactly what is in
+ * `docs/` in the user's own repository, so this asks, and one listing answers
+ * it for every note at once. It is also the only answer that stays true when
+ * somebody deletes a page on GitHub directly — a flag written down here would
+ * go on claiming the note was live.
+ */
+
+export interface PublishedState {
+  /** Every page published from this repository, by slug. */
+  pages: Map<string, PublishedPage>;
+  /** The Pages site itself, or null when it has never been switched on. */
+  site: { url: string; status: string | null; isPublic: boolean } | null;
+  /** Set when the listing could not be read. Never blocks publishing. */
+  error: string | null;
+  /** Re-reads the listing — after publishing or unpublishing. */
+  refresh: () => Promise<void>;
+}
+
+const EMPTY: Map<string, PublishedPage> = new Map();
+
+/**
+ * One answer, and the workspace it is an answer about.
+ *
+ * Kept together so a reply for the repository you have just switched away
+ * from can be recognised as such and ignored, rather than being shown against
+ * the one you switched to.
+ */
+interface Listing {
+  workspaceId: string;
+  pages: Map<string, PublishedPage>;
+  site: PublishedState["site"];
+  error: string | null;
+}
+
+export function usePublishedPages(workspace: Workspace | null): PublishedState {
+  const [listing, setListing] = useState<Listing | null>(null);
+
+  const connected = workspace && !workspace.isLocal ? workspace : null;
+  const id = connected?.id ?? null;
+  const repo = connected?.repo ?? null;
+
+  useEffect(() => {
+    // A local workspace has no repository to publish from, so there is nothing
+    // to ask and nothing to record.
+    if (!repo || !id) return;
+
+    let cancelled = false;
+
+    const load = async () => {
+      const result = await fetchListing(id, repo);
+      if (!cancelled) setListing(result);
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+    // `repo` is rebuilt from the workspace on every render, so the workspace
+    // id is what actually says whether this needs running again.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  /**
+   * Re-reads the listing, and resolves once it has.
+   *
+   * Awaited by the callers that just changed it, so the row they acted on is
+   * still showing "Unpublishing…" when the answer lands rather than flicking
+   * back to a list that has not caught up yet.
+   */
+  const refresh = useCallback(async () => {
+    if (!repo || !id) return;
+    setListing(await fetchListing(id, repo));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  // Last workspace's answer is not this workspace's answer.
+  const current = listing && listing.workspaceId === id ? listing : null;
+
+  return useMemo(
+    () => ({
+      pages: current?.pages ?? EMPTY,
+      site: current?.site ?? null,
+      error: current?.error ?? null,
+      refresh,
+    }),
+    [current, refresh],
+  );
+}
+
+/** Reads the listing, turning a failure into a `Listing` rather than a throw. */
+async function fetchListing(workspaceId: string, repo: RepoRef): Promise<Listing> {
+  try {
+    const result = await listPublishedPages(repo);
+
+    return {
+      workspaceId,
+      pages: new Map(result.pages.map((page) => [page.slug, page] as const)),
+      site: result.site,
+      error: null,
+    };
+  } catch (problem) {
+    // A listing that cannot be read is not a reason to break the editor: the
+    // state is merely unknown, and publishing still works.
+    return {
+      workspaceId,
+      pages: EMPTY,
+      site: null,
+      error: problem instanceof Error ? problem.message : "Could not read your published pages.",
+    };
+  }
+}

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -295,6 +295,33 @@ export async function publishNote(options: {
   });
 }
 
+/** One page published from a repository's `docs/` folder. */
+export interface PublishedPage {
+  slug: string;
+  path: string;
+  size: number;
+  sha: string;
+  /** The public address, or null while Pages is switched off. */
+  url: string | null;
+}
+
+export interface PublishedPages {
+  pages: PublishedPage[];
+  site: { url: string; status: string | null; isPublic: boolean } | null;
+}
+
+/**
+ * Everything this repository currently has published.
+ *
+ * Asked for rather than remembered: what is published is exactly what is in
+ * `docs/`, and the repository is the only copy of that fact worth trusting.
+ * Somebody who deletes a page from GitHub directly has unpublished it, and
+ * a record kept here would go on claiming otherwise.
+ */
+export async function listPublishedPages(repo: RepoRef): Promise<PublishedPages> {
+  return call(`/api/gh/publish?${repoParams(repo)}`);
+}
+
 /** Deletes a published page. The note itself is left alone. */
 export async function unpublishNote(repo: RepoRef, slug: string): Promise<{ path: string }> {
   return call("/api/gh/publish", {

--- a/apps/web/src/lib/library.test.ts
+++ b/apps/web/src/lib/library.test.ts
@@ -10,6 +10,7 @@ import {
   folderCounts,
   folderTrail,
   humanise,
+  orphanedNotes,
   queryIndex,
   subfolders,
   tagCounts,
@@ -36,6 +37,16 @@ function note(path: string, content: string, updatedAt: string, tags: string[] =
     updatedAt,
     dirty: false,
   };
+}
+
+/** A note written here and never pushed, so no tree could list it. */
+function unpushed(path: string, content: string, updatedAt: string): Note {
+  return { ...note(path, content, updatedAt), baseSha: null, dirty: true };
+}
+
+/** A note that was pushed, and has been edited here since. */
+function edited(path: string, content: string, updatedAt: string): Note {
+  return { ...note(path, content, updatedAt), dirty: true };
 }
 
 describe("flattenTree", () => {
@@ -94,17 +105,78 @@ describe("buildIndex", () => {
     const entries = buildIndex(
       workspace,
       ["welcome.md"],
-      [note("drafts/new.md", "# New", "2026-02-02T00:00:00.000Z")],
+      [unpushed("drafts/new.md", "# New", "2026-02-02T00:00:00.000Z")],
+      { treeKnown: true },
     );
 
     expect(entries.map((entry) => entry.path).sort()).toEqual(["drafts/new.md", "welcome.md"]);
   });
 
+  it("keeps a pushed note with unpushed edits, however the tree reads", () => {
+    // Absent from the tree and carrying work that exists nowhere else. This is
+    // the one case where the local copy has to win.
+    const entries = buildIndex(
+      workspace,
+      ["welcome.md"],
+      [edited("notes/roadmap.md", "# Roadmap", "2026-02-02T00:00:00.000Z")],
+      { treeKnown: true },
+    );
+
+    expect(entries.map((entry) => entry.path).sort()).toEqual(["notes/roadmap.md", "welcome.md"]);
+  });
+
   it("drops stored notes that the tree no longer lists", () => {
     // The tree is authoritative about what exists, so a note deleted on GitHub
     // must not linger in the index because a stale copy is still on the device.
-    const entries = buildIndex(workspace, ["welcome.md"], []);
-    expect(entries).toHaveLength(1);
+    // This is what had the dashboard showing folders the repository no longer
+    // had, while the editor — which reads the tree alone — showed the truth.
+    const entries = buildIndex(
+      workspace,
+      ["welcome.md"],
+      [note("deleted/gone.md", "# Gone", "2026-02-02T00:00:00.000Z")],
+      { treeKnown: true },
+    );
+
+    expect(entries.map((entry) => entry.path)).toEqual(["welcome.md"]);
+  });
+
+  it("shows everything stored when no tree has been read yet", () => {
+    // An empty list of paths means "nobody has asked GitHub" here, not "the
+    // repository is empty" — emptying the dashboard while offline would be a
+    // worse lie than showing a note that has since been deleted.
+    const entries = buildIndex(
+      workspace,
+      [],
+      [note("notes/roadmap.md", "# Roadmap", "2026-02-02T00:00:00.000Z")],
+    );
+
+    expect(entries.map((entry) => entry.path)).toEqual(["notes/roadmap.md"]);
+  });
+});
+
+describe("orphanedNotes", () => {
+  it("names the stored copies of notes the repository no longer has", () => {
+    const orphans = orphanedNotes(
+      ["welcome.md"],
+      [
+        note("welcome.md", "# Welcome", "2026-02-01T00:00:00.000Z"),
+        note("deleted/gone.md", "# Gone", "2026-02-01T00:00:00.000Z"),
+      ],
+    );
+
+    expect(orphans.map((orphan) => orphan.path)).toEqual(["deleted/gone.md"]);
+  });
+
+  it("never names a note holding work that has not been pushed", () => {
+    const orphans = orphanedNotes(
+      ["welcome.md"],
+      [
+        unpushed("drafts/new.md", "# New", "2026-02-01T00:00:00.000Z"),
+        edited("notes/roadmap.md", "# Roadmap", "2026-02-01T00:00:00.000Z"),
+      ],
+    );
+
+    expect(orphans).toEqual([]);
   });
 });
 

--- a/apps/web/src/lib/library.ts
+++ b/apps/web/src/lib/library.ts
@@ -171,14 +171,65 @@ export function entryFromNote(workspace: Workspace, note: Note): IndexEntry {
 }
 
 /**
+ * True for a stored note that GitHub has never been told about.
+ *
+ * The two halves matter for different reasons. `baseSha === null` is a note
+ * that was written here and has never been pushed, so no tree could possibly
+ * list it. `dirty` is a note that *was* pushed and has since been edited here,
+ * which is unpushed work regardless of what the tree says. Either way the
+ * local copy is the only copy of something, and dropping it would be losing
+ * it.
+ */
+export function isUnpushed(note: Note): boolean {
+  return note.baseSha === null || note.dirty;
+}
+
+/**
+ * The stored notes a fresh tree says no longer exist.
+ *
+ * These are the notes deleted from the repository somewhere else — on GitHub
+ * itself, or from another device — whose copy in IndexedDB has outlived them.
+ * Notes carrying unpushed work are never orphans: they are absent from the
+ * tree because they have not been pushed yet, not because they are gone.
+ */
+export function orphanedNotes(paths: string[], notes: Note[]): Note[] {
+  const live = new Set(paths);
+  return notes.filter((note) => !live.has(note.path) && !isUnpushed(note));
+}
+
+export interface BuildIndexOptions {
+  /**
+   * Whether `paths` is a real listing of the repository.
+   *
+   * False means "nobody has asked GitHub yet" — a workspace with no cached
+   * tree, or the on-device workspace, which has no tree at all. An empty list
+   * then means *unknown*, not *empty*, and the stored notes are all there is
+   * to show. True means the listing is authoritative and a stored note missing
+   * from it has been deleted.
+   */
+  treeKnown?: boolean;
+}
+
+/**
  * Merges the tree's paths with the notes already read.
  *
  * The tree is authoritative about which notes exist — a note deleted on GitHub
  * should leave the index even if a stale copy is still in IndexedDB — while the
  * stored notes are authoritative about what is in them. Locally created notes
  * that have not been pushed yet are not in the tree, so they are added.
+ *
+ * That first sentence had been the intent all along, and was not what the code
+ * did: every stored note absent from the tree was added back, so deleting a
+ * folder on GitHub left it on the dashboard for as long as the device held a
+ * copy of anything that used to be in it. The editor's sidebar reads the tree
+ * alone and so had always been right, which is what made the two disagree.
  */
-export function buildIndex(workspace: Workspace, paths: string[], notes: Note[]): IndexEntry[] {
+export function buildIndex(
+  workspace: Workspace,
+  paths: string[],
+  notes: Note[],
+  options: BuildIndexOptions = {},
+): IndexEntry[] {
   const byPath = new Map(notes.map((note) => [note.path, note] as const));
   const seen = new Set<string>();
   const entries: IndexEntry[] = [];
@@ -190,7 +241,9 @@ export function buildIndex(workspace: Workspace, paths: string[], notes: Note[])
   }
 
   for (const note of notes) {
-    if (!seen.has(note.path)) entries.push(entryFromNote(workspace, note));
+    if (seen.has(note.path)) continue;
+    if (options.treeKnown && !isUnpushed(note)) continue;
+    entries.push(entryFromNote(workspace, note));
   }
 
   return entries;

--- a/apps/web/src/lib/publish.test.ts
+++ b/apps/web/src/lib/publish.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ApiError } from "./api-helpers";
-import { pagePath, pageUrl } from "./publish";
+import { pagePath, pageUrl, slugOfPage } from "./publish";
 
 /**
  * The slug becomes a path in the user's repository and a segment of a public
@@ -49,5 +49,44 @@ describe("pageUrl", () => {
     expect(pageUrl("https://me.github.io/notes", "roadmap")).toBe(
       "https://me.github.io/notes/roadmap.html",
     );
+  });
+});
+
+/**
+ * Reading the folder back is how the app knows what is published, so the
+ * question this answers is "did ForkLeaf write this file". `docs/` is an
+ * ordinary folder people keep ordinary things in, and offering to unpublish
+ * somebody's hand-written site would be worse than not listing it at all.
+ */
+describe("slugOfPage", () => {
+  it("recognises a page this app would have written", () => {
+    expect(slugOfPage("q3-roadmap.html")).toBe("q3-roadmap");
+    expect(slugOfPage("notes_2026.v2.html")).toBe("notes_2026.v2");
+  });
+
+  it("matches the address the page was published at, not its spelling", () => {
+    // `pagePath` lowercases, so the file on disk is lowercase and this is the
+    // slug that will round-trip back through it.
+    expect(slugOfPage("Q3-Roadmap.html")).toBe("q3-roadmap");
+  });
+
+  it("passes over anything that is not one of its pages", () => {
+    for (const name of [
+      "index.md",
+      "README.md",
+      "style.css",
+      ".nojekyll",
+      "-leading.html",
+      "x".repeat(90) + ".html",
+      "html",
+      "",
+    ]) {
+      expect(slugOfPage(name)).toBeNull();
+    }
+  });
+
+  it("agrees with pagePath, so a listed page can always be unpublished", () => {
+    const slug = slugOfPage("q3-roadmap.html")!;
+    expect(pagePath(slug)).toBe("docs/q3-roadmap.html");
   });
 });

--- a/apps/web/src/lib/publish.ts
+++ b/apps/web/src/lib/publish.ts
@@ -40,3 +40,17 @@ export function pagePath(slug: string | undefined): string {
 export function pageUrl(siteUrl: string, slug: string): string {
   return `${siteUrl.replace(/\/$/, "")}/${slug.toLowerCase()}.html`;
 }
+
+/**
+ * The slug behind a published page's filename, or null if it is not one.
+ *
+ * `docs/` is an ordinary folder that people put ordinary things in — a README,
+ * a stylesheet, a hand-written site. Only the `.html` files whose stem is a
+ * slug this app would itself have produced are reported as published pages, so
+ * listing what ForkLeaf published can never offer to unpublish something it
+ * did not write.
+ */
+export function slugOfPage(filename: string): string | null {
+  const match = /^([a-z0-9][a-z0-9._-]{0,80})\.html$/.exec(filename.toLowerCase());
+  return match ? match[1]! : null;
+}

--- a/packages/github-client/src/client.test.ts
+++ b/packages/github-client/src/client.test.ts
@@ -844,3 +844,54 @@ describe("readFileBase64", () => {
     expect(file?.sha).toBe("png-sha");
   });
 });
+
+/**
+ * Reading a directory without reading its files.
+ *
+ * This is what tells the app which notes are published: the contents API
+ * answers a directory with names and sizes and no bodies, so asking "what is
+ * in docs/" costs one request rather than downloading every page in it.
+ */
+describe("listDirectory", () => {
+  it("returns the files in a directory, without their contents", async () => {
+    const { fetchImpl, calls } = fakeGitHub({
+      "GET /repos/octo/notes/contents/docs?ref=main": [
+        { name: "roadmap.html", path: "docs/roadmap.html", sha: "a", size: 2048, type: "file" },
+        { name: "assets", path: "docs/assets", sha: "b", size: 0, type: "dir" },
+      ],
+    });
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    expect(await client.listDirectory("octo", "notes", "main", "docs")).toEqual([
+      { name: "roadmap.html", path: "docs/roadmap.html", sha: "a", size: 2048 },
+    ]);
+
+    // One request, and not one per file.
+    expect(calls).toHaveLength(1);
+  });
+
+  it("answers a missing directory with nothing rather than an error", async () => {
+    // "Nothing has been published yet" and "the folder does not exist" are the
+    // same answer to the only question being asked of it.
+    const { fetchImpl } = fakeGitHub();
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    expect(await client.listDirectory("octo", "notes", "main", "docs")).toEqual([]);
+  });
+
+  it("answers a path that is a file rather than a directory with nothing", async () => {
+    const { fetchImpl } = fakeGitHub({
+      "GET /repos/octo/notes/contents/docs?ref=main": {
+        name: "docs",
+        path: "docs",
+        sha: "a",
+        size: 12,
+        type: "file",
+        content: "",
+      },
+    });
+    const client = new GitHubClient({ token: "t", fetch: fetchImpl });
+
+    expect(await client.listDirectory("octo", "notes", "main", "docs")).toEqual([]);
+  });
+});

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -4,6 +4,14 @@ import { GitHubError } from "./errors";
 import { encodeBase64, decodeBase64 } from "./base64";
 
 /** A repository's GitHub Pages site, as the publish flow needs it. */
+/** One file in a directory listing — name and size, never the bytes. */
+export interface DirectoryEntry {
+  name: string;
+  path: string;
+  sha: string;
+  size: number;
+}
+
 export interface PagesSite {
   /** Where the site is served from, e.g. `https://you.github.io/notes/`. */
   url: string;
@@ -101,6 +109,15 @@ interface ApiCommitListEntry {
 interface ApiContent {
   content?: string;
   encoding?: string;
+  sha: string;
+  size: number;
+  type: string;
+}
+
+/** One row of a directory listing. The contents API omits bodies for these. */
+interface ApiDirectoryEntry {
+  name: string;
+  path: string;
   sha: string;
   size: number;
   type: string;
@@ -636,6 +653,46 @@ export class GitHubClient {
     });
 
     return buildTree(flat);
+  }
+
+  /**
+   * The files directly inside one directory, without their contents.
+   *
+   * The contents API answers a directory with a list of names, sizes and
+   * SHAs and no bodies, which is what makes this the right way to ask "what
+   * is in here" — `readFile` on each would download every byte, and
+   * `listTree` answers for the whole repository and is scoped to the
+   * workspace's own subfolder, which published pages are not in.
+   *
+   * A directory that does not exist is an empty list, not an error: "nothing
+   * has been published yet" and "the folder is missing" are the same answer
+   * to the only question being asked.
+   */
+  async listDirectory(
+    owner: string,
+    repo: string,
+    branch: string,
+    path: string,
+  ): Promise<DirectoryEntry[]> {
+    const url =
+      `/repos/${owner}/${repo}/contents/${encodePath(path)}` + `?ref=${encodeURIComponent(branch)}`;
+
+    try {
+      const { data } = await this.transport.request<ApiDirectoryEntry[]>(url);
+      if (!Array.isArray(data)) return [];
+
+      return data
+        .filter((entry) => entry.type === "file")
+        .map((entry) => ({
+          name: entry.name,
+          path: entry.path,
+          sha: entry.sha,
+          size: entry.size,
+        }));
+    } catch (error) {
+      if (error instanceof GitHubError && error.code === "not-found") return [];
+      throw error;
+    }
   }
 
   /** Reads one file's decoded text plus its blob SHA. */

--- a/packages/github-client/src/index.ts
+++ b/packages/github-client/src/index.ts
@@ -8,6 +8,7 @@ export {
   type ContentEncoding,
   type CommitOptions,
   type CommitResult,
+  type DirectoryEntry,
   type PagesSite,
   type PullRequestSummary,
   type PullRequestDetail,


### PR DESCRIPTION
## What this fixes

### The dashboard showed folders and notes the repository no longer had

`buildIndex` documented the tree as authoritative about which notes exist —
and then added back *every* stored note the tree did not list. So deleting a
folder on GitHub left it on the dashboard for as long as this device held a
copy of anything that used to be in it.

The editor's sidebar reads the GitHub tree alone, which is exactly why the two
disagreed and the editor was the one telling the truth.

The tree is believed now. Only notes carrying work that has never reached
GitHub — written here (`baseSha === null`), or pushed and edited since
(`dirty`) — survive its absence. The stale copies are deleted from IndexedDB
and taken back out of the full-text index too: fixing only the list would have
left them findable by search and opening nothing.

An empty list of paths still means *"nobody has asked GitHub yet"* rather than
*"the repository is empty"*, so a workspace with no cached tree, and the
on-device workspace, are unaffected — going offline does not empty the page.

### Repositories could never be removed from the list

Both `useLibrary` and `useNotebook` had a `removeWorkspace`, and nothing had
ever called either. Anything opened once stayed in the switcher forever, and
the only way out was clearing the browser's site data.

There is now a disconnect control on each repository, in the editor's switcher
and on the dashboard's repository cards. Local only — the GitHub repository is
untouched — which the confirmation says, along with a count of anything
unpushed that will not survive. Not offered for the on-device workspace, which
has nothing to disconnect from.

### Clicking a repository appeared to do nothing

It always did select it, and the list below did change — three screens further
down, past the stats, the other repositories and the recent notes. It now
brings you to the notes it just selected.

### A published note left no trace anywhere in the app

Publishing had no memory. The address came back from the commit, was shown
once, and lived in the dialog's own React state — so closing it ended any
record that the note was public. Reopening the dialog offered to publish, as
though it never had been: no way to find the link again, and Unpublish sat
behind a screen there was no route back to. The `DELETE` endpoint had existed
since the feature landed and was unreachable after the first close.

Nothing new is stored to fix it. What is published is exactly what is in
`docs/` in the user's own repository, so the app asks:
`GET /api/gh/publish` lists that folder — one request, bodies not downloaded,
via a new `listDirectory` on the GitHub client — and answers for every note at
once, alongside the Pages site itself. Only `.html` files whose stem is a slug
this app would itself have produced are reported, so listing what ForkLeaf
published can never offer to unpublish somebody's hand-written site.

Reading it back rather than remembering is also the only version that stays
true: deleting a page on GitHub directly unpublishes it, and a stored flag
would go on claiming otherwise.

What that buys, in the app:

- The right-hand panel gains a **Published** section on a note that is one,
  with its address; the action reads "Published as a page".
- The publish dialog opens on the published screen when the note is already
  public — the link, **Copy link**, **Update page**, and **Unpublish**.
- The dashboard lists every page the repository serves under **Published
  pages**, each with its link, **Copy link**, and **Unpublish** behind the same
  confirmation every other destructive action uses.

Two previously indistinguishable states now say which they are: a page
committed while Pages is switched off has a file and no address — fixable, and
not the same as not being published.

## Notes

- Repository cards and switcher rows became groups rather than single buttons,
  since a button cannot contain a button.
- The publish dialog is keyed by note id rather than resetting itself in an
  effect, and its published view is derived from the listing instead of copied
  into state on open — mirroring would have wiped the address in the moment
  between publishing and the listing catching up.
- Docs: a new "Publishing a note as a page" section under Repositories &
  workspaces.

## Checks

`typecheck`, `lint`, `format:check` and `build` all pass. 813 tests pass,
including new coverage for tree authority, unpushed-work survival, the offline
case, `orphanedNotes`, the disconnect control, `slugOfPage`, and
`listDirectory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)