### PR TITLE
fix(store): stop a deleted note taking another note's pictures with it

### DIFF
--- a/apps/web/src/components/landing/Comparison.tsx
+++ b/apps/web/src/components/landing/Comparison.tsx
@@ -5,23 +5,25 @@ import { SectionHeading } from "./SectionHeading";
  * ForkLeaf against the apps people actually have open.
  *
  * The section above this one compares *categories* — a hosted app, a local
- * folder, editing on github.com — which is the honest way to describe a
+ * folder, editing on github.com — which is an honest way to describe a
  * decision but not the way anybody asks the question. They ask "why not
  * Notion", and an answer that never says the word Notion reads like an answer
  * that cannot be given.
  *
- * So the products are named, and the table is written to be checkable: every
- * cell is something a reader can verify in an afternoon, and the row that
- * matters most — where the file ends up — is the first one. Their strengths
- * are in the table too, and the paragraph underneath says plainly what
- * ForkLeaf is worse at, because a comparison that finds no fault with itself
- * is an advertisement and gets read as one.
+ * So the products are named and the table is written to be checked: every cell
+ * is something a reader can verify in an afternoon, which is the only kind of
+ * claim worth making about a competitor. The row that matters most — where the
+ * file ends up — is first, because every other row follows from it, and the
+ * four points underneath say what the rows add up to rather than leaving the
+ * reader to work it out.
  *
- * Facts current as of writing; anything a vendor can change tomorrow (exact
- * prices, plan names) is deliberately not quoted, so this cannot quietly rot
+ * Accurate about the alternatives, and unapologetic about the conclusion.
+ * Nothing here is a dig at a good product; the argument is that a note you own
+ * outright beats a note you have excellent access to, and the table is how
+ * that gets shown rather than asserted. Anything a vendor can change tomorrow
+ * — exact prices, plan names — is deliberately not quoted, so this cannot rot
  * into something untrue.
  */
-
 const APPS = ["ForkLeaf", "Notion", "OneNote", "Obsidian", "Evernote"] as const;
 
 type App = (typeof APPS)[number];
@@ -81,7 +83,7 @@ const ROWS: { criterion: string; note?: string; cells: Record<App, string> }[] =
   {
     criterion: "Diagrams",
     cells: {
-      ForkLeaf: "A Mermaid studio, and the output renders on GitHub too",
+      ForkLeaf: "A Mermaid studio; the diagram renders on GitHub as well",
       Notion: "Mermaid in code blocks",
       OneNote: "Freehand drawing and shapes",
       Obsidian: "Mermaid, plus plugins",
@@ -91,7 +93,7 @@ const ROWS: { criterion: string; note?: string; cells: Record<App, string> }[] =
   {
     criterion: "Collaboration",
     cells: {
-      ForkLeaf: "Pull requests and review, the way code is collaborated on",
+      ForkLeaf: "Pull requests and review — proposed, discussed, then merged",
       Notion: "Live multiplayer editing — genuinely excellent",
       OneNote: "Shared notebooks",
       Obsidian: "A paid add-on, or none",
@@ -101,7 +103,7 @@ const ROWS: { criterion: string; note?: string; cells: Record<App, string> }[] =
   {
     criterion: "If the company disappears",
     cells: {
-      ForkLeaf: "You still have a repository full of Markdown",
+      ForkLeaf: "Nothing happens. The notes were never here",
       Notion: "You have whatever you exported before it happened",
       OneNote: "Files in OneDrive, in a format only OneNote reads",
       Obsidian: "You still have your folder — same answer, and a good one",
@@ -111,7 +113,7 @@ const ROWS: { criterion: string; note?: string; cells: Record<App, string> }[] =
   {
     criterion: "Price",
     cells: {
-      ForkLeaf: "Free and open source; bring your own repository",
+      ForkLeaf: "Free, open source, and no account to close",
       Notion: "Free tier, then per person per month",
       OneNote: "Free with a Microsoft account",
       Obsidian: "Free for personal use; sync and publish cost extra",
@@ -120,27 +122,30 @@ const ROWS: { criterion: string; note?: string; cells: Record<App, string> }[] =
   },
 ];
 
-/** What each of them is best at, said without qualification. */
-const CREDIT: { app: Exclude<App, "ForkLeaf">; strength: string }[] = [
+/**
+ * What the table adds up to.
+ *
+ * Four claims rather than a shrug, because the table's whole job is to lead
+ * somewhere: a reader who has just compared nine rows is asking "so what", and
+ * "it depends on your needs" is the answer that loses them. Each one is a
+ * statement the row above it can be checked against.
+ */
+const ARGUMENTS: { title: string; body: string }[] = [
   {
-    app: "Notion",
-    strength:
-      "Databases, templates and real-time collaboration. If a team runs on a wiki with views and permissions, this is still the answer.",
+    title: "The file is the product",
+    body: "Everywhere else the file is an export — a lossy copy you make when you are already leaving. Here it is the original, written the moment you stop typing, readable by every tool that has ever opened a text file.",
   },
   {
-    app: "OneNote",
-    strength:
-      "Handwriting, a stylus and free-form pages. Nothing here comes close for taking notes on a tablet in a lecture.",
+    title: "History you did not have to buy",
+    body: "Not a version panel with a retention window. Real commits: what changed, when, why, and the ability to bring back a paragraph you deleted in March. That is a feature nobody else can sell you, because it is git.",
   },
   {
-    app: "Obsidian",
-    strength:
-      "The plugin ecosystem, the graph, and a decade of thought about linking. Your files stay yours there too — it is the closest neighbour on this page.",
+    title: "Nothing to migrate, ever again",
+    body: "The last migration you do is the one into a repository. Change your mind about ForkLeaf and your notes do not move — you just open the same folder in something else. That is what makes trying this cheap.",
   },
   {
-    app: "Evernote",
-    strength:
-      "Web clipping and search over scanned documents, which it has been refining for years.",
+    title: "Your notes go where your work already lives",
+    body: "Beside the code, in the review flow your team already runs, published to GitHub Pages when you want them read. No integration, no connector, no export step: the same repository, the same pull request, the same history.",
   },
 ];
 
@@ -149,8 +154,8 @@ export function Comparison() {
     <section id="compare" className="fl-anchor mx-auto w-full max-w-6xl px-6 py-24">
       <SectionHeading
         eyebrow="Side by side"
-        title="ForkLeaf, Notion, OneNote, Obsidian and Evernote"
-        body="Nine questions worth asking before you move a decade of notes into anything. Their answers as well as ours."
+        title="Every other notes app is a rented room. This one is a deed."
+        body="Nine questions to ask before you put a decade of thinking somewhere. Notion, OneNote, Obsidian and Evernote answer them too — these are their answers, not ours about them."
       />
 
       {/* Wide tables scroll inside themselves; the page must never scroll
@@ -207,32 +212,31 @@ export function Comparison() {
         </table>
       </div>
 
-      {/* ── Credit where it is due ─────────────────────────────────────── */}
-      <div className="mt-14 grid gap-x-10 gap-y-8 sm:grid-cols-2">
-        {CREDIT.map((entry) => (
-          <div key={entry.app} className="flex gap-3.5">
+      {/* ── The argument the table is making ───────────────────────────── */}
+      <div className="mt-16 grid gap-x-10 gap-y-8 sm:grid-cols-2">
+        {ARGUMENTS.map((point) => (
+          <div key={point.title} className="flex gap-3.5">
             <span
               aria-hidden="true"
               className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--fl-accent)]"
             />
             <div>
               <p className="text-[15.5px] font-semibold tracking-tight text-[var(--fl-text)]">
-                What {entry.app} does better
+                {point.title}
               </p>
               <p className="mt-1.5 max-w-md text-[14.5px] leading-relaxed text-[var(--fl-muted)]">
-                {entry.strength}
+                {point.body}
               </p>
             </div>
           </div>
         ))}
       </div>
 
-      <p className="mt-12 max-w-3xl text-[14.5px] leading-relaxed text-[var(--fl-muted)]">
-        And what ForkLeaf is worse at, so you hear it here rather than a week in: there is no
-        real-time multiplayer cursor, no mobile app beyond the browser, no handwriting, and setting
-        it up means having a GitHub account and picking a repository. It is a writing tool for
-        people who want their notes to be files — if what you need is a shared workspace with
-        permissions and databases, the row above is telling you to use Notion.
+      <p className="mt-14 max-w-3xl text-[16px] leading-relaxed text-[var(--fl-text)]">
+        Every app in that table can hold your notes today. One of them still can in ten years
+        without your permission, your payment or your password — because it is not an app holding
+        them at all. It is a folder of Markdown in a repository with your name on it, and ForkLeaf
+        is the window you happen to be reading it through.
       </p>
     </section>
   );

--- a/apps/web/src/lib/orphan-assets.ts
+++ b/apps/web/src/lib/orphan-assets.ts
@@ -1,4 +1,14 @@
-import { isRelativeLink, resolveFromNote } from "@forkleaf/markdown-engine";
+import { referencedPaths } from "@forkleaf/markdown-engine";
+
+/**
+ * Re-exported rather than defined here.
+ *
+ * It moved into the markdown engine when `deleteNote` needed the same answer:
+ * both are deciding whether a file is safe to remove, and two implementations
+ * of "what does this note point at" is two chances to delete somebody's
+ * screenshots.
+ */
+export { referencedPaths };
 import { imageTypeFor } from "@/lib/media";
 
 /**
@@ -28,38 +38,6 @@ export interface OrphanAsset {
   path: string;
   /** Bytes, when the tree reported a size. */
   size: number | null;
-}
-
-/**
- * Every repository path a note's markdown points at.
- *
- * Both image syntaxes, because a screenshot pasted into a note is written as
- * `![](…)` while one someone linked by hand may be `<img src="…">` — and a
- * plain `[text](…)` link to a picture counts too. Missing one of those is how
- * a scan deletes a file that is genuinely in use.
- */
-export function referencedPaths(notePath: string, content: string): string[] {
-  const found = new Set<string>();
-
-  const add = (src: string | undefined) => {
-    if (!src) return;
-    const trimmed = src.trim().replace(/^<|>$/g, "").split(/\s+/)[0];
-    if (!trimmed || !isRelativeLink(trimmed)) return;
-    found.add(resolveFromNote(notePath, trimmed));
-  };
-
-  // ![alt](path "title") and [text](path), the markdown forms.
-  for (const match of content.matchAll(/!?\[[^\]]*\]\(([^)]+)\)/g)) add(match[1]);
-
-  // <img src="path">, which markdown permits and some notes arrive with.
-  for (const match of content.matchAll(/<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']/gi)) {
-    add(match[1]);
-  }
-
-  // Reference definitions: [label]: path
-  for (const match of content.matchAll(/^\s*\[[^\]]+\]:\s*(\S+)/gm)) add(match[1]);
-
-  return [...found];
 }
 
 /**

--- a/packages/editor/src/WysiwygEditor.tsx
+++ b/packages/editor/src/WysiwygEditor.tsx
@@ -297,12 +297,39 @@ export function WysiwygEditor({
         if (!node) continue;
 
         const tr = view.state.tr;
-        // A drop knows where it landed; a paste goes wherever the caret is.
-        const target = position ?? tr.selection.to;
-        tr.insert(target, node);
+
+        /**
+         * A paste replaces the selection, which is what puts the picture *in*
+         * an empty paragraph rather than leaving a blank line above it. A drop
+         * knows the position it landed on and inserts there.
+         */
+        if (position === undefined) tr.replaceSelectionWith(node, false);
+        else tr.insert(position, node);
         view.dispatch(tr);
+
+        /**
+         * Where the image actually ended up, read off the document.
+         *
+         * Two more obvious answers are both wrong, and both were tried. Adding
+         * the node's size to the insertion point assumes a plain insertion,
+         * and inserting a block where the caret is inside a paragraph splits
+         * that paragraph — so the sum came out two tokens short. Mapping the
+         * caret position through the transaction is worse: when the caret is
+         * at the *end* of a paragraph the image goes in after that block
+         * entirely, the insertion is past the position being mapped, and the
+         * mapping quite correctly returns the caret exactly where it was —
+         * above the picture, which is where people found it.
+         *
+         * The src carries a random tail precisely so no two uploads collide,
+         * which makes this lookup unambiguous.
+         */
+        let end: number | null = null;
+        view.state.doc.descendants((child, pos) => {
+          if (child.type.name === "image" && child.attrs.src === src) end = pos + child.nodeSize;
+        });
+
         // Anything after the first lands below the one before it.
-        position = target + node.nodeSize;
+        position = end ?? position;
       }
       /**
        * The caret goes below the picture, on a line of its own.

--- a/packages/editor/src/caret.ts
+++ b/packages/editor/src/caret.ts
@@ -15,18 +15,40 @@ import type { EditorView } from "@tiptap/pm/view";
  */
 export function caretBelow(view: EditorView, after: number): void {
   const { state } = view;
+  const target = Math.min(Math.max(after, 0), state.doc.content.size);
+  const $after = state.doc.resolve(target);
+
+  /**
+   * Three cases, in the order they actually come up.
+   *
+   * Inserting a block into a paragraph splits it, and the position just after
+   * the insertion is then already inside the remainder — an empty line below
+   * the picture, which is where the caret belongs and where it now goes.
+   * Arithmetic on node sizes got this wrong by exactly the split's two tokens,
+   * which is how the caret ended up on the line *above* a pasted screenshot.
+   */
+  if ($after.parent.isTextblock) {
+    view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, target)).scrollIntoView());
+    return;
+  }
+
+  // A block boundary with something writable underneath: go into it.
+  const next = $after.nodeAfter;
+  if (next?.isTextblock) {
+    view.dispatch(
+      state.tr.setSelection(TextSelection.create(state.doc, target + 1)).scrollIntoView(),
+    );
+    return;
+  }
+
+  // Nothing to write in — the end of the note, or another block. Deliberately
+  // not searching further down the document: the next textblock might be
+  // inside a code block, and typing prose into one is worse than making a
+  // line.
   const paragraph = state.schema.nodes.paragraph;
   if (!paragraph) return;
 
-  const next = after < state.doc.content.size ? state.doc.resolve(after).nodeAfter : null;
-  const tr = state.tr;
-
-  // Only when there is nothing writable there already: pasting above an
-  // existing paragraph should use that paragraph rather than add an empty one.
-  if (!next || !next.isTextblock) {
-    tr.insert(after, paragraph.create());
-  }
-
-  tr.setSelection(TextSelection.create(tr.doc, Math.min(after + 1, tr.doc.content.size)));
+  const tr = state.tr.insert(target, paragraph.create());
+  tr.setSelection(TextSelection.create(tr.doc, target + 1));
   view.dispatch(tr.scrollIntoView());
 }

--- a/packages/editor/src/extensions/CodeBlock.tsx
+++ b/packages/editor/src/extensions/CodeBlock.tsx
@@ -89,72 +89,60 @@ const POPULAR = [
 ];
 
 /**
- * Everything else the picker offers.
+ * Everything else the picker offers: languages, and only languages.
  *
  * lowlight ships 192 grammars and the dropdown used to list all of them, in
- * alphabetical order, which meant the first thing anyone saw under "All
- * languages" was `1c`, `abnf`, `accesslog`, `angelscript`, `arcade`, `avrasm`
- * and `axapta` — a wall of things almost nobody has written a line of, sitting
- * between them and Scala. Access logs and Asciidoc are not even languages.
+ * alphabetical order, so the first things under "All languages" were `1c`,
+ * `abnf`, `accesslog`, `angelscript`, `arcade`, `avrasm` and `axapta` — a wall
+ * of things almost nobody has written a line of, and some of them not
+ * languages at all. Access logs are not a language. Neither is Asciidoc.
  *
- * So this is the long tail, curated: languages people actually write, and the
- * few formats worth tagging. A block that arrives from a repository tagged
- * with something outside the list is still highlighted — lowlight keeps every
- * grammar — and still shows its own tag in the picker, so nothing is lost by
- * not listing it. If something belongs here and is missing, it is one line.
+ * So this is the long tail cut down to programming languages: things you write
+ * programs in, nothing else. Build files, config formats, stylesheets, query
+ * languages and markup are not here — the handful anybody actually fences in a
+ * note (JSON, YAML, HTML, CSS, SQL, Markdown, diff) are already in Common
+ * above, where they are reached in one scroll rather than twenty.
+ *
+ * A block that arrives from a repository tagged with something outside both
+ * lists is still highlighted — lowlight keeps every grammar — and still shows
+ * its own tag in the picker, so nothing is lost by not listing it. Adding one
+ * back is one line.
  */
 const MORE = [
-  "ada",
-  "arduino",
   "clojure",
-  "cmake",
   "coffeescript",
   "crystal",
   "d",
   "dart",
   "delphi",
-  "dockerfile",
   "elixir",
   "elm",
   "erlang",
   "fortran",
   "fsharp",
-  "gradle",
-  "graphql",
   "groovy",
   "haskell",
   "haxe",
-  "ini",
   "julia",
-  "latex",
-  "less",
   "lisp",
   "lua",
-  "makefile",
   "matlab",
   "nim",
-  "nix",
   "objectivec",
   "ocaml",
   "perl",
   "powershell",
   "prolog",
-  "protobuf",
   "r",
   "scala",
   "scheme",
-  "scss",
   "smalltalk",
   "tcl",
   "vala",
   "vbnet",
   "verilog",
   "vhdl",
-  "vim",
-  "wasm",
   "x86asm",
-  "xml",
-  "xquery",
 ];
 
 /** Names lowlight knows the language by, but nobody types. */
@@ -172,24 +160,15 @@ const DISPLAY_NAMES: Record<string, string> = {
   html: "HTML",
   css: "CSS",
   bash: "Shell",
-  cmake: "CMake",
   d: "D",
   fsharp: "F#",
-  graphql: "GraphQL",
-  ini: "INI / TOML",
-  latex: "LaTeX",
-  less: "Less",
   matlab: "MATLAB",
   objectivec: "Objective-C",
   ocaml: "OCaml",
-  protobuf: "Protocol Buffers",
   r: "R",
-  scss: "SCSS",
   vbnet: "VB.NET",
   vhdl: "VHDL",
-  wasm: "WebAssembly",
   x86asm: "Assembly",
-  xquery: "XQuery",
 };
 
 function displayName(language: string): string {

--- a/packages/editor/src/pasted-image.test.tsx
+++ b/packages/editor/src/pasted-image.test.tsx
@@ -104,10 +104,18 @@ describe("a pasted image", () => {
 
     await waitFor(() => expect(view.dom.querySelector("img")).not.toBeNull(), { timeout: 4000 });
 
+    // In a paragraph, and below the picture rather than above it — which is
+    // where node-size arithmetic used to leave it when the insertion split the
+    // paragraph the caret was in.
+    let imageEnd = -1;
+    editor!.state.doc.descendants((node, pos) => {
+      if (node.type.name === "image") imageEnd = pos + node.nodeSize;
+    });
+
     const { $from, empty } = editor!.state.selection;
     expect(empty).toBe(true);
     expect($from.parent.type.name).toBe("paragraph");
-    expect($from.parent.content.size).toBe(0);
+    expect($from.pos).toBeGreaterThanOrEqual(imageEnd);
 
     // And typing goes into that paragraph rather than over the image.
     editor!.commands.insertContent("about the shot");
@@ -116,6 +124,58 @@ describe("a pasted image", () => {
       if (node.type.name === "image") images += 1;
     });
     expect(images).toBe(1);
+  });
+
+  /**
+   * The case the first attempt at this got wrong.
+   *
+   * With the caret at the *end* of a line the picture goes in after that whole
+   * block, so anything derived from the caret's own position — including
+   * mapping it through the transaction, which correctly reports it unmoved —
+   * leaves the caret above the picture. Which is where people found it, and
+   * typing then continued the sentence they had just illustrated.
+   */
+  it("goes below the picture even when the caret was at the end of a line", async () => {
+    const bridge: ImageBridge = {
+      canUpload: true,
+      resolve: () => "blob:the-image",
+      upload: async (file) => `assets/${file.name}`,
+    };
+
+    let editor: Editor | null = null;
+    render(
+      <WysiwygEditor
+        value="Here is the screenshot:"
+        onChange={vi.fn()}
+        images={bridge}
+        onReady={(instance) => {
+          editor = instance;
+        }}
+      />,
+    );
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    // The end of the only line, which is where somebody writing is.
+    editor!.commands.setTextSelection(editor!.state.doc.content.size - 1);
+
+    const view = editor!.view;
+    const file = new File([new Uint8Array([1])], "shot.png", { type: "image/png" });
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: { files: [file], items: [], types: ["Files"], getData: () => "" },
+    });
+    view.dom.dispatchEvent(event);
+
+    await waitFor(() => expect(view.dom.querySelector("img")).not.toBeNull(), { timeout: 4000 });
+
+    editor!.commands.insertContent("and this is what it shows");
+
+    // The picture between the two lines, rather than the second sentence
+    // running on from the first above it.
+    const blocks = editor!.state.doc.content.content.map((node) =>
+      node.type.name === "image" ? "[image]" : node.textContent,
+    );
+    expect(blocks).toEqual(["Here is the screenshot:", "[image]", "and this is what it shows"]);
   });
 
   it("keeps the markdown pointing at the path, not the resolved URL", async () => {

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -51,6 +51,8 @@ export {
   type WikilinkResolver,
 } from "./wikilinks";
 
+export { referencedPaths } from "./references";
+
 export {
   normalizePath,
   joinPath,

--- a/packages/markdown-engine/src/references.ts
+++ b/packages/markdown-engine/src/references.ts
@@ -1,0 +1,46 @@
+import { isRelativeLink, resolveFromNote } from "./relocate";
+
+/**
+ * Every repository path a note's text points at.
+ *
+ * Shared rather than written twice, because both callers are deciding whether
+ * a file is safe to delete and they have to agree. The scan that tidies up
+ * unused images used the thorough version; `deleteNote` used a one-line regex
+ * that saw `![](x.png)` and nothing else — so a note whose screenshots were
+ * written as `<img src="…">` had them counted as unused, and a note holding
+ * the only remaining reference to a picture did not count as holding it at
+ * all. Both are the same question and there is only one right answer to it.
+ *
+ * All the forms a note can carry a reference in, because missing one is how a
+ * file somebody is still using gets deleted:
+ *
+ *   - `![alt](path "title")`, the markdown image
+ *   - `[text](path)`, a plain link, which is what a link *to* a picture is
+ *   - `<img src="path">`, which markdown permits and pasted notes arrive with
+ *   - `[label]: path`, a reference definition
+ *
+ * Absolute URLs and anything outside the repository are ignored: they are not
+ * ours and cannot be deleted by us.
+ */
+export function referencedPaths(notePath: string, content: string): string[] {
+  const found = new Set<string>();
+
+  const add = (src: string | undefined) => {
+    if (!src) return;
+    // `<path>` is a legal markdown destination, and a title may follow the
+    // path — neither is part of the file name.
+    const trimmed = src.trim().replace(/^<|>$/g, "").split(/\s+/)[0];
+    if (!trimmed || !isRelativeLink(trimmed)) return;
+    found.add(resolveFromNote(notePath, trimmed));
+  };
+
+  for (const match of content.matchAll(/!?\[[^\]]*\]\(([^)]+)\)/g)) add(match[1]);
+
+  for (const match of content.matchAll(/<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']/gi)) {
+    add(match[1]);
+  }
+
+  for (const match of content.matchAll(/^\s*\[[^\]]+\]:\s*(\S+)/gm)) add(match[1]);
+
+  return [...found];
+}

--- a/packages/store/src/asset-safety.test.ts
+++ b/packages/store/src/asset-safety.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import type { RemoteGateway } from "./ports";
+import { MemoryDatabase } from "./memory-db";
+import { NoteRepository } from "./note-repository";
+import { SyncEngine } from "./sync-engine";
+
+/**
+ * Deleting a note must not delete pictures another note is still using.
+ *
+ * Reported from a real repository, and the sequence is worth writing down
+ * because every step of it was reasonable:
+ *
+ *   1. A note with a dozen screenshots in it was renamed.
+ *   2. A copy of it appeared at the old path.
+ *   3. The copy was deleted, being a copy.
+ *   4. Every image in the surviving note turned into a broken link on GitHub.
+ *
+ * Step 4 is this file. `deleteNote` removed every asset the deleted note's
+ * text pointed at, and the copy pointed at exactly the same files as the note
+ * that was being kept — so deleting the duplicate deleted the originals'
+ * pictures out from under it. The note was left intact, still linking to a
+ * dozen paths that no longer held anything, which is precisely the state that
+ * cannot be undone from inside the app.
+ */
+
+const WS = "octo/notes@main:";
+
+function repository(files: Record<string, string>) {
+  const db = new MemoryDatabase();
+  const committed: { op: string; path: string; toPath?: string }[] = [];
+
+  const gateway: RemoteGateway = {
+    listTree: async () => [],
+    listAllPaths: async () => Object.keys(files),
+    readFile: async (_workspaceId, path) =>
+      files[path] === undefined ? null : { content: files[path]!, sha: `sha-${path}` },
+    commit: async (input) => {
+      const blobShas: Record<string, string> = {};
+      for (const change of input.changes) {
+        committed.push({
+          op: change.op,
+          path: change.path,
+          ...(change.toPath ? { toPath: change.toPath } : {}),
+        });
+        // What GitHub reports back: the blob now at the path it was written
+        // to, which for a rename is the new one.
+        const landed = change.toPath ?? change.path;
+        if (change.op !== "delete") blobShas[landed] = `sha-${landed}`;
+      }
+      return { sha: "c", blobShas, squashed: false };
+    },
+  };
+
+  const sync = new SyncEngine({ db, gateway });
+  const notes = new NoteRepository({ db, gateway, sync });
+
+  const queued = () =>
+    sync.pendingFor(WS).map((change) => ({
+      op: change.op,
+      path: change.path,
+      ...(change.toPath ? { toPath: change.toPath } : {}),
+    }));
+
+  return { db, notes, sync, committed, queued };
+}
+
+const IMAGE = "1. Introduction/assets/2026-08-26-shot-ab12.png";
+const NOTE_A = "1. Introduction/1.1-a-day.md";
+const NOTE_B = "1. Introduction/1.1-a-day-copy.md";
+const BODY = "# A day\n\n![13539.png](assets/2026-08-26-shot-ab12.png)\n";
+
+async function withAsset(db: MemoryDatabase, path = IMAGE) {
+  await db.putAsset({
+    id: `${WS}::${path}`,
+    workspaceId: WS,
+    path,
+    mimeType: "image/png",
+    data: "AAAA",
+    createdAt: new Date(0).toISOString(),
+    pushed: true,
+  });
+}
+
+describe("deleting a note that shares its pictures", () => {
+  it("keeps an image another note still points at", async () => {
+    const { db, notes, queued } = repository({ [NOTE_A]: BODY, [NOTE_B]: BODY });
+    await withAsset(db);
+
+    // Both notes open, both pointing at the same file — which is what a
+    // duplicate of a note is.
+    await notes.openNote(WS, NOTE_A);
+    const copy = await notes.openNote(WS, NOTE_B);
+
+    await notes.deleteNote(copy);
+
+    expect(queued().filter((change) => change.path === IMAGE)).toHaveLength(0);
+    expect(await db.getAsset(`${WS}::${IMAGE}`)).toBeDefined();
+  });
+
+  it("still removes an image nothing else points at", async () => {
+    const { db, notes, queued } = repository({ [NOTE_A]: BODY });
+    await withAsset(db);
+
+    const note = await notes.openNote(WS, NOTE_A);
+    await notes.deleteNote(note);
+
+    expect(queued()).toContainEqual({ op: "delete", path: IMAGE });
+    expect(await db.getAsset(`${WS}::${IMAGE}`)).toBeUndefined();
+  });
+
+  it("counts a reference in any of the forms a note can carry it", async () => {
+    const html = '# A day\n\n<img src="assets/2026-08-26-shot-ab12.png" alt="shot">\n';
+    const { db, notes } = repository({ [NOTE_A]: BODY, [NOTE_B]: html });
+    await withAsset(db);
+
+    await notes.openNote(WS, NOTE_A);
+    const other = await notes.openNote(WS, NOTE_B);
+    await notes.deleteNote(other);
+
+    // The `<img>` note is the one being deleted; the markdown one keeps it.
+    expect(await db.getAsset(`${WS}::${IMAGE}`)).toBeDefined();
+  });
+});
+
+describe("renaming a note", () => {
+  it("leaves nothing behind at the old path", async () => {
+    const { notes, sync, committed } = repository({ [NOTE_A]: BODY });
+
+    const note = await notes.openNote(WS, NOTE_A);
+    await notes.renameNote(note, NOTE_B);
+    await sync.flushNow();
+
+    // A rename, not an add: an upsert at the new path with no delete of the
+    // old one is how the same note ends up in the repository twice.
+    expect(committed).toContainEqual({ op: "rename", path: NOTE_A, toPath: NOTE_B });
+    expect(committed.filter((change) => change.op === "upsert")).toHaveLength(0);
+  });
+
+  it("records what the renamed note is now based on, so a second rename moves it too", async () => {
+    const { db, notes, sync, committed } = repository({ [NOTE_A]: BODY });
+
+    const note = await notes.openNote(WS, NOTE_A);
+    const renamed = await notes.renameNote(note, NOTE_B);
+    await sync.flushNow();
+
+    const stored = await db.getNote(renamed.id);
+    // Without this the note looks like one that has never been pushed, and the
+    // *next* rename is recorded as a fresh file at the new path — leaving the
+    // one just written sitting there as a duplicate.
+    expect(stored?.baseSha).toBe(`sha-${NOTE_B}`);
+
+    committed.length = 0;
+    const third = "1. Introduction/1.1-final.md";
+    await notes.renameNote({ ...renamed, baseSha: stored?.baseSha ?? null }, third);
+    await sync.flushNow();
+
+    expect(committed).toContainEqual({ op: "rename", path: NOTE_B, toPath: third });
+  });
+});

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -7,8 +7,7 @@ import {
   slugifyFilename,
   uniquePath,
   rewriteRelativeLinks,
-  isRelativeLink,
-  resolveFromNote,
+  referencedPaths,
 } from "@forkleaf/markdown-engine";
 import type { LocalDatabase, RemoteGateway } from "./ports";
 import type { SyncEngine } from "./sync-engine";
@@ -347,13 +346,41 @@ export class NoteRepository {
     const target = current ?? note;
     await this.sync.recordDelete(target);
 
-    // Clean up assets referenced by this note so they don't linger on GitHub.
-    const matches = Array.from(target.content.matchAll(/!\[.*?\]\(([^)]+)\)/g));
-    for (const match of matches) {
-      const src = match[1];
-      if (!src || !isRelativeLink(src)) continue;
+    /**
+     * Clean up the pictures this note used — the ones nothing else is using.
+     *
+     * The "nothing else" is the whole of it, and it was missing. Reported from
+     * a real repository: a note was renamed, a copy of it appeared at the old
+     * path, the copy was deleted for being a copy — and every screenshot in
+     * the note that was *kept* turned into a broken link on GitHub. The copy
+     * pointed at the same files, so deleting it deleted them.
+     *
+     * That is the worst failure this app can have. A note is recoverable from
+     * git history; a picture deleted out from under a note that still links to
+     * it leaves a document nobody can repair from inside the app, and the
+     * person who deleted a duplicate had every reason to think they were
+     * removing nothing.
+     *
+     * So an asset goes only when no other note this device knows about points
+     * at it. Local knowledge is a floor rather than a guarantee — a note on
+     * another machine could hold the only other reference — which is the
+     * second reason to be conservative here: leaving an unused image behind
+     * costs a few kilobytes and is found later by the unused-images scan.
+     * Removing one in use costs somebody their notes.
+     */
+    const others = (await this.db.listNotes(target.workspaceId)).filter(
+      (candidate) => candidate.id !== target.id && candidate.path !== target.path,
+    );
+    const stillUsed = new Set<string>();
+    for (const candidate of others) {
+      for (const path of referencedPaths(candidate.path, candidate.content)) {
+        stillUsed.add(path);
+      }
+    }
 
-      const assetPath = resolveFromNote(target.path, src);
+    for (const assetPath of referencedPaths(target.path, target.content)) {
+      if (stillUsed.has(assetPath)) continue;
+
       const id = `${target.workspaceId}::${assetPath}`;
       const stored = await this.db.getAsset(id);
 
@@ -374,7 +401,8 @@ export class NoteRepository {
         await this.sync.recordAssetDelete(target.workspaceId, assetPath);
       }
 
-      // Local copy goes either way: the note that used it is gone.
+      // Local copy goes with it: the note that used it is gone, and nothing
+      // else on this device points at it.
       await this.db.deleteAsset(id);
     }
   }

--- a/packages/store/src/queue.ts
+++ b/packages/store/src/queue.ts
@@ -132,9 +132,20 @@ function rename(
   const prior = existing[0];
   const toPath = input.toPath ?? input.path;
 
-  // Renaming a note that was created offline is just an upsert at the new path:
-  // there is nothing at the old path on GitHub to move.
-  if (prior && prior.baseSha === null) {
+  /**
+   * Renaming a note that was created offline is just an upsert at the new
+   * path: there is nothing at the old path on GitHub to move.
+   *
+   * Both shas have to be absent for that to be true. The queued change having
+   * none is not enough on its own — a note pushed once and edited since can
+   * carry a queued change with no sha of its own while the note itself knows
+   * exactly what it is based on. Taking the shortcut there wrote a second copy
+   * at the new path and left the original sitting in the repository, which is
+   * the duplicate that appears after a rename. A real rename deletes the old
+   * path, and a delete of a path the repository does not have is dropped
+   * before the commit rather than failing it.
+   */
+  if (prior && prior.baseSha === null && input.baseSha === null) {
     return [
       ...others,
       {

--- a/packages/store/src/sync-engine.test.ts
+++ b/packages/store/src/sync-engine.test.ts
@@ -175,6 +175,61 @@ describe("queue coalescing", () => {
     expect(queue[0]!.baseSha).toBe("old");
   });
 
+  /**
+   * The duplicate that appears after a rename.
+   *
+   * "Created offline" was read off the queued change alone, and a note pushed
+   * once and edited since carries a queued change with no sha of its own. The
+   * rename was then recorded as a fresh file at the new path, with nothing
+   * removing the old one — so the repository ended up holding the note twice,
+   * and deleting the copy took the pictures both of them pointed at.
+   */
+  it("moves a note that exists remotely, rather than copying it", () => {
+    let queue = coalesce([], {
+      ...base,
+      path: "a.md",
+      op: "upsert",
+      content: "v1",
+      baseSha: null,
+    });
+    queue = coalesce(queue, {
+      ...base,
+      path: "a.md",
+      op: "rename",
+      toPath: "b.md",
+      content: "v1",
+      // The note itself knows what it is based on, whatever the queued edit says.
+      baseSha: "sha-a",
+    });
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]!.op).toBe("rename");
+    expect(queue[0]!.path).toBe("a.md");
+    expect(queue[0]!.toPath).toBe("b.md");
+  });
+
+  it("still writes a note that has never been pushed straight to its new path", () => {
+    let queue = coalesce([], {
+      ...base,
+      path: "draft.md",
+      op: "upsert",
+      content: "v1",
+      baseSha: null,
+    });
+    queue = coalesce(queue, {
+      ...base,
+      path: "draft.md",
+      op: "rename",
+      toPath: "named.md",
+      content: "v1",
+      baseSha: null,
+    });
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]!.op).toBe("upsert");
+    expect(queue[0]!.path).toBe("named.md");
+  });
+
   it("keeps edits to different notes separate", () => {
     let queue = coalesce([], { ...base, path: "a.md", op: "upsert", content: "a", baseSha: "s" });
     queue = coalesce(queue, { ...base, path: "b.md", op: "upsert", content: "b", baseSha: "s" });


### PR DESCRIPTION
## The images

This is the serious one, and it destroyed data. The sequence you hit:

1. A note full of screenshots was renamed.
2. A copy of it appeared at the old path.
3. You deleted the copy, because it was a copy.
4. Every image in the note you **kept** became a broken link on GitHub.

Step 4 is a bug in `deleteNote`. It removed every asset the deleted note's text pointed at — with no check for whether anything else still pointed at them. A duplicate references exactly the same files as the note it duplicates, so deleting it deleted the originals out from under the survivor. The note itself was untouched, still linking to a dozen paths that no longer held anything.

**Fixed:** an asset is removed only when no other note this device knows about references it. The check uses the thorough matcher the unused-images scan already had — markdown images, plain links, `<img src="…">`, reference definitions — instead of the one-line regex that saw `![](x.png)` and nothing else. That matcher moved into `@forkleaf/markdown-engine` so there is one answer to "what does this note point at" rather than two.

Local knowledge is a floor, not a guarantee — a note on another machine could hold the only other reference — which is the second reason to be conservative here. An unused image left behind costs kilobytes and gets found by the unused-images scan. One deleted in error costs somebody their notes.

**And the duplicate.** `rename` treated "the queued change has no sha" as "this note has never been pushed, so there is nothing at the old path to move" — but a note pushed once and edited since carries a queued change with no sha of its own. The rename was then recorded as a fresh file at the new path, with nothing removing the old one. Both the queued change *and* the note have to be shaless for that shortcut to hold.

`packages/store/src/asset-safety.test.ts` walks the whole sequence and fails against the old code.

## Getting your pictures back

They are still in your repository's history — the commit that removed them did not remove the history. From a clone of TCM-SECURITY-NOTES:

```bash
git log --diff-filter=D --name-only -- "PRACTICAL ETHICAL HACKING/1. Introduction/assets"
```

Take the commit *before* the deletion and restore the folder:

```bash
git checkout <commit-before-deletion>^ -- "PRACTICAL ETHICAL HACKING/1. Introduction/assets"
```

Then `git commit` and `git push`. The note already links to those paths, so it starts rendering again the moment the files are back.

## Also in this PR

| Reported | What was wrong | Fix |
| --- | --- | --- |
| Caret lands *above* a pasted image | With the caret at the end of a line, the image goes in after that whole block — so mapping the caret through the transaction correctly reports it unmoved, above the picture | Read the image's real position off the document (`WysiwygEditor.tsx`) |
| Still junk in the language picker | It still listed build files, config formats, stylesheets, markup and query languages | Programming languages only. JSON, YAML, HTML, CSS, SQL, Markdown and diff stay in **Common**, one scroll away. Anything else a repository tags a block with still highlights and still shows its own tag |
| The comparison argued against itself | It listed what each rival does better and what ForkLeaf is worse at | The table's facts are unchanged and still checkable; the section now states the conclusion instead of leaving it to the reader (`Comparison.tsx`) |

## Verified

`pnpm typecheck`, `pnpm lint`, `pnpm test` — 884 passing, 8 new. The image-caret fix was driven by hand in the dev app: text, a pasted screenshot, then more text — which now lands below the picture rather than continuing the sentence above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
