### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+Notable changes to ForkLeaf. Dates are the release date; the git history is the
+full record.
+
+## 1.0.0 — 2026-08-26
+
+The first release.
+
+ForkLeaf is a local-first Markdown workspace whose storage is a GitHub
+repository you already own. Every note is a plain `.md` file committed to your
+repo: real version history, no database to be locked out of, and nothing to
+export because there was never anything to import.
+
+### Writing
+
+- Three editing modes per note — rich text, split source/preview, raw markdown
+- Slash commands, a command palette (`⌘K`), and a properties panel that edits
+  the note's YAML frontmatter directly
+- Enter makes a line, not a paragraph, so the rich and source views agree about
+  what the file contains
+- Code blocks with syntax highlighting and a language picker; pasted code is
+  detected and fenced with the language it appears to be in
+- Document outline, word count, reading time, task progress
+
+### Links and search
+
+- `[[Wikilinks]]` in the Obsidian dialect, resolved by path, filename or title
+- Backlinks that quote the line they were written on
+- Full-text BM25 search across every note, in the browser, offline
+
+### Diagrams
+
+- A Mermaid studio: pick a diagram type, drag shapes onto a canvas, or write
+  the source with autocomplete and plain-language errors
+- 14 templates; six types drawable rather than typed
+- Stored as ordinary ` ```mermaid ` blocks, so they render on github.com too
+
+### Sync and history
+
+- Local-first: edits land in IndexedDB immediately and push in the background
+- Rapid edits coalesce into one commit rather than a thousand autosaves
+- Offline-safe queue, conflict prompts, branch switching from the status bar
+- Every version of every note read from the repository's own commit log
+- Propose changes as a pull request against a repository you cannot push to
+- Notes refresh themselves when someone else commits, without a reload
+
+### Sharing and export
+
+- Publish a note as a self-contained page committed to `docs/` and served by
+  GitHub Pages
+- Export to PDF, Word, HTML, Markdown, plain text or JSON — one note or the
+  whole workspace, rendered in the browser
+
+### Desktop
+
+- Installs as an app and registers as a Markdown editor: `xdg-open note.md`
+  opens it, and `⌘S` writes back to the file it came from
+
+### Known limits
+
+- No real-time multiplayer editing
+- Editing files on your machine needs a Chromium-based browser (File System
+  Access API); everything else works everywhere

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forkleaf/web",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forkleaf",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "description": "A local-first Markdown notes editor with first-class Mermaid diagrams that uses your own GitHub repositories as storage.",
   "license": "Apache-2.0",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forkleaf/diagrams",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forkleaf/editor",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/exporter/package.json
+++ b/packages/exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forkleaf/exporter",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forkleaf/github-client",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/markdown-engine/package.json
+++ b/packages/markdown-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forkleaf/markdown-engine",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forkleaf/store",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forkleaf/types",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
The first release.

- Version bumped to `1.0.0` across the workspace, so the tag, the packages and the release notes all say the same thing.
- `CHANGELOG.md` started, with 1.0.0 describing what the app does rather than what changed since a version nobody used.

`pnpm check` — format, types, lint, 884 tests and a production build — passes on this commit. Tag and GitHub release follow once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)