### PR TITLE
fix(editor): pasting, formatting, block gaps and remote refresh

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -530,11 +530,20 @@ select:focus-visible {
   color: var(--fl-muted);
 }
 
+/* Inline code, which has to be visible at a glance.
+   It used to be `--fl-elevated` on `--fl-surface` with a `--fl-border` outline
+   — in the dark theme, #131313 on #0a0a0a inside a #1f1f1f border. Three
+   near-blacks: a word marked as code looked exactly like a word that was not,
+   and the only way to find out was to put the caret in it and read the
+   toolbar. The accent tint carries in both themes, and the letters take the
+   accent colour so the span reads as code even where a background is hard to
+   see (inside a selection, or on a coloured highlight). */
 .fl-prose code {
   font-family: var(--font-mono);
   font-size: 0.85em;
-  background: var(--fl-elevated);
-  border: 1px solid var(--fl-border);
+  background: var(--fl-accent-soft);
+  color: var(--fl-accent);
+  border: 1px solid var(--fl-border-strong);
   padding: 0.1em 0.35em;
   border-radius: 5px;
 }
@@ -555,6 +564,50 @@ select:focus-visible {
   border: none;
   padding: 0;
   color: inherit;
+}
+
+/* A link inside inline code keeps the code colour: two colours fighting over
+   the same three characters reads as neither. */
+.fl-prose a code {
+  color: inherit;
+}
+
+/* The gap cursor: where the caret goes between two blocks that are not text —
+   a code block above a rule, an image above a diagram. ProseMirror puts one
+   there already, and shipped it invisible, so the one place in the document
+   where people could not tell whether they had a caret was the one place they
+   needed to know. Typing or pressing Enter here makes a paragraph. */
+.ProseMirror-gapcursor {
+  display: none;
+  pointer-events: none;
+  position: absolute;
+}
+
+.ProseMirror-gapcursor::after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -2px;
+  width: 100%;
+  border-top: 2px solid var(--fl-accent);
+  animation: fl-gapcursor 1.1s steps(2, start) infinite;
+}
+
+.ProseMirror-focused .ProseMirror-gapcursor,
+.ProseMirror-gapcursor:focus {
+  display: block;
+}
+
+@keyframes fl-gapcursor {
+  to {
+    visibility: hidden;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ProseMirror-gapcursor::after {
+    animation: none;
+  }
 }
 
 /* ── Syntax highlighting ──────────────────────────────────────────────────

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,6 +7,7 @@ import { HowItWorks } from "@/components/landing/HowItWorks";
 import { Toolkit } from "@/components/landing/Toolkit";
 import { Features } from "@/components/landing/Features";
 import { Positioning } from "@/components/landing/Positioning";
+import { Comparison } from "@/components/landing/Comparison";
 import { Ownership } from "@/components/landing/Ownership";
 import { Faq } from "@/components/landing/Faq";
 import { Pricing } from "@/components/landing/Pricing";
@@ -73,6 +74,7 @@ export default async function Home({
         <Toolkit />
         <Features />
         <Positioning />
+        <Comparison />
         <Ownership />
         <Pricing />
         <Faq />

--- a/apps/web/src/components/EditorSidebar.test.tsx
+++ b/apps/web/src/components/EditorSidebar.test.tsx
@@ -54,7 +54,7 @@ function renderSidebar(currentFolder: string, overrides: Record<string, unknown>
   const onCreateNote = vi.fn();
   const onCreateFolder = vi.fn();
 
-  render(
+  const draw = (activePath: string | null = "Fieldwork/Soil surveys/introduction.md") => (
     <EditorSidebar
       collapsed={false}
       onToggle={() => {}}
@@ -64,7 +64,7 @@ function renderSidebar(currentFolder: string, overrides: Record<string, unknown>
       onConnectRepo={() => {}}
       onDisconnectRepo={() => {}}
       tree={tree}
-      activePath="Fieldwork/Soil surveys/introduction.md"
+      activePath={activePath}
       currentFolder={currentFolder}
       onOpenNote={() => {}}
       onCreateNote={onCreateNote}
@@ -85,11 +85,57 @@ function renderSidebar(currentFolder: string, overrides: Record<string, unknown>
       onOpenPalette={() => {}}
       githubAvailable
       {...overrides}
-    />,
+    />
   );
 
-  return { onCreateNote, onCreateFolder };
+  const view = render(draw());
+
+  return {
+    onCreateNote,
+    onCreateFolder,
+    /** Re-renders with a different note selected, as opening one would. */
+    rerender: (activePath: string | null) => view.rerender(draw(activePath)),
+  };
 }
+
+/**
+ * A filter that hides the note you just made.
+ *
+ * The field narrows the tree by filename, so a note created — or opened from
+ * ⌘K, which searches everything — while something was typed in it landed in a
+ * tree that refused to draw it, under the words "Nothing matches".
+ */
+describe("EditorSidebar — the filename filter", () => {
+  function filterFor(text: string) {
+    const field = screen.getByLabelText("Filter notes by filename") as HTMLInputElement;
+    fireEvent.change(field, { target: { value: text } });
+    return field;
+  }
+
+  it("stands down when the note that gets selected does not match it", () => {
+    const { rerender } = renderSidebar("");
+    const field = filterFor("zzz");
+    expect(screen.getByText(/Nothing matches/)).toBeTruthy();
+
+    rerender("Fieldwork/Soil surveys/second.md");
+
+    expect(field.value).toBe("");
+  });
+
+  it("stays put while it is being typed", () => {
+    renderSidebar("");
+    expect(filterFor("zzz").value).toBe("zzz");
+  });
+
+  it("stays put when the selected note matches it anyway", () => {
+    const { rerender } = renderSidebar("");
+    const field = filterFor("intro");
+
+    rerender("Fieldwork/Soil surveys/introduction.md");
+
+    expect(field.value).toBe("intro");
+  });
+});
 
 describe("EditorSidebar — where new things go", () => {
   it("creates a note in the folder you are working in", () => {
@@ -134,9 +180,12 @@ describe("EditorSidebar — where new things go", () => {
 
 describe("EditorSidebar — pinned notes", () => {
   const pinned = ["Fieldwork/Soil surveys/introduction.md"];
+  // Nothing selected, so the tree does not open the folders above a selected
+  // note and draw a second row carrying the same path as the pinned one.
+  const unselected = { activePath: null };
 
   it("shows a pinned note above the tree", () => {
-    renderSidebar("", { pinnedPaths: pinned });
+    renderSidebar("", { pinnedPaths: pinned, ...unselected });
 
     expect(screen.getByText("Pinned")).toBeTruthy();
     expect(screen.getByTitle(pinned[0]!)).toBeTruthy();
@@ -149,7 +198,7 @@ describe("EditorSidebar — pinned notes", () => {
 
   it("opens the note when the pinned row is clicked", () => {
     const onOpenNote = vi.fn();
-    renderSidebar("", { pinnedPaths: pinned, onOpenNote });
+    renderSidebar("", { pinnedPaths: pinned, onOpenNote, ...unselected });
 
     fireEvent.click(screen.getByTitle(pinned[0]!));
 

--- a/apps/web/src/components/EditorSidebar.tsx
+++ b/apps/web/src/components/EditorSidebar.tsx
@@ -93,6 +93,28 @@ export function EditorSidebar(props: EditorSidebarProps) {
   useDismissable(accountRef, showAccount, () => setShowAccount(false));
   const searchRef = useRef<HTMLInputElement>(null);
 
+  /**
+   * Drops a filename filter that would hide the note just selected.
+   *
+   * The filter narrows the tree to matching filenames, so a note created while
+   * one was typed — or opened from ⌘K, which searches everything — landed
+   * somewhere the sidebar was refusing to draw. The tree said "Nothing matches
+   * ‘soil’" about a note that certainly existed.
+   *
+   * Only when the selection moves, and only when it does not match: clearing
+   * the field whenever the two disagreed would empty it as it was being typed,
+   * because a half-typed filter rarely matches the note already open.
+   */
+  const [filteredFor, setFilteredFor] = useState(props.activePath);
+
+  if (props.activePath !== filteredFor) {
+    setFilteredFor(props.activePath);
+    const path = props.activePath;
+    if (filter && path && !path.toLowerCase().includes(filter.toLowerCase())) {
+      setFilter("");
+    }
+  }
+
   // Every folder at every depth, so "new note" can mean "new note somewhere in
   // particular" without making the reader find the folder first. Listing only
   // the top level meant a note could never be put in a subfolder from here.

--- a/apps/web/src/components/FileTree.test.tsx
+++ b/apps/web/src/components/FileTree.test.tsx
@@ -108,6 +108,72 @@ describe("which folders are open", () => {
 });
 
 /**
+ * Finding a note you just made.
+ *
+ * A note created into a shut folder was selected, opened in the editor, and
+ * nowhere to be seen in the sidebar — so people went looking through GitHub
+ * for a file the app had just told them it created.
+ */
+describe("showing where the selected note lives", () => {
+  it("opens every folder above it", () => {
+    draw({ openFolders: [], activePath: "OSINT/Sources/feeds.md" });
+
+    expect(screen.getByText("feeds")).toBeTruthy();
+  });
+
+  it("does not record them as folders the reader chose to open", () => {
+    const onOpenFoldersChange = vi.fn();
+    draw({ openFolders: [], activePath: "OSINT/Sources/feeds.md", onOpenFoldersChange });
+
+    expect(onOpenFoldersChange).not.toHaveBeenCalled();
+  });
+
+  it("lets a revealed folder be closed again, and leaves it closed", () => {
+    draw({ openFolders: [], activePath: "OSINT/Sources/feeds.md" });
+
+    fireEvent.click(screen.getByText("Sources"));
+
+    expect(screen.queryByText("feeds")).toBeNull();
+  });
+
+  it("opens them when the selection moves, not only on arrival", () => {
+    const { rerender } = draw({ openFolders: [], activePath: null });
+    expect(screen.queryByText("notes")).toBeNull();
+
+    rerender(
+      <FileTree
+        nodes={tree}
+        activePath="Fieldwork/notes.md"
+        onOpen={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onCreateIn={vi.fn()}
+        onCreateFolder={vi.fn()}
+        onRenameFolder={vi.fn()}
+        onDeleteFolder={vi.fn()}
+        openFolders={[]}
+        filter=""
+      />,
+    );
+
+    expect(screen.getByText("notes")).toBeTruthy();
+  });
+
+  it("leaves a closed tree closed for a note at the top level", () => {
+    const onOpenFoldersChange = vi.fn();
+    draw({
+      nodes: [...tree, { kind: "file", name: "readme", path: "readme.md" }],
+      openFolders: [],
+      activePath: "readme.md",
+      onOpenFoldersChange,
+    });
+
+    expect(screen.queryByText("osint")).toBeNull();
+    expect(onOpenFoldersChange).not.toHaveBeenCalled();
+  });
+});
+
+/**
  * Dragging things around the tree.
  *
  * Notes could always be dragged into a folder. Folders could not, so the one

--- a/apps/web/src/components/FileTree.tsx
+++ b/apps/web/src/components/FileTree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TreeNode } from "@forkleaf/types";
 import { ContextMenu, useContextMenu, type MenuItem } from "./ContextMenu";
 
@@ -97,11 +97,21 @@ export function FileTree({
     () => new Set(openFolders ?? rootFolders(nodes)),
   );
 
-  /** Reports the open set outwards, so it can be remembered for next time. */
+  /**
+   * Records a new open set and reports it outwards, so it can be remembered
+   * for next time.
+   *
+   * Both together, and never from inside a `setExpanded` updater: React is
+   * free to run an updater during a later render pass rather than where it was
+   * queued, and a parent's `setState` reached from there is an update to one
+   * component while another is rendering — which React refuses, and which it
+   * only started refusing out loud once anything else in here set state during
+   * render.
+   */
   const remember = useCallback(
     (next: Set<string>) => {
+      setExpanded(next);
       onOpenFoldersChange?.([...next]);
-      return next;
     },
     [onOpenFoldersChange],
   );
@@ -155,25 +165,63 @@ export function FileTree({
 
   const toggle = useCallback(
     (path: string) => {
-      setExpanded((current) => {
-        const next = new Set(current);
-        // Deleted and re-added rather than left in place, so the record keeps
-        // the order folders were opened in.
-        next.delete(path);
-        if (!current.has(path)) next.add(path);
-        return remember(next);
-      });
+      const next = new Set(expanded);
+      // Deleted and re-added rather than left in place, so the record keeps
+      // the order folders were opened in.
+      next.delete(path);
+      if (!expanded.has(path)) next.add(path);
+      remember(next);
     },
-    [remember],
+    [expanded, remember],
   );
 
   /** Opening a folder before creating something in it, so the result is visible. */
   const reveal = useCallback(
     (path: string) => {
-      setExpanded((current) => remember(new Set(current).add(path)));
+      remember(new Set(expanded).add(path));
     },
-    [remember],
+    [expanded, remember],
   );
+
+  /**
+   * Opens every folder above whichever note is selected.
+   *
+   * A note made from the "New note" button, the ⌘⇧N shortcut or the folder
+   * menu became the selected note and was then invisible: it had landed inside
+   * a folder that was shut, and nothing in the sidebar said so. People went
+   * looking for a file they had just watched the app claim to create. Only the
+   * right-click menu opened its folder first, and only the one folder it was
+   * aimed at.
+   *
+   * Selecting a note is the moment to show where it lives, whether it arrived
+   * by being created, opened from ⌘K, or followed through a link.
+   *
+   * Adjusted during render against the last path revealed, rather than in an
+   * effect, so the tree is drawn open on the first pass — an effect would draw
+   * the shut tree first and open it a frame later. It is deliberately not
+   * reported through `onOpenFoldersChange`: what is remembered for next time
+   * is the set of folders the reader chose to open, and this is the app
+   * pointing at something rather than the reader opening it. Closing a
+   * revealed folder therefore sticks, which it would not if the open state
+   * were simply derived from the selection.
+   */
+  const [revealedFor, setRevealedFor] = useState<string | null>(null);
+
+  if (activePath !== revealedFor) {
+    setRevealedFor(activePath);
+    const ancestors = ancestorsOf(activePath ?? "");
+
+    if (ancestors.some((folder) => !expanded.has(folder))) {
+      const next = new Set(expanded);
+      // Re-added rather than left where they were, so the set still reads as
+      // "most recently opened last".
+      for (const folder of ancestors) {
+        next.delete(folder);
+        next.add(folder);
+      }
+      setExpanded(next);
+    }
+  }
 
   const menuItems = useMemo((): MenuItem[] => {
     if (!menu) return [];
@@ -358,6 +406,22 @@ const TreeItem = memo(function TreeItem({
     dragging !== null && (dragging.path === node.path || node.path.startsWith(`${dragging.path}/`));
   const dropFolder = isFolder ? node.path : dirnameOf(node.path);
 
+  /**
+   * Brings the selected row into view.
+   *
+   * Opening its folders is only half of "show me where it is": in a repository
+   * of any size the row it just revealed is as likely as not below the fold,
+   * and a sidebar that has scrolled somewhere else entirely still looks like
+   * nothing happened. `nearest` leaves the scroll alone when the row is
+   * already on screen, so selecting a visible note does not jump the tree.
+   * The call itself is optional because jsdom, where the tests run, has no
+   * layout and so does not implement it.
+   */
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (active) rowRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [active]);
+
   // The whole row is one indent step deeper than its parent. Every row reserves
   // the triangle's width whether or not it has one, so names line up in a
   // column instead of stepping raggedly in and out.
@@ -370,6 +434,7 @@ const TreeItem = memo(function TreeItem({
   return (
     <li role="treeitem" aria-expanded={isFolder ? open : undefined} aria-selected={active}>
       <div
+        ref={rowRef}
         className={`relative flex items-center rounded-md pr-1.5 transition-colors ${
           lifted ? "opacity-40" : ""
         } ${
@@ -579,6 +644,13 @@ function FileGlyph() {
 function dirnameOf(path: string): string {
   const cut = path.lastIndexOf("/");
   return cut === -1 ? "" : path.slice(0, cut);
+}
+
+/** Every folder above a path, outermost first. `[]` for anything at the root. */
+function ancestorsOf(path: string): string[] {
+  const parts = path.split("/");
+  parts.pop();
+  return parts.map((_, index) => parts.slice(0, index + 1).join("/"));
 }
 
 /** Top-level folders, which start open so the tree is never a single closed row. */

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -708,6 +708,27 @@ export function EditorWorkspace() {
     return () => clearTimeout(timer);
   }, [notice]);
 
+  /**
+   * Says so when a note is updated from GitHub behind your back.
+   *
+   * Notes now refresh themselves when somebody else commits — but text that
+   * rewrites itself while you are reading it is unnerving unless something
+   * says why, and "which of my open notes just changed" is exactly what you
+   * need to know afterwards.
+   */
+  const remoteChange = notebook.remoteChange;
+  const [announcedPull, setAnnouncedPull] = useState<number | null>(null);
+
+  if (remoteChange && remoteChange.at !== announcedPull) {
+    setAnnouncedPull(remoteChange.at);
+    const names = remoteChange.paths.map((path) => path.split("/").pop() ?? path);
+    setNotice(
+      names.length === 1
+        ? `Updated ${names[0]} with a change from GitHub`
+        : `Updated ${names.length} notes with changes from GitHub: ${names.join(", ")}`,
+    );
+  }
+
   const handleSignOut = useCallback(async () => {
     await signOut();
     router.push("/");
@@ -754,6 +775,13 @@ export function EditorWorkspace() {
         hint: "⌘S",
         keywords: "commit save upload",
         run: () => void notebook.syncNow(),
+      },
+      {
+        id: "pull",
+        label: "Check GitHub for changes now",
+        group: "Sync",
+        keywords: "pull refresh fetch update remote",
+        run: () => void notebook.pullRemote(),
       },
       {
         id: "repair-images",

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -364,8 +364,25 @@ export function EditorWorkspace() {
           ? `Saved as a file inside “${folder}”.`
           : "Saved at the top of your repository. Open a note first to create alongside it.",
         onConfirm: async (value) => {
-          await notebook.createNote(value || "Untitled note", folder);
+          const created = await notebook.createNote(value || "Untitled note", folder);
           track("note_created");
+          if (!created) return;
+
+          /**
+           * Where it went, said out loud and pointed at.
+           *
+           * The sidebar now opens the folders above a new note and scrolls to
+           * it, which answers "where is it" for anybody looking at the sidebar
+           * — but not for anybody who has it collapsed, or who is on a phone
+           * where the tree is a drawer over the note. So the path is stated
+           * too, and the sidebar is put back if it was folded away.
+           */
+          setSidebarCollapsed(false);
+          setNotice(
+            dirname(created.path)
+              ? `Created ${created.path}`
+              : `Created ${created.path}, at the top of the repository`,
+          );
         },
       });
     },

--- a/apps/web/src/components/landing/Comparison.tsx
+++ b/apps/web/src/components/landing/Comparison.tsx
@@ -1,0 +1,239 @@
+import React from "react";
+import { SectionHeading } from "./SectionHeading";
+
+/**
+ * ForkLeaf against the apps people actually have open.
+ *
+ * The section above this one compares *categories* — a hosted app, a local
+ * folder, editing on github.com — which is the honest way to describe a
+ * decision but not the way anybody asks the question. They ask "why not
+ * Notion", and an answer that never says the word Notion reads like an answer
+ * that cannot be given.
+ *
+ * So the products are named, and the table is written to be checkable: every
+ * cell is something a reader can verify in an afternoon, and the row that
+ * matters most — where the file ends up — is the first one. Their strengths
+ * are in the table too, and the paragraph underneath says plainly what
+ * ForkLeaf is worse at, because a comparison that finds no fault with itself
+ * is an advertisement and gets read as one.
+ *
+ * Facts current as of writing; anything a vendor can change tomorrow (exact
+ * prices, plan names) is deliberately not quoted, so this cannot quietly rot
+ * into something untrue.
+ */
+
+const APPS = ["ForkLeaf", "Notion", "OneNote", "Obsidian", "Evernote"] as const;
+
+type App = (typeof APPS)[number];
+
+const ROWS: { criterion: string; note?: string; cells: Record<App, string> }[] = [
+  {
+    criterion: "Where a note ends up",
+    note: "The thing everything else follows from.",
+    cells: {
+      ForkLeaf: "A .md file in a GitHub repository you own",
+      Notion: "A row in Notion's database, on Notion's servers",
+      OneNote: "A .one notebook in OneDrive",
+      Obsidian: "A .md file in a folder on that device",
+      Evernote: "A note in Evernote's cloud",
+    },
+  },
+  {
+    criterion: "Format",
+    cells: {
+      ForkLeaf: "Markdown — readable in any editor, for ever",
+      Notion: "Blocks. Markdown export exists and loses things",
+      OneNote: "A proprietary binary format",
+      Obsidian: "Markdown",
+      Evernote: "ENEX, an XML format only Evernote writes",
+    },
+  },
+  {
+    criterion: "History",
+    cells: {
+      ForkLeaf: "Every save is a git commit — diffs, blame, revert",
+      Notion: "Page history, on paid plans, for a limited window",
+      OneNote: "Recent versions, per page",
+      Obsidian: "Nothing built in; a plugin or git of your own",
+      Evernote: "Note history on paid plans",
+    },
+  },
+  {
+    criterion: "Sync",
+    cells: {
+      ForkLeaf: "git push, to a repository you already pay nothing for",
+      Notion: "Theirs, included, and required",
+      OneNote: "OneDrive, included",
+      Obsidian: "A paid add-on, or a folder-sync tool you wire up",
+      Evernote: "Theirs, limited on the free tier",
+    },
+  },
+  {
+    criterion: "Offline",
+    cells: {
+      ForkLeaf: "Fully — edits queue locally and push when you reconnect",
+      Notion: "Partial, and not something to rely on",
+      OneNote: "Yes",
+      Obsidian: "Yes — it is a local app",
+      Evernote: "Partial, on paid plans",
+    },
+  },
+  {
+    criterion: "Diagrams",
+    cells: {
+      ForkLeaf: "A Mermaid studio, and the output renders on GitHub too",
+      Notion: "Mermaid in code blocks",
+      OneNote: "Freehand drawing and shapes",
+      Obsidian: "Mermaid, plus plugins",
+      Evernote: "Sketches",
+    },
+  },
+  {
+    criterion: "Collaboration",
+    cells: {
+      ForkLeaf: "Pull requests and review, the way code is collaborated on",
+      Notion: "Live multiplayer editing — genuinely excellent",
+      OneNote: "Shared notebooks",
+      Obsidian: "A paid add-on, or none",
+      Evernote: "Shared notes",
+    },
+  },
+  {
+    criterion: "If the company disappears",
+    cells: {
+      ForkLeaf: "You still have a repository full of Markdown",
+      Notion: "You have whatever you exported before it happened",
+      OneNote: "Files in OneDrive, in a format only OneNote reads",
+      Obsidian: "You still have your folder — same answer, and a good one",
+      Evernote: "You have an ENEX file to find a converter for",
+    },
+  },
+  {
+    criterion: "Price",
+    cells: {
+      ForkLeaf: "Free and open source; bring your own repository",
+      Notion: "Free tier, then per person per month",
+      OneNote: "Free with a Microsoft account",
+      Obsidian: "Free for personal use; sync and publish cost extra",
+      Evernote: "Free tier with limits, then paid",
+    },
+  },
+];
+
+/** What each of them is best at, said without qualification. */
+const CREDIT: { app: Exclude<App, "ForkLeaf">; strength: string }[] = [
+  {
+    app: "Notion",
+    strength:
+      "Databases, templates and real-time collaboration. If a team runs on a wiki with views and permissions, this is still the answer.",
+  },
+  {
+    app: "OneNote",
+    strength:
+      "Handwriting, a stylus and free-form pages. Nothing here comes close for taking notes on a tablet in a lecture.",
+  },
+  {
+    app: "Obsidian",
+    strength:
+      "The plugin ecosystem, the graph, and a decade of thought about linking. Your files stay yours there too — it is the closest neighbour on this page.",
+  },
+  {
+    app: "Evernote",
+    strength:
+      "Web clipping and search over scanned documents, which it has been refining for years.",
+  },
+];
+
+export function Comparison() {
+  return (
+    <section id="compare" className="fl-anchor mx-auto w-full max-w-6xl px-6 py-24">
+      <SectionHeading
+        eyebrow="Side by side"
+        title="ForkLeaf, Notion, OneNote, Obsidian and Evernote"
+        body="Nine questions worth asking before you move a decade of notes into anything. Their answers as well as ours."
+      />
+
+      {/* Wide tables scroll inside themselves; the page must never scroll
+          sideways because of one. */}
+      <div className="mt-12 overflow-x-auto rounded-2xl border border-[var(--fl-border)]">
+        <table className="w-full min-w-[56rem] border-collapse text-left text-[13.5px]">
+          <caption className="sr-only">
+            How ForkLeaf compares with Notion, OneNote, Obsidian and Evernote
+          </caption>
+          <thead>
+            <tr className="border-b border-[var(--fl-border)] bg-[var(--fl-elevated)]">
+              <th scope="col" className="w-48 px-4 py-3 font-semibold text-[var(--fl-muted)]">
+                <span className="text-[11px] uppercase tracking-[0.14em]">Question</span>
+              </th>
+              {APPS.map((app) => (
+                <th
+                  key={app}
+                  scope="col"
+                  className={`px-4 py-3 font-semibold ${
+                    app === "ForkLeaf" ? "text-[var(--fl-accent)]" : "text-[var(--fl-text)]"
+                  }`}
+                >
+                  {app}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map((row) => (
+              <tr key={row.criterion} className="border-b border-[var(--fl-border)] last:border-0">
+                <th scope="row" className="px-4 py-4 align-top font-medium text-[var(--fl-text)]">
+                  {row.criterion}
+                  {row.note && (
+                    <span className="mt-1 block text-[12px] font-normal leading-snug text-[var(--fl-muted)]">
+                      {row.note}
+                    </span>
+                  )}
+                </th>
+                {APPS.map((app) => (
+                  <td
+                    key={app}
+                    className={`px-4 py-4 align-top leading-relaxed ${
+                      app === "ForkLeaf"
+                        ? "bg-[var(--fl-accent-soft)] text-[var(--fl-text)]"
+                        : "text-[var(--fl-muted)]"
+                    }`}
+                  >
+                    {row.cells[app]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* ── Credit where it is due ─────────────────────────────────────── */}
+      <div className="mt-14 grid gap-x-10 gap-y-8 sm:grid-cols-2">
+        {CREDIT.map((entry) => (
+          <div key={entry.app} className="flex gap-3.5">
+            <span
+              aria-hidden="true"
+              className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--fl-accent)]"
+            />
+            <div>
+              <p className="text-[15.5px] font-semibold tracking-tight text-[var(--fl-text)]">
+                What {entry.app} does better
+              </p>
+              <p className="mt-1.5 max-w-md text-[14.5px] leading-relaxed text-[var(--fl-muted)]">
+                {entry.strength}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <p className="mt-12 max-w-3xl text-[14.5px] leading-relaxed text-[var(--fl-muted)]">
+        And what ForkLeaf is worse at, so you hear it here rather than a week in: there is no
+        real-time multiplayer cursor, no mobile app beyond the browser, no handwriting, and setting
+        it up means having a GitHub account and picking a repository. It is a writing tool for
+        people who want their notes to be files — if what you need is a shared workspace with
+        permissions and databases, the row above is telling you to use Notion.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/Nav.tsx
+++ b/apps/web/src/components/landing/Nav.tsx
@@ -20,6 +20,7 @@ const SECTIONS = [
   { hash: "#how", label: "How it works" },
   { hash: "#toolkit", label: "What it does" },
   { hash: "#features", label: "Features" },
+  { hash: "#compare", label: "Compare" },
   { hash: "#pricing", label: "Pricing" },
 ] as const;
 

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -96,6 +96,14 @@ export interface NotebookState {
    * first-run repository chooser.
    */
   needsRepoChoice: boolean;
+  /**
+   * The last set of notes a background refresh brought down from GitHub.
+   *
+   * Held in state, rather than applied silently, so the editor can say what
+   * changed: a note rewriting itself under the caret with no explanation is
+   * alarming even when it is exactly what was asked for.
+   */
+  remoteChange: { paths: string[]; at: number } | null;
 }
 
 /** Keys the open set is remembered under, so a reload reopens the same tabs. */
@@ -136,6 +144,16 @@ const STORAGE_UNAVAILABLE =
 
 /** How many notes may be open at once, to bound memory and tab-strip width. */
 const MAX_OPEN_NOTES = 12;
+
+/**
+ * How often to look for changes made somewhere else.
+ *
+ * A minute is short enough that a note edited on a phone is on the laptop
+ * before anybody goes looking for it, and long enough to be nothing next to
+ * GitHub's rate limit — 60 requests an hour per open tab, against a budget of
+ * 5,000. Tabs in the background ask for nothing at all.
+ */
+const REMOTE_POLL_MS = 60_000;
 
 /** What the URL asked for: a specific workspace, and a note inside it. */
 export interface NotebookRequest {
@@ -183,6 +201,7 @@ export function useNotebook(request: NotebookRequest = {}) {
     pinnedPaths: [],
     expandedFolders: null,
     needsRepoChoice: false,
+    remoteChange: null,
   });
 
   // Long-lived singletons. Refs rather than state: replacing the sync engine
@@ -193,6 +212,15 @@ export function useNotebook(request: NotebookRequest = {}) {
   const repoRef = useRef<NoteRepository | null>(null);
   /** A URL-requested note is opened once, not on every workspace switch. */
   const openedRequestRef = useRef(false);
+  /**
+   * The current `pullRemote`, for the polling effect to call.
+   *
+   * That function closes over the open notes, so it is a different function on
+   * every keystroke; listing it as a dependency of the interval would tear the
+   * interval down and build a new one just as often, and a one-minute timer
+   * that is replaced every second never fires.
+   */
+  const pullRef = useRef<(() => Promise<void>) | null>(null);
 
   const patch = useCallback((updates: Partial<NotebookState>) => {
     setState((current) => ({ ...current, ...updates }));
@@ -438,6 +466,44 @@ export function useNotebook(request: NotebookRequest = {}) {
     window.addEventListener("online", onOnline);
     return () => window.removeEventListener("online", onOnline);
   }, []);
+
+  // ── Bring down what other people changed ────────────────────────────────
+  /**
+   * On a timer, and whenever the tab comes back to the front.
+   *
+   * The timer catches a colleague committing while you read; coming back to
+   * the tab is the moment somebody has most likely been editing the same
+   * notebook somewhere else — on their phone, on github.com, in another
+   * window — and it is also the cheapest possible trigger, because a tab
+   * nobody is looking at asks GitHub for nothing at all.
+   *
+   * Manual sync means manual: somebody who has turned off automatic pushing
+   * has said they want the network left alone, and quietly polling it every
+   * minute would be a strange reading of that.
+   */
+  useEffect(() => {
+    const workspace = state.activeWorkspace;
+    if (!workspace || workspace.isLocal) return;
+    if (state.syncPreference.mode === "manual") return;
+
+    const pull = () => {
+      if (document.visibilityState !== "visible") return;
+      void pullRef.current?.();
+    };
+
+    const timer = window.setInterval(pull, REMOTE_POLL_MS);
+    window.addEventListener("visibilitychange", pull);
+    window.addEventListener("focus", pull);
+
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener("visibilitychange", pull);
+      window.removeEventListener("focus", pull);
+    };
+    // Deliberately not depending on `pullRemote` itself, which changes
+    // whenever an open note does: rebuilding the interval on every keystroke
+    // would mean it never fired.
+  }, [state.activeWorkspace, state.syncPreference.mode]);
 
   // ── Warn before closing with unsaved work ───────────────────────────────
   useEffect(() => {
@@ -977,6 +1043,63 @@ export function useNotebook(request: NotebookRequest = {}) {
   const syncNow = useCallback(() => syncRef.current?.flushNow(), []);
 
   /**
+   * Brings down anything that changed on GitHub since the last look.
+   *
+   * Sync used to be one-directional: edits were pushed, and anything that
+   * arrived from anywhere else — a colleague's commit, the same notebook on a
+   * phone, an edit made on github.com — was invisible until the page was
+   * reloaded by hand. Which meant the reload had to be guessed at, and
+   * anybody who did not guess was writing against a stale copy.
+   *
+   * Two rules keep this safe. Notes with unpushed local edits are never
+   * touched, so a background refresh cannot overwrite something half-written;
+   * their divergence is the push's problem, and the conflict machinery already
+   * handles it. And the notes that *are* replaced are reported back, so the
+   * editor can say so rather than letting the text change by itself.
+   */
+  const pullRemote = useCallback(async () => {
+    const workspace = state.activeWorkspace;
+    const notes = repoRef.current;
+    if (!workspace || !notes || workspace.isLocal) return;
+    if (typeof navigator !== "undefined" && navigator.onLine === false) return;
+
+    // The tree first: it is one request, and it is what the sidebar shows.
+    // `getTree` answers from the cache and refreshes behind it, so the
+    // callback is where a real change arrives.
+    await notes.getTree(workspace.id, (tree) => patch({ tree }));
+
+    const changed: string[] = [];
+    const refreshed = await Promise.all(
+      state.openNotes.map(async (note) => {
+        if (note.dirty) return note;
+
+        try {
+          const latest = await notes.openNote(workspace.id, note.path);
+          if (latest.content === note.content) return note;
+          changed.push(note.path);
+          return latest;
+        } catch {
+          // Deleted on the remote, or unreachable. Neither is this function's
+          // business: closing the tab is the reader's call, and the sidebar
+          // has already been told the file is gone.
+          return note;
+        }
+      }),
+    );
+
+    if (changed.length > 0) {
+      patch({ openNotes: refreshed, remoteChange: { paths: changed, at: Date.now() } });
+    }
+  }, [state.activeWorkspace, state.openNotes, patch]);
+
+  // Written in an effect rather than during render: a ref is an external
+  // system as far as React is concerned, and touching one mid-render is how
+  // you get two different answers out of the same pass.
+  useEffect(() => {
+    pullRef.current = pullRemote;
+  }, [pullRemote]);
+
+  /**
    * The unpushed changes for the workspace currently open.
    *
    * Read by the propose-changes flow, which has to write them onto a new
@@ -1180,6 +1303,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       addWorkspace,
       removeWorkspace,
       syncNow,
+      pullRemote,
       pendingChanges,
       discardPending,
       setSyncMode,
@@ -1231,6 +1355,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       addWorkspace,
       removeWorkspace,
       syncNow,
+      pullRemote,
       pendingChanges,
       discardPending,
       setSyncMode,

--- a/packages/editor/src/EditorToolbar.tsx
+++ b/packages/editor/src/EditorToolbar.tsx
@@ -54,6 +54,14 @@ export interface ToolbarSurface {
   blockStyle: BlockStyle | null;
   setBlockStyle: (style: BlockStyle) => void;
   isListActive: (kind: "bullet" | "ordered" | "task") => boolean;
+  /**
+   * Whether the text under the caret is a link.
+   *
+   * Optional because raw markdown has no reliable answer: `[a](b)` is text
+   * there, and the button would have to guess at the caret's relationship to a
+   * pair of brackets.
+   */
+  isLinkActive?: () => boolean;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
@@ -104,7 +112,9 @@ const MARKS: { mark: FormatMark; label: string; hint: string; render: React.Reac
   {
     mark: "code",
     label: "Inline code",
-    hint: "⌘E",
+    // How to get back out again, which is the part nobody could find: a code
+    // span at the end of a line swallowed everything typed after it.
+    hint: "⌘E · → to leave",
     render: <span className="font-mono text-[11px]">{"</>"}</span>,
   },
   {
@@ -282,7 +292,8 @@ export function EditorToolbar({
         {has("link") && (
           <Button
             label="Link"
-            hint="⌘K in the document"
+            hint="⌘K in the document · → to leave"
+            pressed={surface?.isLinkActive?.() ?? false}
             disabled={disabled}
             onClick={() => onRun("link")}
           >

--- a/packages/editor/src/MarkdownEditor.tsx
+++ b/packages/editor/src/MarkdownEditor.tsx
@@ -14,6 +14,7 @@ import {
   type ToolbarSurface,
 } from "./EditorToolbar";
 import { insertActionsFor, runRichAction, runSourceAction } from "./insert-actions";
+import { isolateCurrentLine } from "./isolate-line";
 import { ImageDialog } from "./ui/ImageDialog";
 import { LinkDialog } from "./ui/LinkDialog";
 import type { ImageBridge } from "./images";
@@ -516,6 +517,12 @@ function richSurface(editor: Editor): ToolbarSurface {
     },
     blockStyle: richBlockStyle(editor),
     setBlockStyle: (style) => {
+      // The line, or the lines highlighted — not the whole paragraph they
+      // happen to share. Without this, choosing Heading 3 with one line
+      // selected made a heading of every line in the paragraph, the link
+      // above it included.
+      isolateCurrentLine(editor);
+
       const chain = editor.chain().focus();
       if (style === "paragraph") {
         // Blockquote and code block are wrappers rather than node types, so
@@ -535,6 +542,7 @@ function richSurface(editor: Editor): ToolbarSurface {
       editor.isActive(
         kind === "bullet" ? "bulletList" : kind === "ordered" ? "orderedList" : "taskList",
       ),
+    isLinkActive: () => editor.isActive("link"),
     undo: () => editor.chain().focus().undo().run(),
     redo: () => editor.chain().focus().redo().run(),
     canUndo: editor.can().undo(),
@@ -667,7 +675,10 @@ function sourceBlockStyle(line: string): BlockStyle {
  * showing the state of wherever the caret used to be.
  */
 function signatureOf(editor: Editor): string {
-  const marks = ["bold", "italic", "strike", "code", "highlight"]
+  // `link` is in here for the same reason as the rest: the toolbar reports
+  // what is applied to the text under the caret, and a link is applied to text
+  // as much as bold is.
+  const marks = ["bold", "italic", "strike", "code", "highlight", "link"]
     .map((mark) => (editor.isActive(mark) ? "1" : "0"))
     .join("");
   const lists = ["bulletList", "orderedList", "taskList"]

--- a/packages/editor/src/WysiwygEditor.tsx
+++ b/packages/editor/src/WysiwygEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
-import { useEditor, EditorContent } from "@tiptap/react";
+import { useEditor, useEditorState, EditorContent } from "@tiptap/react";
 import type { EditorView } from "@tiptap/pm/view";
 import { BubbleMenu } from "@tiptap/react/menus";
 import StarterKit from "@tiptap/starter-kit";
@@ -74,9 +74,13 @@ import { MermaidBlock } from "./extensions/MermaidBlock";
 import { Wikilink } from "./extensions/Wikilink";
 import { EnterIsALineBreak } from "./extensions/EnterIsALineBreak";
 import { ShortcutsAfterLineBreak } from "./extensions/ShortcutsAfterLineBreak";
+import { SmartPaste } from "./extensions/SmartPaste";
+import { LeaveInlineMark } from "./extensions/LeaveInlineMark";
+import { RoomToWrite } from "./extensions/RoomToWrite";
 import type { LinkBridge } from "./links";
 import { readSlashState } from "./extensions/SlashCommands";
 import { isolateCurrentLine } from "./isolate-line";
+import { caretBelow } from "./caret";
 import { filterInsertActions, type ActionContext, type InsertDefinition } from "./insert-actions";
 
 export interface WysiwygEditorProps {
@@ -233,6 +237,18 @@ export function WysiwygEditor({
       // After it, because it exists to repair what that one changes: a line
       // that begins after a hard break rather than at the start of a block.
       ShortcutsAfterLineBreak,
+      // Reshapes what the clipboard hands over — code into a code block, lines
+      // into lines. Registered before the markdown extension because it
+      // borrows that one's text parser and has to be able to stand aside for
+      // it, not the other way round.
+      SmartPaste,
+      // Before the marks' own `exitable` handling, which only fires at the end
+      // of a whole paragraph — which, with Enter making lines, is rarely where
+      // anybody is standing.
+      LeaveInlineMark,
+      // Last of the keyboard extensions: its Enter and ↓ only do anything in
+      // the places every other handler has already declined.
+      RoomToWrite,
       Markdown.configure({
         html: false,
         transformPastedText: true,
@@ -288,6 +304,17 @@ export function WysiwygEditor({
         // Anything after the first lands below the one before it.
         position = target + node.nodeSize;
       }
+      /**
+       * The caret goes below the picture, on a line of its own.
+       *
+       * An image is a block, so after inserting one the selection sat on the
+       * node itself: the next thing typed replaced the image that had just
+       * been uploaded, and the way to avoid that was to know to click below it
+       * first. Pasting a screenshot into a note is nearly always followed by
+       * writing about the screenshot.
+       */
+      if (position !== undefined) caretBelow(view, position);
+
       // The upload stored the image locally and called setAssetUrls(), which
       // is a React state update. That update was processed while `await`
       // yielded — *before* the node was created and its view registered a
@@ -508,7 +535,21 @@ function FormatButton({
   glyph: string;
   className?: string;
 }) {
-  const active = editor.isActive(mark);
+  /**
+   * Read live, not at render time.
+   *
+   * The bubble's buttons used to compute this while `WysiwygEditor` rendered,
+   * which happens when the note changes and almost never when the *selection*
+   * does. So selecting a bold, highlighted phrase popped up a toolbar with
+   * nothing pressed on it: the buttons were reporting the formatting of
+   * wherever the caret had been at the last render. There was no way to tell
+   * from the toolbar what was already applied to the words in front of you,
+   * which is most of what a toolbar is for.
+   */
+  const active = useEditorState({
+    editor,
+    selector: ({ editor: instance }) => instance.isActive(mark),
+  });
 
   return (
     <button
@@ -567,7 +608,19 @@ function FormatButton({
  * should not be two clicks deep.
  */
 function HighlightPicker({ editor }: { editor: Editor }) {
-  const active = editor.isActive("highlight");
+  // Live, for the same reason as the buttons above: which colour is on has to
+  // be read when the selection moves, not when the document does.
+  const state = useEditorState({
+    editor,
+    selector: ({ editor: instance }) => ({
+      active: instance.isActive("highlight"),
+      colour:
+        HIGHLIGHT_COLOURS.find((candidate) =>
+          instance.isActive("highlight", { color: candidate.name }),
+        )?.name ?? null,
+    }),
+  });
+  const active = state.active;
 
   return (
     <span className="flex items-center gap-0.5">
@@ -576,7 +629,7 @@ function HighlightPicker({ editor }: { editor: Editor }) {
       <span className="mx-0.5 h-4 w-px bg-[var(--fl-inverse-text)]/20" aria-hidden="true" />
 
       {HIGHLIGHT_COLOURS.filter((colour) => colour.name !== DEFAULT_HIGHLIGHT).map((colour) => {
-        const on = active && editor.isActive("highlight", { color: colour.name });
+        const on = active && state.colour === colour.name;
 
         return (
           <button

--- a/packages/editor/src/backspace-joins.test.tsx
+++ b/packages/editor/src/backspace-joins.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { WysiwygEditor, markdownOf } from "./WysiwygEditor";
+
+afterEach(cleanup);
+
+/**
+ * Deleting the gap between two lines.
+ *
+ * Enter here makes a line rather than a paragraph, so the blank line between
+ * two paragraphs is two presses of Enter. Backspace used to undo both of them
+ * at once and run the lines together: `assetfinder tcm-sec.com` and `amass
+ * enum -d tcm-sec.com` became one line reading `tcm-sec.comamass`, which reads
+ * as a typo rather than as an edit anybody asked for.
+ */
+
+async function mount(value: string): Promise<Editor> {
+  let editor: Editor | null = null;
+  render(
+    <WysiwygEditor
+      value={value}
+      onChange={vi.fn()}
+      onReady={(instance) => {
+        editor = instance;
+      }}
+    />,
+  );
+
+  await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+  return editor!;
+}
+
+/** A key press, offered to the editor exactly as the browser would offer it. */
+function press(editor: Editor, key: string): boolean {
+  const { view } = editor;
+  return Boolean(
+    view.someProp("handleKeyDown", (handler) =>
+      handler(view, new KeyboardEvent("keydown", { key, bubbles: true })),
+    ),
+  );
+}
+
+const TWO = "assetfinder tcm-sec.com\n\namass enum -d tcm-sec.com";
+
+/**
+ * The document as lines: a line break is a newline, a paragraph break a blank
+ * line. Read off the document rather than from the markdown, because the
+ * serialiser turns `tcm-sec.com` into a link once it sits next to other text
+ * and that is a different question from this one.
+ */
+function lines(editor: Editor): string {
+  const { doc } = editor.state;
+  return doc.textBetween(0, doc.content.size, "\n\n", "\n");
+}
+
+describe("backspace at the start of a line", () => {
+  it("closes the gap without running the lines together", async () => {
+    const editor = await mount(TWO);
+    // The start of the second paragraph, which is where the caret goes when
+    // somebody clicks the blank line and presses Backspace.
+    editor.commands.setTextSelection(editor.state.doc.child(0).nodeSize + 1);
+
+    expect(press(editor, "Backspace")).toBe(true);
+
+    // One paragraph now, but still two lines inside it.
+    expect(editor.state.doc.childCount).toBe(1);
+    expect(lines(editor)).toBe("assetfinder tcm-sec.com\namass enum -d tcm-sec.com");
+    // And in the file: one line each, where there was a blank line before.
+    expect(markdownOf(editor).trim().split("\n")).toHaveLength(2);
+  });
+
+  it("leaves the caret at the start of the line it moved, not somewhere else", async () => {
+    const editor = await mount(TWO);
+    editor.commands.setTextSelection(editor.state.doc.child(0).nodeSize + 1);
+    press(editor, "Backspace");
+
+    // Typing now continues the second line rather than the first.
+    editor.commands.insertContent("x");
+    expect(lines(editor)).toBe("assetfinder tcm-sec.com\nxamass enum -d tcm-sec.com");
+  });
+
+  it("leaves a break behind that one more press removes", async () => {
+    const editor = await mount(TWO);
+    editor.commands.setTextSelection(editor.state.doc.child(0).nodeSize + 1);
+    press(editor, "Backspace");
+
+    // A hard break sits between them and the caret is right after it, so the
+    // next Backspace deletes that break and the lines join for real. The press
+    // itself is the browser's own character delete, which jsdom has no
+    // contentEditable to perform, so this checks the state it acts on.
+    expect(countHardBreaks(editor)).toBe(1);
+    // Right after the break: one for the paragraph's opening token, the first
+    // line's characters, and one for the break itself.
+    expect(editor.state.selection.from).toBe("assetfinder tcm-sec.com".length + 2);
+  });
+
+  it("still deletes an empty line rather than turning it into a break", async () => {
+    const editor = await mount("");
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "one" }] },
+        { type: "paragraph" },
+        { type: "paragraph", content: [{ type: "text", text: "two" }] },
+      ],
+    });
+    // The start of "two", with an empty paragraph above it.
+    editor.commands.setTextSelection(editor.state.doc.content.size - 4);
+
+    press(editor, "Backspace");
+
+    // The empty paragraph goes and the two paragraphs stay two paragraphs: a
+    // blank line being deleted is not two lines being joined.
+    expect(editor.state.doc.childCount).toBe(2);
+    expect(countHardBreaks(editor)).toBe(0);
+  });
+
+  it("stays out of lists, where joining means something else", async () => {
+    const editor = await mount("- one\n- two");
+    // The start of the second item.
+    editor.commands.setTextSelection(editor.state.doc.child(0).child(0).nodeSize + 2);
+
+    press(editor, "Backspace");
+
+    // Whatever the list does with that press is the list's business. What
+    // matters is that this did not step in and put a line break inside it.
+    expect(countHardBreaks(editor)).toBe(0);
+  });
+});
+
+describe("delete at the end of a line", () => {
+  it("pulls the next line up as a line, not as more of this one", async () => {
+    const editor = await mount(TWO);
+    editor.commands.setTextSelection(editor.state.doc.child(0).nodeSize - 1);
+
+    expect(press(editor, "Delete")).toBe(true);
+    expect(lines(editor)).toBe("assetfinder tcm-sec.com\namass enum -d tcm-sec.com");
+  });
+});
+
+/** How many hard breaks the document holds, at any depth. */
+function countHardBreaks(editor: Editor): number {
+  let count = 0;
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === "hardBreak") count += 1;
+  });
+  return count;
+}

--- a/packages/editor/src/caret.ts
+++ b/packages/editor/src/caret.ts
@@ -1,0 +1,32 @@
+import { TextSelection } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
+
+/**
+ * Puts the caret on a line below whatever was just inserted, making one if the
+ * document has nothing there.
+ *
+ * Blocks that are not text — a pasted screenshot, an embedded video, a diagram
+ * — leave the selection *on the node* once they are inserted, so the next
+ * keystroke replaces the thing that was just added. Pasting a picture into a
+ * note is almost always followed by writing about the picture, and having to
+ * know to click below it first is a rule nobody should have to learn.
+ *
+ * `after` is the position immediately following the inserted node.
+ */
+export function caretBelow(view: EditorView, after: number): void {
+  const { state } = view;
+  const paragraph = state.schema.nodes.paragraph;
+  if (!paragraph) return;
+
+  const next = after < state.doc.content.size ? state.doc.resolve(after).nodeAfter : null;
+  const tr = state.tr;
+
+  // Only when there is nothing writable there already: pasting above an
+  // existing paragraph should use that paragraph rather than add an empty one.
+  if (!next || !next.isTextblock) {
+    tr.insert(after, paragraph.create());
+  }
+
+  tr.setSelection(TextSelection.create(tr.doc, Math.min(after + 1, tr.doc.content.size)));
+  view.dispatch(tr.scrollIntoView());
+}

--- a/packages/editor/src/coloured-highlight.test.tsx
+++ b/packages/editor/src/coloured-highlight.test.tsx
@@ -54,6 +54,40 @@ describe("coloured highlights in rich text", () => {
     expect(markdownOf(editor)).toContain('<mark class="fl-hl-pink">pink</mark>');
   });
 
+  /**
+   * The default colour, which is written as `==text==` and was the one that
+   * did not come back: the serialiser wrote it, the preview rendered it, and
+   * the rich editor showed the equals signs as text the next time the note was
+   * opened.
+   */
+  it("reads a plain ==highlight== back as a highlight", async () => {
+    const editor = await mount("a ==yellow== word");
+
+    let found = false;
+    editor.state.doc.descendants((node) => {
+      for (const mark of node.marks) {
+        if (mark.type.name === "highlight" && node.textContent === "yellow") found = true;
+      }
+    });
+
+    expect(found).toBe(true);
+    // And writes it back the way it was written, so opening a note is not an
+    // edit to it.
+    expect(markdownOf(editor).trim()).toBe("a ==yellow== word");
+  });
+
+  it("leaves == inside code exactly as typed, where it is an operator", async () => {
+    const editor = await mount("check `a ==b== c` here\n\n```js\nif (a ==b== c) {}\n```");
+
+    let highlights = 0;
+    editor.state.doc.descendants((node) => {
+      for (const mark of node.marks) if (mark.type.name === "highlight") highlights += 1;
+    });
+
+    expect(highlights).toBe(0);
+    expect(markdownOf(editor)).toContain("`a ==b== c`");
+  });
+
   it("leaves a colour it does not know as the text it was written as", async () => {
     const editor = await mount('a <mark class="fl-hl-chartreuse">odd</mark> word');
 

--- a/packages/editor/src/extensions/CodeBlock.tsx
+++ b/packages/editor/src/extensions/CodeBlock.tsx
@@ -60,9 +60,8 @@ function isKnown(language: string): boolean {
 /**
  * The languages worth putting at the top of the list.
  *
- * Everything lowlight supports is still in the dropdown underneath; this is
- * only about not making someone scroll past `abnf` and `arcade` to reach
- * TypeScript.
+ * The rest of the list follows underneath; this is about not making someone
+ * scroll past a dozen things to reach TypeScript.
  */
 const POPULAR = [
   "javascript",
@@ -89,6 +88,75 @@ const POPULAR = [
   "diff",
 ];
 
+/**
+ * Everything else the picker offers.
+ *
+ * lowlight ships 192 grammars and the dropdown used to list all of them, in
+ * alphabetical order, which meant the first thing anyone saw under "All
+ * languages" was `1c`, `abnf`, `accesslog`, `angelscript`, `arcade`, `avrasm`
+ * and `axapta` — a wall of things almost nobody has written a line of, sitting
+ * between them and Scala. Access logs and Asciidoc are not even languages.
+ *
+ * So this is the long tail, curated: languages people actually write, and the
+ * few formats worth tagging. A block that arrives from a repository tagged
+ * with something outside the list is still highlighted — lowlight keeps every
+ * grammar — and still shows its own tag in the picker, so nothing is lost by
+ * not listing it. If something belongs here and is missing, it is one line.
+ */
+const MORE = [
+  "ada",
+  "arduino",
+  "clojure",
+  "cmake",
+  "coffeescript",
+  "crystal",
+  "d",
+  "dart",
+  "delphi",
+  "dockerfile",
+  "elixir",
+  "elm",
+  "erlang",
+  "fortran",
+  "fsharp",
+  "gradle",
+  "graphql",
+  "groovy",
+  "haskell",
+  "haxe",
+  "ini",
+  "julia",
+  "latex",
+  "less",
+  "lisp",
+  "lua",
+  "makefile",
+  "matlab",
+  "nim",
+  "nix",
+  "objectivec",
+  "ocaml",
+  "perl",
+  "powershell",
+  "prolog",
+  "protobuf",
+  "r",
+  "scala",
+  "scheme",
+  "scss",
+  "smalltalk",
+  "tcl",
+  "vala",
+  "vbnet",
+  "verilog",
+  "vhdl",
+  "vim",
+  "wasm",
+  "x86asm",
+  "xml",
+  "xquery",
+];
+
 /** Names lowlight knows the language by, but nobody types. */
 const DISPLAY_NAMES: Record<string, string> = {
   cpp: "C++",
@@ -104,27 +172,47 @@ const DISPLAY_NAMES: Record<string, string> = {
   html: "HTML",
   css: "CSS",
   bash: "Shell",
+  cmake: "CMake",
+  d: "D",
+  fsharp: "F#",
+  graphql: "GraphQL",
+  ini: "INI / TOML",
+  latex: "LaTeX",
+  less: "Less",
+  matlab: "MATLAB",
+  objectivec: "Objective-C",
+  ocaml: "OCaml",
+  protobuf: "Protocol Buffers",
+  r: "R",
+  scss: "SCSS",
+  vbnet: "VB.NET",
+  vhdl: "VHDL",
+  wasm: "WebAssembly",
+  x86asm: "Assembly",
+  xquery: "XQuery",
 };
 
 function displayName(language: string): string {
   return DISPLAY_NAMES[language] ?? language.charAt(0).toUpperCase() + language.slice(1);
 }
 
-function CodeBlockView({ node, updateAttributes, extension, editor, getPos }: NodeViewProps) {
+function CodeBlockView({ node, updateAttributes, editor, getPos }: NodeViewProps) {
   const language = (node.attrs.language as string) ?? "";
   const [copied, setCopied] = useState(false);
 
   const languages = useMemo(() => {
-    const listed: string[] = extension.options.lowlight.listLanguages();
     const popular = POPULAR.filter(isKnown);
-    const rest = listed.filter((name) => !popular.includes(name)).sort();
-    // A block that arrived from a repository may be tagged with something no
-    // grammar covers. Keeping that tag in the list means opening the dropdown
-    // cannot silently retag the block.
+    const rest = MORE.filter((name) => isKnown(name) && !popular.includes(name)).sort((a, b) =>
+      displayName(a).localeCompare(displayName(b)),
+    );
+    // A block that arrived from a repository may be tagged with a language
+    // this list leaves out, or with something no grammar covers at all.
+    // Keeping that tag in the picker means opening it cannot silently retag
+    // the block.
     const unlisted =
       language && !popular.includes(language) && !rest.includes(language) ? [language] : [];
     return { popular, rest, unlisted };
-  }, [extension.options.lowlight, language]);
+  }, [language]);
 
   /**
    * Puts the caret in the code when the click lands on the block's padding

--- a/packages/editor/src/extensions/ColouredHighlight.ts
+++ b/packages/editor/src/extensions/ColouredHighlight.ts
@@ -109,9 +109,62 @@ export const ColouredHighlight = Highlight.extend({
 
             const next = rewrite(element.innerHTML);
             if (next !== element.innerHTML) element.innerHTML = next;
+
+            markPlainHighlights(element);
           },
         },
       },
     };
   },
 });
+
+/**
+ * `==text==` → a highlight, on the way into the rich editor.
+ *
+ * The serialiser has always written the plain yellow highlight as `==text==`,
+ * and the preview has always rendered it — but nothing turned it back into a
+ * mark when the note was opened. So highlighting a phrase, closing the note
+ * and opening it again showed `==the phrase==`, equals signs and all, in an
+ * editor that had written them itself. The colours round-tripped, because they
+ * are written as `<mark>`; only the default one did not.
+ *
+ * Done over text nodes rather than by rewriting the HTML as a string, so `==`
+ * inside a code span or a code block is left exactly as typed — which is the
+ * whole reason to be careful here, since `==` is an operator in most languages.
+ */
+const PLAIN_HIGHLIGHT = /==(?!\s)([^=\n]+?)(?<!\s)==/g;
+
+function markPlainHighlights(root: HTMLElement): void {
+  const document = root.ownerDocument;
+  if (!document) return;
+
+  const walker = document.createTreeWalker(root, 4 /* SHOW_TEXT */);
+  const targets: Text[] = [];
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode as Text;
+    if (!node.data.includes("==")) continue;
+    if (node.parentElement?.closest("code, pre, mark")) continue;
+    targets.push(node);
+  }
+
+  for (const node of targets) {
+    const fragment = document.createDocumentFragment();
+    let cursor = 0;
+    let match: RegExpExecArray | null;
+
+    PLAIN_HIGHLIGHT.lastIndex = 0;
+    while ((match = PLAIN_HIGHLIGHT.exec(node.data)) !== null) {
+      if (match.index > cursor) fragment.append(node.data.slice(cursor, match.index));
+
+      const mark = document.createElement("mark");
+      mark.textContent = match[1] ?? "";
+      fragment.append(mark);
+      cursor = match.index + match[0].length;
+    }
+
+    if (cursor === 0) continue;
+    if (cursor < node.data.length) fragment.append(node.data.slice(cursor));
+    node.replaceWith(fragment);
+  }
+}

--- a/packages/editor/src/extensions/EnterIsALineBreak.ts
+++ b/packages/editor/src/extensions/EnterIsALineBreak.ts
@@ -1,4 +1,6 @@
 import { Extension } from "@tiptap/core";
+import { TextSelection } from "@tiptap/pm/state";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
 
 /**
  * Enter makes a line, not a paragraph.
@@ -18,6 +20,9 @@ import { Extension } from "@tiptap/core";
  * breaks serialise to a blank line, markdown reads that back as two paragraphs,
  * and it re-serialises to the same blank line — so the file is stable however
  * the document happens to be shaped in memory.
+ *
+ * Backspace is the other half of the same contract, and undoes exactly what
+ * Enter did: see `joinAcross` below.
  *
  * This deliberately does *not* touch Enter anywhere it already means something
  * else. In a list it makes the next item, in a heading it starts the paragraph
@@ -64,6 +69,94 @@ export const EnterIsALineBreak = Extension.create({
 
         return editor.commands.splitBlock();
       },
+
+      /**
+       * Backspace undoes Enter, one press per press.
+       *
+       * Deleting the gap between two paragraphs used to run them into each
+       * other: the caret went to the start of the second line, Backspace
+       * joined the blocks, and `assetfinder tcm-sec.com` and `amass enum -d
+       * tcm-sec.com` became one line reading `tcm-sec.comamass`. Two words
+       * that were never next to each other now are, and nothing says a
+       * character was not deleted — it looks like a typo you made.
+       *
+       * That is ProseMirror's default and it is the right default for an
+       * editor where Enter splits the paragraph. Here Enter makes a line, so
+       * the paragraph gap someone is deleting was *two* presses of Enter, and
+       * taking it away in one press has to leave the line break behind. Press
+       * Backspace again and that break goes too, which is where the old
+       * behaviour ends up — a press later, and on purpose.
+       */
+      Backspace: () =>
+        this.editor.commands.command(({ state, tr, dispatch }) =>
+          joinAcross(state, tr, Boolean(dispatch), "backward"),
+        ),
+
+      /** Delete, from the end of the line above. The same edit, aimed forward. */
+      Delete: () =>
+        this.editor.commands.command(({ state, tr, dispatch }) =>
+          joinAcross(state, tr, Boolean(dispatch), "forward"),
+        ),
     };
   },
 });
+
+/**
+ * Merges two adjacent paragraphs into one, with a line break between them.
+ *
+ * Declines — leaving ProseMirror's own handling in place — for anything that
+ * is not two plain, non-empty, top-level paragraphs with the caret exactly on
+ * the boundary between them. Deleting an empty paragraph should still delete
+ * it rather than turn it into a break, and a list item, a quote or a table
+ * cell has its own idea of what joining means.
+ */
+function joinAcross(
+  state: EditorState,
+  tr: Transaction,
+  apply: boolean,
+  direction: "backward" | "forward",
+): boolean {
+  const { selection, schema } = state;
+  if (!selection.empty) return false;
+
+  const $caret = selection.$from;
+  // Top level only, and only between two paragraphs.
+  if ($caret.depth !== 1 || $caret.parent.type.name !== "paragraph") return false;
+
+  const atStart = $caret.parentOffset === 0;
+  const atEnd = $caret.parentOffset === $caret.parent.content.size;
+  if (direction === "backward" ? !atStart : !atEnd) return false;
+
+  const index = $caret.index(0);
+  const doc = $caret.node(0);
+  const otherIndex = direction === "backward" ? index - 1 : index + 1;
+  if (otherIndex < 0 || otherIndex >= doc.childCount) return false;
+
+  const other = doc.child(otherIndex);
+  if (other.type.name !== "paragraph") return false;
+
+  // An empty paragraph on either side is a blank line somebody is removing,
+  // not two lines they are joining.
+  if (other.content.size === 0 || $caret.parent.content.size === 0) return false;
+
+  const hardBreak = schema.nodes.hardBreak;
+  if (!hardBreak) return false;
+
+  // The boundary between the two blocks: the closing token of the first sits
+  // immediately before it, the opening token of the second immediately after.
+  const boundary = direction === "backward" ? $caret.before() : $caret.after();
+
+  if (apply) {
+    // Into the end of the first paragraph, then close the gap. Inserting
+    // before joining keeps the break on the line it belongs to and moves the
+    // boundary along by exactly the one node inserted.
+    tr.insert(boundary - 1, hardBreak.create());
+    tr.join(boundary + 1);
+    // Just after the break, which is where the caret was in relation to the
+    // text either side of it before the join.
+    tr.setSelection(TextSelection.create(tr.doc, boundary));
+    tr.scrollIntoView();
+  }
+
+  return true;
+}

--- a/packages/editor/src/extensions/LeaveInlineMark.ts
+++ b/packages/editor/src/extensions/LeaveInlineMark.ts
@@ -1,0 +1,72 @@
+import { Extension } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
+
+/**
+ * Getting out of inline code, or out of a link, without leaving the line.
+ *
+ * Marks that reach the end of the text carry on: type after a code span and
+ * the new words are code too, type after a link and they are part of the link.
+ * Tiptap has an answer — `exitable` marks step out when you press → at the end
+ * of a *node* — but a node here is a paragraph, and Enter in this editor makes
+ * a line rather than a paragraph. So the escape only worked on the last line
+ * of a paragraph, and everywhere else the only way out of a code span was to
+ * start a new line and come back, or to select the following words and untick
+ * the button. People wrote the rest of the sentence in monospace instead.
+ *
+ * This is the same gesture, extended to where the writing actually happens:
+ * pressing → at the end of a code span or a link — end of the line, end of the
+ * paragraph, or with the rest of the line already written — drops the mark and
+ * puts the caret outside it. At the very end of a line it leaves a space
+ * behind, because a caret with nothing after it needs somewhere to sit that is
+ * visibly *not* in the code; mid-line it simply steps over the boundary, which
+ * is what → has always done there.
+ *
+ * Escape does the same thing without moving the caret at all, for anyone who
+ * would rather not have the space.
+ */
+
+/** The marks that trap the caret. Bold and the rest have an obvious toggle. */
+const TRAPPING = ["code", "link"] as const;
+
+export const LeaveInlineMark = Extension.create({
+  name: "leaveInlineMark",
+
+  addKeyboardShortcuts() {
+    return {
+      ArrowRight: () => leave(this.editor, true),
+      Escape: () => leave(this.editor, false),
+    };
+  },
+});
+
+function leave(editor: Editor, spacer: boolean): boolean {
+  const { state } = editor;
+  const { selection, storedMarks } = state;
+  if (!selection.empty) return false;
+
+  const $caret = selection.$from;
+  const here = storedMarks ?? $caret.marks();
+  const trapping = here.filter((mark) =>
+    TRAPPING.includes(mark.type.name as (typeof TRAPPING)[number]),
+  );
+  if (trapping.length === 0) return false;
+
+  // Only at the end of the run: anywhere else, → moves through the text and
+  // the mark ends on its own.
+  const after = $caret.nodeAfter;
+  const stillInside = after?.isText && trapping.every((mark) => mark.isInSet(after.marks));
+  if (stillInside) return false;
+
+  const tr = state.tr;
+  for (const mark of trapping) tr.removeStoredMark(mark);
+
+  // Nothing after the caret but the end of the line, so there is nowhere
+  // unmarked to stand. A space is somewhere.
+  if (spacer && (!after || after.type.name === "hardBreak")) {
+    tr.insertText(" ", $caret.pos);
+    for (const mark of trapping) tr.removeStoredMark(mark);
+  }
+
+  editor.view.dispatch(tr);
+  return true;
+}

--- a/packages/editor/src/extensions/RoomToWrite.ts
+++ b/packages/editor/src/extensions/RoomToWrite.ts
@@ -1,0 +1,113 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
+import { GapCursor } from "@tiptap/pm/gapcursor";
+
+/**
+ * Somewhere to write next to a block that is not text.
+ *
+ * A code block, a diagram, an image or a rule that ends the note ends the
+ * note: there is no paragraph after it to put a caret in, clicking the empty
+ * space underneath drops the caret *into* the block — so the next sentence is
+ * typed inside the code — and there is no key that makes a new line below it.
+ * The same thing happens between two such blocks, which is how a code block
+ * followed by a horizontal rule became a place nobody could write.
+ *
+ * ProseMirror already has a gap cursor for the between case, and it is now
+ * drawn (see `.ProseMirror-gapcursor` in the stylesheet) rather than being an
+ * invisible thing you have to know exists. This adds the two ways people
+ * actually reach for:
+ *
+ * - clicking the empty space below the last block puts a paragraph there;
+ * - ↓ from the last block does the same, for anyone not using a mouse.
+ *
+ * Deliberately on demand. The obvious alternative — always keeping a trailing
+ * paragraph in the document — rewrites every note that ends in a code block
+ * the moment it is opened, which on a connected repository is a commit nobody
+ * asked for.
+ */
+export const RoomToWrite = Extension.create({
+  name: "roomToWrite",
+
+  addKeyboardShortcuts() {
+    return {
+      /** Down from the last block, when there is nothing below it to reach. */
+      ArrowDown: () => {
+        const { state, view } = this.editor;
+        const { selection } = state;
+        const last = state.doc.lastChild;
+        if (!last || isWritable(last.type.name)) return false;
+
+        // Only when the selection is actually in that last block.
+        const lastStart = state.doc.content.size - last.nodeSize;
+        if (selection.from < lastStart) return false;
+
+        return appendParagraph(state, view);
+      },
+
+      /** Enter at a gap cursor, which otherwise waits for a character. */
+      Enter: () => {
+        const { state, view } = this.editor;
+        if (!(state.selection instanceof GapCursor)) return false;
+
+        const paragraph = state.schema.nodes.paragraph;
+        if (!paragraph) return false;
+
+        const tr = state.tr.insert(state.selection.from, paragraph.create());
+        tr.setSelection(TextSelection.create(tr.doc, state.selection.from + 1));
+        view.dispatch(tr.scrollIntoView());
+        return true;
+      },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("roomToWrite"),
+        props: {
+          handleDOMEvents: {
+            mousedown: (view, event) => {
+              if ((event as MouseEvent).button !== 0) return false;
+
+              const last = view.state.doc.lastChild;
+              if (!last || isWritable(last.type.name)) return false;
+
+              // Below everything in the document, rather than on it. The
+              // editor's own padding is the target: a click on the block
+              // itself must still go where it was aimed.
+              const dom = view.dom as HTMLElement;
+              const bottom = dom.lastElementChild?.getBoundingClientRect().bottom;
+              if (bottom === undefined || (event as MouseEvent).clientY <= bottom) return false;
+              if (!dom.getBoundingClientRect().width) return false;
+
+              event.preventDefault();
+              return appendParagraph(view.state, view);
+            },
+          },
+        },
+      }),
+    ];
+  },
+});
+
+/** Blocks you can already type in, which need no help from any of this. */
+function isWritable(name: string): boolean {
+  return name === "paragraph" || name === "heading" || name === "blockquote" || name === "listItem";
+}
+
+/** A new paragraph at the end of the document, with the caret in it. */
+function appendParagraph(
+  state: EditorState,
+  view: { dispatch: (tr: Transaction) => void } | EditorView,
+): boolean {
+  const paragraph = state.schema.nodes.paragraph;
+  if (!paragraph) return false;
+
+  const end = state.doc.content.size;
+  const tr = state.tr.insert(end, paragraph.create());
+  tr.setSelection(TextSelection.create(tr.doc, end + 1));
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}

--- a/packages/editor/src/extensions/SmartPaste.ts
+++ b/packages/editor/src/extensions/SmartPaste.ts
@@ -1,0 +1,122 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
+import { detectLanguage, evenSpacing, isLinesOfText, looksLikeCode } from "../paste";
+
+/**
+ * Pasting things that are not prose.
+ *
+ * The clipboard is the only content this editor does not shape itself, and
+ * what arrives on it is routinely the wrong shape for a note. Two cases came
+ * up over and over:
+ *
+ * A script, or a run of shell commands, pasted as writing — every line its own
+ * paragraph, a paragraph's margin between each, no monospace and no
+ * highlighting. Selecting the lot afterwards and pressing the code button made
+ * it worse: twenty paragraphs became twenty separate code blocks, each one
+ * line long.
+ *
+ * And notes apps, chat clients and code panes that write one `<p>` per *line*.
+ * ProseMirror believes the HTML it is given, which is right in general and
+ * wrong here: the note ends up as a column of one-line paragraphs, spaced as
+ * if every line were a new thought, and closing the gaps by hand runs a second
+ * line into the end of the one above it.
+ *
+ * So: a paste that looks like code becomes one code block, tagged with the
+ * language it appears to be in. A paste whose HTML says nothing the plain text
+ * does not goes through the markdown parser instead, where a newline is a line
+ * break and a bare address becomes a link. Everything else — real headings,
+ * lists, tables, images, prose — is left to ProseMirror, which handles it
+ * well.
+ *
+ * The decisions live in `../paste`; this is only the wiring.
+ */
+export const SmartPaste = Extension.create({
+  name: "smartPaste",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("smartPaste"),
+        props: {
+          handlePaste: (view, event) => {
+            const clipboard = (event as ClipboardEvent).clipboardData;
+            if (!clipboard) return false;
+
+            // A screenshot is somebody else's job, and it is already done by
+            // the time this runs.
+            if (clipboard.files?.length) return false;
+
+            // Inside a code block or a diagram, a paste is text and only text.
+            // Reshaping it there would be actively destructive.
+            if (view.state.selection.$from.parent.type.spec.code) return false;
+
+            const text = evenSpacing(clipboard.getData("text/plain") ?? "");
+            if (text === "") return false;
+
+            if (looksLikeCode(text)) {
+              event.preventDefault();
+              return insertCodeBlock(view, text, detectLanguage(text));
+            }
+
+            const html = clipboard.getData("text/html") ?? "";
+            if (html !== "" && isLinesOfText(html, parseHtml)) {
+              event.preventDefault();
+              return insertAsMarkdown(view, text);
+            }
+
+            return false;
+          },
+        },
+      }),
+    ];
+  },
+});
+
+/** The clipboard's HTML, read as a document rather than as a string. */
+function parseHtml(html: string): Document {
+  return new DOMParser().parseFromString(html, "text/html");
+}
+
+/** One code block holding the whole paste, however many lines it runs to. */
+function insertCodeBlock(view: EditorView, text: string, language: string): boolean {
+  const type = view.state.schema.nodes.codeBlock;
+  if (!type) return false;
+
+  const node = type.create(language ? { language } : null, view.state.schema.text(text));
+  const tr = view.state.tr.replaceSelectionWith(node);
+
+  /**
+   * Somewhere to carry on writing.
+   *
+   * A code block that ends the document is a wall: there is no block after it
+   * to put the caret in, so the note is finished whether or not its author
+   * was. A paste should never be able to do that.
+   */
+  const end = tr.selection.$to;
+  if (end.pos >= tr.doc.content.size - 1) {
+    const paragraph = view.state.schema.nodes.paragraph?.create();
+    if (paragraph) tr.insert(tr.doc.content.size, paragraph);
+  }
+
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}
+
+/**
+ * The plain text, read as markdown.
+ *
+ * Exactly the path a text-only paste already takes — `clipboardTextParser` is
+ * the markdown extension's own hook — so a paste that carries useless HTML
+ * lands identically to the same paste without it, rather than in some third
+ * shape invented here.
+ */
+function insertAsMarkdown(view: EditorView, text: string): boolean {
+  const slice = view.someProp("clipboardTextParser", (parser) =>
+    parser(text, view.state.selection.$from, false, view),
+  );
+  if (!slice) return false;
+
+  view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
+  return true;
+}

--- a/packages/editor/src/extensions/YoutubeEmbed.tsx
+++ b/packages/editor/src/extensions/YoutubeEmbed.tsx
@@ -2,6 +2,7 @@
 
 import { Node, mergeAttributes } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { caretBelow } from "../caret";
 import { ReactNodeViewRenderer, NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import { youtubeEmbedUrl, youtubeVideoFrom, youtubeWatchUrl } from "@forkleaf/markdown-engine";
 
@@ -156,6 +157,10 @@ export const YoutubeEmbed = Node.create({
             const node = type.create({ src: youtubeWatchUrl(video) });
             const tr = view.state.tr.replaceSelectionWith(node);
             view.dispatch(tr);
+            // On a line below the player, like a pasted image: a video is a
+            // block, and the selection would otherwise sit on the node itself
+            // with the next keystroke replacing it.
+            caretBelow(view, view.state.selection.to);
             return true;
           },
         },

--- a/packages/editor/src/insert-actions.tsx
+++ b/packages/editor/src/insert-actions.tsx
@@ -5,6 +5,8 @@ import type { Editor } from "@tiptap/core";
 import type { InsertAction } from "./EditorToolbar";
 import type { SourceEditorHandle } from "./SourceEditor";
 import { isYoutubeUrl } from "@forkleaf/markdown-engine";
+import { detectLanguage } from "./paste";
+import { isolateCurrentLine } from "./isolate-line";
 
 /** Matches any ATX heading marker, so switching levels replaces rather than stacks. */
 const HEADING_PATTERN = /^#{1,6} /;
@@ -52,6 +54,53 @@ export interface InsertDefinition extends InsertAction {
    * menus filter by view instead of showing an item that half-works.
    */
   availableIn?: "both" | "rich" | "source";
+}
+
+/**
+ * Turns the selection into code — all of it, as one block.
+ *
+ * Tiptap's `toggleCodeBlock` works a block at a time, so a script pasted as
+ * twenty one-line paragraphs and then selected in full became twenty code
+ * blocks, each with its own header, its own language picker and one line of
+ * code in it. That is the opposite of what "make this code" means, and
+ * unpicking it by hand is worse than having pasted the thing again.
+ *
+ * So a selection that spans more than one block is collapsed into a single
+ * block whose text is those blocks joined by newlines — which is what they
+ * looked like on the clipboard before the editor got hold of them. A selection
+ * inside one block is left to Tiptap, which already does the right thing, and
+ * so is a code block being turned back into prose.
+ */
+function makeCodeBlock(editor: Editor): void {
+  const { state } = editor;
+  const { from, to, empty } = state.selection;
+
+  if (empty || editor.isActive("codeBlock")) {
+    editor.chain().focus().toggleCodeBlock().run();
+    return;
+  }
+
+  // The text of every block the selection touches, one per line. `blockSeparator`
+  // is what keeps the lines apart; without it ProseMirror runs them together
+  // exactly as the multi-block paste did.
+  const text = state.doc.textBetween(from, to, "\n", "\n");
+  if (!text.includes("\n")) {
+    editor.chain().focus().toggleCodeBlock().run();
+    return;
+  }
+
+  editor
+    .chain()
+    .focus()
+    .insertContentAt(
+      { from, to },
+      {
+        type: "codeBlock",
+        ...(detectLanguage(text) ? { attrs: { language: detectLanguage(text) } } : {}),
+        content: [{ type: "text", text }],
+      },
+    )
+    .run();
 }
 
 /**
@@ -194,7 +243,7 @@ export const INSERT_DEFINITIONS: InsertDefinition[] = [
     label: "Code block",
     hint: "Syntax-highlighted code",
     icon: <TextGlyph>{"</>"}</TextGlyph>,
-    rich: (editor) => editor.chain().focus().toggleCodeBlock().run(),
+    rich: (editor) => makeCodeBlock(editor),
     markdown: { text: "```\n\n```\n", cursor: 4 },
   },
   {
@@ -415,7 +464,17 @@ export function runRichAction(editor: Editor, id: string, context: ActionContext
   if (id === "image" && context.requestImage) return context.requestImage();
   if (id === "link" && context.requestLink) return context.requestLink();
 
-  INSERT_DEFINITIONS.find((definition) => definition.id === id)?.rich(editor);
+  const definition = INSERT_DEFINITIONS.find((candidate) => candidate.id === id);
+  if (!definition) return;
+
+  // Enter makes a line rather than a paragraph here, so one paragraph is
+  // usually several visible lines and a block command handed the paragraph
+  // takes every one of them. The slash menu has always done this; the toolbar
+  // did not, so pressing a list button on the third line of a paragraph turned
+  // the two above it into list items as well.
+  if (!definition.inline) isolateCurrentLine(editor);
+
+  definition.rich(editor);
 }
 
 /** Applies an action to a CodeMirror source editor, at the caret. */

--- a/packages/editor/src/isolate-line.test.tsx
+++ b/packages/editor/src/isolate-line.test.tsx
@@ -45,6 +45,17 @@ function caretAtEndOf(editor: Editor, text: string) {
   editor.commands.setTextSelection(found);
 }
 
+/** Selects exactly `text`, the way dragging across it with the mouse would. */
+function selectText(editor: Editor, text: string) {
+  let found = -1;
+  editor.state.doc.descendants((node, pos) => {
+    const index = node.isText ? (node.text ?? "").indexOf(text) : -1;
+    if (index !== -1 && found === -1) found = pos + index;
+  });
+  expect(found).toBeGreaterThan(-1);
+  editor.commands.setTextSelection({ from: found, to: found + text.length });
+}
+
 describe("isolateCurrentLine", () => {
   it("splits the last line of a multi-line paragraph out on its own", async () => {
     const editor = await mount("alpha\nbravo\ncharlie");
@@ -87,6 +98,40 @@ describe("isolateCurrentLine", () => {
     isolateCurrentLine(editor);
 
     expect(markdownOf(editor)).toBe("alpha\n\nbravo\n\ncharlie");
+  });
+
+  /**
+   * The same bug, reached through the toolbar rather than the slash menu: a
+   * line highlighted with the mouse and then given a heading took the line
+   * above it — a link, in the report where this was found — along with it.
+   */
+  it("isolates the lines a selection covers, not just the caret's line", async () => {
+    const editor = await mount("OneNote: https://onenote.example\nFor screen shots\nGreenShot");
+    selectText(editor, "For screen shots");
+
+    expect(isolateCurrentLine(editor)).toBe(true);
+    expect(editor.state.selection.$from.parent.textContent).toBe("For screen shots");
+    // And the selection still covers exactly the words that were highlighted.
+    const { from, to } = editor.state.selection;
+    expect(editor.state.doc.textBetween(from, to)).toBe("For screen shots");
+  });
+
+  it("makes a heading of the selected line alone", async () => {
+    const editor = await mount("OneNote: link\nFor screen shots\nGreenShot");
+    selectText(editor, "For screen shots");
+
+    isolateCurrentLine(editor);
+    editor.chain().focus().toggleHeading({ level: 3 }).run();
+
+    expect(markdownOf(editor)).toBe("OneNote: link\n\n### For screen shots\n\nGreenShot");
+  });
+
+  it("keeps a selection that already spans whole blocks working", async () => {
+    const editor = await mount("alpha\n\nbravo");
+    editor.commands.selectAll();
+
+    // Nothing to isolate: both blocks are already one line each.
+    expect(isolateCurrentLine(editor)).toBe(false);
   });
 
   it("leaves only the isolated line as a heading, not the lines above it", async () => {

--- a/packages/editor/src/isolate-line.ts
+++ b/packages/editor/src/isolate-line.ts
@@ -1,5 +1,6 @@
 import type { Editor } from "@tiptap/core";
 import { TextSelection } from "@tiptap/pm/state";
+import type { ResolvedPos } from "@tiptap/pm/model";
 
 /**
  * Make the line the cursor is on into a block of its own.
@@ -17,6 +18,12 @@ import { TextSelection } from "@tiptap/pm/state";
  * it become real block boundaries, and the command then has exactly the line
  * the writer was looking at to work on.
  *
+ * The same is true of a selection: highlighting one line of a paragraph and
+ * pressing Heading 3 made a heading of every line in that paragraph, including
+ * the link above it that nobody had selected. So the lines the selection
+ * covers are separated out too, and the selection is carried across the splits
+ * so the command lands on exactly what was highlighted.
+ *
  * Inline commands — bold, a link, an image — must not do this, or asking for
  * bold would silently break a paragraph in three.
  *
@@ -24,38 +31,27 @@ import { TextSelection } from "@tiptap/pm/state";
  */
 export function isolateCurrentLine(editor: Editor): boolean {
   const { state } = editor;
-  const { $from, empty } = state.selection;
+  const { $from, $to, empty } = state.selection;
 
-  if (!empty) return false;
+  if (!$from.parent.isTextblock || !$to.parent.isTextblock) return false;
 
-  const parent = $from.parent;
-  if (!parent.isTextblock) return false;
-
-  const blockStart = $from.start();
-  const cursor = $from.pos;
-
-  // Absolute positions of the hard breaks inside this block.
-  const breaks: number[] = [];
-  parent.forEach((child, offset) => {
-    if (child.type.name === "hardBreak") breaks.push(blockStart + offset);
-  });
-
-  if (breaks.length === 0) return false;
-
-  // The breaks that bound the line the cursor sits on. Either may be absent:
-  // the cursor can be on the first or the last line of the block.
-  const before = breaks.filter((position) => position < cursor).pop();
-  const after = breaks.find((position) => position >= cursor);
+  // The breaks bounding the lines the selection touches. Either may be absent:
+  // it can start on the first line of its block and end on the last of its own.
+  const before = breaksIn($from)
+    .filter((position) => position < $from.pos)
+    .pop();
+  const after = breaksIn($to).find((position) => position >= $to.pos);
 
   if (before === undefined && after === undefined) return false;
 
-  // Where the line begins and ends, and how far into it the caret sits. The
+  // Where the first line begins, and how far into it the caret sits. The
   // caret's own position is no use for restoring it: an empty line puts it
   // exactly on a split boundary, and a boundary belongs to both blocks — map it
   // forward and `/h1` styles the line below, map it back and it styles the line
   // above. Both of those were observed. The line's *start* is unambiguous.
-  const lineStart = before === undefined ? blockStart : before + 1;
-  const offsetInLine = cursor - lineStart;
+  const lineStart = before === undefined ? $from.start() : before + 1;
+  const offsetInLine = $from.pos - lineStart;
+  const { from, to } = state.selection;
 
   const tr = state.tr;
 
@@ -72,11 +68,32 @@ export function isolateCurrentLine(editor: Editor): boolean {
     tr.split(before);
   }
 
-  // Put the caret back where it was, measured from the start of the line it was
-  // on — which is now the start of a block of its own.
-  const restored = tr.mapping.map(lineStart, 1) + offsetInLine;
-  tr.setSelection(TextSelection.near(tr.doc.resolve(Math.min(restored, tr.doc.content.size))));
+  if (empty) {
+    // Put the caret back where it was, measured from the start of the line it
+    // was on — which is now the start of a block of its own.
+    const restored = tr.mapping.map(lineStart, 1) + offsetInLine;
+    tr.setSelection(TextSelection.near(tr.doc.resolve(Math.min(restored, tr.doc.content.size))));
+  } else {
+    // A range has two unambiguous ends, so they can simply be carried through
+    // the splits: forward at the start, backward at the end, so neither end
+    // slides onto a boundary that now belongs to the block next door.
+    const start = tr.mapping.map(from, 1);
+    const end = tr.mapping.map(to, -1);
+    tr.setSelection(TextSelection.create(tr.doc, start, Math.max(start, end)));
+  }
 
   editor.view.dispatch(tr);
   return true;
+}
+
+/** Absolute positions of the hard breaks in the block a position sits in. */
+function breaksIn($position: ResolvedPos): number[] {
+  const start = $position.start();
+  const breaks: number[] = [];
+
+  $position.parent.forEach((child, offset) => {
+    if (child.type.name === "hardBreak") breaks.push(start + offset);
+  });
+
+  return breaks;
 }

--- a/packages/editor/src/leave-inline-mark.test.tsx
+++ b/packages/editor/src/leave-inline-mark.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { WysiwygEditor, markdownOf } from "./WysiwygEditor";
+
+afterEach(cleanup);
+
+/**
+ * Getting back out of a code span or a link.
+ *
+ * Both marks carry on into whatever you type next, and the escape Tiptap ships
+ * only fires at the end of a paragraph — which, in an editor where Enter makes
+ * a line, is almost never where the caret is. So a three-letter code span at
+ * the end of a line meant the rest of the sentence was in monospace too.
+ */
+
+async function mount(markdown: string): Promise<Editor> {
+  let editor: Editor | null = null;
+  render(
+    <WysiwygEditor
+      value={markdown}
+      onChange={vi.fn()}
+      onReady={(instance) => {
+        editor = instance;
+      }}
+    />,
+  );
+  await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+  return editor!;
+}
+
+function press(editor: Editor, key: string): boolean {
+  const { view } = editor;
+  return Boolean(
+    view.someProp("handleKeyDown", (handler) =>
+      handler(view, new KeyboardEvent("keydown", { key, bubbles: true })),
+    ),
+  );
+}
+
+/** The caret at the end of the code span, which is where people get stuck. */
+function caretAfterCode(editor: Editor): void {
+  let end = -1;
+  editor.state.doc.descendants((node, pos) => {
+    if (node.isText && node.marks.some((mark) => mark.type.name === "code")) {
+      end = pos + node.nodeSize;
+    }
+  });
+  expect(end).toBeGreaterThan(-1);
+  editor.commands.setTextSelection(end);
+}
+
+describe("leaving a code span at the end of a line", () => {
+  it("lets the next words be ordinary text", async () => {
+    // A code span at the end of a line, with another line under it — so this
+    // is not the end of the paragraph and Tiptap's own escape does nothing.
+    const editor = await mount("use the `MHA` \nnext line");
+    caretAfterCode(editor);
+
+    expect(press(editor, "ArrowRight")).toBe(true);
+    editor.commands.insertContent("tool");
+
+    expect(markdownOf(editor)).toContain("`MHA`");
+    expect(markdownOf(editor)).not.toContain("`MHAtool`");
+    expect(markdownOf(editor)).not.toContain("`MHA tool`");
+  });
+
+  it("puts a space in, so there is somewhere outside the span to stand", async () => {
+    const editor = await mount("use the `MHA`\nnext line");
+    caretAfterCode(editor);
+
+    press(editor, "ArrowRight");
+
+    expect(editor.state.doc.textBetween(0, editor.state.doc.content.size, "\n", "\n")).toContain(
+      "MHA ",
+    );
+  });
+
+  it("leaves the caret unmarked, whatever is typed next", async () => {
+    const editor = await mount("use the `MHA`\nnext line");
+    caretAfterCode(editor);
+    press(editor, "ArrowRight");
+
+    const marks = editor.state.storedMarks ?? editor.state.selection.$from.marks();
+    expect(marks.some((mark) => mark.type.name === "code")).toBe(false);
+  });
+
+  it("gets out on Escape too, without adding anything", async () => {
+    const editor = await mount("use the `MHA`\nnext line");
+    caretAfterCode(editor);
+
+    expect(press(editor, "Escape")).toBe(true);
+    expect(editor.state.doc.textContent).toContain("MHA");
+    expect(editor.state.doc.textContent).not.toContain("MHA ");
+  });
+
+  it("does nothing in the middle of a span, where the arrow key already works", async () => {
+    const editor = await mount("use the `MHA` tool");
+    let start = -1;
+    editor.state.doc.descendants((node, pos) => {
+      if (node.isText && node.marks.some((mark) => mark.type.name === "code")) start = pos;
+    });
+    editor.commands.setTextSelection(start + 1);
+
+    expect(press(editor, "ArrowRight")).toBe(false);
+  });
+
+  it("does nothing in ordinary text", async () => {
+    const editor = await mount("just writing");
+    editor.commands.setTextSelection(5);
+
+    expect(press(editor, "ArrowRight")).toBe(false);
+  });
+});
+
+describe("leaving a link at the end of a line", () => {
+  it("stops the next words being swallowed by the address", async () => {
+    const editor = await mount("GreenShot: https://getgreenshot.org/downloads/\nFlameShot");
+    let end = -1;
+    editor.state.doc.descendants((node, pos) => {
+      if (node.isText && node.marks.some((mark) => mark.type.name === "link")) {
+        end = pos + node.nodeSize;
+      }
+    });
+    editor.commands.setTextSelection(end);
+
+    expect(press(editor, "ArrowRight")).toBe(true);
+    editor.commands.insertContent("(prefer)");
+
+    const links: string[] = [];
+    editor.state.doc.descendants((node) => {
+      if (node.marks.some((mark) => mark.type.name === "link")) links.push(node.textContent);
+    });
+    expect(links.join("")).not.toContain("prefer");
+  });
+});

--- a/packages/editor/src/paste.test.ts
+++ b/packages/editor/src/paste.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { detectLanguage, evenSpacing, isLinesOfText, looksLikeCode } from "./paste";
+
+const parse = (html: string) => new DOMParser().parseFromString(html, "text/html");
+
+/**
+ * The paste that started this: a bash script and the list of commands above
+ * it, copied out of a notes app.
+ */
+const SCRIPT = `#!/bin/bash
+# Use the first argument as the domain name
+
+domain=$1
+
+# Define directories
+base_dir="$domain"
+info_path="$base_dir/info"
+
+for path in "$info_path" "$subdomain_path"; do
+        if [ ! -d "$path" ]; then
+                mkdir -p "$path"
+        fi
+done
+
+echo -e "\${RED} [+] Launching subfinder ... \${RESET}"
+subfinder -d "$domain" > "$subdomain_path/found.txt"`;
+
+const COMMANDS = `whois tcm-sec.com
+subfinder -d tcm-sec.com
+assetfinder tcm-sec.com
+amass enum -d tcm-sec.com
+cat tesla.txt | sort -u | httprobe -s -p https:443
+gowitness file -f ./alive.txt -P ./pics --no-http`;
+
+describe("telling code from writing", () => {
+  it("knows a script", () => {
+    expect(looksLikeCode(SCRIPT)).toBe(true);
+  });
+
+  it("knows a list of shell commands, which is the most common paste of all", () => {
+    expect(looksLikeCode(COMMANDS)).toBe(true);
+  });
+
+  it("knows a short list of commands, where half the lines are bare words", () => {
+    const short = [
+      "whois tcm-sec.com",
+      "subfinder -d tcm-sec.com",
+      "assetfinder tcm-sec.com",
+      "cat tesla.txt | sort -u",
+    ].join("\n");
+
+    expect(looksLikeCode(short)).toBe(true);
+  });
+
+  it("knows JavaScript", () => {
+    expect(looksLikeCode("const total = items.length;\nconsole.log(total);")).toBe(true);
+  });
+
+  it("knows Python", () => {
+    expect(looksLikeCode("import os\n\ndef main():\n    print(os.getcwd())")).toBe(true);
+  });
+
+  it("does not take short lowercase notes for commands without shell punctuation", () => {
+    const notes = ["ring the bank", "book the flights", "email priya"].join("\n");
+    expect(looksLikeCode(notes)).toBe(false);
+  });
+
+  it("leaves ordinary writing alone", () => {
+    const prose = [
+      "Met the team about the migration today.",
+      "We agreed to ship the importer first and leave search until March.",
+      "Priya is writing up the API contract.",
+    ].join("\n");
+
+    expect(looksLikeCode(prose)).toBe(false);
+  });
+
+  it("leaves a list of links alone", () => {
+    const links = [
+      "Subfinder - https://github.com/projectdiscovery/subfinder",
+      "Assetfinder - https://github.com/tomnomnom/assetfinder",
+      "Amass - https://github.com/OWASP/Amass",
+    ].join("\n");
+
+    expect(looksLikeCode(links)).toBe(false);
+  });
+
+  it("leaves a markdown document alone, fences and all", () => {
+    const document = ["# Setup", "", "- install the tools", "- run the script", ""].join("\n");
+
+    expect(looksLikeCode(document)).toBe(false);
+    expect(looksLikeCode("Here is the fix:\n\n```js\nconst a = 1;\n```")).toBe(false);
+  });
+
+  it("never turns a single line into a code block", () => {
+    // Sentences have brackets in them, and one line is not a program.
+    expect(looksLikeCode("Call Priya (she has the keys) before Friday.")).toBe(false);
+    expect(looksLikeCode("npm install")).toBe(false);
+  });
+});
+
+describe("which language it is", () => {
+  it("reads the shebang", () => {
+    expect(detectLanguage(SCRIPT)).toBe("bash");
+    expect(detectLanguage("#!/usr/bin/env python3\nprint(1)")).toBe("python");
+    expect(detectLanguage("#!/usr/bin/env node\nconsole.log(1)")).toBe("javascript");
+  });
+
+  it("recognises a run of shell commands with no shebang at all", () => {
+    expect(detectLanguage(COMMANDS)).toBe("bash");
+  });
+
+  it("recognises the languages people paste", () => {
+    expect(detectLanguage("const a = 1;\nfunction go() {\n  return a;\n}")).toBe("javascript");
+    expect(detectLanguage("interface Note {\n  title: string;\n}")).toBe("typescript");
+    expect(detectLanguage("def main():\n    return 1")).toBe("python");
+    expect(detectLanguage("package main\n\nfunc main() {\n}")).toBe("go");
+    expect(detectLanguage("fn main() {\n    let mut x = 1;\n}")).toBe("rust");
+    expect(detectLanguage("SELECT id FROM notes WHERE id = 3;")).toBe("sql");
+    expect(detectLanguage("FROM node:20\nRUN npm ci")).toBe("dockerfile");
+    expect(detectLanguage('{"a": [1, 2], "b": null}')).toBe("json");
+    expect(detectLanguage("name: build\non: push\njobs: {}")).toBe("yaml");
+  });
+
+  it("says nothing rather than guessing", () => {
+    expect(detectLanguage("one two three\nfour five six")).toBe("");
+  });
+});
+
+describe("evening out the spacing", () => {
+  it("collapses a run of blank lines to a single paragraph break", () => {
+    expect(evenSpacing("one\n\n\n\ntwo")).toBe("one\n\ntwo");
+  });
+
+  it("drops trailing spaces and the blank lines around the whole paste", () => {
+    expect(evenSpacing("\n\none   \ntwo\n\n\n")).toBe("one\ntwo");
+  });
+
+  it("normalises Windows line endings", () => {
+    expect(evenSpacing("one\r\ntwo")).toBe("one\ntwo");
+  });
+});
+
+describe("HTML that is only lines of text", () => {
+  it("recognises one paragraph per line, which is what notes apps write", () => {
+    const html = "<p>whois tcm-sec.com</p><p>subfinder -d tcm-sec.com</p><p>amass enum</p>";
+    expect(isLinesOfText(html, parse)).toBe(true);
+  });
+
+  it("keeps out of the way of real structure", () => {
+    expect(isLinesOfText("<h1>Title</h1><p>one</p><p>two</p>", parse)).toBe(false);
+    expect(isLinesOfText("<ul><li>one</li><li>two</li></ul>", parse)).toBe(false);
+    expect(isLinesOfText("<p>one</p><table><tr><td>x</td></tr></table>", parse)).toBe(false);
+    expect(isLinesOfText("<pre><code>const a = 1;</code></pre>", parse)).toBe(false);
+  });
+
+  it("keeps out of the way of prose, which is paragraphs and means to be", () => {
+    const paragraph = `<p>${"word ".repeat(40)}</p><p>${"word ".repeat(40)}</p>`;
+    expect(isLinesOfText(paragraph, parse)).toBe(false);
+  });
+
+  it("refuses when a link would lose its label", () => {
+    const labelled = '<p>see <a href="https://example.com/docs">the docs</a></p><p>then run it</p>';
+    expect(isLinesOfText(labelled, parse)).toBe(false);
+  });
+
+  it("allows a bare address, which the plain text carries just as well", () => {
+    const bare = '<p><a href="https://example.com">https://example.com</a></p><p>next line</p>';
+    expect(isLinesOfText(bare, parse)).toBe(true);
+  });
+});

--- a/packages/editor/src/paste.ts
+++ b/packages/editor/src/paste.ts
@@ -1,0 +1,293 @@
+/**
+ * What a paste actually is.
+ *
+ * Text arriving from the clipboard is the one place this editor gets content
+ * it did not shape itself, and the shape it arrives in is usually wrong for a
+ * notebook. Two failures happened constantly:
+ *
+ * A script or a list of shell commands pasted as prose — one paragraph per
+ * line, a blank line of margin between every one of them, no monospace and no
+ * highlighting. Turning that into code afterwards was worse, because a
+ * selection of twenty paragraphs became twenty code blocks.
+ *
+ * And notes apps that write one `<p>` per *line* rather than per paragraph.
+ * ProseMirror is right to trust the HTML it is handed, and the result is a
+ * page of single lines each sitting in its own paragraph, spaced as if every
+ * line were a new thought.
+ *
+ * These are the decisions behind fixing both, kept away from the editor so
+ * they can be tested as what they are: guesses about text.
+ */
+
+/** What a shebang line says to run, and the fence label that matches it. */
+const INTERPRETERS: Record<string, string> = {
+  bash: "bash",
+  sh: "bash",
+  zsh: "bash",
+  dash: "bash",
+  ksh: "bash",
+  python: "python",
+  python2: "python",
+  python3: "python",
+  node: "javascript",
+  deno: "typescript",
+  ruby: "ruby",
+  perl: "perl",
+  php: "php",
+  pwsh: "powershell",
+  lua: "lua",
+  rscript: "r",
+};
+
+/**
+ * The shell case, which is the most common paste of all and the hardest to pin
+ * down: a shell command is just words, and what marks it out is the
+ * punctuation around them — a flag, a pipe, a redirect, a `$variable`, a
+ * relative path — or one of the words only a shell uses.
+ */
+const SHELL =
+  /(^|\s)(-{1,2}[a-zA-Z][\w-]*|\|\s*\w|>>?\s*\S|\$\{?\w+|\.\/\S+)|^\s*(sudo|apt|apt-get|brew|npm|pnpm|yarn|git|docker|kubectl|curl|wget|echo|cat|cd|mkdir|rm|cp|mv|chmod|chown|export|source|ssh|scp|grep|sed|awk|find|tar|make|whois|ping|nmap)\b|^\s*(fi|done|esac|then|else)\s*$/m;
+
+/**
+ * Signals that a language is the one, in the order they are checked.
+ *
+ * Deliberately hand-written rather than handed to highlight.js's automatic
+ * detection, which scores a grammar per line and, run over a couple of hundred
+ * grammars, confidently reports that a JavaScript function is an INI file. A
+ * short list of things only one language says is both more accurate on the
+ * pastes people actually make and legible when it gets one wrong.
+ */
+const LANGUAGE_RULES: ReadonlyArray<{ language: string; pattern: RegExp }> = [
+  { language: "php", pattern: /<\?php\b/ },
+  { language: "go", pattern: /^\s*package\s+\w+\s*$|\bfunc\s+\w+\s*\([^)]*\)\s*[\w*[\]]*\s*\{/m },
+  { language: "rust", pattern: /\bfn\s+\w+\s*\(|\blet\s+mut\s+\w+|\buse\s+std::/ },
+  { language: "csharp", pattern: /\busing\s+System\b|\bnamespace\s+\w+\s*[;{]/ },
+  {
+    language: "java",
+    pattern: /\b(public|private|protected)\s+(static\s+)?(final\s+)?(class|void|int|String)\b/,
+  },
+  { language: "cpp", pattern: /#include\s*<\w+>|\bstd::\w+/ },
+  { language: "c", pattern: /#include\s*<\w+\.h>/ },
+  {
+    language: "swift",
+    pattern: /\bimport\s+(Foundation|SwiftUI|UIKit)\b|\bfunc\s+\w+\([^)]*\)\s*->/,
+  },
+  { language: "kotlin", pattern: /\bfun\s+\w+\s*\(|\bval\s+\w+\s*(:|=)/ },
+  {
+    language: "typescript",
+    pattern: /\binterface\s+\w+\s*\{|:\s*(string|number|boolean|void|unknown)\b|\btype\s+\w+\s*=/,
+  },
+  {
+    language: "javascript",
+    pattern: /\b(const|let|var)\s+[\w{[]|\bfunction\s*\w*\s*\(|=>\s*[{(]|\bconsole\.\w+\(/,
+  },
+  {
+    language: "python",
+    pattern: /^\s*(def|class)\s+\w+.*:\s*$|^\s*(from\s+[\w.]+\s+)?import\s+\w+/m,
+  },
+  { language: "ruby", pattern: /^\s*(require|puts)\s+['"\w]|\bdef\s+\w+.*\n[\s\S]*^\s*end\s*$/m },
+  {
+    language: "sql",
+    pattern: /\b(select\s+[\w*,\s]+\s+from|insert\s+into|create\s+table|update\s+\w+\s+set)\b/i,
+  },
+  { language: "dockerfile", pattern: /^FROM\s+\S+/m },
+  { language: "html", pattern: /<\/(html|body|head|div|section|main|p|span)>/ },
+  { language: "css", pattern: /^[.#@]?[\w-]+[^{}\n]*\{\s*$[\s\S]*?^\s*[\w-]+\s*:\s*[^;]+;/m },
+  { language: "powershell", pattern: /\b(Get|Set|New|Remove)-\w+\b/ },
+  { language: "bash", pattern: SHELL },
+];
+
+/** The language a piece of code is in, or `""` when nothing says clearly. */
+export function detectLanguage(text: string): string {
+  const shebang = /^#!\s*(?:\S*\/)?(?:env\s+)?(\w+)/.exec(text);
+  if (shebang) {
+    const named = INTERPRETERS[shebang[1]!.toLowerCase()];
+    if (named) return named;
+  }
+
+  // JSON before the rest: it is the one format that can be *proved* rather
+  // than guessed at, and a JSON object matches several of the rules below.
+  const trimmed = text.trim();
+  if (/^[[{]/.test(trimmed) && isJson(trimmed)) return "json";
+
+  for (const rule of LANGUAGE_RULES) {
+    if (rule.pattern.test(text)) return rule.language;
+  }
+
+  // Documents of `key: value` lines, once everything with a stronger claim on
+  // them has passed. Checked last because a single colon is the weakest signal
+  // in this file.
+  if (isYaml(text)) return "yaml";
+
+  return "";
+}
+
+function isJson(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isYaml(text: string): boolean {
+  const lines = contentLines(text);
+  if (lines.length < 2) return false;
+  const pairs = lines.filter((line) => /^\s*(-\s+)?[\w.-]+:(\s|$)/.test(line));
+  return pairs.length / lines.length >= 0.7;
+}
+
+/** Everything with something on it, trailing spaces removed. */
+function contentLines(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/\s+$/, ""))
+    .filter((line) => line.trim() !== "");
+}
+
+/** Marks of a line of code rather than a line of writing. */
+const CODE_LINE_SIGNALS: readonly RegExp[] = [
+  // Punctuation no sentence ends on.
+  /[;{}]\s*$/,
+  /^\s*[)}\]]+[;,]?\s*$/,
+  // A comment, in any of the languages that spell it differently.
+  /^\s*(#|\/\/|\/\*|\*\/|--\s|<!--)/,
+  // An assignment, but not "Total: 40" — the right-hand side has to look like
+  // a value rather than the rest of an English sentence.
+  /^\s*(const|let|var|val|my|export|local)?\s*[\w.$[\]-]+\s*(=|:=|\+=|\|\|=)\s*\S/,
+  // A call, a definition, or an index.
+  /\w+\([^)]*\)/,
+  /^\s*(function|def|fun|fn|class|struct|impl|interface|module|package|import|from|require|return|if|elif|else|for|while|switch|case|try|catch|finally|echo|print|printf|puts|end|fi|done|then|do)\b/,
+  // Shell furniture: flags, pipes, redirects, variables, relative paths.
+  /(^|\s)-{1,2}[a-zA-Z][\w-]*(\s|=|$)/,
+  /\|\s*\w|>>?\s*\S|\$\{?\w+|&&|\.\/\S/,
+  // Indented continuation, which prose in a notebook does not do.
+  /^(\t| {2,})\S/,
+  // Markup and tags.
+  /^\s*<\/?[a-zA-Z][\w-]*/,
+];
+
+function isCodeLine(line: string): boolean {
+  return CODE_LINE_SIGNALS.some((signal) => signal.test(line));
+}
+
+/** Shell punctuation strong enough to say what the whole block is. */
+const SHELL_STRONG = /(^|\s)-{1,2}[a-zA-Z][\w-]*(\s|=|$)|\|\s*\w|>>?\s*\S|\$\{?\w+|&&|\.\/\S/;
+
+/** A bare command and its arguments: `whois tcm-sec.com`. */
+const COMMAND_LINE = /^[a-z][\w./-]*(\s+\S+){1,5}$/;
+
+/**
+ * A command judged by the company it keeps.
+ *
+ * Half the lines in a list of shell commands have nothing in them but words —
+ * `whois tcm-sec.com`, `assetfinder tcm-sec.com` — and on their own they are
+ * indistinguishable from a note to self. Read next to a line carrying a pipe
+ * or a flag, they are obviously the same kind of thing, and that context is
+ * what this asks for: it only counts when the paste has already shown its
+ * hand. Anything ending in sentence punctuation is a sentence, not a command.
+ */
+function isCommandLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (/[.,;:!?]$/.test(trimmed)) return false;
+  return COMMAND_LINE.test(trimmed);
+}
+
+/**
+ * Whether a paste should become one code block.
+ *
+ * Conservative on purpose, and in one direction: mistaking prose for code puts
+ * someone's writing in a monospace box they have to undo, while missing a
+ * snippet leaves them exactly where they were before any of this existed. So a
+ * single line never qualifies — "Meeting at 4pm (bring notes)" has a call in
+ * it as far as any regex is concerned — and a clear majority of the lines have
+ * to look like code, not just a couple of them.
+ */
+export function looksLikeCode(text: string): boolean {
+  const body = text.trim();
+  if (body === "") return false;
+
+  // A shebang is not ambiguous, whatever follows it.
+  if (body.startsWith("#!")) return true;
+
+  // Already fenced, or a markdown document that contains a fence: the markdown
+  // parser makes a better job of that than anything here would.
+  if (/^\s*```/m.test(body)) return false;
+
+  const lines = contentLines(body);
+  if (lines.length < 2) return false;
+
+  // A markdown document is prose with punctuation, and its headings and
+  // bullets trip the comment and flag signals. Left alone deliberately.
+  if (looksLikeMarkdown(lines)) return false;
+
+  const shellContext = lines.some((line) => SHELL_STRONG.test(line));
+  const code = lines.filter(
+    (line) => isCodeLine(line) || (shellContext && isCommandLine(line)),
+  ).length;
+
+  return code / lines.length >= 0.6;
+}
+
+/** Headings, bullets and links: a document, not a program. */
+function looksLikeMarkdown(lines: string[]): boolean {
+  const markers = lines.filter((line) =>
+    /^\s{0,3}(#{1,6}\s|[-*+]\s|\d+\.\s|>\s|\|.*\|)/.test(line),
+  ).length;
+  return markers / lines.length >= 0.5;
+}
+
+/**
+ * The clipboard's own line spacing, made even.
+ *
+ * Sources vary in how many blank lines they put between things, and a paste
+ * that arrives with three of them keeps all three. One is a paragraph break;
+ * more than one is the same paragraph break with padding.
+ */
+export function evenSpacing(text: string): string {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/^\n+|\n+$/g, "");
+}
+
+/** Elements that carry structure worth keeping exactly as the source had it. */
+const STRUCTURAL = "h1,h2,h3,h4,h5,h6,ul,ol,li,table,tr,td,th,img,pre,code,blockquote,hr,figure";
+
+/**
+ * Whether pasted HTML is only lines of text dressed as blocks.
+ *
+ * Notes apps, chat clients and code panes on the web all emit one `<p>` or
+ * `<div>` per line. ProseMirror believes them — correctly, in general — and
+ * the result here is a run of one-line paragraphs with a paragraph's margin
+ * between each, which is not what the source looked like and not what anybody
+ * meant. When the HTML says nothing that the plain text does not, the plain
+ * text is the better of the two: it goes through the markdown parser, where a
+ * newline is a line break and a bare URL becomes a link.
+ *
+ * Anything with real structure in it — a heading, a list, a table, an image —
+ * is left to ProseMirror, along with anything whose blocks are long enough to
+ * be actual paragraphs, and anything carrying a link whose label is not just
+ * its address, which is the one thing the plain text would lose.
+ */
+export function isLinesOfText(html: string, parse: (html: string) => Document): boolean {
+  const body = parse(html).body;
+  if (!body) return false;
+  if (body.querySelector(STRUCTURAL)) return false;
+
+  for (const anchor of Array.from(body.querySelectorAll("a"))) {
+    const href = anchor.getAttribute("href") ?? "";
+    const label = (anchor.textContent ?? "").trim();
+    if (label !== "" && href !== "" && label !== href && href !== `${label}/`) return false;
+  }
+
+  const blocks = Array.from(body.querySelectorAll("p,div"));
+  if (blocks.length < 2) return false;
+
+  // A block long enough to wrap is a paragraph, and paragraphs keep their
+  // spacing. This is the line between "a note written in lines" and "prose
+  // copied off a web page".
+  return blocks.every((block) => (block.textContent ?? "").trim().length <= 120);
+}

--- a/packages/editor/src/pasted-image.test.tsx
+++ b/packages/editor/src/pasted-image.test.tsx
@@ -66,6 +66,58 @@ describe("a pasted image", () => {
     );
   });
 
+  /**
+   * Where the caret ends up afterwards.
+   *
+   * An image is a block, so inserting one left the selection on the node
+   * itself: the next keystroke replaced the screenshot that had just been
+   * uploaded. Pasting a picture into a note is almost always followed by
+   * writing about the picture.
+   */
+  it("leaves the caret on an empty line below the picture", async () => {
+    const bridge: ImageBridge = {
+      canUpload: true,
+      resolve: () => "blob:the-image",
+      upload: async (file) => `assets/${file.name}`,
+    };
+
+    let editor: Editor | null = null;
+    render(
+      <WysiwygEditor
+        value="hello"
+        onChange={vi.fn()}
+        images={bridge}
+        onReady={(instance) => {
+          editor = instance;
+        }}
+      />,
+    );
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    const view = editor!.view;
+    const file = new File([new Uint8Array([1])], "shot.png", { type: "image/png" });
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: { files: [file], items: [], types: ["Files"], getData: () => "" },
+    });
+    view.dom.dispatchEvent(event);
+
+    await waitFor(() => expect(view.dom.querySelector("img")).not.toBeNull(), { timeout: 4000 });
+
+    const { $from, empty } = editor!.state.selection;
+    expect(empty).toBe(true);
+    expect($from.parent.type.name).toBe("paragraph");
+    expect($from.parent.content.size).toBe(0);
+
+    // And typing goes into that paragraph rather than over the image.
+    editor!.commands.insertContent("about the shot");
+    let images = 0;
+    editor!.state.doc.descendants((node) => {
+      if (node.type.name === "image") images += 1;
+    });
+    expect(images).toBe(1);
+  });
+
   it("keeps the markdown pointing at the path, not the resolved URL", async () => {
     const bridge: ImageBridge = {
       canUpload: true,

--- a/packages/editor/src/smart-paste.test.tsx
+++ b/packages/editor/src/smart-paste.test.tsx
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { WysiwygEditor, markdownOf } from "./WysiwygEditor";
+import { runRichAction } from "./insert-actions";
+
+afterEach(cleanup);
+
+/**
+ * What happens to something pasted in from somewhere else.
+ *
+ * A script copied out of a notes app used to arrive as one paragraph per line,
+ * with a paragraph's margin between every line of it, and turning the lot into
+ * code afterwards produced one code block per line. These drive the real paste
+ * hook with the two flavours a clipboard actually carries, because the bug was
+ * in which of them the editor believed.
+ */
+
+async function mount(value = ""): Promise<Editor> {
+  let editor: Editor | null = null;
+  render(
+    <WysiwygEditor
+      value={value}
+      onChange={vi.fn()}
+      onReady={(instance) => {
+        editor = instance;
+      }}
+    />,
+  );
+
+  await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+  return editor!;
+}
+
+/**
+ * A paste, as ProseMirror sees one.
+ *
+ * `clipboardData` is a stub because jsdom has no clipboard: what matters is
+ * that both flavours are offered, since the whole question is which one the
+ * editor should trust.
+ */
+function paste(editor: Editor, text: string, html = ""): boolean {
+  const { view } = editor;
+  const event = {
+    clipboardData: {
+      files: [] as File[],
+      // Only the two flavours a real clipboard offers here. Anything else —
+      // `vscode-editor-data`, say — has to come back empty, because the
+      // handler that reads it parses whatever it is given.
+      getData: (type: string) => (type === "text/html" ? html : type === "text/plain" ? text : ""),
+    },
+    preventDefault: () => {},
+  };
+
+  return Boolean(
+    view.someProp("handlePaste", (handler) =>
+      handler(view, event as unknown as ClipboardEvent, view.state.selection.content()),
+    ),
+  );
+}
+
+const SCRIPT = `#!/bin/bash
+domain=$1
+
+info_path="$domain/info"
+mkdir -p "$info_path"
+whois "$domain" > "$info_path/whois.txt"`;
+
+const COMMANDS = `whois tcm-sec.com
+subfinder -d tcm-sec.com
+assetfinder tcm-sec.com
+cat tesla.txt | sort -u | httprobe -s -p https:443`;
+
+describe("pasting code", () => {
+  it("makes one code block, not one paragraph per line", async () => {
+    const editor = await mount();
+
+    expect(paste(editor, SCRIPT)).toBe(true);
+
+    const blocks = editor.state.doc.content.content.filter(
+      (node) => node.type.name === "codeBlock",
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.textContent).toBe(SCRIPT);
+  });
+
+  it("tags it with the language it is in", async () => {
+    const editor = await mount();
+    paste(editor, SCRIPT);
+
+    expect(markdownOf(editor)).toContain("```bash");
+  });
+
+  it("catches a run of shell commands, which carries no shebang", async () => {
+    const editor = await mount();
+    paste(editor, COMMANDS);
+
+    const markdown = markdownOf(editor);
+    expect(markdown).toContain("```bash");
+    expect(markdown).toContain("cat tesla.txt | sort -u");
+    // One fence, opened and closed, rather than one per command.
+    expect(markdown.match(/```/g)).toHaveLength(2);
+  });
+
+  it("does it even when the clipboard also carries the source's own HTML", async () => {
+    const editor = await mount();
+    const html = COMMANDS.split("\n")
+      .map((line) => `<p>${line}</p>`)
+      .join("");
+
+    paste(editor, COMMANDS, html);
+
+    expect(markdownOf(editor)).toContain("```bash");
+  });
+
+  it("leaves the note somewhere to carry on writing", async () => {
+    const editor = await mount();
+    paste(editor, SCRIPT);
+
+    const last = editor.state.doc.lastChild;
+    expect(last?.type.name).toBe("paragraph");
+  });
+
+  it("stays out of a code block, where a paste is just text", async () => {
+    const editor = await mount("```js\nconst a = 1;\n```");
+    editor.commands.setTextSelection(3);
+
+    expect(paste(editor, COMMANDS)).toBe(false);
+  });
+
+  it("leaves ordinary writing alone", async () => {
+    const editor = await mount();
+    const prose = "Met the team about the migration.\nWe ship the importer first.";
+
+    expect(paste(editor, prose)).toBe(false);
+  });
+});
+
+describe("pasting from something that writes one paragraph per line", () => {
+  const LINES = ["Subfinder - https://github.com/projectdiscovery/subfinder", "Amass - see wiki"];
+  const HTML = LINES.map((line) => `<p>${line}</p>`).join("");
+
+  it("keeps them as lines rather than as spaced-out paragraphs", async () => {
+    const editor = await mount();
+
+    expect(paste(editor, LINES.join("\n"), HTML)).toBe(true);
+
+    // One paragraph holding both lines with a break between them, rather than
+    // two paragraphs with a margin between them.
+    expect(editor.state.doc.childCount).toBe(1);
+    expect(countHardBreaks(editor)).toBe(1);
+    // And one newline in the file, which is what a line break is here.
+    expect(markdownOf(editor).trim().split("\n")).toHaveLength(2);
+  });
+
+  it("finds the links in them", async () => {
+    const editor = await mount();
+    paste(editor, LINES.join("\n"), HTML);
+
+    expect(markdownOf(editor)).toContain("https://github.com/projectdiscovery/subfinder");
+    expect(hasLink(editor)).toBe(true);
+  });
+
+  it("leaves real structure to ProseMirror, which handles it", async () => {
+    const editor = await mount();
+    const structured = "<h1>Setup</h1><ul><li>one</li><li>two</li></ul>";
+
+    expect(paste(editor, "Setup\none\ntwo", structured)).toBe(false);
+  });
+});
+
+describe("turning a selection into code", () => {
+  it("makes one block out of everything selected, not one block per line", async () => {
+    const editor = await mount("whois tcm-sec.com\n\nsubfinder -d tcm-sec.com\n\namass enum");
+    editor.commands.selectAll();
+
+    runRichAction(editor, "code");
+
+    const blocks = editor.state.doc.content.content.filter(
+      (node) => node.type.name === "codeBlock",
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.textContent.split("\n")).toHaveLength(3);
+  });
+
+  it("keeps the lines apart instead of running them together", async () => {
+    const editor = await mount("assetfinder tcm-sec.com\n\namass enum -d tcm-sec.com");
+    editor.commands.selectAll();
+
+    runRichAction(editor, "code");
+
+    expect(editor.state.doc.firstChild?.textContent).toContain("tcm-sec.com\namass");
+  });
+
+  it("still toggles a single block the way it always did", async () => {
+    const editor = await mount("one line");
+    // A selection within the one paragraph, which is the case Tiptap's own
+    // toggle already handles correctly and which this must not take over.
+    editor.commands.setTextSelection({ from: 1, to: 9 });
+
+    runRichAction(editor, "code");
+    expect(editor.isActive("codeBlock")).toBe(true);
+
+    runRichAction(editor, "code");
+    expect(editor.isActive("codeBlock")).toBe(false);
+  });
+});
+
+/** How many hard breaks the document holds, at any depth. */
+function countHardBreaks(editor: Editor): number {
+  let count = 0;
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === "hardBreak") count += 1;
+  });
+  return count;
+}
+
+/** Whether anything in the document carries a link mark. */
+function hasLink(editor: Editor): boolean {
+  let found = false;
+  editor.state.doc.descendants((node) => {
+    if (node.marks.some((mark) => mark.type.name === "link")) found = true;
+  });
+  return found;
+}

--- a/packages/editor/src/youtube-embed.test.tsx
+++ b/packages/editor/src/youtube-embed.test.tsx
@@ -54,4 +54,37 @@ describe("YouTube videos in rich text", () => {
       expect(found).toEqual(["https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s"]);
     });
   });
+
+  /**
+   * Where the caret goes afterwards, which is the same question a pasted
+   * screenshot raises: a player is a block, and a selection left sitting on it
+   * means the next thing typed replaces the video.
+   */
+  it("leaves the caret on a line below the player", async () => {
+    const editor = await mount("");
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        files: [],
+        items: [],
+        types: ["text/plain"],
+        getData: (type: string) => (type === "text/plain" ? "https://youtu.be/dQw4w9WgXcQ" : ""),
+      },
+    });
+    editor.view.dom.dispatchEvent(event);
+
+    await waitFor(() => {
+      const { $from, empty } = editor.state.selection;
+      expect(empty).toBe(true);
+      expect($from.parent.type.name).toBe("paragraph");
+    });
+
+    editor.commands.insertContent("what a video");
+
+    let players = 0;
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === "youtubeEmbed") players += 1;
+    });
+    expect(players).toBe(1);
+  });
 });


### PR DESCRIPTION
## The bug

Creating a note selected it and opened it, then left it invisible in the sidebar — it had landed inside a folder that was shut, and nothing said so. Only the right-click "New note here" opened a folder first, and only the one it was aimed at; the New Note button, ⌘⇧N and the folder menu didn't. A typed filename filter made it worse: the tree said "Nothing matches" about the note just created.

That was the first commit. The rest of this PR is the batch of editor bugs found from there.

## Where a new note goes

- **`FileTree`** opens every folder above whichever note is selected and scrolls that row into view — creation, ⌘K and links alike. The reveal is not recorded as folders the reader chose to open, so closing a revealed folder stays closed.
- **`EditorSidebar`** drops the filename filter when the newly selected note doesn't match it — only on the selection moving, never mid-typing.
- **`EditorWorkspace`** states the path after creating (`Created Fieldwork/Sources/feeds.md`) and un-collapses the sidebar.

## Pasting

A script or a list of commands copied out of a notes app arrived as one paragraph per line, with a paragraph's margin between each, no monospace and no highlighting — and selecting the lot and pressing the code button made one code block *per line*.

- **A paste that looks like code becomes one code block**, tagged with the language it appears to be in (shebang, then a short list of things only one language says — highlight.js's own auto-detection reports that a JavaScript function is an INI file). Deliberately conservative: a single line never qualifies, and a clear majority of lines have to look like code.
- **A paste whose HTML says nothing the plain text does not** goes through the markdown parser instead, where a newline is a line break and a bare address becomes a link. Real structure — headings, lists, tables, images — is still left to ProseMirror, and so is any HTML carrying a link whose label is not its address.
- **Making code out of a multi-block selection** now joins it into one block rather than one block per paragraph.

## Deleting the gap between two lines

Enter here makes a line, not a paragraph, so the blank line between two paragraphs is two presses of Enter. Backspace undid both at once and ran the lines together: `assetfinder tcm-sec.com` and `amass enum -d tcm-sec.com` became one line reading `tcm-sec.comamass`. Backspace now leaves the line break behind, and one more press joins them for real. Delete does the same, aimed forward.

## The language picker

It listed all 192 of lowlight's grammars alphabetically, so the first thing under "All languages" was `1c`, `abnf`, `accesslog`, `angelscript`, `arcade`, `avrasm`, `axapta` — a wall of things almost nobody has written a line of, and two of them not languages at all. It now lists ~70 languages people actually write. A block that arrives tagged with something else is still highlighted and still shows its own tag in the picker, so nothing is lost by not listing it — if something belongs there and is missing, it is one line.

## The rest, all reported

| Reported | Fixed in |
| --- | --- |
| Heading 3 on one highlighted line made a heading of the line above it too | `isolate-line.ts` — line isolation now covers selections, and the toolbar's block commands use it, as the slash menu already did |
| Inline code invisible — `#131313` on `#0a0a0a` inside a `#1f1f1f` border | `globals.css` — accent tint and accent text |
| No way out of inline code or a link except starting a new line | `LeaveInlineMark.ts` — → leaves the mark at the end of a *line*, not only at the end of a paragraph (Tiptap's own `exitable` only fires at the end of a node); Escape does it without the space |
| A code block or rule at the end of a note left nowhere to write; no way to write between two of them | `RoomToWrite.ts` + a drawn gap cursor — click below, or press ↓; Enter at a gap cursor makes a paragraph |
| A pasted image or video left the caret on the node, so the next keystroke replaced it | `caret.ts`, used by the image upload and the video embed |
| The toolbar didn't show what was applied to the selected text | `WysiwygEditor.tsx` — the bubble buttons read their state live (`useEditorState`) instead of at render time, which is not when the selection moves; `link` joins the main toolbar's tracked marks |
| Had to reload to see someone else's changes | `useNotebook.ts` — a pull on a one-minute timer and when the tab comes forward, skipped for hidden tabs, offline, local workspaces and manual sync mode. Notes with unpushed edits are never touched; the ones that are replaced are named in a banner |
| No comparison with the apps people already use | `Comparison.tsx` — ForkLeaf against Notion, OneNote, Obsidian and Evernote across nine questions, with what each of them does better and what ForkLeaf is worse at |

Found while testing rather than reported: **`==text==` was written by the editor and never read back**, so a plain highlight came back as literal equals signs the next time the note was opened. Only the coloured highlights round-tripped, because they are written as `<mark>`. Fixed in `ColouredHighlight.ts`, over text nodes so `==` inside code is left exactly as typed.

## Verified

`pnpm typecheck`, `pnpm lint`, `pnpm test` — 876 passing, 55 of them new. And driven by hand in the dev app: the command list pasting as one Shell block, clicking below it to write, `MHA` as visible inline code that → escapes, Heading 3 landing on one line only, B and H both lit for bold-and-highlighted text, and `==text==` surviving a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
