### PR TITLE
feat(history): understand a note's history — replay it, and see when each paragraph was written

### DIFF
--- a/apps/web/src/app/api/gh/history/route.test.ts
+++ b/apps/web/src/app/api/gh/history/route.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const listFileCommits = vi.fn();
+const readFileAtCommit = vi.fn();
+const getCommitFiles = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+}));
+
+vi.mock("@forkleaf/github-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@forkleaf/github-client")>("@forkleaf/github-client");
+  return {
+    ...actual,
+    GitHubClient: class {
+      listFileCommits = listFileCommits;
+      readFileAtCommit = readFileAtCommit;
+      getCommitFiles = getCommitFiles;
+    },
+  };
+});
+
+const { GET } = await import("./route");
+
+afterEach(() => vi.clearAllMocks());
+
+const BASE = "http://localhost/api/gh/history?owner=me&repo=notes&branch=main&dir=";
+
+async function get(query: string) {
+  const response = await GET(new Request(`${BASE}${query}`) as never);
+  return { status: response.status, body: await response.json() };
+}
+
+describe("GET /api/gh/history", () => {
+  it("refuses a request with no path", async () => {
+    const { status } = await get("");
+    expect(status).toBe(400);
+  });
+
+  it("lists a note's commits", async () => {
+    listFileCommits.mockResolvedValue([{ sha: "a" }]);
+    const { status, body } = await get("&path=notes/a.md");
+
+    expect(status).toBe(200);
+    expect(body.commits).toEqual([{ sha: "a" }]);
+  });
+
+  it("keeps the default window when no limit is asked for", async () => {
+    listFileCommits.mockResolvedValue([]);
+    await get("&path=notes/a.md");
+    // `Number(null)` is 0, not NaN: parsing an absent parameter without
+    // checking for it clamped this to a single commit.
+    expect(listFileCommits).toHaveBeenCalledWith(expect.anything(), "notes/a.md", 30);
+  });
+
+  it("honours a longer window, which blame needs", async () => {
+    listFileCommits.mockResolvedValue([]);
+    await get("&path=notes/a.md&limit=100");
+    expect(listFileCommits).toHaveBeenCalledWith(expect.anything(), "notes/a.md", 100);
+  });
+
+  it("clamps a limit outside the usable range", async () => {
+    listFileCommits.mockResolvedValue([]);
+
+    await get("&path=notes/a.md&limit=5000");
+    expect(listFileCommits).toHaveBeenLastCalledWith(expect.anything(), "notes/a.md", 100);
+
+    await get("&path=notes/a.md&limit=0");
+    expect(listFileCommits).toHaveBeenLastCalledWith(expect.anything(), "notes/a.md", 1);
+
+    await get("&path=notes/a.md&limit=-9");
+    expect(listFileCommits).toHaveBeenLastCalledWith(expect.anything(), "notes/a.md", 1);
+  });
+
+  it("falls back to the default for a limit that is not a number", async () => {
+    listFileCommits.mockResolvedValue([]);
+    await get("&path=notes/a.md&limit=lots");
+    expect(listFileCommits).toHaveBeenCalledWith(expect.anything(), "notes/a.md", 30);
+  });
+
+  it("reads one revision's content", async () => {
+    readFileAtCommit.mockResolvedValue("# hello");
+    const { body } = await get("&path=notes/a.md&sha=abc1234");
+    expect(body.content).toBe("# hello");
+  });
+
+  it("returns what else a commit touched", async () => {
+    getCommitFiles.mockResolvedValue({ files: [{ path: "notes/b.md" }], truncated: false });
+    const { body } = await get("&path=notes/a.md&sha=abc1234&files=1");
+
+    expect(body.files).toEqual([{ path: "notes/b.md" }]);
+    expect(readFileAtCommit).not.toHaveBeenCalled();
+  });
+
+  it("rejects a SHA that is not an object name", async () => {
+    // This value is interpolated into the upstream URL.
+    const { status } = await get("&path=notes/a.md&sha=../../etc/passwd");
+    expect(status).toBe(400);
+    expect(readFileAtCommit).not.toHaveBeenCalled();
+    expect(getCommitFiles).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/gh/history/route.ts
+++ b/apps/web/src/app/api/gh/history/route.ts
@@ -24,9 +24,26 @@ export async function GET(request: NextRequest) {
       if (!/^[0-9a-f]{7,40}$/i.test(sha)) {
         throw new ApiError(400, "validation", "That is not a valid commit SHA.");
       }
+
+      // `files` asks what else that commit touched, which is what turns a date
+      // on a paragraph into a memory of what you were working on.
+      if (params.get("files") === "1") {
+        return await client.getCommitFiles(repo, sha);
+      }
+
       return { content: await client.readFileAtCommit(repo, path, sha) };
     }
 
-    return { commits: await client.listFileCommits(repo, path) };
+    // Blame needs a longer window than a commit list does: every revision it
+    // cannot see becomes a line it has to describe as "at or before". Clamped
+    // at both ends, since it reaches GitHub as a page size.
+    // `Number(null)` is 0, not NaN, so an absent parameter has to be checked
+    // for rather than parsed — otherwise omitting it clamps history to one
+    // commit instead of leaving the default alone.
+    const raw = params.get("limit");
+    const requested = raw === null ? Number.NaN : Number(raw);
+    const limit = Number.isFinite(requested) ? Math.min(Math.max(requested, 1), 100) : 30;
+
+    return { commits: await client.listFileCommits(repo, path, limit) };
   });
 }

--- a/apps/web/src/app/docs/content/start.tsx
+++ b/apps/web/src/app/docs/content/start.tsx
@@ -74,6 +74,12 @@ export function GettingStarted() {
           this note.
         </LI>
         <LI>
+          <strong>When each paragraph was written</strong> — properties panel. Every paragraph with
+          its date in the margin, shaded by age, and the commit behind whichever one you point at —
+          including what else you changed that day. <Code>git blame</Code>, for prose: the answer to
+          &ldquo;when did I learn this, and do I still believe it?&rdquo;
+        </LI>
+        <LI>
           <strong>Replay how this was written</strong> — properties panel, right below it. A chart
           of the note&rsquo;s word count across every revision, and a scrubber that plays through
           them. Useful for the question a commit list cannot answer: whether this page arrived in

--- a/apps/web/src/app/docs/content/start.tsx
+++ b/apps/web/src/app/docs/content/start.tsx
@@ -73,6 +73,12 @@ export function GettingStarted() {
           <strong>Version history</strong> — properties panel. Every commit that has ever touched
           this note.
         </LI>
+        <LI>
+          <strong>Replay how this was written</strong> — properties panel, right below it. A chart
+          of the note&rsquo;s word count across every revision, and a scrubber that plays through
+          them. Useful for the question a commit list cannot answer: whether this page arrived in
+          one sitting or was assembled over a year.
+        </LI>
       </UL>
       <P>You can also just clone it. Nothing about a ForkLeaf repository is special:</P>
       <Pre label="terminal">{`git clone https://github.com/you/forkleaf-notes.git

--- a/apps/web/src/components/BlameView.test.tsx
+++ b/apps/web/src/components/BlameView.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { RepoRef } from "@forkleaf/types";
+import { BlameView } from "./BlameView";
+import type { RevisionTexts } from "@/hooks/useRevisionTexts";
+import type { NoteCommitDto } from "@/lib/gateway";
+
+const readCommitFiles = vi.fn();
+
+vi.mock("@/lib/gateway", () => ({
+  readCommitFiles: (...args: unknown[]) => readCommitFiles(...args),
+}));
+
+beforeEach(() => {
+  // A default a test can override. It used to live in `view()`, which meant
+  // rendering overwrote whatever the test had just set up.
+  readCommitFiles.mockResolvedValue({ files: [], truncated: false });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+const REPO: RepoRef = { owner: "me", repo: "notes", branch: "main", directory: "" };
+const PATH = "notes/ad-engagement.md";
+
+function commit(sha: string, day: number, extra: Partial<NoteCommitDto> = {}): NoteCommitDto {
+  return {
+    sha,
+    message: `commit ${sha}`,
+    authorName: "Ada",
+    authorLogin: "ada",
+    avatarUrl: null,
+    date: `2026-03-${String(day).padStart(2, "0")}T10:00:00.000Z`,
+    byForkLeaf: false,
+    ...extra,
+  };
+}
+
+function cache(texts: Record<string, string | null>): RevisionTexts {
+  return {
+    texts,
+    has: (sha: string) => sha in texts,
+    request: vi.fn(),
+    prefetch: vi.fn(),
+  };
+}
+
+/** Newest first, as the history API returns them. */
+const COMMITS = [commit("ccc", 20), commit("bbb", 10), commit("aaa", 1)];
+const TEXTS = {
+  aaa: "# Kickoff\n\nScope is the corp forest.",
+  bbb: "# Kickoff\n\nScope is the corp forest.\n\nSMB signing is off on three hosts.",
+  ccc: "# Kickoff\n\nScope is the corp forest.\n\nSMB signing is off on three hosts.\n\nKerberoasted svc-sql.",
+};
+
+function view(overrides: Partial<React.ComponentProps<typeof BlameView>> = {}) {
+  render(
+    <BlameView
+      commits={COMMITS}
+      revisions={overrides.revisions ?? cache(TEXTS)}
+      repo={REPO}
+      path={PATH}
+      {...overrides}
+    />,
+  );
+}
+
+const paragraphs = () => screen.getAllByRole("button");
+
+describe("BlameView", () => {
+  it("shows every paragraph with its date already in the margin", () => {
+    view();
+    // The dates are on screen without hovering anything: a gutter you have to
+    // discover by accident is one nobody reads.
+    expect(screen.getByText("# Kickoff")).toBeTruthy();
+    expect(screen.getByText("Scope is the corp forest.")).toBeTruthy();
+    expect(screen.getByText("Kerberoasted svc-sql.")).toBeTruthy();
+    expect(document.querySelectorAll("[data-blame-date]")).toHaveLength(4);
+  });
+
+  it("attributes each paragraph to the commit that introduced it", () => {
+    view();
+    const rows = paragraphs();
+    // Newest first in the fixture: heading and scope are oldest, the
+    // Kerberoast note is newest.
+    expect(rows[0]!.textContent).toContain("aaa");
+    expect(rows[2]!.textContent).toContain("bbb");
+    expect(rows[3]!.textContent).toContain("ccc");
+  });
+
+  it("marks the oldest visible text as possibly older still", () => {
+    view();
+    // Nothing before the first revision we can read, so we do not claim it.
+    expect(paragraphs()[0]!.textContent).toContain("≤");
+    expect(paragraphs()[3]!.textContent).not.toContain("≤");
+  });
+
+  it("invites you to point at something before you have", () => {
+    view();
+    expect(screen.getByText(/point at a paragraph/i)).toBeTruthy();
+  });
+
+  it("names the commit behind a paragraph on hover", async () => {
+    view();
+    fireEvent.mouseEnter(paragraphs()[3]!);
+    expect(screen.getByText("commit ccc")).toBeTruthy();
+    expect(screen.getByText(/Ada \(@ada\)/)).toBeTruthy();
+  });
+
+  it("reaches the same detail from the keyboard", () => {
+    view();
+    fireEvent.focus(paragraphs()[2]!);
+    expect(screen.getByText("commit bbb")).toBeTruthy();
+  });
+
+  it("says what else that commit touched", async () => {
+    readCommitFiles.mockResolvedValue({
+      files: [
+        { path: PATH, status: "modified", previousPath: null },
+        { path: "notes/kerberos.md", status: "added", previousPath: null },
+      ],
+      truncated: false,
+    });
+    view();
+
+    fireEvent.mouseEnter(paragraphs()[3]!);
+    await waitFor(() => expect(screen.getByText("notes/kerberos.md")).toBeTruthy());
+    expect(screen.getByText(/committed alongside/i)).toBeTruthy();
+    // The note being blamed is not "what else".
+    expect(screen.queryByText(PATH)).toBeNull();
+  });
+
+  it("says so plainly when a commit touched only this note", async () => {
+    readCommitFiles.mockResolvedValue({
+      files: [{ path: PATH, status: "modified", previousPath: null }],
+      truncated: false,
+    });
+    view();
+
+    fireEvent.mouseEnter(paragraphs()[3]!);
+    await waitFor(() => expect(screen.getByText(/touched only this note/i)).toBeTruthy());
+  });
+
+  it("does not make an alarm out of a failed lookup", async () => {
+    readCommitFiles.mockRejectedValue(new Error("offline"));
+    view();
+
+    fireEvent.mouseEnter(paragraphs()[3]!);
+    await waitFor(() => expect(screen.getByText(/could not read what else/i)).toBeTruthy());
+    // The date and message it already had are still there.
+    expect(screen.getByText("commit ccc")).toBeTruthy();
+  });
+
+  it("summarises the page and explains the shading", () => {
+    view();
+    expect(screen.getByText(/3 commits still visible/i)).toBeTruthy();
+    expect(screen.getByText("older")).toBeTruthy();
+    expect(screen.getByText("newer")).toBeTruthy();
+  });
+
+  it("waits rather than attributing everything to the newest commit", () => {
+    view({ revisions: cache({}) });
+    expect(screen.getByText(/reading 3 revisions/i)).toBeTruthy();
+    expect(screen.queryByText("# Kickoff")).toBeNull();
+  });
+
+  it("warns that attribution will move as older revisions arrive", () => {
+    view({ revisions: cache({ ccc: TEXTS.ccc }) });
+    expect(screen.getByText(/attribution will move earlier/i)).toBeTruthy();
+    expect(screen.getByText("reading 1/3")).toBeTruthy();
+  });
+
+  it("marks a paragraph assembled over several commits", () => {
+    view({
+      revisions: cache({
+        aaa: "one line",
+        bbb: "one line\nsecond line",
+        ccc: "one line\nsecond line",
+      }),
+    });
+    // Both lines are one block, built by two different commits.
+    expect(screen.getByText("2×")).toBeTruthy();
+  });
+
+  it("handles a note that is empty in its newest commit", () => {
+    view({ revisions: cache({ aaa: "gone now", bbb: "", ccc: "" }) });
+    expect(screen.getByText(/nothing to attribute/i)).toBeTruthy();
+  });
+
+  it("renders nothing to blame when there are no commits", () => {
+    view({ commits: [], revisions: cache({}) });
+    expect(screen.getByText(/nothing to attribute/i)).toBeTruthy();
+  });
+
+  it("links a commit out to GitHub", () => {
+    view();
+    fireEvent.mouseEnter(paragraphs()[3]!);
+    const link = screen.getByRole("link", { name: "ccc" });
+    expect(link.getAttribute("href")).toBe("https://github.com/me/notes/commit/ccc");
+  });
+
+  it("asks for every revision it needs up front", () => {
+    const revisions = cache(TEXTS);
+    view({ revisions });
+    expect(revisions.prefetch).toHaveBeenCalledWith(["ccc", "bbb", "aaa"]);
+  });
+});

--- a/apps/web/src/components/BlameView.tsx
+++ b/apps/web/src/components/BlameView.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  buildBlame,
+  ageRatio,
+  type BlameBlock,
+  type BlameRevision,
+} from "@forkleaf/markdown-engine";
+import type { RepoRef } from "@forkleaf/types";
+import type { NoteCommitDto, CommitFileDto } from "@/lib/gateway";
+import { readCommitFiles } from "@/lib/gateway";
+import type { RevisionTexts } from "@/hooks/useRevisionTexts";
+import { relativeTime, relativeAge } from "@/lib/relative-time";
+
+export interface BlameViewProps {
+  /** The note's commits, newest first — the order the history API returns. */
+  commits: readonly NoteCommitDto[];
+  /** Shared revision cache, so this costs nothing the replay has not paid. */
+  revisions: RevisionTexts;
+  /** Where the note lives, for looking up what else a commit touched. */
+  repo: RepoRef;
+  /** The note's path, so a commit's other files can exclude it. */
+  path: string;
+}
+
+/**
+ * When each paragraph was written, and what you were doing at the time.
+ *
+ * `git blame`, for prose. Re-reading your own notes months later, the question
+ * is rarely "what changed?" — it is "when did I learn this, and do I still
+ * believe it?". A paragraph untouched since March sitting next to one added
+ * last week looks identical on the page, and that difference is most of what
+ * you want to know.
+ *
+ * The dates live in a gutter that is always on screen rather than behind a
+ * hover, because a feature you have to discover by accident is one nobody
+ * uses. Hovering or focusing a paragraph fills in the rest: the commit, its
+ * message, and the other files it touched — which is what turns "2 March" into
+ * "during the AD engagement".
+ */
+export function BlameView({ commits, revisions, repo, path }: BlameViewProps) {
+  const [active, setActive] = useState<string | null>(null);
+  const { texts, has, prefetch } = revisions;
+
+  const shas = useMemo(() => commits.map((commit) => commit.sha), [commits]);
+
+  useEffect(() => {
+    prefetch(shas);
+  }, [shas, prefetch]);
+
+  const input = useMemo<BlameRevision[]>(
+    () =>
+      commits.map((commit) => ({
+        sha: commit.sha,
+        date: commit.date,
+        text: has(commit.sha) ? (texts[commit.sha] ?? null) : null,
+        message: commit.byForkLeaf && !commit.message ? "Autosaved" : commit.message,
+        authorName: commit.authorName,
+        authorLogin: commit.authorLogin,
+      })),
+    [commits, texts, has],
+  );
+
+  const blame = useMemo(() => buildBlame(input), [input]);
+
+  const loadedCount = shas.filter((sha) => sha in texts).length;
+  const loading = loadedCount < shas.length;
+
+  // The age scale is relative to this page, not to the calendar: a note
+  // written across one afternoon and one written across four years should each
+  // use the whole range, because in both the question is which parts are old.
+  const [oldest, newest] = useMemo(() => {
+    const dates = blame.lines.map((line) => line.date);
+    if (dates.length === 0) return ["", ""] as const;
+    const sorted = [...dates].sort();
+    return [sorted[0]!, sorted[sorted.length - 1]!] as const;
+  }, [blame.lines]);
+
+  const activeBlock = useMemo(
+    () => blame.blocks.find((block) => key(block) === active) ?? null,
+    [blame.blocks, active],
+  );
+
+  // Nothing has arrived yet — the first frame of a note whose history is still
+  // loading. Distinct from a note with no attributable content.
+  if (loadedCount === 0 && commits.length > 0) {
+    return (
+      <p aria-busy="true" className="py-10 text-center text-[13.5px] text-[var(--fl-muted)]">
+        Reading {commits.length} {commits.length === 1 ? "revision" : "revisions"}…
+      </p>
+    );
+  }
+
+  if (blame.empty) {
+    return (
+      <p className="py-10 text-center text-[13.5px] leading-relaxed text-[var(--fl-muted)]">
+        Nothing to attribute.
+        <br />
+        This note is empty in its most recent commit.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-col gap-3">
+      {/* ── What you are looking at, and how to read it ─────────────────── */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg bg-[var(--fl-elevated)] px-3 py-2 text-[12px]">
+        <span className="text-[var(--fl-text)]">
+          {blame.commits.length} {blame.commits.length === 1 ? "commit" : "commits"} still visible
+          on this page
+        </span>
+        <span className="text-[var(--fl-muted)]">
+          oldest {relativeTime(oldest)} · newest {relativeTime(newest)}
+        </span>
+
+        <span
+          className="ml-auto flex items-center gap-1.5 text-[11px] text-[var(--fl-muted)]"
+          title="Paragraphs are shaded by when they last changed"
+        >
+          <span>older</span>
+          <span
+            aria-hidden="true"
+            className="h-1.5 w-16 rounded-full"
+            style={{
+              background:
+                "linear-gradient(to right, color-mix(in srgb, var(--fl-accent) 18%, transparent), var(--fl-accent))",
+            }}
+          />
+          <span>newer</span>
+        </span>
+
+        {loading && (
+          <span className="text-[11px] text-[var(--fl-muted)]">
+            reading {loadedCount}/{shas.length}
+          </span>
+        )}
+      </div>
+
+      {/* ── The commit behind whatever is under the cursor ───────────────── */}
+      <CommitCard block={activeBlock} repo={repo} notePath={path} />
+
+      {/* ── The note, with its dates in the margin ──────────────────────── */}
+      <div
+        className="min-h-[200px] max-h-[46vh] overflow-y-auto rounded-xl border border-[var(--fl-border)] p-2"
+        onMouseLeave={() => setActive(null)}
+      >
+        {blame.blocks.map((block) => (
+          <BlockRow
+            key={key(block)}
+            block={block}
+            oldest={oldest}
+            newest={newest}
+            active={key(block) === active}
+            onActivate={() => setActive(key(block))}
+          />
+        ))}
+      </div>
+
+      {loading && (
+        <p className="text-[11.5px] leading-relaxed text-[var(--fl-muted)]">
+          Still reading older revisions. Attribution will move earlier as they arrive.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Stable within one render of one blame, which is all a React key needs. */
+function key(block: BlameBlock): string {
+  return `${block.start}-${block.end}`;
+}
+
+/**
+ * One paragraph, with its age in the margin.
+ *
+ * A button rather than a div with a mouse handler: this is the control that
+ * reveals a paragraph's history, and a keyboard user has as much right to it
+ * as a mouse user. Focus activates it exactly as hover does.
+ */
+function BlockRow({
+  block,
+  oldest,
+  newest,
+  active,
+  onActivate,
+}: {
+  block: BlameBlock;
+  oldest: string;
+  newest: string;
+  active: boolean;
+  onActivate: () => void;
+}) {
+  const ratio = ageRatio(block.newest.date, oldest, newest);
+  // Floored well above zero: the oldest paragraph on the page should read as
+  // old, not as absent.
+  const strength = Math.round((0.18 + ratio * 0.82) * 100);
+
+  return (
+    <button
+      type="button"
+      onMouseEnter={onActivate}
+      onFocus={onActivate}
+      onClick={onActivate}
+      aria-pressed={active}
+      aria-label={`Lines ${block.start} to ${block.end}, last changed ${relativeTime(
+        block.newest.date,
+      )}${block.newest.atOrBefore ? " or earlier" : ""}`}
+      className={`flex w-full gap-3 rounded-lg px-2 py-1.5 text-left transition-colors ${
+        active ? "bg-[var(--fl-accent-soft)]" : "hover:bg-[var(--fl-elevated)]"
+      }`}
+    >
+      <span className="flex shrink-0 items-stretch gap-2">
+        <span
+          aria-hidden="true"
+          className="w-[3px] shrink-0 rounded-full bg-[var(--fl-accent)]"
+          style={{ opacity: strength / 100 }}
+        />
+        {/* Narrower on a phone, where a fixed gutter this wide leaves the
+            prose in a column two words across. */}
+        <span className="w-[3.5rem] shrink-0 pt-0.5 text-[10.5px] leading-tight text-[var(--fl-muted)] sm:w-[5.5rem]">
+          <span className="block">
+            {block.newest.atOrBefore && (
+              <span
+                title="Or earlier — older than the history ForkLeaf can read"
+                aria-label="at or before"
+              >
+                ≤{" "}
+              </span>
+            )}
+            <span data-blame-date>{shortDate(block.newest.date)}</span>
+          </span>
+          {/* The SHA is a detail — the card names it too — so it is the first
+              thing to go when there is no room for both it and the date. */}
+          <span className="mt-0.5 hidden font-mono text-[10px] opacity-70 sm:block">
+            {block.newest.sha.slice(0, 7)}
+          </span>
+        </span>
+      </span>
+
+      <span className="min-w-0 flex-1 whitespace-pre-wrap break-words text-[13.5px] leading-relaxed text-[var(--fl-text)]">
+        {block.text}
+      </span>
+
+      {/* A paragraph assembled over several sittings is a different kind of
+          thing from one written in a single pass, and only the count says so. */}
+      {block.commitCount > 1 && (
+        <span
+          title={`${block.commitCount} commits went into this paragraph`}
+          className="shrink-0 self-start rounded bg-[var(--fl-border)] px-1.5 py-0.5 text-[10px] text-[var(--fl-muted)]"
+        >
+          {block.commitCount}×
+        </span>
+      )}
+    </button>
+  );
+}
+
+/**
+ * The commit behind the paragraph under the cursor.
+ *
+ * Fixed above the document rather than floating beside it: a popover next to a
+ * paragraph has to dodge the edges of a dialog, and it covers the very text
+ * you are reading to decide whether you still believe it.
+ */
+function CommitCard({
+  block,
+  repo,
+  notePath,
+}: {
+  block: BlameBlock | null;
+  repo: RepoRef;
+  notePath: string;
+}) {
+  const sha = block?.newest.sha ?? null;
+
+  /**
+   * The lookup, tagged with the commit it was for.
+   *
+   * Tagged rather than cleared when the cursor moves, because clearing means
+   * writing state from inside the effect — a render spent undoing the last
+   * one. Reading it back through the current SHA gives the same "nothing yet"
+   * for a commit not looked up, with no extra render and no window in which
+   * the previous commit's files sit under the new commit's name.
+   */
+  const [result, setResult] = useState<{
+    sha: string;
+    files: CommitFileDto[];
+    truncated: boolean;
+    failed: boolean;
+  } | null>(null);
+
+  const found = result && result.sha === sha ? result : null;
+
+  useEffect(() => {
+    if (!sha) return;
+
+    let cancelled = false;
+
+    void readCommitFiles(repo, notePath, sha)
+      .then((next) => {
+        if (!cancelled) setResult({ sha, ...next, failed: false });
+      })
+      .catch(() => {
+        // Not worth an alarm: the date and the message are already on screen,
+        // and this is the garnish on top of them.
+        if (!cancelled) setResult({ sha, files: [], truncated: false, failed: true });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sha, repo, notePath]);
+
+  const others = useMemo(
+    () => (found?.files ?? []).filter((file) => file.path !== notePath),
+    [found, notePath],
+  );
+
+  if (!block) {
+    return (
+      <p className="flex min-h-[6.5rem] items-center rounded-lg border border-dashed border-[var(--fl-border)] px-3 py-2.5 text-[12.5px] text-[var(--fl-muted)]">
+        Point at a paragraph to see when it was written, and what else you changed that day.
+      </p>
+    );
+  }
+
+  const line = block.newest;
+  // Null once it would only repeat the date already printed beside it.
+  const age = relativeAge(line.date);
+
+  return (
+    <div className="min-h-[6.5rem] rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] px-3 py-2.5">
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <span className="text-[13px] font-medium text-[var(--fl-text)]">
+          {line.message || "(no message)"}
+        </span>
+        <a
+          href={`https://github.com/${repo.owner}/${repo.repo}/commit/${line.sha}`}
+          target="_blank"
+          rel="noreferrer"
+          className="font-mono text-[11px] text-[var(--fl-muted)] underline decoration-[var(--fl-border-strong)] underline-offset-[3px] transition-colors hover:text-[var(--fl-text)]"
+        >
+          {line.sha.slice(0, 7)}
+        </a>
+      </div>
+
+      <p className="mt-1 text-[11.5px] text-[var(--fl-muted)]">
+        {line.authorName}
+        {line.authorLogin ? ` (@${line.authorLogin})` : ""} ·{" "}
+        <time dateTime={line.date} title={new Date(line.date).toLocaleString()}>
+          {line.atOrBefore ? "at or before " : ""}
+          {new Date(line.date).toLocaleDateString()}
+          {age && ` (${age})`}
+        </time>
+        {block.commitCount > 1 && ` · first written ${relativeTime(block.oldest.date)}`}
+      </p>
+
+      {line.atOrBefore && (
+        <p className="mt-1 text-[11px] leading-relaxed text-[var(--fl-muted)]">
+          This text was already here in the oldest revision ForkLeaf can read, so it may be older
+          than the commit named.
+        </p>
+      )}
+
+      {/* The part that turns a date into a memory. */}
+      <div className="mt-2 border-t border-[var(--fl-border)] pt-2 text-[11.5px]">
+        {found?.failed ? (
+          <span className="text-[var(--fl-muted)]">
+            Could not read what else this commit touched.
+          </span>
+        ) : found === null ? (
+          <span aria-busy="true" className="text-[var(--fl-muted)]">
+            Looking up what else changed…
+          </span>
+        ) : others.length === 0 ? (
+          <span className="text-[var(--fl-muted)]">This commit touched only this note.</span>
+        ) : (
+          <>
+            <span className="text-[var(--fl-muted)]">Committed alongside</span>
+            <ul className="mt-1 flex flex-wrap gap-1">
+              {others.map((file) => (
+                <li
+                  key={file.path}
+                  title={`${file.path} (${file.status})`}
+                  className="max-w-full truncate rounded bg-[var(--fl-surface)] px-1.5 py-0.5 font-mono text-[10.5px] text-[var(--fl-text)]"
+                >
+                  {file.path}
+                </li>
+              ))}
+              {found.truncated && (
+                <li className="px-1.5 py-0.5 text-[10.5px] text-[var(--fl-muted)]">and more…</li>
+              )}
+            </ul>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * "2 Mar", or "2 Mar 24" once a year has passed.
+ *
+ * The year is the whole point for an old note — "2 Mar" on a page written
+ * across three years says nothing — but repeating it on every line of a note
+ * written this year is noise in a gutter that has to stay narrow.
+ */
+function shortDate(iso: string, now: Date = new Date()): string {
+  const date = new Date(iso);
+  if (!Number.isFinite(date.getTime())) return "";
+
+  const short = date.toLocaleDateString(undefined, { day: "numeric", month: "short" });
+  return date.getFullYear() === now.getFullYear()
+    ? short
+    : `${short} ${String(date.getFullYear()).slice(-2)}`;
+}

--- a/apps/web/src/components/EditorRightPanel.test.tsx
+++ b/apps/web/src/components/EditorRightPanel.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Note, Workspace } from "@forkleaf/types";
+import { EditorRightPanel } from "./EditorRightPanel";
+
+afterEach(cleanup);
+
+const NOTE = {
+  path: "notes/a.md",
+  content: "# Title\n\nSome words.",
+  frontmatter: {},
+} as unknown as Note;
+
+const CONNECTED = {
+  isLocal: false,
+  repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
+} as Workspace;
+
+const LOCAL = { isLocal: true } as Workspace;
+
+function panel(workspace: Workspace | null = CONNECTED) {
+  const onShowHistory = vi.fn();
+  const onReplay = vi.fn();
+
+  render(
+    <EditorRightPanel
+      collapsed={false}
+      onToggle={vi.fn()}
+      note={NOTE}
+      workspace={workspace}
+      onFrontmatterChange={vi.fn()}
+      onExport={vi.fn()}
+      onShowHistory={onShowHistory}
+      onReplay={onReplay}
+      syncMode="auto"
+      onSyncNow={vi.fn()}
+      links={{
+        ready: true,
+        backlinks: [],
+        outgoing: [],
+        titleFor: (path: string) => path,
+        onOpen: vi.fn(),
+        onCreate: vi.fn(),
+      }}
+      assetUrls={{}}
+    />,
+  );
+
+  return { onShowHistory, onReplay };
+}
+
+/**
+ * The properties panel is where somebody goes looking for what they can do
+ * with the note in front of them, which makes it the one place the replay has
+ * to be named. It shipped reachable only as a tab inside the history dialog —
+ * two steps past anywhere its name appears — so these guard the way in, not
+ * just the thing at the end of it.
+ */
+describe("EditorRightPanel actions", () => {
+  it("offers the replay by name, next to history", () => {
+    panel();
+    const replay = screen.getByRole("button", { name: /replay how this was written/i });
+    const history = screen.getByRole("button", { name: /history & commits/i });
+    expect(replay).toBeTruthy();
+    // Adjacent, so finding one finds the other.
+    expect(history.compareDocumentPosition(replay) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("opens the replay when that button is pressed", () => {
+    const { onReplay, onShowHistory } = panel();
+    fireEvent.click(screen.getByRole("button", { name: /replay how this was written/i }));
+    expect(onReplay).toHaveBeenCalledTimes(1);
+    expect(onShowHistory).not.toHaveBeenCalled();
+  });
+
+  it("hides both when there is no repository to read history from", () => {
+    panel(LOCAL);
+    expect(screen.queryByRole("button", { name: /replay how this was written/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /history & commits/i })).toBeNull();
+  });
+});

--- a/apps/web/src/components/EditorRightPanel.test.tsx
+++ b/apps/web/src/components/EditorRightPanel.test.tsx
@@ -23,6 +23,7 @@ const LOCAL = { isLocal: true } as Workspace;
 function panel(workspace: Workspace | null = CONNECTED) {
   const onShowHistory = vi.fn();
   const onReplay = vi.fn();
+  const onBlame = vi.fn();
 
   render(
     <EditorRightPanel
@@ -34,6 +35,7 @@ function panel(workspace: Workspace | null = CONNECTED) {
       onExport={vi.fn()}
       onShowHistory={onShowHistory}
       onReplay={onReplay}
+      onBlame={onBlame}
       syncMode="auto"
       onSyncNow={vi.fn()}
       links={{
@@ -48,7 +50,7 @@ function panel(workspace: Workspace | null = CONNECTED) {
     />,
   );
 
-  return { onShowHistory, onReplay };
+  return { onShowHistory, onReplay, onBlame };
 }
 
 /**
@@ -75,9 +77,26 @@ describe("EditorRightPanel actions", () => {
     expect(onShowHistory).not.toHaveBeenCalled();
   });
 
-  it("hides both when there is no repository to read history from", () => {
+  it("offers the blame view by name, beside the replay", () => {
+    panel();
+    const blame = screen.getByRole("button", { name: /when each paragraph was written/i });
+    const replay = screen.getByRole("button", { name: /replay how this was written/i });
+    expect(blame).toBeTruthy();
+    expect(replay.compareDocumentPosition(blame) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("opens the blame view when that button is pressed", () => {
+    const { onBlame, onReplay, onShowHistory } = panel();
+    fireEvent.click(screen.getByRole("button", { name: /when each paragraph was written/i }));
+    expect(onBlame).toHaveBeenCalledTimes(1);
+    expect(onReplay).not.toHaveBeenCalled();
+    expect(onShowHistory).not.toHaveBeenCalled();
+  });
+
+  it("hides all three when there is no repository to read history from", () => {
     panel(LOCAL);
     expect(screen.queryByRole("button", { name: /replay how this was written/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /when each paragraph was written/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /history & commits/i })).toBeNull();
   });
 });

--- a/apps/web/src/components/EditorRightPanel.tsx
+++ b/apps/web/src/components/EditorRightPanel.tsx
@@ -25,6 +25,13 @@ export interface EditorRightPanelProps {
    * place nobody looks for something they have never heard of.
    */
   onReplay: () => void;
+  /**
+   * Opens the per-paragraph attribution view.
+   *
+   * Beside the replay, because they answer the two halves of the same
+   * question — how this page grew, and which parts of it are old.
+   */
+  onBlame: () => void;
   /** Opens the publish dialog. Absent for a workspace with no repository. */
   onPublish?: (() => void) | undefined;
   /**
@@ -92,6 +99,7 @@ export function EditorRightPanel({
   onExport,
   onShowHistory,
   onReplay,
+  onBlame,
   onPublish,
   published,
   syncMode,
@@ -444,6 +452,11 @@ export function EditorRightPanel({
                 {hasHistory && (
                   <PanelButton onClick={onReplay} icon={<ReplayGlyph />}>
                     Replay how this was written
+                  </PanelButton>
+                )}
+                {hasHistory && (
+                  <PanelButton onClick={onBlame} icon={<BlameGlyph />}>
+                    When each paragraph was written
                   </PanelButton>
                 )}
                 <button
@@ -799,6 +812,24 @@ function LinkGlyph() {
     >
       <path d="M6.5 9.5a2.75 2.75 0 0 0 4 .25l2-2a2.75 2.75 0 0 0-3.9-3.9l-1.1 1.1" />
       <path d="M9.5 6.5a2.75 2.75 0 0 0-4-.25l-2 2a2.75 2.75 0 0 0 3.9 3.9l1.1-1.1" />
+    </svg>
+  );
+}
+
+/** Lines of text with a marked margin — the blame gutter, in miniature. */
+function BlameGlyph() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    >
+      <path d="M2.25 3.5v9" strokeWidth="2" />
+      <path d="M5.5 4h8.25M5.5 7h8.25M5.5 10h5.5M5.5 13h7" />
     </svg>
   );
 }

--- a/apps/web/src/components/EditorRightPanel.tsx
+++ b/apps/web/src/components/EditorRightPanel.tsx
@@ -17,6 +17,14 @@ export interface EditorRightPanelProps {
   /** Opens the full export dialog, for the formats and options not shortcut here. */
   onExport: () => void;
   onShowHistory: () => void;
+  /**
+   * Opens the replay of how this note was written.
+   *
+   * Its own button rather than a tab you have to know about: the replay was
+   * only reachable by opening history and noticing a second tab, which is a
+   * place nobody looks for something they have never heard of.
+   */
+  onReplay: () => void;
   /** Opens the publish dialog. Absent for a workspace with no repository. */
   onPublish?: (() => void) | undefined;
   /**
@@ -83,6 +91,7 @@ export function EditorRightPanel({
   onFrontmatterChange,
   onExport,
   onShowHistory,
+  onReplay,
   onPublish,
   published,
   syncMode,
@@ -430,6 +439,11 @@ export function EditorRightPanel({
                 {hasHistory && (
                   <PanelButton onClick={onShowHistory} icon={<HistoryGlyph />}>
                     History &amp; commits
+                  </PanelButton>
+                )}
+                {hasHistory && (
+                  <PanelButton onClick={onReplay} icon={<ReplayGlyph />}>
+                    Replay how this was written
                   </PanelButton>
                 )}
                 <button
@@ -785,6 +799,26 @@ function LinkGlyph() {
     >
       <path d="M6.5 9.5a2.75 2.75 0 0 0 4 .25l2-2a2.75 2.75 0 0 0-3.9-3.9l-1.1 1.1" />
       <path d="M9.5 6.5a2.75 2.75 0 0 0-4-.25l-2 2a2.75 2.75 0 0 0 3.9 3.9l1.1-1.1" />
+    </svg>
+  );
+}
+
+/** A play head over a rising line — the replay's own chart, in miniature. */
+function ReplayGlyph() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M1.75 11.5 5 8l2.5 2 4.75-5.5" />
+      <path d="M1.75 14.25h12.5" />
+      <circle cx="12.25" cy="4.5" r="1.4" fill="currentColor" stroke="none" />
     </svg>
   );
 }

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -188,7 +188,8 @@ export function HelpDialog({
                 <span className="mt-3 block">
                   To see how a note has changed, open <strong>Version history</strong> in the
                   properties panel on the right — the whole commit log, and any earlier version,
-                  without leaving ForkLeaf.
+                  without leaving ForkLeaf. <strong>Replay how this was written</strong>, just below
+                  it, plays through those revisions instead of listing them.
                 </span>
                 <span className="mt-3 block">
                   You can also clone it. <Mono>git clone</Mono> the repository and every note is

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -189,7 +189,9 @@ export function HelpDialog({
                   To see how a note has changed, open <strong>Version history</strong> in the
                   properties panel on the right — the whole commit log, and any earlier version,
                   without leaving ForkLeaf. <strong>Replay how this was written</strong>, just below
-                  it, plays through those revisions instead of listing them.
+                  it, plays through those revisions instead of listing them, and{" "}
+                  <strong>When each paragraph was written</strong> puts the date each paragraph last
+                  changed in the margin beside it.
                 </span>
                 <span className="mt-3 block">
                   You can also clone it. <Mono>git clone</Mono> the repository and every note is

--- a/apps/web/src/components/HistoryDialog.test.tsx
+++ b/apps/web/src/components/HistoryDialog.test.tsx
@@ -51,7 +51,7 @@ const WORKSPACE = {
   repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
 } as Workspace;
 
-function open(commits: NoteCommitDto[] = COMMITS) {
+function open(commits: NoteCommitDto[] = COMMITS, initialTab?: "changes" | "replay") {
   listNoteHistory.mockResolvedValue(commits);
   readNoteAtCommit.mockImplementation((_repo: unknown, _path: string, sha: string) =>
     Promise.resolve(TEXT[sha] ?? null),
@@ -60,7 +60,13 @@ function open(commits: NoteCommitDto[] = COMMITS) {
   const onRestore = vi.fn();
   const onClose = vi.fn();
   render(
-    <HistoryDialog note={NOTE} workspace={WORKSPACE} onClose={onClose} onRestore={onRestore} />,
+    <HistoryDialog
+      note={NOTE}
+      workspace={WORKSPACE}
+      onClose={onClose}
+      onRestore={onRestore}
+      initialTab={initialTab}
+    />,
   );
   return { onRestore, onClose };
 }
@@ -75,6 +81,26 @@ describe("HistoryDialog", () => {
     // The diff view's own controls, not the replay's.
     expect(screen.getByLabelText(/compare with/i)).toBeTruthy();
     expect(screen.queryByRole("slider")).toBeNull();
+  });
+
+  it("opens straight onto the replay when sent there", async () => {
+    // The panel and the command palette both point at the replay directly.
+    // Landing on the diff view first and making people find a tab is exactly
+    // the burial this prop exists to undo.
+    open(COMMITS, "replay");
+    await screen.findByRole("slider");
+
+    expect(screen.getByRole("tab", { name: "Replay" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.queryByLabelText(/compare with/i)).toBeNull();
+  });
+
+  it("names what you are looking at in the title", async () => {
+    open(COMMITS, "replay");
+    await screen.findByRole("slider");
+    expect(screen.getByRole("dialog", { name: "Replay this note" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Changes" }));
+    expect(screen.getByRole("dialog", { name: "Version history" })).toBeTruthy();
   });
 
   it("switches to the replay and back", async () => {

--- a/apps/web/src/components/HistoryDialog.test.tsx
+++ b/apps/web/src/components/HistoryDialog.test.tsx
@@ -9,9 +9,12 @@ import type { NoteCommitDto } from "@/lib/gateway";
 const listNoteHistory = vi.fn();
 const readNoteAtCommit = vi.fn();
 
+const readCommitFiles = vi.fn();
+
 vi.mock("@/lib/gateway", () => ({
   listNoteHistory: (...args: unknown[]) => listNoteHistory(...args),
   readNoteAtCommit: (...args: unknown[]) => readNoteAtCommit(...args),
+  readCommitFiles: (...args: unknown[]) => readCommitFiles(...args),
 }));
 
 vi.mock("@forkleaf/editor", () => ({
@@ -51,11 +54,12 @@ const WORKSPACE = {
   repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
 } as Workspace;
 
-function open(commits: NoteCommitDto[] = COMMITS, initialTab?: "changes" | "replay") {
+function open(commits: NoteCommitDto[] = COMMITS, initialTab?: "changes" | "replay" | "blame") {
   listNoteHistory.mockResolvedValue(commits);
   readNoteAtCommit.mockImplementation((_repo: unknown, _path: string, sha: string) =>
     Promise.resolve(TEXT[sha] ?? null),
   );
+  readCommitFiles.mockResolvedValue({ files: [], truncated: false });
 
   const onRestore = vi.fn();
   const onClose = vi.fn();
@@ -101,6 +105,39 @@ describe("HistoryDialog", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Changes" }));
     expect(screen.getByRole("dialog", { name: "Version history" })).toBeTruthy();
+  });
+
+  it("opens straight onto the blame view when sent there", async () => {
+    open(COMMITS, "blame");
+    await screen.findByText(/still visible on this page/i);
+
+    expect(screen.getByRole("tab", { name: "Who wrote what" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("dialog", { name: "When each paragraph was written" })).toBeTruthy();
+  });
+
+  it("reads far enough back for blame to attribute anything", async () => {
+    open();
+    // GitHub's default page is 30 commits. Every revision blame cannot see is
+    // a line it has to hedge as "at or before", so it asks for the deepest
+    // window a single page will serve.
+    await waitFor(() =>
+      expect(listNoteHistory).toHaveBeenCalledWith(expect.anything(), NOTE.path, 100),
+    );
+  });
+
+  it("shares its revision cache across all three tabs", async () => {
+    open();
+    await waitFor(() => expect(readNoteAtCommit).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByRole("tab", { name: "Replay" }));
+    await screen.findByRole("slider");
+    fireEvent.click(screen.getByRole("tab", { name: "Who wrote what" }));
+    await screen.findByText(/still visible on this page/i);
+
+    // Two commits, fetched once between them, however many tabs ask.
+    expect(readNoteAtCommit).toHaveBeenCalledTimes(2);
   });
 
   it("switches to the replay and back", async () => {

--- a/apps/web/src/components/HistoryDialog.test.tsx
+++ b/apps/web/src/components/HistoryDialog.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Note, Workspace } from "@forkleaf/types";
+import { HistoryDialog } from "./HistoryDialog";
+import type { NoteCommitDto } from "@/lib/gateway";
+
+const listNoteHistory = vi.fn();
+const readNoteAtCommit = vi.fn();
+
+vi.mock("@/lib/gateway", () => ({
+  listNoteHistory: (...args: unknown[]) => listNoteHistory(...args),
+  readNoteAtCommit: (...args: unknown[]) => readNoteAtCommit(...args),
+}));
+
+vi.mock("@forkleaf/editor", () => ({
+  Preview: ({ markdown }: { markdown: string }) => <pre data-testid="preview">{markdown}</pre>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const COMMITS: NoteCommitDto[] = [
+  {
+    sha: "bbbbbbb",
+    message: "Second",
+    authorName: "Ada",
+    authorLogin: "ada",
+    avatarUrl: null,
+    date: "2026-03-02T10:00:00.000Z",
+    byForkLeaf: false,
+  },
+  {
+    sha: "aaaaaaa",
+    message: "First",
+    authorName: "Ada",
+    authorLogin: "ada",
+    avatarUrl: null,
+    date: "2026-03-01T10:00:00.000Z",
+    byForkLeaf: false,
+  },
+];
+
+const TEXT: Record<string, string> = { aaaaaaa: "one", bbbbbbb: "one\ntwo" };
+
+const NOTE = { path: "notes/a.md", content: "one\ntwo" } as Note;
+const WORKSPACE = {
+  repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
+} as Workspace;
+
+function open(commits: NoteCommitDto[] = COMMITS) {
+  listNoteHistory.mockResolvedValue(commits);
+  readNoteAtCommit.mockImplementation((_repo: unknown, _path: string, sha: string) =>
+    Promise.resolve(TEXT[sha] ?? null),
+  );
+
+  const onRestore = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <HistoryDialog note={NOTE} workspace={WORKSPACE} onClose={onClose} onRestore={onRestore} />,
+  );
+  return { onRestore, onClose };
+}
+
+describe("HistoryDialog", () => {
+  it("opens on the diff view, with the replay a tab away", async () => {
+    open();
+    await screen.findByRole("tab", { name: "Changes" });
+
+    expect(screen.getByRole("tab", { name: "Changes" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByRole("tab", { name: "Replay" }).getAttribute("aria-selected")).toBe("false");
+    // The diff view's own controls, not the replay's.
+    expect(screen.getByLabelText(/compare with/i)).toBeTruthy();
+    expect(screen.queryByRole("slider")).toBeNull();
+  });
+
+  it("switches to the replay and back", async () => {
+    open();
+    fireEvent.click(await screen.findByRole("tab", { name: "Replay" }));
+
+    const scrubber = await screen.findByRole("slider");
+    expect(scrubber).toBeTruthy();
+    expect(screen.queryByLabelText(/compare with/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Changes" }));
+    expect(screen.getByLabelText(/compare with/i)).toBeTruthy();
+  });
+
+  it("fetches each revision once across both tabs", async () => {
+    open();
+    // The diff view opens on the newest commit against the one before it.
+    await waitFor(() => expect(readNoteAtCommit).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByRole("tab", { name: "Replay" }));
+    await screen.findByRole("slider");
+
+    // The replay wants the same two revisions and finds them already cached.
+    await waitFor(() => expect(screen.getByText("1/2")).toBeTruthy());
+    expect(readNoteAtCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it("offers no tabs at all when the note has no history", async () => {
+    open([]);
+    await screen.findByText(/no commits yet for this note/i);
+    expect(screen.queryByRole("tab", { name: "Replay" })).toBeNull();
+  });
+
+  it("closes after restoring from the replay", async () => {
+    const { onRestore, onClose } = open();
+    fireEvent.click(await screen.findByRole("tab", { name: "Replay" }));
+    await screen.findByRole("slider");
+    await waitFor(() => expect(screen.getByText("1/2")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: /restore this version/i }));
+    await waitFor(() => expect(onRestore).toHaveBeenCalledWith("one"));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/components/HistoryDialog.tsx
+++ b/apps/web/src/components/HistoryDialog.tsx
@@ -9,6 +9,9 @@ import { useRevisionTexts } from "@/hooks/useRevisionTexts";
 import { relativeTime } from "@/lib/relative-time";
 import { listNoteHistory, type NoteCommitDto } from "@/lib/gateway";
 
+/** Which of the two ways of looking at history is on screen. */
+export type Tab = "changes" | "replay";
+
 export interface HistoryDialogProps {
   note: Note;
   workspace: Workspace;
@@ -17,10 +20,16 @@ export interface HistoryDialogProps {
   onRestore: (content: string) => void | Promise<void>;
   /** Maps an image `src` in the note to something the browser can load. */
   resolveImageSrc?: (src: string) => string;
+  /**
+   * Which view to open on.
+   *
+   * The replay is worth having its own way in — a tab inside a dialog reached
+   * from a panel is three steps deep, and a feature nobody finds is a feature
+   * that does not exist. Opening straight onto it lets the panel and the
+   * command palette point at the thing itself rather than at its container.
+   */
+  initialTab?: Tab;
 }
-
-/** Which of the two ways of looking at history is on screen. */
-type Tab = "changes" | "replay";
 
 /** What a selected revision is being compared against. */
 type Baseline = "previous" | "current" | "pinned";
@@ -40,8 +49,9 @@ export function HistoryDialog({
   onClose,
   onRestore,
   resolveImageSrc,
+  initialTab = "changes",
 }: HistoryDialogProps) {
-  const [tab, setTab] = useState<Tab>("changes");
+  const [tab, setTab] = useState<Tab>(initialTab);
   const [commits, setCommits] = useState<NoteCommitDto[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<NoteCommitDto | null>(null);
@@ -134,7 +144,7 @@ export function HistoryDialog({
 
   return (
     <Dialog
-      title="Version history"
+      title={tab === "replay" ? "Replay this note" : "Version history"}
       subtitle={`${note.path} · ${workspace.repo.owner}/${workspace.repo.repo}`}
       onClose={onClose}
       wide

--- a/apps/web/src/components/HistoryDialog.tsx
+++ b/apps/web/src/components/HistoryDialog.tsx
@@ -5,12 +5,23 @@ import type { Note, Workspace } from "@forkleaf/types";
 import { Dialog } from "./Dialog";
 import { DiffView } from "./DiffView";
 import { TimeTravelPanel } from "./TimeTravelPanel";
+import { BlameView } from "./BlameView";
 import { useRevisionTexts } from "@/hooks/useRevisionTexts";
 import { relativeTime } from "@/lib/relative-time";
 import { listNoteHistory, type NoteCommitDto } from "@/lib/gateway";
 
-/** Which of the two ways of looking at history is on screen. */
-export type Tab = "changes" | "replay";
+/**
+ * How far back to read.
+ *
+ * The commit list alone was happy with GitHub's default page of 30. Blame is
+ * not: every revision it cannot see becomes a line it has to hedge as "at or
+ * before", and the replay likewise just stops early. 100 is the most GitHub
+ * will serve in one page, and it is still one request.
+ */
+const HISTORY_LIMIT = 100;
+
+/** Which of the three ways of looking at history is on screen. */
+export type Tab = "changes" | "replay" | "blame";
 
 export interface HistoryDialogProps {
   note: Note;
@@ -68,7 +79,7 @@ export function HistoryDialog({
   useEffect(() => {
     let cancelled = false;
 
-    void listNoteHistory(workspace.repo, note.path)
+    void listNoteHistory(workspace.repo, note.path, HISTORY_LIMIT)
       .then((result) => {
         if (cancelled) return;
         setCommits(result);
@@ -144,7 +155,13 @@ export function HistoryDialog({
 
   return (
     <Dialog
-      title={tab === "replay" ? "Replay this note" : "Version history"}
+      title={
+        tab === "replay"
+          ? "Replay this note"
+          : tab === "blame"
+            ? "When each paragraph was written"
+            : "Version history"
+      }
       subtitle={`${note.path} · ${workspace.repo.owner}/${workspace.repo.repo}`}
       onClose={onClose}
       wide
@@ -179,6 +196,7 @@ export function HistoryDialog({
             [
               ["changes", "Changes", "One commit at a time, as a diff"],
               ["replay", "Replay", "Watch the note being written"],
+              ["blame", "Who wrote what", "The date each paragraph was last touched"],
             ] as const
           ).map(([value, label, hint]) => (
             <button
@@ -211,6 +229,10 @@ export function HistoryDialog({
             onClose();
           }}
         />
+      )}
+
+      {commits && commits.length > 0 && tab === "blame" && (
+        <BlameView commits={commits} revisions={revisions} repo={workspace.repo} path={note.path} />
       )}
 
       {commits && commits.length > 0 && tab === "changes" && (

--- a/apps/web/src/components/HistoryDialog.tsx
+++ b/apps/web/src/components/HistoryDialog.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Note, Workspace } from "@forkleaf/types";
 import { Dialog } from "./Dialog";
 import { DiffView } from "./DiffView";
-import { listNoteHistory, readNoteAtCommit, type NoteCommitDto } from "@/lib/gateway";
+import { TimeTravelPanel } from "./TimeTravelPanel";
+import { useRevisionTexts } from "@/hooks/useRevisionTexts";
+import { relativeTime } from "@/lib/relative-time";
+import { listNoteHistory, type NoteCommitDto } from "@/lib/gateway";
 
 export interface HistoryDialogProps {
   note: Note;
@@ -12,7 +15,12 @@ export interface HistoryDialogProps {
   onClose: () => void;
   /** Replaces the note's content with an older revision. */
   onRestore: (content: string) => void | Promise<void>;
+  /** Maps an image `src` in the note to something the browser can load. */
+  resolveImageSrc?: (src: string) => string;
 }
+
+/** Which of the two ways of looking at history is on screen. */
+type Tab = "changes" | "replay";
 
 /** What a selected revision is being compared against. */
 type Baseline = "previous" | "current" | "pinned";
@@ -26,7 +34,14 @@ type Baseline = "previous" | "current" | "pinned";
  * body is now a diff, and what it is measured against is the reader's choice:
  * the commit before it, the working copy, or any other revision they pin.
  */
-export function HistoryDialog({ note, workspace, onClose, onRestore }: HistoryDialogProps) {
+export function HistoryDialog({
+  note,
+  workspace,
+  onClose,
+  onRestore,
+  resolveImageSrc,
+}: HistoryDialogProps) {
+  const [tab, setTab] = useState<Tab>("changes");
   const [commits, setCommits] = useState<NoteCommitDto[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<NoteCommitDto | null>(null);
@@ -35,12 +50,10 @@ export function HistoryDialog({ note, workspace, onClose, onRestore }: HistoryDi
   const [mode, setMode] = useState<"unified" | "split">("split");
   const [restoring, setRestoring] = useState(false);
 
-  // Revisions are fetched once each and kept, so flipping between versions or
-  // baselines does not re-hit the API for text already on screen.
-  const [texts, setTexts] = useState<Record<string, string | null>>({});
-  // Tracks what has been requested, so a second render while a fetch is in
-  // flight does not start the same request again.
-  const requested = useRef<Set<string>>(new Set());
+  // Revisions are fetched once each and kept — shared with the replay tab, so
+  // switching between the two re-uses everything already on screen.
+  const revisions = useRevisionTexts(workspace.repo, note.path);
+  const { texts, request } = revisions;
 
   useEffect(() => {
     let cancelled = false;
@@ -87,29 +100,8 @@ export function HistoryDialog({ note, workspace, onClose, onRestore }: HistoryDi
   const loading = needed.some((sha) => !(sha in texts));
 
   useEffect(() => {
-    const missing = needed.filter((sha) => !requested.current.has(sha));
-    if (missing.length === 0) return;
-
-    for (const sha of missing) requested.current.add(sha);
-    let cancelled = false;
-
-    void Promise.all(
-      missing.map(async (sha) => {
-        try {
-          return [sha, await readNoteAtCommit(workspace.repo, note.path, sha)] as const;
-        } catch {
-          return [sha, null] as const;
-        }
-      }),
-    ).then((entries) => {
-      if (cancelled) return;
-      setTexts((current) => ({ ...current, ...Object.fromEntries(entries) }));
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [needed, workspace.repo, note.path]);
+    request(needed);
+  }, [needed, request]);
 
   const selectedText = selected ? texts[selected.sha] : null;
   const baselineText =
@@ -168,6 +160,50 @@ export function HistoryDialog({ note, workspace, onClose, onRestore }: HistoryDi
       )}
 
       {commits && commits.length > 0 && (
+        <div
+          role="tablist"
+          aria-label="History view"
+          className="mb-4 flex rounded-lg border border-[var(--fl-border)] p-0.5"
+        >
+          {(
+            [
+              ["changes", "Changes", "One commit at a time, as a diff"],
+              ["replay", "Replay", "Watch the note being written"],
+            ] as const
+          ).map(([value, label, hint]) => (
+            <button
+              key={value}
+              type="button"
+              role="tab"
+              aria-selected={tab === value}
+              title={hint}
+              onClick={() => setTab(value)}
+              className={`flex-1 rounded-[6px] px-3 py-1.5 text-[12.5px] font-medium transition-colors ${
+                tab === value
+                  ? "bg-[var(--fl-accent)] text-[var(--fl-accent-contrast)]"
+                  : "text-[var(--fl-muted)] hover:text-[var(--fl-text)]"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {commits && commits.length > 0 && tab === "replay" && (
+        <TimeTravelPanel
+          commits={commits}
+          revisions={revisions}
+          workingCopy={note.content}
+          resolveImageSrc={resolveImageSrc}
+          onRestore={async (content) => {
+            await onRestore(content);
+            onClose();
+          }}
+        />
+      )}
+
+      {commits && commits.length > 0 && tab === "changes" && (
         <div className="grid gap-4 md:grid-cols-[minmax(0,290px)_minmax(0,1fr)]">
           <ol className="max-h-[56vh] space-y-1 overflow-y-auto pr-1">
             {commits.map((commit, index) => (
@@ -344,7 +380,7 @@ function CommitRow({
 
         <span className="mt-0.5 flex items-center gap-2 text-[11px] text-[var(--fl-muted)]">
           <time dateTime={commit.date} title={new Date(commit.date).toLocaleString()}>
-            {relative(commit.date)}
+            {relativeTime(commit.date)}
           </time>
           <span aria-hidden="true">·</span>
           <span className="font-mono text-[10.5px]">{commit.sha.slice(0, 7)}</span>
@@ -372,14 +408,4 @@ function CommitRow({
       </div>
     </div>
   );
-}
-
-function relative(iso: string): string {
-  const seconds = Math.round((Date.now() - new Date(iso).getTime()) / 1000);
-  if (!Number.isFinite(seconds)) return "";
-  if (seconds < 60) return "just now";
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
-  if (seconds < 2592000) return `${Math.floor(seconds / 86400)}d ago`;
-  return new Date(iso).toLocaleDateString();
 }

--- a/apps/web/src/components/TimeTravelPanel.test.tsx
+++ b/apps/web/src/components/TimeTravelPanel.test.tsx
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { TimeTravelPanel } from "./TimeTravelPanel";
+import type { RevisionTexts } from "@/hooks/useRevisionTexts";
+import type { NoteCommitDto } from "@/lib/gateway";
+
+// The replay's job is transport, measurement and frame selection. Rendering
+// markdown is `Preview`'s job and is tested where it lives; pulling the real
+// one in would drag mermaid into every one of these tests.
+vi.mock("@forkleaf/editor", () => ({
+  Preview: ({ markdown }: { markdown: string }) => <pre data-testid="preview">{markdown}</pre>,
+}));
+
+afterEach(cleanup);
+
+function commit(sha: string, day: number, extra: Partial<NoteCommitDto> = {}): NoteCommitDto {
+  return {
+    sha,
+    message: `commit ${sha}`,
+    authorName: "Ada",
+    authorLogin: "ada",
+    avatarUrl: null,
+    date: `2026-03-${String(day).padStart(2, "0")}T10:00:00.000Z`,
+    byForkLeaf: false,
+    ...extra,
+  };
+}
+
+/** A stand-in cache holding text that is already there, with spies on the rest. */
+function cache(texts: Record<string, string | null>): RevisionTexts & {
+  request: ReturnType<typeof vi.fn>;
+  prefetch: ReturnType<typeof vi.fn>;
+} {
+  return {
+    texts,
+    has: (sha: string) => sha in texts,
+    request: vi.fn(),
+    prefetch: vi.fn(),
+  };
+}
+
+/** Newest first, the way the history API returns commits. */
+const COMMITS = [commit("ccc", 3), commit("bbb", 2), commit("aaa", 1)];
+const TEXTS = {
+  aaa: "one",
+  bbb: "one\ntwo",
+  ccc: "one\ntwo\nthree",
+};
+
+function panel(overrides: Partial<React.ComponentProps<typeof TimeTravelPanel>> = {}) {
+  const revisions = overrides.revisions ?? cache(TEXTS);
+  const onRestore = vi.fn();
+  render(
+    <TimeTravelPanel
+      commits={COMMITS}
+      revisions={revisions}
+      workingCopy={TEXTS.ccc}
+      onRestore={onRestore}
+      {...overrides}
+    />,
+  );
+  return { revisions, onRestore };
+}
+
+const slider = () => screen.getByRole("slider") as HTMLInputElement;
+const play = () => screen.getByRole("button", { name: /play replay/i });
+const pause = () => screen.getByRole("button", { name: /pause replay/i });
+const readout = () => screen.getByTestId("preview").textContent;
+
+describe("TimeTravelPanel", () => {
+  it("starts at the oldest revision, not the newest", () => {
+    panel();
+    expect(slider().value).toBe("0");
+    expect(readout()).toBe("one");
+    expect(screen.getByText("1/3")).toBeTruthy();
+  });
+
+  it("asks for every revision up front so playback does not stutter", () => {
+    const { revisions } = panel();
+    expect(revisions.prefetch).toHaveBeenCalledWith(["ccc", "bbb", "aaa"]);
+  });
+
+  it("plays a note forwards through its history", () => {
+    panel();
+    expect(slider().max).toBe("2");
+    fireEvent.change(slider(), { target: { value: "2" } });
+    expect(readout()).toBe("one\ntwo\nthree");
+    expect(screen.getByText("3/3")).toBeTruthy();
+  });
+
+  it("steps one revision at a time with the transport buttons", () => {
+    panel();
+    fireEvent.click(screen.getByRole("button", { name: /next revision/i }));
+    expect(readout()).toBe("one\ntwo");
+    fireEvent.click(screen.getByRole("button", { name: /previous revision/i }));
+    expect(readout()).toBe("one");
+  });
+
+  it("disables stepping past either end", () => {
+    panel();
+    expect(screen.getByRole("button", { name: /previous revision/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+    fireEvent.change(slider(), { target: { value: "2" } });
+    expect(screen.getByRole("button", { name: /next revision/i })).toHaveProperty("disabled", true);
+  });
+
+  it("reports the words and the line churn of each step", () => {
+    panel();
+    expect(screen.getByText("1 words")).toBeTruthy();
+
+    fireEvent.change(slider(), { target: { value: "1" } });
+    expect(screen.getByText("2 words")).toBeTruthy();
+    // One word gained, one line added, none removed. Both "+1"s are on screen,
+    // so they are read off the row rather than matched individually.
+    const row = screen.getByText("2 words").parentElement!;
+    expect(row.textContent).toContain("+1");
+    expect(row.textContent).toContain("−0");
+  });
+
+  it("shows the shape of the history above the scrubber", () => {
+    panel();
+    const chart = screen.getByRole("img", { name: /word count across 3 revisions/i });
+    expect(chart.querySelector("path")).toBeTruthy();
+  });
+
+  it("says so when a revision has not arrived yet, rather than showing a blank page", () => {
+    panel({ revisions: cache({ ccc: TEXTS.ccc, bbb: TEXTS.bbb }) });
+    expect(screen.getByText(/loading this revision/i)).toBeTruthy();
+    expect(screen.queryByTestId("preview")).toBeNull();
+  });
+
+  it("says so when a revision could not be read", () => {
+    panel({ revisions: cache({ ...TEXTS, aaa: null }) });
+    expect(screen.getByText(/could not be read/i)).toBeTruthy();
+  });
+
+  it("notes an empty revision instead of rendering nothing", () => {
+    panel({ revisions: cache({ ...TEXTS, aaa: "" }) });
+    expect(screen.getByText(/note was empty at this point/i)).toBeTruthy();
+  });
+
+  it("shows the loading tally while revisions are still coming in", () => {
+    panel({ revisions: cache({ ccc: TEXTS.ccc }) });
+    expect(screen.getByText("loading 1/3")).toBeTruthy();
+  });
+
+  it("lights up the lines a revision introduced in the source view", () => {
+    panel();
+    fireEvent.change(slider(), { target: { value: "1" } });
+    fireEvent.click(screen.getByRole("tab", { name: /source/i }));
+
+    const rendered = screen.getByText("two");
+    // The whole document is on screen, with only the new line marked.
+    expect(screen.getByText("one")).toBeTruthy();
+    expect(rendered.className).toContain("bg-[var(--fl-accent)]/15");
+    expect(screen.getByText("one").className).not.toContain("bg-[var(--fl-accent)]/15");
+  });
+
+  it("highlights against the last revision it could read, not a gap", () => {
+    // Frame two is unreadable, so frame three's additions are measured against
+    // frame one — which is what the readout above it already reports.
+    panel({ revisions: cache({ aaa: "one", bbb: null, ccc: "one\ntwo\nthree" }) });
+    fireEvent.change(slider(), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("tab", { name: /source/i }));
+
+    expect(screen.getByText("two").className).toContain("bg-[var(--fl-accent)]/15");
+    expect(screen.getByText("three").className).toContain("bg-[var(--fl-accent)]/15");
+    expect(screen.getByText("one").className).not.toContain("bg-[var(--fl-accent)]/15");
+  });
+
+  it("shows the opening revision plain rather than lit up end to end", () => {
+    panel();
+    fireEvent.click(screen.getByRole("tab", { name: /source/i }));
+    expect(screen.getByText("one").className).not.toContain("bg-[var(--fl-accent)]/15");
+  });
+
+  it("appends the unsaved working copy as a final frame", () => {
+    panel({ workingCopy: "one\ntwo\nthree\nfour" });
+    expect(slider().max).toBe("3");
+    fireEvent.change(slider(), { target: { value: "3" } });
+    expect(screen.getByText("working copy")).toBeTruthy();
+    expect(readout()).toBe("one\ntwo\nthree\nfour");
+  });
+
+  it("does not invent a working-copy frame when the note is saved", () => {
+    panel({ workingCopy: TEXTS.ccc });
+    expect(slider().max).toBe("2");
+  });
+
+  it("does not offer to restore the working copy over itself", () => {
+    panel({ workingCopy: "one\ntwo\nthree\nfour" });
+    fireEvent.change(slider(), { target: { value: "3" } });
+    expect(screen.getByRole("button", { name: /restore this version/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+
+  it("restores the revision on screen", async () => {
+    const { onRestore } = panel();
+    fireEvent.change(slider(), { target: { value: "1" } });
+    fireEvent.click(screen.getByRole("button", { name: /restore this version/i }));
+    await waitFor(() => expect(onRestore).toHaveBeenCalledWith("one\ntwo"));
+  });
+
+  it("locks the controls down to a single frame when there is one commit", () => {
+    render(
+      <TimeTravelPanel
+        commits={[commit("aaa", 1)]}
+        revisions={cache({ aaa: "one" })}
+        workingCopy="one"
+        onRestore={vi.fn()}
+      />,
+    );
+    expect(slider()).toHaveProperty("disabled", true);
+    expect(play()).toHaveProperty("disabled", true);
+    expect(screen.getByText("1/1")).toBeTruthy();
+  });
+
+  it("renders an empty state rather than crashing with no commits", () => {
+    render(
+      <TimeTravelPanel commits={[]} revisions={cache({})} workingCopy="" onRestore={vi.fn()} />,
+    );
+    expect(screen.getByText(/nothing to replay yet/i)).toBeTruthy();
+    expect(screen.queryByRole("slider")).toBeNull();
+  });
+});
+
+describe("TimeTravelPanel playback", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const advance = async (ms: number) => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  };
+
+  it("advances one revision per beat while playing", async () => {
+    panel();
+    fireEvent.click(play());
+
+    await advance(900);
+    expect(slider().value).toBe("1");
+
+    await advance(900);
+    expect(slider().value).toBe("2");
+  });
+
+  it("stops of its own accord at the newest revision", async () => {
+    panel();
+    fireEvent.click(play());
+
+    // Beat by beat: a single long jump would land past the point where the
+    // next beat gets scheduled, which says nothing about how playback behaves.
+    for (let beat = 0; beat < 5; beat += 1) await advance(900);
+
+    expect(slider().value).toBe("2");
+    // Back to a play button — nothing left to play.
+    expect(play()).toBeTruthy();
+  });
+
+  it("plays faster when asked to", async () => {
+    panel();
+    fireEvent.change(screen.getByLabelText(/speed/i), { target: { value: "4" } });
+    fireEvent.click(play());
+
+    await advance(225);
+    expect(slider().value).toBe("1");
+  });
+
+  it("pauses where it is", async () => {
+    panel();
+    fireEvent.click(play());
+    await advance(900);
+    fireEvent.click(pause());
+    for (let beat = 0; beat < 4; beat += 1) await advance(900);
+    expect(slider().value).toBe("1");
+  });
+
+  it("restarts from the beginning when played from the end", async () => {
+    panel();
+    fireEvent.change(slider(), { target: { value: "2" } });
+    fireEvent.click(play());
+    // Pressing play at the end rewinds rather than sitting there doing nothing.
+    expect(slider().value).toBe("0");
+  });
+
+  it("waits for a revision that has not arrived instead of flashing past it", async () => {
+    const { revisions } = panel({ revisions: cache({ aaa: "one", ccc: TEXTS.ccc }) });
+    fireEvent.click(play());
+
+    await advance(5000);
+
+    // Frame two is missing, so the playhead holds at frame one and asks again.
+    expect(slider().value).toBe("0");
+    expect(revisions.request).toHaveBeenCalledWith(["bbb"]);
+  });
+
+  it("stops playing when the scrubber is dragged", async () => {
+    panel();
+    fireEvent.click(play());
+    fireEvent.change(slider(), { target: { value: "2" } });
+    for (let beat = 0; beat < 4; beat += 1) await advance(900);
+    expect(slider().value).toBe("2");
+    expect(play()).toBeTruthy();
+  });
+
+  it("seeks to where the chart is clicked", async () => {
+    panel();
+    const chart = screen.getByRole("img", { name: /word count across/i });
+    chart.getBoundingClientRect = () => ({ left: 0, width: 100, top: 0, height: 64 }) as DOMRect;
+
+    fireEvent.pointerDown(chart, { clientX: 100, buttons: 1 });
+    expect(slider().value).toBe("2");
+
+    fireEvent.pointerDown(chart, { clientX: 50, buttons: 1 });
+    expect(slider().value).toBe("1");
+  });
+});

--- a/apps/web/src/components/TimeTravelPanel.tsx
+++ b/apps/web/src/components/TimeTravelPanel.tsx
@@ -1,0 +1,594 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { buildTimeline, diffLines, sparkline, type RevisionInput } from "@forkleaf/markdown-engine";
+import { Preview } from "@forkleaf/editor";
+import type { NoteCommitDto } from "@/lib/gateway";
+import type { RevisionTexts } from "@/hooks/useRevisionTexts";
+import { relativeTime, durationLabel } from "@/lib/relative-time";
+
+/**
+ * The SHA given to the unsaved working copy when it differs from the newest
+ * commit. Not a hex string, so it can never collide with a real object name.
+ */
+export const WORKING_COPY_SHA = "working-copy";
+
+/** Milliseconds per step at 1×. Slow enough to read a paragraph appearing. */
+const STEP_MS = 900;
+
+const SPEEDS = [0.5, 1, 2, 4] as const;
+type Speed = (typeof SPEEDS)[number];
+
+const CHART_WIDTH = 1000;
+const CHART_HEIGHT = 64;
+
+export interface TimeTravelPanelProps {
+  /** The note's commits, newest first — the order the history API returns. */
+  commits: readonly NoteCommitDto[];
+  /** Shared revision cache, so switching tabs re-uses what has been fetched. */
+  revisions: RevisionTexts;
+  /** The note as it stands right now, unsaved edits included. */
+  workingCopy: string;
+  /** Maps an image `src` in the note to something the browser can load. */
+  resolveImageSrc?: (src: string) => string;
+  /** Writes the revision on screen back into the note as a new change. */
+  onRestore: (content: string) => void | Promise<void>;
+}
+
+/**
+ * A note's history as a thing you can watch happen.
+ *
+ * The diff pane answers "what changed in this commit?" one commit at a time.
+ * That is the right tool for reviewing a change and the wrong one for the
+ * question people actually have about their own notes months later: how did
+ * this page come to be? A page that arrived whole in one sitting and a page
+ * assembled from ten years of scraps look identical in a commit list, and
+ * nothing else in a notes app will tell you which one you are looking at.
+ *
+ * So: every revision measured on one axis, drawn as a curve, with a scrubber
+ * that plays through them. The curve is the shape of the thinking — the
+ * plateaus, the night it doubled, the week it was cut in half — and the
+ * playhead lets you stop on any of those and read what was actually there.
+ */
+export function TimeTravelPanel({
+  commits,
+  revisions,
+  workingCopy,
+  resolveImageSrc,
+  onRestore,
+}: TimeTravelPanelProps) {
+  const [index, setIndex] = useState(0);
+  const [wantsToPlay, setWantsToPlay] = useState(false);
+  const [speed, setSpeed] = useState<Speed>(1);
+  const [view, setView] = useState<"rendered" | "source">("rendered");
+  const [restoring, setRestoring] = useState(false);
+  const chartRef = useRef<SVGSVGElement>(null);
+
+  const shas = useMemo(() => commits.map((commit) => commit.sha), [commits]);
+  const { texts, has, request, prefetch } = revisions;
+
+  // A replay needs the whole history, so it asks for the whole history — a few
+  // at a time, in the background, while the reader looks at the first frame.
+  useEffect(() => {
+    prefetch(shas);
+  }, [shas, prefetch]);
+
+  const newestText = commits[0] ? texts[commits[0].sha] : undefined;
+
+  /**
+   * The frames of the replay, oldest first.
+   *
+   * The working copy is appended as its own frame when it differs from the
+   * newest commit — otherwise the replay would stop short of what is actually
+   * on screen in the editor, which reads as a bug. It is left out until the
+   * newest revision has arrived, because until then there is nothing to
+   * compare against and every note would sprout a spurious final frame.
+   */
+  const inputs = useMemo<RevisionInput[]>(() => {
+    const frames: RevisionInput[] = commits
+      .map((commit) => ({
+        sha: commit.sha,
+        date: commit.date,
+        text: has(commit.sha) ? (texts[commit.sha] ?? null) : null,
+        message: commit.byForkLeaf && !commit.message ? "Autosaved" : commit.message,
+        authorName: commit.authorName,
+      }))
+      .reverse();
+
+    if (typeof newestText === "string" && newestText !== workingCopy) {
+      frames.push({
+        sha: WORKING_COPY_SHA,
+        // Now, so it sorts after every commit however the clocks disagree.
+        date: new Date().toISOString(),
+        text: workingCopy,
+        message: "Unsaved working copy",
+      });
+    }
+
+    return frames;
+  }, [commits, texts, has, newestText, workingCopy]);
+
+  const timeline = useMemo(() => buildTimeline(inputs), [inputs]);
+  const frames = timeline.revisions;
+  const last = Math.max(0, frames.length - 1);
+
+  // A frame can disappear from under the playhead — the working-copy frame
+  // does exactly that the moment the note is saved — so the index is clamped
+  // rather than trusted.
+  const position = Math.min(index, last);
+  const current = frames[position];
+  const previous = position > 0 ? frames[position - 1] : null;
+
+  /**
+   * The text this frame's changes are measured against.
+   *
+   * Not simply the frame before it: that frame may be one we could not read,
+   * and `buildTimeline` already skips over such gaps when counting what a
+   * revision added. The source view has to skip the same ones, or a revision
+   * whose predecessor failed to load would report "+4 lines" in the readout
+   * and highlight none of them in the body.
+   *
+   * `null` means there is nothing to compare against at all, which is a
+   * different thing from comparing against an empty file — the opening frame
+   * is shown plain rather than lit up end to end.
+   */
+  const baselineText = useMemo(() => {
+    for (let at = position - 1; at >= 0; at -= 1) {
+      const frame = frames[at];
+      if (!frame || frame.missing) continue;
+      return frame.sha === WORKING_COPY_SHA ? workingCopy : (texts[frame.sha] ?? null);
+    }
+    return null;
+  }, [frames, position, texts, workingCopy]);
+
+  const currentText = current
+    ? current.sha === WORKING_COPY_SHA
+      ? workingCopy
+      : texts[current.sha]
+    : undefined;
+  const currentLoaded = current ? current.sha === WORKING_COPY_SHA || has(current.sha) : false;
+
+  const loadedCount = shas.filter((sha) => sha in texts).length;
+  const loading = loadedCount < shas.length;
+
+  // Derived, not stored: reaching the last frame *is* the end of playback, and
+  // storing that as state would mean an effect writing state to correct itself
+  // one render after the fact.
+  const playing = wantsToPlay && position < last;
+
+  const step = useCallback(
+    (delta: number) => {
+      setWantsToPlay(false);
+      setIndex((at) => Math.min(Math.max(0, at + delta), last));
+    },
+    [last],
+  );
+
+  const seek = useCallback(
+    (to: number) => {
+      setWantsToPlay(false);
+      setIndex(Math.min(Math.max(0, to), last));
+    },
+    [last],
+  );
+
+  const toggle = useCallback(() => {
+    if (frames.length < 2) return;
+    if (playing) {
+      setWantsToPlay(false);
+      return;
+    }
+    // Pressing play at the end restarts rather than doing nothing, which is
+    // what every other transport control on a computer does.
+    if (position >= last) setIndex(0);
+    setWantsToPlay(true);
+  }, [frames.length, playing, position, last]);
+
+  // ── Playback ──────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!playing) return;
+
+    const next = frames[position + 1];
+    if (!next) return;
+
+    // Never advance onto a frame whose text has not arrived: playback would
+    // flash a blank page and carry on. Waiting is not a stall — the effect
+    // re-runs the moment the fetch lands, and a fetch that fails is recorded
+    // as unreadable, which also counts as arrived.
+    if (next.sha !== WORKING_COPY_SHA && !has(next.sha)) {
+      request([next.sha]);
+      return;
+    }
+
+    const timer = setTimeout(() => setIndex(position + 1), STEP_MS / speed);
+    return () => clearTimeout(timer);
+  }, [playing, position, last, frames, speed, has, request]);
+
+  // ── Chart geometry ────────────────────────────────────────────────────────
+  const geometry = useMemo(
+    () =>
+      sparkline(
+        frames.map((frame) => frame.words),
+        CHART_WIDTH,
+        CHART_HEIGHT,
+        timeline.maxWords,
+      ),
+    [frames, timeline.maxWords],
+  );
+
+  const seekFromPointer = useCallback(
+    (clientX: number) => {
+      const box = chartRef.current?.getBoundingClientRect();
+      if (!box || box.width === 0 || frames.length === 0) return;
+      const ratio = (clientX - box.left) / box.width;
+      seek(Math.round(ratio * last));
+    },
+    [frames.length, last, seek],
+  );
+
+  const restore = useCallback(async () => {
+    if (typeof currentText !== "string") return;
+    setWantsToPlay(false);
+    setRestoring(true);
+    try {
+      await onRestore(currentText);
+    } finally {
+      setRestoring(false);
+    }
+  }, [currentText, onRestore]);
+
+  if (frames.length === 0) {
+    return (
+      <p className="py-10 text-center text-[13.5px] text-[var(--fl-muted)]">
+        Nothing to replay yet.
+      </p>
+    );
+  }
+
+  const churnRatio = current ? (current.added + current.removed) / timeline.maxChurn : 0;
+
+  return (
+    <div className="flex min-h-0 flex-col gap-3">
+      {/* ── Chart ─────────────────────────────────────────────────────────── */}
+      <div className="rounded-xl border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-3">
+        <div className="mb-2 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+          <p className="text-[12px] font-medium text-[var(--fl-text)]">
+            {frames.length} {frames.length === 1 ? "revision" : "revisions"}
+            {timeline.spanMs > 0 && (
+              <span className="font-normal text-[var(--fl-muted)]">
+                {" "}
+                over {durationLabel(timeline.spanMs)}
+              </span>
+            )}
+          </p>
+          <p className="text-[11.5px] text-[var(--fl-muted)]">
+            peak {timeline.maxWords.toLocaleString()} words
+            {timeline.netWords !== 0 && (
+              <>
+                {" · "}
+                <span
+                  className={
+                    timeline.netWords > 0 ? "text-[var(--fl-accent)]" : "text-[var(--fl-danger)]"
+                  }
+                >
+                  {timeline.netWords > 0 ? "+" : "−"}
+                  {Math.abs(timeline.netWords).toLocaleString()} net
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+
+        <svg
+          ref={chartRef}
+          viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`Word count across ${frames.length} revisions, peaking at ${timeline.maxWords} words`}
+          className="h-16 w-full cursor-pointer touch-none"
+          onPointerDown={(event) => {
+            // Optional: not every environment implements pointer capture, and
+            // losing it costs only the drag-outside-the-box case.
+            event.currentTarget.setPointerCapture?.(event.pointerId);
+            seekFromPointer(event.clientX);
+          }}
+          onPointerMove={(event) => {
+            // Only while dragging — `buttons` is 0 for a plain hover.
+            if (event.buttons === 1) seekFromPointer(event.clientX);
+          }}
+        >
+          {geometry.area && (
+            <path d={geometry.area} fill="var(--fl-accent)" opacity="0.14" stroke="none" />
+          )}
+          {geometry.line && (
+            <path
+              d={geometry.line}
+              fill="none"
+              stroke="var(--fl-accent)"
+              strokeWidth="2"
+              vectorEffect="non-scaling-stroke"
+              strokeLinejoin="round"
+            />
+          )}
+
+          {/* Revisions we could not read are marked, so a flat stretch of the
+              curve is never mistaken for a week when nothing was written. */}
+          {frames.map((frame, at) =>
+            frame.missing && geometry.points[at] ? (
+              <circle
+                key={frame.sha}
+                cx={geometry.points[at]!.x}
+                cy={CHART_HEIGHT - 3}
+                r="2"
+                fill="var(--fl-muted)"
+                opacity="0.5"
+              />
+            ) : null,
+          )}
+
+          {geometry.points[position] && (
+            <g>
+              <line
+                x1={geometry.points[position]!.x}
+                y1="0"
+                x2={geometry.points[position]!.x}
+                y2={CHART_HEIGHT}
+                stroke="var(--fl-accent)"
+                strokeWidth="1"
+                vectorEffect="non-scaling-stroke"
+                opacity="0.65"
+              />
+              <circle
+                cx={geometry.points[position]!.x}
+                cy={geometry.points[position]!.y}
+                r="4"
+                fill="var(--fl-accent)"
+                stroke="var(--fl-surface)"
+                strokeWidth="2"
+                vectorEffect="non-scaling-stroke"
+              />
+            </g>
+          )}
+        </svg>
+
+        <input
+          type="range"
+          min={0}
+          max={last}
+          step={1}
+          value={position}
+          disabled={frames.length < 2}
+          onChange={(event) => seek(Number(event.target.value))}
+          aria-label="Revision"
+          aria-valuetext={
+            current
+              ? `Revision ${position + 1} of ${frames.length}, ${new Date(current.date).toLocaleString()}`
+              : undefined
+          }
+          className="mt-1 h-1.5 w-full cursor-pointer appearance-none rounded-full bg-[var(--fl-border-strong)] accent-[var(--fl-accent)] disabled:cursor-default disabled:opacity-40"
+        />
+      </div>
+
+      {/* ── Transport ─────────────────────────────────────────────────────── */}
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => step(-1)}
+          disabled={position === 0}
+          aria-label="Previous revision"
+          title="Previous revision"
+          className="rounded-lg border border-[var(--fl-border)] p-1.5 text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)] disabled:opacity-35"
+        >
+          <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="currentColor" aria-hidden="true">
+            <path d="M11.5 2.5v11L4 8l7.5-5.5ZM3.5 2.5h1.5v11H3.5z" />
+          </svg>
+        </button>
+
+        <button
+          type="button"
+          onClick={toggle}
+          disabled={frames.length < 2}
+          aria-label={playing ? "Pause replay" : "Play replay"}
+          aria-pressed={playing}
+          title={playing ? "Pause" : "Play"}
+          className="rounded-lg bg-[var(--fl-accent)] px-3 py-1.5 text-[var(--fl-accent-contrast)] transition-colors hover:bg-[var(--fl-accent-hover)] disabled:opacity-35"
+        >
+          <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="currentColor" aria-hidden="true">
+            {playing ? <path d="M4 2.5h3v11H4zM9 2.5h3v11H9z" /> : <path d="M4 2.5 13 8l-9 5.5z" />}
+          </svg>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => step(1)}
+          disabled={position >= last}
+          aria-label="Next revision"
+          title="Next revision"
+          className="rounded-lg border border-[var(--fl-border)] p-1.5 text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)] disabled:opacity-35"
+        >
+          <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="currentColor" aria-hidden="true">
+            <path d="M4.5 2.5 12 8l-7.5 5.5zM11 2.5h1.5v11H11z" />
+          </svg>
+        </button>
+
+        <label className="flex items-center gap-1.5 text-[12px] text-[var(--fl-muted)]">
+          Speed
+          <select
+            value={speed}
+            onChange={(event) => setSpeed(Number(event.target.value) as Speed)}
+            className="rounded-md border border-[var(--fl-border)] bg-[var(--fl-surface)] px-1.5 py-1 text-[12px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
+          >
+            {SPEEDS.map((value) => (
+              <option key={value} value={value}>
+                {value}×
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div
+          role="tablist"
+          aria-label="Replay view"
+          className="flex rounded-lg border border-[var(--fl-border)] p-0.5"
+        >
+          {(["rendered", "source"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              role="tab"
+              aria-selected={view === value}
+              onClick={() => setView(value)}
+              className={`rounded-[6px] px-2.5 py-1 text-[12px] font-medium capitalize transition-colors ${
+                view === value
+                  ? "bg-[var(--fl-accent)] text-[var(--fl-accent-contrast)]"
+                  : "text-[var(--fl-muted)] hover:text-[var(--fl-text)]"
+              }`}
+            >
+              {value}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void restore()}
+          disabled={
+            typeof currentText !== "string" || restoring || current?.sha === WORKING_COPY_SHA
+          }
+          className="ml-auto shrink-0 rounded-lg bg-[var(--fl-accent)] px-3 py-1.5 text-[12.5px] font-semibold text-[var(--fl-accent-contrast)] transition-colors hover:bg-[var(--fl-accent-hover)] disabled:opacity-40"
+        >
+          {restoring ? "Restoring…" : "Restore this version"}
+        </button>
+      </div>
+
+      {/* ── Readout ───────────────────────────────────────────────────────── */}
+      {current && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg bg-[var(--fl-elevated)] px-3 py-2 text-[12px]">
+          <span className="font-medium text-[var(--fl-text)]">
+            {position + 1}/{frames.length}
+          </span>
+          <span className="font-mono text-[11px] text-[var(--fl-muted)]">
+            {current.sha === WORKING_COPY_SHA ? "working copy" : current.sha.slice(0, 7)}
+          </span>
+          <time
+            dateTime={current.date}
+            title={new Date(current.date).toLocaleString()}
+            className="text-[var(--fl-muted)]"
+          >
+            {relativeTime(current.date)}
+          </time>
+          {current.authorName && (
+            <span className="text-[var(--fl-muted)]">{current.authorName}</span>
+          )}
+          <span className="text-[var(--fl-text)]">{current.words.toLocaleString()} words</span>
+          {previous && current.wordDelta !== 0 && (
+            <span
+              className={
+                current.wordDelta > 0 ? "text-[var(--fl-accent)]" : "text-[var(--fl-danger)]"
+              }
+            >
+              {current.wordDelta > 0 ? "+" : "−"}
+              {Math.abs(current.wordDelta).toLocaleString()}
+            </span>
+          )}
+          <span className="text-[var(--fl-muted)]">
+            <span className="text-[var(--fl-accent)]">+{current.added}</span>{" "}
+            <span className="text-[var(--fl-danger)]">−{current.removed}</span> lines
+          </span>
+          {/* A bar rather than a number: the point is which revisions were the
+              busy ones, and that is a comparison, not a quantity. */}
+          <span
+            aria-hidden="true"
+            className="h-1 w-10 overflow-hidden rounded-full bg-[var(--fl-border-strong)]"
+          >
+            <span
+              className="block h-full rounded-full bg-[var(--fl-accent)]"
+              style={{ width: `${Math.round(Math.min(1, churnRatio) * 100)}%` }}
+            />
+          </span>
+          {current.message && (
+            <span
+              className="min-w-0 flex-1 truncate text-[var(--fl-muted)]"
+              title={current.message}
+            >
+              {current.message}
+            </span>
+          )}
+          {loading && (
+            <span className="shrink-0 text-[11px] text-[var(--fl-muted)]">
+              loading {loadedCount}/{shas.length}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* ── The note, as it was ───────────────────────────────────────────── */}
+      <div className="min-h-[220px] overflow-y-auto rounded-xl border border-[var(--fl-border)] p-4 max-h-[42vh]">
+        {!currentLoaded && (
+          <p aria-busy="true" className="py-10 text-center text-[13px] text-[var(--fl-muted)]">
+            Loading this revision…
+          </p>
+        )}
+
+        {currentLoaded && typeof currentText !== "string" && (
+          <p className="py-10 text-center text-[13px] text-[var(--fl-danger)]">
+            This revision could not be read. The replay holds the previous one in its place.
+          </p>
+        )}
+
+        {currentLoaded && typeof currentText === "string" && currentText.trim() === "" && (
+          <p className="py-10 text-center text-[13px] text-[var(--fl-muted)]">
+            The note was empty at this point.
+          </p>
+        )}
+
+        {currentLoaded && typeof currentText === "string" && currentText.trim() !== "" && (
+          <>
+            {view === "rendered" ? (
+              <Preview markdown={currentText} resolveImageSrc={resolveImageSrc} />
+            ) : (
+              <SourceFrame text={currentText} previousText={baselineText} />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The revision's source with this step's new lines lit up.
+ *
+ * Rendered markdown is the honest answer to "what did the page look like", but
+ * it hides the thing a replay is for: watching writing arrive. Highlighting the
+ * lines this revision introduced, in place, in the whole document, shows where
+ * in the page the growth happened — which the diff pane, showing hunks out of
+ * context, cannot.
+ */
+function SourceFrame({ text, previousText }: { text: string; previousText: string | null }) {
+  const lines = useMemo(() => {
+    if (previousText === null) {
+      return text.split("\n").map((content) => ({ content, added: false }));
+    }
+    return diffLines(previousText, text)
+      .filter((line) => line.kind !== "delete")
+      .map((line) => ({ content: line.text, added: line.kind === "add" }));
+  }, [text, previousText]);
+
+  return (
+    <pre className="whitespace-pre-wrap break-words font-mono text-[12.5px] leading-relaxed text-[var(--fl-text)]">
+      {lines.map((line, at) => (
+        <span
+          key={at}
+          className={
+            line.added
+              ? "-mx-1 block rounded-sm bg-[var(--fl-accent)]/15 px-1"
+              : "block px-1 opacity-70"
+          }
+        >
+          {line.content === "" ? " " : line.content}
+        </span>
+      ))}
+    </pre>
+  );
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -97,7 +97,7 @@ export function EditorWorkspace() {
    */
   const [drawer, setDrawer] = useState<"files" | "document" | null>(null);
   const [dialog, setDialog] = useState<
-    "export" | "connect" | "help" | "history" | "propose" | "publish" | null
+    "export" | "connect" | "help" | "history" | "replay" | "propose" | "publish" | null
   >(null);
   /**
    * Something worth saying that is not a failure.
@@ -896,6 +896,16 @@ export function EditorWorkspace() {
           keywords: "git commits versions diff revisions",
           run: () => setDialog("history"),
         });
+
+        list.push({
+          id: "replay",
+          label: "Replay how this note was written",
+          group: "Notes",
+          hint: "Scrub through every revision and watch it grow",
+          keywords:
+            "replay time travel timeline scrubber watch animate playback evolution growth shape history revisions",
+          run: () => setDialog("replay"),
+        });
       }
     }
 
@@ -1358,6 +1368,10 @@ export function EditorWorkspace() {
                 setDrawer(null);
                 setDialog("history");
               }}
+              onReplay={() => {
+                setDrawer(null);
+                setDialog("replay");
+              }}
               onPublish={
                 workspace && !workspace.isLocal
                   ? () => {
@@ -1421,15 +1435,19 @@ export function EditorWorkspace() {
         />
       )}
 
-      {openDialog === "history" && note && workspace && !workspace.isLocal && (
-        <HistoryDialog
-          note={note}
-          workspace={workspace}
-          onClose={() => setDialog(null)}
-          onRestore={notebook.saveNote}
-          resolveImageSrc={images.resolve}
-        />
-      )}
+      {(openDialog === "history" || openDialog === "replay") &&
+        note &&
+        workspace &&
+        !workspace.isLocal && (
+          <HistoryDialog
+            note={note}
+            workspace={workspace}
+            initialTab={openDialog === "replay" ? "replay" : "changes"}
+            onClose={() => setDialog(null)}
+            onRestore={notebook.saveNote}
+            resolveImageSrc={images.resolve}
+          />
+        )}
 
       {showConflicts && (
         <ConflictDialog

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -97,7 +97,7 @@ export function EditorWorkspace() {
    */
   const [drawer, setDrawer] = useState<"files" | "document" | null>(null);
   const [dialog, setDialog] = useState<
-    "export" | "connect" | "help" | "history" | "replay" | "propose" | "publish" | null
+    "export" | "connect" | "help" | "history" | "replay" | "blame" | "propose" | "publish" | null
   >(null);
   /**
    * Something worth saying that is not a failure.
@@ -906,6 +906,16 @@ export function EditorWorkspace() {
             "replay time travel timeline scrubber watch animate playback evolution growth shape history revisions",
           run: () => setDialog("replay"),
         });
+
+        list.push({
+          id: "blame",
+          label: "See when each paragraph was written",
+          group: "Notes",
+          hint: "Dates in the margin, and what else you changed that day",
+          keywords:
+            "blame who wrote when written provenance attribution authorship age stale old paragraph line origin annotate",
+          run: () => setDialog("blame"),
+        });
       }
     }
 
@@ -1372,6 +1382,10 @@ export function EditorWorkspace() {
                 setDrawer(null);
                 setDialog("replay");
               }}
+              onBlame={() => {
+                setDrawer(null);
+                setDialog("blame");
+              }}
               onPublish={
                 workspace && !workspace.isLocal
                   ? () => {
@@ -1435,14 +1449,14 @@ export function EditorWorkspace() {
         />
       )}
 
-      {(openDialog === "history" || openDialog === "replay") &&
+      {(openDialog === "history" || openDialog === "replay" || openDialog === "blame") &&
         note &&
         workspace &&
         !workspace.isLocal && (
           <HistoryDialog
             note={note}
             workspace={workspace}
-            initialTab={openDialog === "replay" ? "replay" : "changes"}
+            initialTab={openDialog === "history" ? "changes" : openDialog}
             onClose={() => setDialog(null)}
             onRestore={notebook.saveNote}
             resolveImageSrc={images.resolve}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -1427,6 +1427,7 @@ export function EditorWorkspace() {
           workspace={workspace}
           onClose={() => setDialog(null)}
           onRestore={notebook.saveNote}
+          resolveImageSrc={images.resolve}
         />
       )}
 

--- a/apps/web/src/hooks/useRevisionTexts.test.tsx
+++ b/apps/web/src/hooks/useRevisionTexts.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { RepoRef } from "@forkleaf/types";
+import { useRevisionTexts } from "./useRevisionTexts";
+
+const readNoteAtCommit = vi.fn();
+
+vi.mock("@/lib/gateway", () => ({
+  readNoteAtCommit: (...args: unknown[]) => readNoteAtCommit(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const REPO: RepoRef = { owner: "me", repo: "notes", branch: "main", directory: "" };
+
+/**
+ * A probe that reports the cache as text, and exposes its two entry points.
+ *
+ * The `repo` object is rebuilt on every render on purpose: a caller passing a
+ * fresh object literal is the normal case, and it must not defeat the cache.
+ */
+function Probe({
+  path,
+  onReady,
+}: {
+  path: string;
+  onReady: (api: ReturnType<typeof useRevisionTexts>) => void;
+}) {
+  const revisions = useRevisionTexts({ ...REPO }, path);
+  onReady(revisions);
+  return (
+    <div data-testid="cache">
+      {Object.entries(revisions.texts)
+        .map(([sha, text]) => `${sha}=${text ?? "<unreadable>"}`)
+        .sort()
+        .join(",")}
+    </div>
+  );
+}
+
+function mount(path = "notes/a.md") {
+  let api!: ReturnType<typeof useRevisionTexts>;
+  const view = render(<Probe path={path} onReady={(next) => (api = next)} />);
+  return {
+    view,
+    request: (shas: string[]) => act(() => api.request(shas)),
+    prefetch: (shas: string[]) => act(() => api.prefetch(shas)),
+    cache: () => screen.getByTestId("cache").textContent,
+  };
+}
+
+describe("useRevisionTexts", () => {
+  it("starts empty and fetches nothing", () => {
+    const { cache } = mount();
+    expect(cache()).toBe("");
+    expect(readNoteAtCommit).not.toHaveBeenCalled();
+  });
+
+  it("fetches what is asked for and files it under its SHA", async () => {
+    readNoteAtCommit.mockResolvedValue("hello");
+    const { request, cache } = mount();
+
+    request(["aaa"]);
+    await waitFor(() => expect(cache()).toBe("aaa=hello"));
+    expect(readNoteAtCommit).toHaveBeenCalledWith(REPO, "notes/a.md", "aaa");
+  });
+
+  it("fetches a revision once however many times it is asked for", async () => {
+    readNoteAtCommit.mockResolvedValue("hello");
+    const { request, cache } = mount();
+
+    request(["aaa"]);
+    request(["aaa"]);
+    request(["aaa", "bbb"]);
+    await waitFor(() => expect(cache()).toContain("bbb="));
+
+    expect(readNoteAtCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not re-fetch after a re-render with a new repo object", async () => {
+    readNoteAtCommit.mockResolvedValue("hello");
+    const { request, view, cache } = mount();
+
+    request(["aaa"]);
+    await waitFor(() => expect(cache()).toBe("aaa=hello"));
+
+    view.rerender(<Probe path="notes/a.md" onReady={() => {}} />);
+    request(["aaa"]);
+    expect(readNoteAtCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("records a revision that could not be read, rather than retrying forever", async () => {
+    readNoteAtCommit.mockRejectedValue(new Error("offline"));
+    const { request, cache } = mount();
+
+    request(["aaa"]);
+    await waitFor(() => expect(cache()).toBe("aaa=<unreadable>"));
+
+    request(["aaa"]);
+    expect(readNoteAtCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads a whole history through the prefetch path", async () => {
+    readNoteAtCommit.mockImplementation((_repo: unknown, _path: string, sha: string) =>
+      Promise.resolve(`text-${sha}`),
+    );
+    const { prefetch, cache } = mount();
+
+    prefetch(["aaa", "bbb", "ccc"]);
+    await waitFor(() => expect(cache()).toBe("aaa=text-aaa,bbb=text-bbb,ccc=text-ccc"));
+  });
+
+  it("does not fetch the same revision through both paths", async () => {
+    readNoteAtCommit.mockResolvedValue("hello");
+    const { request, prefetch, cache } = mount();
+
+    request(["aaa"]);
+    prefetch(["aaa", "bbb"]);
+    await waitFor(() => expect(cache()).toContain("bbb="));
+    expect(readNoteAtCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it("empties the cache when the note changes", async () => {
+    readNoteAtCommit.mockResolvedValue("from note a");
+    const { view, request, cache } = mount("notes/a.md");
+
+    request(["shared"]);
+    await waitFor(() => expect(cache()).toBe("shared=from note a"));
+
+    // A commit that touched two notes appears in both their histories under
+    // the same SHA, with different content for each — so switching notes has
+    // to invalidate, not just accumulate.
+    let api!: ReturnType<typeof useRevisionTexts>;
+    view.rerender(<Probe path="notes/b.md" onReady={(next) => (api = next)} />);
+    expect(cache()).toBe("");
+
+    readNoteAtCommit.mockResolvedValue("from note b");
+    act(() => api.request(["shared"]));
+    await waitFor(() => expect(cache()).toBe("shared=from note b"));
+    expect(readNoteAtCommit).toHaveBeenLastCalledWith(REPO, "notes/b.md", "shared");
+  });
+
+  it("drops a result that lands after the note has changed", async () => {
+    let settle!: (text: string) => void;
+    readNoteAtCommit.mockReturnValue(
+      new Promise<string>((resolve) => {
+        settle = resolve;
+      }),
+    );
+
+    const { view, request, cache } = mount("notes/a.md");
+    request(["shared"]);
+
+    view.rerender(<Probe path="notes/b.md" onReady={() => {}} />);
+    await act(async () => {
+      settle("stale text from note a");
+    });
+
+    expect(cache()).toBe("");
+  });
+
+  it("reports whether a revision has settled", async () => {
+    readNoteAtCommit.mockResolvedValue("hello");
+    let api!: ReturnType<typeof useRevisionTexts>;
+    render(<Probe path="notes/a.md" onReady={(next) => (api = next)} />);
+
+    expect(api.has("aaa")).toBe(false);
+    act(() => api.request(["aaa"]));
+    await waitFor(() => expect(api.has("aaa")).toBe(true));
+  });
+});

--- a/apps/web/src/hooks/useRevisionTexts.ts
+++ b/apps/web/src/hooks/useRevisionTexts.ts
@@ -1,0 +1,157 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RepoRef } from "@forkleaf/types";
+import { readNoteAtCommit } from "@/lib/gateway";
+import { mapPool } from "@/lib/pool";
+
+/** How many revisions to fetch at once when loading a whole history. */
+const PREFETCH_CONCURRENCY = 4;
+
+/** Shared empty map, so a cache miss does not hand out a fresh object each render. */
+const EMPTY: Readonly<Record<string, string | null>> = Object.freeze({});
+
+export interface RevisionTexts {
+  /**
+   * What has arrived so far, keyed by commit SHA. A `null` value means the
+   * revision was asked for and could not be read — distinct from an absent
+   * key, which means it has not arrived yet.
+   */
+  texts: Readonly<Record<string, string | null>>;
+  /** True once a fetch for this SHA has settled, either way. */
+  has: (sha: string) => boolean;
+  /** Fetches these revisions now. Safe to call on every render. */
+  request: (shas: readonly string[]) => void;
+  /**
+   * Fetches all of these revisions a few at a time.
+   *
+   * Separate from `request` because it is background work with a different
+   * shape: a replay wants the whole history eventually and needs none of it
+   * urgently, so it must not crowd out the revision the reader is looking at.
+   */
+  prefetch: (shas: readonly string[]) => void;
+}
+
+/**
+ * A per-note cache of "the file as of commit X".
+ *
+ * Both history views need the same revisions — the diff pane fetches two at a
+ * time, the replay wants all of them — and they are shown side by side under
+ * one dialog. Keeping the cache here means switching between them re-uses
+ * everything already fetched instead of paying for it twice, and it is the only
+ * place that has to know a revision's text never changes once read.
+ */
+export function useRevisionTexts(repo: RepoRef, path: string): RevisionTexts {
+  // Everything below is scoped to this string rather than to the `repo`
+  // object, whose identity a caller may change on every render.
+  const { owner, repo: name, branch, directory } = repo;
+  const key = `${owner}/${name}@${branch}:${directory}:${path}`;
+
+  /**
+   * The cache, tagged with the note it belongs to.
+   *
+   * Tagged rather than cleared in an effect, because a commit SHA is not
+   * unique to a note: one commit that touched two files appears in both their
+   * histories, so a revision left over from the previously open note would be
+   * served for the wrong file. Carrying the key inside the state makes a stale
+   * cache unreadable by construction, with no render in between where the old
+   * note's text is still on offer.
+   */
+  const [cache, setCache] = useState<{ key: string; texts: Record<string, string | null> }>(() => ({
+    key,
+    texts: {},
+  }));
+  const texts = cache.key === key ? cache.texts : EMPTY;
+
+  // What has already been asked for. A ref rather than state because it must
+  // be readable and writable synchronously: two calls in the same tick have to
+  // see each other's marks, or the same revision is fetched twice.
+  const claimed = useRef<{ key: string; shas: Set<string> }>({ key, shas: new Set() });
+
+  // The key as of the last committed render, for rejecting results from a
+  // fetch that was started for a note the reader has since navigated away from.
+  const liveKey = useRef(key);
+  const alive = useRef(true);
+
+  useEffect(() => {
+    liveKey.current = key;
+  }, [key]);
+
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+
+  const fetchOne = useCallback(
+    async (sha: string): Promise<readonly [string, string | null]> => {
+      try {
+        return [
+          sha,
+          await readNoteAtCommit({ owner, repo: name, branch, directory }, path, sha),
+        ] as const;
+      } catch {
+        // A failed revision is recorded as null rather than retried forever:
+        // the panel shows it as unreadable and the rest of the history still
+        // works. Closing and re-opening the dialog is the retry.
+        return [sha, null] as const;
+      }
+    },
+    [owner, name, branch, directory, path],
+  );
+
+  /** Files results into the cache, unless they are for a note left behind. */
+  const absorb = useCallback(
+    (entries: readonly (readonly [string, string | null])[]) => {
+      if (!alive.current || entries.length === 0) return;
+      if (liveKey.current !== key) return;
+
+      setCache((current) =>
+        current.key === key
+          ? { key, texts: { ...current.texts, ...Object.fromEntries(entries) } }
+          : { key, texts: Object.fromEntries(entries) },
+      );
+    },
+    [key],
+  );
+
+  /** Marks the SHAs not yet asked for, and returns them. */
+  const claim = useCallback(
+    (shas: readonly string[]): string[] => {
+      if (claimed.current.key !== key) claimed.current = { key, shas: new Set() };
+      const missing = shas.filter((sha) => sha && !claimed.current.shas.has(sha));
+      for (const sha of missing) claimed.current.shas.add(sha);
+      return missing;
+    },
+    [key],
+  );
+
+  const request = useCallback(
+    (shas: readonly string[]) => {
+      const missing = claim(shas);
+      if (missing.length === 0) return;
+      void Promise.all(missing.map(fetchOne)).then(absorb);
+    },
+    [claim, fetchOne, absorb],
+  );
+
+  const prefetch = useCallback(
+    (shas: readonly string[]) => {
+      const missing = claim(shas);
+      if (missing.length === 0) return;
+
+      // Absorbed as each one lands rather than in one batch at the end, so a
+      // long history fills the chart in progressively instead of sitting empty
+      // and then appearing whole.
+      void mapPool(missing, PREFETCH_CONCURRENCY, async (sha) => {
+        absorb([await fetchOne(sha)]);
+      });
+    },
+    [claim, fetchOne, absorb],
+  );
+
+  const has = useCallback((sha: string) => sha in texts, [texts]);
+
+  return useMemo(() => ({ texts, has, request, prefetch }), [texts, has, request, prefetch]);
+}

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -336,11 +336,41 @@ export async function unpublishNote(repo: RepoRef, slug: string): Promise<{ path
   });
 }
 
-export async function listNoteHistory(repo: RepoRef, path: string): Promise<NoteCommitDto[]> {
+export async function listNoteHistory(
+  repo: RepoRef,
+  path: string,
+  limit?: number,
+): Promise<NoteCommitDto[]> {
   const { commits } = await call<{ commits: NoteCommitDto[] }>(
-    `/api/gh/history?${repoParams(repo)}&path=${encodeURIComponent(path)}`,
+    `/api/gh/history?${repoParams(repo)}&path=${encodeURIComponent(path)}` +
+      (limit ? `&limit=${limit}` : ""),
   );
   return commits;
+}
+
+/** One file a commit touched, beside the note being looked at. */
+export interface CommitFileDto {
+  path: string;
+  status: string;
+  previousPath: string | null;
+}
+
+/**
+ * What else one commit changed.
+ *
+ * Fetched separately from the commit list, and only for the commit somebody is
+ * actually looking at: asking this of every commit in a history would be one
+ * request per revision for a detail almost none of them will be asked about.
+ */
+export async function readCommitFiles(
+  repo: RepoRef,
+  path: string,
+  sha: string,
+): Promise<{ files: CommitFileDto[]; truncated: boolean }> {
+  return await call<{ files: CommitFileDto[]; truncated: boolean }>(
+    `/api/gh/history?${repoParams(repo)}&path=${encodeURIComponent(path)}` +
+      `&sha=${encodeURIComponent(sha)}&files=1`,
+  );
 }
 
 /** The content of a note as of one commit, for previewing an old revision. */

--- a/apps/web/src/lib/pool.test.ts
+++ b/apps/web/src/lib/pool.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { mapPool } from "./pool";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("mapPool", () => {
+  it("returns an empty result for no items without running the job", async () => {
+    let calls = 0;
+    const result = await mapPool([], 4, async () => {
+      calls += 1;
+      return 1;
+    });
+    expect(result).toEqual([]);
+    expect(calls).toBe(0);
+  });
+
+  it("keeps results in input order even when jobs finish out of order", async () => {
+    const result = await mapPool([30, 10, 20, 0], 4, async (delay, index) => {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return `${index}:${delay}`;
+    });
+    expect(result).toEqual(["0:30", "1:10", "2:20", "3:0"]);
+  });
+
+  it("never runs more than the limit at once", async () => {
+    let running = 0;
+    let peak = 0;
+
+    await mapPool(
+      Array.from({ length: 20 }, (_, i) => i),
+      3,
+      async () => {
+        running += 1;
+        peak = Math.max(peak, running);
+        await tick();
+        running -= 1;
+      },
+    );
+
+    expect(peak).toBe(3);
+  });
+
+  it("runs every item exactly once", async () => {
+    const seen: number[] = [];
+    await mapPool(
+      Array.from({ length: 50 }, (_, i) => i),
+      5,
+      async (item) => {
+        await tick();
+        seen.push(item);
+      },
+    );
+    expect(seen).toHaveLength(50);
+    expect(new Set(seen).size).toBe(50);
+  });
+
+  it("does not start more workers than there are items", async () => {
+    let peak = 0;
+    let running = 0;
+    await mapPool([1, 2], 10, async () => {
+      running += 1;
+      peak = Math.max(peak, running);
+      await tick();
+      running -= 1;
+    });
+    expect(peak).toBe(2);
+  });
+
+  it("settles rather than hanging when the limit is zero or negative", async () => {
+    await expect(mapPool([1, 2, 3], 0, async (n) => n * 2)).resolves.toEqual([2, 4, 6]);
+    await expect(mapPool([1, 2, 3], -5, async (n) => n * 2)).resolves.toEqual([2, 4, 6]);
+  });
+
+  it("rejects when a job throws, rather than resolving with a hole", async () => {
+    await expect(
+      mapPool([1, 2, 3], 2, async (n) => {
+        if (n === 2) throw new Error("boom");
+        return n;
+      }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("stops taking new work once the signal aborts", async () => {
+    const controller = new AbortController();
+    let started = 0;
+
+    await mapPool(
+      Array.from({ length: 20 }, (_, i) => i),
+      2,
+      async () => {
+        started += 1;
+        if (started === 4) controller.abort();
+        await tick();
+      },
+      { signal: controller.signal },
+    );
+
+    // The in-flight pair finishes; nothing new is picked up after that.
+    expect(started).toBeLessThan(20);
+    expect(started).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/apps/web/src/lib/pool.ts
+++ b/apps/web/src/lib/pool.ts
@@ -1,0 +1,44 @@
+/**
+ * Runs an async job over a list, a few at a time.
+ *
+ * The history replay needs every revision of a note in memory before it can
+ * play smoothly, and a note edited daily for a year has a lot of revisions.
+ * Firing all of them at once is the obvious thing and the wrong one: the
+ * browser caps its own connections anyway, so the requests queue regardless,
+ * and GitHub's rate limit is spent in one burst that the rest of the app then
+ * has to wait out. A small pool keeps the network busy without doing either.
+ *
+ * Results come back in the order the items were given, not the order they
+ * finished — a caller indexing into the result by position should not have to
+ * think about scheduling.
+ */
+export async function mapPool<T, R>(
+  items: readonly T[],
+  limit: number,
+  job: (item: T, index: number) => Promise<R>,
+  options: { signal?: AbortSignal } = {},
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  if (items.length === 0) return results;
+
+  // A limit below one would mean no worker ever starts, and the returned
+  // promise would never settle. Treat it as "one at a time".
+  const workers = Math.max(1, Math.min(Math.floor(limit) || 1, items.length));
+  let next = 0;
+
+  async function run(): Promise<void> {
+    for (;;) {
+      // Read and advance in one step: this is single-threaded, so no two
+      // workers can land on the same index between these two lines.
+      const index = next;
+      next += 1;
+      if (index >= items.length) return;
+      if (options.signal?.aborted) return;
+
+      results[index] = await job(items[index]!, index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: workers }, run));
+  return results;
+}

--- a/apps/web/src/lib/relative-time.test.ts
+++ b/apps/web/src/lib/relative-time.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { relativeTime, durationLabel } from "./relative-time";
+
+const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe("relativeTime", () => {
+  it("returns nothing for an unparseable date", () => {
+    expect(relativeTime("not a date", NOW)).toBe("");
+  });
+
+  it("calls the last minute 'just now'", () => {
+    expect(relativeTime(ago(0), NOW)).toBe("just now");
+    expect(relativeTime(ago(59 * SECOND), NOW)).toBe("just now");
+  });
+
+  it("reads a slightly future timestamp as recent rather than negative", () => {
+    expect(relativeTime(new Date(NOW + 30 * SECOND).toISOString(), NOW)).toBe("just now");
+  });
+
+  it("counts minutes, then hours, then days", () => {
+    expect(relativeTime(ago(5 * MINUTE), NOW)).toBe("5m ago");
+    expect(relativeTime(ago(3 * HOUR), NOW)).toBe("3h ago");
+    expect(relativeTime(ago(6 * DAY), NOW)).toBe("6d ago");
+  });
+
+  it("switches unit exactly on the boundary", () => {
+    expect(relativeTime(ago(MINUTE), NOW)).toBe("1m ago");
+    expect(relativeTime(ago(HOUR), NOW)).toBe("1h ago");
+    expect(relativeTime(ago(DAY), NOW)).toBe("1d ago");
+  });
+
+  it("falls back to a date once past a month", () => {
+    const result = relativeTime(ago(40 * DAY), NOW);
+    expect(result).not.toMatch(/ago/);
+    expect(result).toBe(new Date(NOW - 40 * DAY).toLocaleDateString());
+  });
+});
+
+describe("durationLabel", () => {
+  it("handles nothing and nonsense", () => {
+    expect(durationLabel(0)).toBe("a moment");
+    expect(durationLabel(-1)).toBe("a moment");
+    expect(durationLabel(Number.NaN)).toBe("a moment");
+  });
+
+  it("uses singular forms where they read better", () => {
+    expect(durationLabel(MINUTE)).toBe("a minute");
+    expect(durationLabel(HOUR)).toBe("an hour");
+  });
+
+  it("scales through minutes, hours, days, weeks, months and years", () => {
+    expect(durationLabel(20 * MINUTE)).toBe("20 minutes");
+    expect(durationLabel(5 * HOUR)).toBe("5 hours");
+    expect(durationLabel(4 * DAY)).toBe("4 days");
+    expect(durationLabel(30 * DAY)).toBe("4 weeks");
+    // Weeks run up to two months and months up to two years, so those two
+    // units always read as plural.
+    expect(durationLabel(70 * DAY)).toBe("2 months");
+    expect(durationLabel(365 * DAY)).toBe("12 months");
+    expect(durationLabel(200 * DAY)).toBe("7 months");
+    expect(durationLabel(1000 * DAY)).toBe("3 years");
+  });
+});

--- a/apps/web/src/lib/relative-time.test.ts
+++ b/apps/web/src/lib/relative-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { relativeTime, durationLabel } from "./relative-time";
+import { relativeTime, relativeAge, durationLabel } from "./relative-time";
 
 const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
 const ago = (ms: number) => new Date(NOW - ms).toISOString();
@@ -39,6 +39,28 @@ describe("relativeTime", () => {
     const result = relativeTime(ago(40 * DAY), NOW);
     expect(result).not.toMatch(/ago/);
     expect(result).toBe(new Date(NOW - 40 * DAY).toLocaleDateString());
+  });
+});
+
+describe("relativeAge", () => {
+  it("agrees with relativeTime while there is something relative to say", () => {
+    expect(relativeAge(ago(5 * MINUTE), NOW)).toBe("5m ago");
+    expect(relativeAge(ago(3 * HOUR), NOW)).toBe("3h ago");
+    expect(relativeAge(ago(29 * DAY), NOW)).toBe("29d ago");
+  });
+
+  it("gives up rather than repeating a date the caller already printed", () => {
+    // "3/12/2026 (3/12/2026)" reads as a bug, so the parenthetical is dropped.
+    expect(relativeAge(ago(40 * DAY), NOW)).toBeNull();
+  });
+
+  it("switches to null exactly where relativeTime stops counting", () => {
+    expect(relativeAge(ago(2592000 * SECOND - SECOND), NOW)).toBe("29d ago");
+    expect(relativeAge(ago(2592000 * SECOND), NOW)).toBeNull();
+  });
+
+  it("returns null for an unparseable date", () => {
+    expect(relativeAge("not a date", NOW)).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/relative-time.ts
+++ b/apps/web/src/lib/relative-time.ts
@@ -1,0 +1,46 @@
+/**
+ * "3d ago" for a timestamp.
+ *
+ * Lifted out of the history dialog when the replay panel needed the same
+ * phrasing: two copies of this would drift, and a commit that reads "2h ago" in
+ * one pane and "today" in the other is a bug report waiting to happen.
+ */
+export function relativeTime(iso: string, now: number = Date.now()): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return "";
+
+  const seconds = Math.round((now - then) / 1000);
+  // A commit dated slightly in the future — a clock skewed by a few seconds on
+  // the machine that made it — should read as recent, not as a negative age.
+  if (seconds < 60) return "just now";
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  if (seconds < 2592000) return `${Math.floor(seconds / 86400)}d ago`;
+  return new Date(then).toLocaleDateString();
+}
+
+/** "4 days", "6 weeks" — how long a stretch of time lasted. */
+export function durationLabel(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "a moment";
+
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return minutes <= 1 ? "a minute" : `${minutes} minutes`;
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return hours <= 1 ? "an hour" : `${hours} hours`;
+
+  const days = Math.round(hours / 24);
+  if (days < 14) return `${days} days`;
+
+  const weeks = Math.round(days / 7);
+  if (weeks < 9) return `${weeks} weeks`;
+
+  // No singular case here: the weeks branch above already covers everything
+  // short of two months, so `1 month` is unreachable.
+  const months = Math.round(days / 30);
+  if (months < 24) return `${months} months`;
+
+  // Likewise plural-only: nothing under two years reaches this branch.
+  const years = Math.round(days / 365);
+  return `${years} years`;
+}

--- a/apps/web/src/lib/relative-time.ts
+++ b/apps/web/src/lib/relative-time.ts
@@ -19,6 +19,21 @@ export function relativeTime(iso: string, now: number = Date.now()): string {
   return new Date(then).toLocaleDateString();
 }
 
+/**
+ * The same, but null once it would just repeat a date.
+ *
+ * `relativeTime` falls back to an absolute date past a month, which is right
+ * where it stands alone and wrong beside one: "3/12/2026 (3/12/2026)" reads as
+ * a bug. Callers showing both ask for this and drop the parenthetical when
+ * there is nothing left in it.
+ */
+export function relativeAge(iso: string, now: number = Date.now()): string | null {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return null;
+  if (Math.round((now - then) / 1000) >= 2592000) return null;
+  return relativeTime(iso, now);
+}
+
 /** "4 days", "6 weeks" — how long a stretch of time lasted. */
 export function durationLabel(ms: number): string {
   if (!Number.isFinite(ms) || ms <= 0) return "a moment";

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -68,6 +68,10 @@ interface ApiPullRequest {
   merged?: boolean;
 }
 
+interface ApiCommitDetail {
+  files?: { filename: string; status: string; previous_filename?: string }[];
+}
+
 interface ApiPullRequestFile {
   filename: string;
   status: string;
@@ -182,6 +186,20 @@ export interface PullRequestFile {
 }
 
 /** One entry in a note's history, flattened for display. */
+/**
+ * One file a commit touched, beyond the note being blamed.
+ *
+ * The interesting half of "when did I write this?" is what else you were doing
+ * at the time: a paragraph committed alongside four other notes from the same
+ * engagement carries a context the date alone does not.
+ */
+export interface CommitFile {
+  path: string;
+  /** GitHub's own word: added, modified, removed, renamed. */
+  status: string;
+  previousPath: string | null;
+}
+
 export interface NoteCommit {
   sha: string;
   /** The commit subject line only. */
@@ -801,6 +819,33 @@ export class GitHubClient {
       // autosave from an edit someone made elsewhere.
       byForkLeaf: (entry.commit.message ?? "").startsWith(COMMIT_MARKER),
     }));
+  }
+
+  /**
+   * The other files one commit touched.
+   *
+   * Capped, because a commit can legitimately touch a thousand files — an
+   * import, a bulk rename — and the caller wants the flavour of what else was
+   * going on, not a directory listing. `truncated` says when there was more.
+   */
+  async getCommitFiles(
+    repo: RepoRef,
+    sha: string,
+    limit = 20,
+  ): Promise<{ files: CommitFile[]; truncated: boolean }> {
+    const { data } = await this.transport.request<ApiCommitDetail>(
+      `/repos/${repo.owner}/${repo.repo}/commits/${encodeURIComponent(sha)}`,
+    );
+
+    const all = data?.files ?? [];
+    return {
+      files: all.slice(0, limit).map((file) => ({
+        path: file.filename,
+        status: file.status,
+        previousPath: file.previous_filename ?? null,
+      })),
+      truncated: all.length > limit,
+    };
   }
 
   /** The content of one file at one commit, for previewing an old version. */

--- a/packages/github-client/src/index.ts
+++ b/packages/github-client/src/index.ts
@@ -13,6 +13,7 @@ export {
   type PullRequestSummary,
   type PullRequestDetail,
   type PullRequestFile,
+  type CommitFile,
 } from "./client";
 
 export { Transport, type RateLimit, type TransportConfig, type HttpResponse } from "./http";

--- a/packages/markdown-engine/src/analyze.ts
+++ b/packages/markdown-engine/src/analyze.ts
@@ -93,10 +93,22 @@ const TASK_RE = /^[ \t]*[-*+] \[( |x|X)\]/gm;
  */
 const HIGHLIGHT_TAG_RE = /<\/?mark(?: class="fl-hl-[a-z]+")?>/g;
 
+/**
+ * Words in a document, ignoring highlight markup.
+ *
+ * Split out of `documentStats` because the history timeline needs this one
+ * number for every revision of a note and nothing else it computes: parsing
+ * thirty revisions to markdown ASTs to count words would be thirty parses
+ * spent on a figure a regular expression already has.
+ */
+export function countWords(markdown: string): number {
+  return markdown.replace(HIGHLIGHT_TAG_RE, "").match(WORD_RE)?.length ?? 0;
+}
+
 /** Cheap document statistics for the properties panel. */
 export function documentStats(markdown: string): DocumentStats {
   const prose = markdown.replace(HIGHLIGHT_TAG_RE, "");
-  const words = prose.match(WORD_RE)?.length ?? 0;
+  const words = countWords(markdown);
 
   let total = 0;
   let done = 0;

--- a/packages/markdown-engine/src/blame.test.ts
+++ b/packages/markdown-engine/src/blame.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from "vitest";
+import { buildBlame, toBlocks, ageRatio, type BlameRevision } from "./blame";
+
+const at = (day: number) => `2026-03-${String(day).padStart(2, "0")}T10:00:00.000Z`;
+
+function rev(sha: string, day: number, text: string | null): BlameRevision {
+  return { sha, date: at(day), text };
+}
+
+/** Shorthand: the SHA blamed for each line, in order. */
+const shas = (input: readonly BlameRevision[]) => buildBlame(input).lines.map((line) => line.sha);
+
+describe("buildBlame", () => {
+  it("returns an empty result for nothing at all", () => {
+    const blame = buildBlame([]);
+    expect(blame.empty).toBe(true);
+    expect(blame.lines).toEqual([]);
+    expect(blame.blocks).toEqual([]);
+  });
+
+  it("returns an empty result when no revision could be read", () => {
+    expect(buildBlame([rev("a", 1, null), rev("b", 2, null)]).empty).toBe(true);
+  });
+
+  it("attributes a single revision to itself, flagged as possibly older", () => {
+    const blame = buildBlame([rev("a", 1, "one\ntwo")]);
+    expect(blame.lines.map((line) => [line.number, line.text, line.sha])).toEqual([
+      [1, "one", "a"],
+      [2, "two", "a"],
+    ]);
+    // We cannot see before the oldest revision we were given, so we do not
+    // claim this is where the lines were written.
+    expect(blame.lines.every((line) => line.atOrBefore)).toBe(true);
+  });
+
+  it("credits a new line to the revision that introduced it", () => {
+    const blame = buildBlame([rev("a", 1, "one"), rev("b", 2, "one\ntwo")]);
+    expect(shas([rev("a", 1, "one"), rev("b", 2, "one\ntwo")])).toEqual(["a", "b"]);
+    expect(blame.lines[1]!.atOrBefore).toBe(false);
+  });
+
+  it("leaves an untouched line with its original commit across many revisions", () => {
+    const revisions = [
+      rev("a", 1, "the original line"),
+      rev("b", 2, "the original line\nsecond"),
+      rev("c", 3, "the original line\nsecond\nthird"),
+      rev("d", 4, "the original line\nsecond edited\nthird"),
+    ];
+    expect(shas(revisions)).toEqual(["a", "d", "c"]);
+  });
+
+  it("blames the rewrite, not the original, when a line is edited", () => {
+    const revisions = [rev("a", 1, "before"), rev("b", 2, "after")];
+    expect(shas(revisions)).toEqual(["b"]);
+  });
+
+  it("forgets a line that was deleted, without shifting its neighbours", () => {
+    const revisions = [
+      rev("a", 1, "keep one\ndrop me\nkeep two"),
+      rev("b", 2, "keep one\nkeep two"),
+    ];
+    const blame = buildBlame(revisions);
+    expect(blame.lines.map((line) => line.text)).toEqual(["keep one", "keep two"]);
+    expect(blame.lines.map((line) => line.sha)).toEqual(["a", "a"]);
+  });
+
+  it("keeps attribution correct when a line is inserted in the middle", () => {
+    const revisions = [rev("a", 1, "first\nlast"), rev("b", 2, "first\nmiddle\nlast")];
+    expect(shas(revisions)).toEqual(["a", "b", "a"]);
+  });
+
+  it("re-blames a line that was deleted and later written again", () => {
+    const revisions = [rev("a", 1, "one\ntwo"), rev("b", 2, "one"), rev("c", 3, "one\ntwo")];
+    // The text is identical to revision a, but this "two" is not that "two".
+    expect(shas(revisions)).toEqual(["a", "c"]);
+  });
+
+  it("sorts revisions oldest first whatever order they arrive in", () => {
+    const newestFirst = [
+      rev("c", 3, "one\ntwo\nthree"),
+      rev("b", 2, "one\ntwo"),
+      rev("a", 1, "one"),
+    ];
+    expect(shas(newestFirst)).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps input order for revisions sharing a timestamp", () => {
+    const revisions: BlameRevision[] = [
+      { sha: "first", date: at(1), text: "one" },
+      { sha: "second", date: at(1), text: "one\ntwo" },
+    ];
+    expect(shas(revisions)).toEqual(["first", "second"]);
+  });
+
+  it("skips an unreadable revision instead of treating it as an empty file", () => {
+    const revisions = [rev("a", 1, "one\ntwo"), rev("b", 2, null), rev("c", 3, "one\ntwo\nthree")];
+    // Had the gap been read as empty, every line would be blamed on c.
+    expect(shas(revisions)).toEqual(["a", "a", "c"]);
+  });
+
+  it("attributes everything to the newest revision when only it is readable", () => {
+    const revisions = [rev("a", 1, null), rev("b", 2, "only this")];
+    const blame = buildBlame(revisions);
+    expect(blame.lines.map((line) => line.sha)).toEqual(["b"]);
+    expect(blame.lines[0]!.atOrBefore).toBe(true);
+  });
+
+  it("handles a note emptied and then rewritten", () => {
+    const revisions = [rev("a", 1, "old text"), rev("b", 2, ""), rev("c", 3, "new text")];
+    expect(shas(revisions)).toEqual(["c"]);
+  });
+
+  it("reports an empty newest revision as nothing to attribute", () => {
+    const blame = buildBlame([rev("a", 1, "something"), rev("b", 2, "")]);
+    expect(blame.lines).toEqual([]);
+    expect(blame.empty).toBe(true);
+  });
+
+  it("normalises CRLF so a line ending change is not a rewrite", () => {
+    const revisions = [rev("a", 1, "one\ntwo"), rev("b", 2, "one\r\ntwo")];
+    expect(shas(revisions)).toEqual(["a", "a"]);
+  });
+
+  it("carries the commit's own details onto the lines it wrote", () => {
+    const revisions: BlameRevision[] = [
+      { sha: "a", date: at(1), text: "one", message: "Start", authorName: "Ada" },
+      {
+        sha: "b",
+        date: at(2),
+        text: "one\ntwo",
+        message: "Add the second",
+        authorName: "Grace",
+        authorLogin: "grace",
+      },
+    ];
+    const blame = buildBlame(revisions);
+    expect(blame.lines[1]).toMatchObject({
+      message: "Add the second",
+      authorName: "Grace",
+      authorLogin: "grace",
+      date: at(2),
+    });
+  });
+
+  it("tallies distinct commits newest first", () => {
+    const revisions = [
+      rev("a", 1, "one\ntwo"),
+      rev("b", 2, "one\ntwo\nthree"),
+      rev("c", 3, "one\ntwo\nthree\nfour"),
+    ];
+    expect(buildBlame(revisions).commits).toEqual([
+      { sha: "c", date: at(3), lineCount: 1 },
+      { sha: "b", date: at(2), lineCount: 1 },
+      { sha: "a", date: at(1), lineCount: 2 },
+    ]);
+  });
+
+  it("stays quick over a long history", () => {
+    const revisions: BlameRevision[] = Array.from({ length: 120 }, (_, index) => ({
+      sha: `sha${index}`,
+      date: new Date(Date.UTC(2026, 0, 1) + index * 3600_000).toISOString(),
+      text: Array.from({ length: index + 1 }, (_, line) => `line ${line}`).join("\n"),
+    }));
+
+    const started = Date.now();
+    const blame = buildBlame(revisions);
+    expect(blame.lines).toHaveLength(120);
+    // Each revision appended exactly one line, so each owns exactly one.
+    expect(blame.lines[119]!.sha).toBe("sha119");
+    expect(blame.lines[0]!.sha).toBe("sha0");
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+});
+
+describe("toBlocks", () => {
+  const lines = (spec: [string, string, number][]) =>
+    spec.map(([text, sha, day], index) => ({
+      number: index + 1,
+      text,
+      sha,
+      date: at(day),
+      atOrBefore: false,
+    }));
+
+  it("returns nothing for no lines", () => {
+    expect(toBlocks([])).toEqual([]);
+  });
+
+  it("groups consecutive lines and breaks on blank ones", () => {
+    const blocks = toBlocks(
+      lines([
+        ["# Heading", "a", 1],
+        ["", "a", 1],
+        ["First paragraph", "a", 1],
+        ["wrapped onto two lines", "b", 2],
+        ["", "b", 2],
+        ["Second paragraph", "c", 3],
+      ]),
+    );
+
+    expect(blocks.map((block) => block.text)).toEqual([
+      "# Heading",
+      "First paragraph\nwrapped onto two lines",
+      "Second paragraph",
+    ]);
+    expect(blocks.map((block) => [block.start, block.end])).toEqual([
+      [1, 1],
+      [3, 4],
+      [6, 6],
+    ]);
+  });
+
+  it("gives no block to a blank line", () => {
+    // A gap between paragraphs carries no writing, so attributing it would
+    // paint a stripe between every two paragraphs for a change nobody made.
+    expect(toBlocks(lines([["", "a", 1]]))).toEqual([]);
+  });
+
+  it("treats a whitespace-only line as a boundary", () => {
+    const blocks = toBlocks(
+      lines([
+        ["one", "a", 1],
+        ["   ", "a", 1],
+        ["two", "a", 1],
+      ]),
+    );
+    expect(blocks).toHaveLength(2);
+  });
+
+  it("reports when a block last changed and when it first appeared", () => {
+    const [block] = toBlocks(
+      lines([
+        ["written first", "a", 1],
+        ["edited last", "c", 9],
+        ["in between", "b", 4],
+      ]),
+    );
+
+    expect(block!.newest.sha).toBe("c");
+    expect(block!.oldest.sha).toBe("a");
+    expect(block!.commitCount).toBe(3);
+  });
+
+  it("counts a single-commit block as one", () => {
+    const [block] = toBlocks(
+      lines([
+        ["one", "a", 1],
+        ["two", "a", 1],
+      ]),
+    );
+    expect(block!.commitCount).toBe(1);
+    expect(block!.newest.sha).toBe("a");
+    expect(block!.oldest.sha).toBe("a");
+  });
+
+  it("closes the last block at the end of the document", () => {
+    const blocks = toBlocks(lines([["trailing", "a", 1]]));
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.end).toBe(1);
+  });
+});
+
+describe("ageRatio", () => {
+  const OLD = at(1);
+  const NEW = at(11);
+
+  it("puts the oldest at 0 and the newest at 1", () => {
+    expect(ageRatio(OLD, OLD, NEW)).toBe(0);
+    expect(ageRatio(NEW, OLD, NEW)).toBe(1);
+  });
+
+  it("places the middle in the middle", () => {
+    expect(ageRatio(at(6), OLD, NEW)).toBeCloseTo(0.5, 5);
+  });
+
+  it("reads a document written all at once as new, not ancient", () => {
+    expect(ageRatio(OLD, OLD, OLD)).toBe(1);
+  });
+
+  it("clamps anything outside the range", () => {
+    expect(ageRatio(at(1), at(5), NEW)).toBe(0);
+    expect(ageRatio(at(20), OLD, NEW)).toBe(1);
+  });
+
+  it("does not produce NaN for an unparseable date", () => {
+    expect(Number.isFinite(ageRatio("nonsense", OLD, NEW))).toBe(true);
+  });
+});

--- a/packages/markdown-engine/src/blame.ts
+++ b/packages/markdown-engine/src/blame.ts
@@ -1,0 +1,284 @@
+/**
+ * Who wrote each line, and when.
+ *
+ * `git blame` for prose. The commit list tells you a note changed thirty
+ * times; the diff view tells you what one of those changes did. Neither
+ * answers the question you have while re-reading your own notes: *when did I
+ * learn this?* A paragraph that has sat untouched since March, next to one
+ * added last week, looks identical on the page — and the difference is most of
+ * what you want to know about whether you still believe it.
+ *
+ * Computed here rather than fetched, because GitHub's REST API has no blame
+ * endpoint and the app is REST throughout. The inputs are the same revision
+ * texts the replay already loads and caches, so the second feature costs
+ * nothing the first has not already paid for: walk the revisions oldest to
+ * newest, diff each against the one before, and every line that survives keeps
+ * the commit that introduced it.
+ *
+ * The limit worth being honest about: a line present in the oldest revision we
+ * were given was not necessarily *written* there — it may be older than the
+ * window of history we can see. Those lines are flagged `atOrBefore` so the UI
+ * can say "at or before" rather than claiming a date it cannot support.
+ */
+
+import { diffLines } from "./diff";
+
+/** One revision, as the caller has it. Mirrors `RevisionInput` in ./timeline. */
+export interface BlameRevision {
+  sha: string;
+  /** ISO 8601 commit date. */
+  date: string;
+  /** The note at this commit, or null when it could not be read. */
+  text: string | null;
+  message?: string;
+  authorName?: string;
+  authorLogin?: string | null;
+}
+
+/** Where one line of the current text came from. */
+export interface BlameLine {
+  /** 1-based line number in the newest revision. */
+  number: number;
+  text: string;
+  sha: string;
+  date: string;
+  message?: string;
+  authorName?: string;
+  authorLogin?: string | null;
+  /**
+   * True when this line was already present in the oldest revision available,
+   * so the commit named is the earliest we can see rather than the one that
+   * wrote it. The real origin may be older.
+   */
+  atOrBefore: boolean;
+}
+
+/**
+ * A run of consecutive lines, split the way the document reads.
+ *
+ * Line-level blame is the correct computation and the wrong unit to show: a
+ * wrapped paragraph is one thought, and attributing its four lines separately
+ * turns a page of prose into a barcode. Blocks are separated by blank lines —
+ * a Markdown paragraph, list, heading or fenced block — which is the unit a
+ * reader would point at and ask "when did I write that?".
+ */
+export interface BlameBlock {
+  /** 1-based line number this block starts at. */
+  start: number;
+  /** 1-based line number this block ends at, inclusive. */
+  end: number;
+  text: string;
+  lines: BlameLine[];
+  /** The most recent commit touching this block — when it last changed. */
+  newest: BlameLine;
+  /** The oldest commit still represented in it — when it first appeared. */
+  oldest: BlameLine;
+  /** How many distinct commits this block is made of. */
+  commitCount: number;
+}
+
+export interface Blame {
+  lines: BlameLine[];
+  blocks: BlameBlock[];
+  /** Distinct commits represented in the current text, newest first. */
+  commits: { sha: string; date: string; lineCount: number }[];
+  /** True when nothing could be attributed — no readable revisions at all. */
+  empty: boolean;
+}
+
+const EMPTY: Blame = { lines: [], blocks: [], commits: [], empty: true };
+
+function splitLines(text: string): string[] {
+  if (text === "") return [];
+  const normalized = text.replace(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+  // A trailing newline ends the last line rather than starting an empty one,
+  // matching how `diffLines` counts.
+  if (lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+function timeOf(iso: string): number {
+  const value = new Date(iso).getTime();
+  return Number.isFinite(value) ? value : 0;
+}
+
+/** The origin of one line, before it is paired back up with its text. */
+interface Origin {
+  sha: string;
+  date: string;
+  message?: string;
+  authorName?: string;
+  authorLogin?: string | null;
+  atOrBefore: boolean;
+}
+
+/**
+ * Attributes every line of the newest revision to the commit that introduced it.
+ *
+ * Revisions may arrive in any order — the history API returns them newest
+ * first — and are sorted here, ties keeping their input order.
+ *
+ * Unreadable revisions are skipped rather than treated as an empty file, which
+ * would attribute the entire note to whichever commit came after the gap.
+ */
+export function buildBlame(input: readonly BlameRevision[]): Blame {
+  const readable = input
+    .map((revision, position) => ({ revision, position }))
+    .filter((entry) => entry.revision.text !== null)
+    .sort((a, b) => timeOf(a.revision.date) - timeOf(b.revision.date) || a.position - b.position)
+    .map((entry) => entry.revision);
+
+  if (readable.length === 0) return EMPTY;
+
+  const first = readable[0]!;
+  let origins: Origin[] = splitLines(first.text!).map(() => ({
+    sha: first.sha,
+    date: first.date,
+    message: first.message,
+    authorName: first.authorName,
+    authorLogin: first.authorLogin,
+    // Everything in the oldest revision we can see predates our window.
+    atOrBefore: true,
+  }));
+
+  let previousText = first.text!;
+
+  for (const revision of readable.slice(1)) {
+    const text = revision.text!;
+    const next: Origin[] = [];
+    let oldIndex = 0;
+
+    for (const line of diffLines(previousText, text)) {
+      if (line.kind === "delete") {
+        // Gone from the new revision: its origin goes with it.
+        oldIndex += 1;
+        continue;
+      }
+
+      if (line.kind === "add") {
+        next.push({
+          sha: revision.sha,
+          date: revision.date,
+          message: revision.message,
+          authorName: revision.authorName,
+          authorLogin: revision.authorLogin,
+          atOrBefore: false,
+        });
+        continue;
+      }
+
+      // Unchanged: it keeps whatever origin it already had. A line that
+      // survives fifty commits still belongs to the one that wrote it, which
+      // is the whole point of blame.
+      next.push(
+        origins[oldIndex] ?? {
+          sha: revision.sha,
+          date: revision.date,
+          message: revision.message,
+          authorName: revision.authorName,
+          authorLogin: revision.authorLogin,
+          atOrBefore: false,
+        },
+      );
+      oldIndex += 1;
+    }
+
+    origins = next;
+    previousText = text;
+  }
+
+  const texts = splitLines(previousText);
+  const lines: BlameLine[] = texts.map((text, index) => {
+    const origin = origins[index]!;
+    return {
+      number: index + 1,
+      text,
+      sha: origin.sha,
+      date: origin.date,
+      message: origin.message,
+      authorName: origin.authorName,
+      authorLogin: origin.authorLogin,
+      atOrBefore: origin.atOrBefore,
+    };
+  });
+
+  return {
+    lines,
+    blocks: toBlocks(lines),
+    commits: tally(lines),
+    empty: lines.length === 0,
+  };
+}
+
+/**
+ * Groups blamed lines into the blocks a reader sees.
+ *
+ * Blank lines are boundaries and belong to no block: a gap between paragraphs
+ * carries no writing, and attributing it produces a stripe of colour between
+ * every two paragraphs for a change nobody made.
+ */
+export function toBlocks(lines: readonly BlameLine[]): BlameBlock[] {
+  const blocks: BlameBlock[] = [];
+  let run: BlameLine[] = [];
+
+  const flush = () => {
+    if (run.length === 0) return;
+
+    let newest = run[0]!;
+    let oldest = run[0]!;
+    for (const line of run) {
+      if (timeOf(line.date) > timeOf(newest.date)) newest = line;
+      if (timeOf(line.date) < timeOf(oldest.date)) oldest = line;
+    }
+
+    blocks.push({
+      start: run[0]!.number,
+      end: run[run.length - 1]!.number,
+      text: run.map((line) => line.text).join("\n"),
+      lines: run,
+      newest,
+      oldest,
+      commitCount: new Set(run.map((line) => line.sha)).size,
+    });
+    run = [];
+  };
+
+  for (const line of lines) {
+    if (line.text.trim() === "") flush();
+    else run.push(line);
+  }
+  flush();
+
+  return blocks;
+}
+
+/** Distinct commits in the current text, newest first, with their line counts. */
+function tally(lines: readonly BlameLine[]): { sha: string; date: string; lineCount: number }[] {
+  const counts = new Map<string, { sha: string; date: string; lineCount: number }>();
+
+  for (const line of lines) {
+    const existing = counts.get(line.sha);
+    if (existing) existing.lineCount += 1;
+    else counts.set(line.sha, { sha: line.sha, date: line.date, lineCount: 1 });
+  }
+
+  return [...counts.values()].sort((a, b) => timeOf(b.date) - timeOf(a.date));
+}
+
+/**
+ * How old a line is, as a fraction from 0 (oldest on the page) to 1 (newest).
+ *
+ * For shading the gutter: the useful comparison in a blamed document is
+ * relative, not absolute. A note written across one afternoon and a note
+ * written across four years should both use the whole range, because in each
+ * the question is the same — which parts here are the old ones?
+ */
+export function ageRatio(date: string, oldest: string, newest: string): number {
+  const from = timeOf(oldest);
+  const to = timeOf(newest);
+  // Everything written at once is uniformly new rather than uniformly old:
+  // a flat document should not render as though all of it were ancient.
+  if (to <= from) return 1;
+  return Math.min(1, Math.max(0, (timeOf(date) - from) / (to - from)));
+}

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -10,6 +10,7 @@ export {
   extractOutline,
   extractMermaidBlocks,
   documentStats,
+  countWords,
   deriveTitle,
   extractTags,
   type OutlineEntry,
@@ -78,3 +79,12 @@ export {
   type DiffStats,
   type WordSpan,
 } from "./diff";
+
+export {
+  buildTimeline,
+  sparkline,
+  type RevisionInput,
+  type Timeline,
+  type TimelineRevision,
+  type SparklineGeometry,
+} from "./timeline";

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -88,3 +88,13 @@ export {
   type TimelineRevision,
   type SparklineGeometry,
 } from "./timeline";
+
+export {
+  buildBlame,
+  toBlocks,
+  ageRatio,
+  type Blame,
+  type BlameBlock,
+  type BlameLine,
+  type BlameRevision,
+} from "./blame";

--- a/packages/markdown-engine/src/timeline.test.ts
+++ b/packages/markdown-engine/src/timeline.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import { buildTimeline, sparkline, type RevisionInput } from "./timeline";
+
+const at = (day: number) => `2026-03-${String(day).padStart(2, "0")}T10:00:00.000Z`;
+
+function rev(sha: string, day: number, text: string | null): RevisionInput {
+  return { sha, date: at(day), text };
+}
+
+describe("buildTimeline", () => {
+  it("returns an empty, still-usable timeline for no revisions", () => {
+    const timeline = buildTimeline([]);
+    expect(timeline.revisions).toEqual([]);
+    // Scales are floored at 1 so a caller dividing by them cannot produce NaN.
+    expect(timeline.maxWords).toBe(1);
+    expect(timeline.maxChurn).toBe(1);
+    expect(timeline.spanMs).toBe(0);
+    expect(timeline.netWords).toBe(0);
+  });
+
+  it("measures a single revision as an opening addition", () => {
+    const timeline = buildTimeline([rev("a", 1, "one two three\nfour")]);
+    expect(timeline.revisions).toHaveLength(1);
+    const [only] = timeline.revisions;
+    expect(only!.words).toBe(4);
+    expect(only!.lines).toBe(2);
+    expect(only!.added).toBe(2);
+    expect(only!.removed).toBe(0);
+    expect(only!.wordDelta).toBe(4);
+    expect(only!.index).toBe(0);
+    expect(timeline.spanMs).toBe(0);
+  });
+
+  it("orders revisions oldest first regardless of input order", () => {
+    const timeline = buildTimeline([
+      rev("newest", 3, "a b c"),
+      rev("oldest", 1, "a"),
+      rev("middle", 2, "a b"),
+    ]);
+
+    expect(timeline.revisions.map((r) => r.sha)).toEqual(["oldest", "middle", "newest"]);
+    expect(timeline.revisions.map((r) => r.index)).toEqual([0, 1, 2]);
+    expect(timeline.netWords).toBe(2);
+    expect(timeline.spanMs).toBe(2 * 24 * 60 * 60 * 1000);
+  });
+
+  it("keeps input order for revisions sharing a timestamp", () => {
+    const timeline = buildTimeline([
+      { sha: "first", date: at(1), text: "a" },
+      { sha: "second", date: at(1), text: "a b" },
+    ]);
+    expect(timeline.revisions.map((r) => r.sha)).toEqual(["first", "second"]);
+  });
+
+  it("counts lines added and removed against the previous revision", () => {
+    const timeline = buildTimeline([
+      rev("a", 1, "alpha\nbeta\ngamma"),
+      rev("b", 2, "alpha\nBETA CHANGED\ngamma\ndelta"),
+    ]);
+
+    const [, second] = timeline.revisions;
+    expect(second!.added).toBe(2); // the rewritten line plus the new one
+    expect(second!.removed).toBe(1);
+    expect(second!.wordDelta).toBe(2); // "BETA CHANGED" and "delta" less "beta"
+  });
+
+  it("reports zero churn for a commit that did not touch this note", () => {
+    const timeline = buildTimeline([rev("a", 1, "same text"), rev("b", 2, "same text")]);
+    const [, second] = timeline.revisions;
+    expect(second!.added).toBe(0);
+    expect(second!.removed).toBe(0);
+    expect(second!.wordDelta).toBe(0);
+  });
+
+  it("tracks a note being gutted", () => {
+    const timeline = buildTimeline([rev("a", 1, "one two three four five"), rev("b", 2, "one")]);
+    const [, second] = timeline.revisions;
+    expect(second!.wordDelta).toBe(-4);
+    expect(timeline.netWords).toBe(-4);
+  });
+
+  it("handles an empty revision without dividing by zero", () => {
+    const timeline = buildTimeline([rev("a", 1, ""), rev("b", 2, "words here")]);
+    const [first, second] = timeline.revisions;
+    expect(first!.words).toBe(0);
+    expect(first!.lines).toBe(0);
+    expect(first!.added).toBe(0);
+    expect(second!.added).toBe(1);
+    expect(timeline.maxWords).toBe(2);
+  });
+
+  it("counts a trailing newline as ending a line, not starting one", () => {
+    const timeline = buildTimeline([rev("a", 1, "one\ntwo\n")]);
+    expect(timeline.revisions[0]!.lines).toBe(2);
+  });
+
+  it("normalises CRLF so a line ending change is not counted as content", () => {
+    const timeline = buildTimeline([rev("a", 1, "one\r\ntwo")]);
+    expect(timeline.revisions[0]!.lines).toBe(2);
+  });
+
+  it("ignores highlight markup when counting words", () => {
+    const timeline = buildTimeline([rev("a", 1, '<mark class="fl-hl-blue">two words</mark>')]);
+    expect(timeline.revisions[0]!.words).toBe(2);
+  });
+
+  it("carries measurements across a revision that could not be read", () => {
+    const timeline = buildTimeline([
+      rev("a", 1, "one two three"),
+      rev("b", 2, null),
+      rev("c", 3, "one two three four"),
+    ]);
+
+    const [first, gap, third] = timeline.revisions;
+    expect(gap!.missing).toBe(true);
+    // The curve holds level across the gap rather than dropping to zero.
+    expect(gap!.words).toBe(first!.words);
+    expect(gap!.added).toBe(0);
+    expect(gap!.removed).toBe(0);
+
+    // And the revision after the gap is compared with the last one we could
+    // actually read, so the gap costs the diff nothing.
+    expect(third!.missing).toBe(false);
+    expect(third!.added).toBe(1);
+    expect(third!.removed).toBe(1);
+    expect(third!.wordDelta).toBe(1);
+    expect(timeline.missingCount).toBe(1);
+  });
+
+  it("survives a leading run of unreadable revisions", () => {
+    const timeline = buildTimeline([rev("a", 1, null), rev("b", 2, null), rev("c", 3, "hello")]);
+    expect(timeline.revisions.map((r) => r.words)).toEqual([0, 0, 1]);
+    expect(timeline.missingCount).toBe(2);
+    // The first readable revision is still an opening addition.
+    expect(timeline.revisions[2]!.added).toBe(1);
+  });
+
+  it("does not throw away a timeline over one unparseable date", () => {
+    const timeline = buildTimeline([
+      { sha: "bad", date: "not a date", text: "a" },
+      { sha: "good", date: at(2), text: "a b" },
+    ]);
+    expect(timeline.revisions.map((r) => r.sha)).toEqual(["bad", "good"]);
+    expect(Number.isFinite(timeline.spanMs)).toBe(true);
+  });
+
+  it("passes commit metadata through untouched", () => {
+    const timeline = buildTimeline([
+      { sha: "a", date: at(1), text: "x", message: "Start the note", authorName: "Ada" },
+    ]);
+    expect(timeline.revisions[0]!.message).toBe("Start the note");
+    expect(timeline.revisions[0]!.authorName).toBe("Ada");
+  });
+
+  it("reports the tallest word count and the busiest single step", () => {
+    const timeline = buildTimeline([
+      rev("a", 1, "one"),
+      rev("b", 2, "one\ntwo\nthree\nfour"),
+      rev("c", 3, "one"),
+    ]);
+    expect(timeline.maxWords).toBe(4);
+    expect(timeline.maxChurn).toBe(3 + 0); // three lines appended in one step
+  });
+
+  it("stays linear enough for a long history", () => {
+    const many: RevisionInput[] = Array.from({ length: 200 }, (_, index) => ({
+      sha: `sha${index}`,
+      date: new Date(Date.UTC(2026, 0, 1) + index * 3600_000).toISOString(),
+      text: Array.from({ length: index + 1 }, (_, line) => `line ${line}`).join("\n"),
+    }));
+
+    const started = Date.now();
+    const timeline = buildTimeline(many);
+    expect(timeline.revisions).toHaveLength(200);
+    expect(timeline.revisions[199]!.added).toBe(1);
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+});
+
+describe("sparkline", () => {
+  it("returns nothing drawable for no values", () => {
+    expect(sparkline([], 100, 20)).toEqual({ line: "", area: "", points: [] });
+  });
+
+  it("returns nothing drawable for a zero-sized box", () => {
+    expect(sparkline([1, 2], 0, 20).points).toEqual([]);
+    expect(sparkline([1, 2], 100, 0).points).toEqual([]);
+  });
+
+  it("centres a lone value instead of pinning it to the left edge", () => {
+    const { points } = sparkline([5], 100, 20);
+    expect(points).toEqual([{ x: 50, y: 0 }]);
+  });
+
+  it("spreads values evenly across the width", () => {
+    const { points } = sparkline([0, 5, 10], 100, 20);
+    expect(points.map((p) => p.x)).toEqual([0, 50, 100]);
+  });
+
+  it("puts the largest value at the top and zero on the baseline", () => {
+    const { points } = sparkline([0, 10], 100, 20);
+    expect(points[0]!.y).toBe(20);
+    expect(points[1]!.y).toBe(0);
+  });
+
+  it("scales against a supplied ceiling so several charts can share an axis", () => {
+    const { points } = sparkline([5], 100, 20, 10);
+    expect(points[0]!.y).toBe(10);
+  });
+
+  it("clamps a value above the ceiling rather than drawing outside the box", () => {
+    const { points } = sparkline([50], 100, 20, 10);
+    expect(points[0]!.y).toBe(0);
+  });
+
+  it("treats an all-zero series as a flat baseline rather than dividing by zero", () => {
+    const { points } = sparkline([0, 0, 0], 100, 20);
+    expect(points.every((point) => point.y === 20)).toBe(true);
+  });
+
+  it("closes the area path back to the baseline", () => {
+    const { line, area } = sparkline([0, 10], 100, 20);
+    expect(line).toBe("M0 20 L100 0");
+    expect(area).toBe("M0 20 L100 0 L100 20 L0 20 Z");
+  });
+});

--- a/packages/markdown-engine/src/timeline.ts
+++ b/packages/markdown-engine/src/timeline.ts
@@ -1,0 +1,254 @@
+/**
+ * The shape of a note over time.
+ *
+ * Version history answers "what changed in this commit?". It does not answer
+ * "how did this page come to exist?" — whether it landed fully formed, grew a
+ * paragraph a week for two months, or was gutted and rewritten in March. That
+ * second question needs every revision measured on the same axes and laid out
+ * against the clock, which is what this builds: one row per revision, carrying
+ * its size, its churn against the revision before it, and where it sits in the
+ * span of the note's life.
+ *
+ * Deliberately free of any rendering: the chart geometry lives here as plain
+ * numbers so it can be tested without a browser, and the panel is left to turn
+ * those numbers into pixels.
+ */
+
+import { countWords } from "./analyze";
+import { diffLines, diffStats } from "./diff";
+
+/** One revision, as the caller has it: a commit plus the text at that commit. */
+export interface RevisionInput {
+  sha: string;
+  /** ISO 8601 commit date. */
+  date: string;
+  /**
+   * The note as of this commit, or null when it could not be read — a fetch
+   * that failed, or a revision not loaded yet.
+   */
+  text: string | null;
+  /** Commit subject, carried through untouched for the panel to display. */
+  message?: string;
+  authorName?: string;
+}
+
+export interface TimelineRevision {
+  sha: string;
+  date: string;
+  message?: string;
+  authorName?: string;
+  /** 0-based position, oldest first. */
+  index: number;
+  words: number;
+  characters: number;
+  lines: number;
+  /** Lines added relative to the previous revision. */
+  added: number;
+  /** Lines removed relative to the previous revision. */
+  removed: number;
+  /** Net change in words relative to the previous revision. */
+  wordDelta: number;
+  /**
+   * True when this revision's text was not available.
+   *
+   * Its measurements are carried forward from the last revision that was
+   * readable, so the curve holds a flat line across the gap instead of
+   * plunging to zero and inventing a rewrite that never happened. The flag is
+   * what lets the panel say so rather than quietly showing a lie.
+   */
+  missing: boolean;
+}
+
+export interface Timeline {
+  /** Oldest first — the order a replay plays in. */
+  revisions: TimelineRevision[];
+  /** Largest word count reached, for scaling a chart. Never below 1. */
+  maxWords: number;
+  /** Largest single-step churn (added + removed). Never below 1. */
+  maxChurn: number;
+  /** Milliseconds between the first and last revision; 0 for fewer than two. */
+  spanMs: number;
+  /** Words in the newest revision less words in the oldest. */
+  netWords: number;
+  /** How many revisions could not be read. */
+  missingCount: number;
+}
+
+const EMPTY: Timeline = {
+  revisions: [],
+  maxWords: 1,
+  maxChurn: 1,
+  spanMs: 0,
+  netWords: 0,
+  missingCount: 0,
+};
+
+function lineCount(text: string): number {
+  if (text === "") return 0;
+  const normalized = text.replace(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+  // A trailing newline ends the last line rather than starting an empty one,
+  // which is how `diffLines` counts too — the two must agree or the row would
+  // report a line count that its own added/removed figures contradict.
+  if (lines[lines.length - 1] === "") lines.pop();
+  return lines.length;
+}
+
+function timeOf(iso: string): number {
+  const value = new Date(iso).getTime();
+  // An unparseable date must not poison the sort. Treating it as 0 keeps such
+  // a revision at the start rather than throwing the whole timeline away.
+  return Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Measures a note across its revisions.
+ *
+ * Input may arrive in any order — GitHub lists commits newest first, which is
+ * the opposite of the order a replay wants — so it is sorted by date here.
+ * Revisions sharing a timestamp keep the order they were given in, which is
+ * the only tie-break available when two commits claim the same second.
+ */
+export function buildTimeline(input: readonly RevisionInput[]): Timeline {
+  if (input.length === 0) return EMPTY;
+
+  const ordered = input
+    .map((revision, position) => ({ revision, position }))
+    .sort((a, b) => timeOf(a.revision.date) - timeOf(b.revision.date) || a.position - b.position)
+    .map((entry) => entry.revision);
+
+  const revisions: TimelineRevision[] = [];
+  let maxWords = 0;
+  let maxChurn = 0;
+  let missingCount = 0;
+
+  // The last text actually read, which is what a missing revision is measured
+  // against — and what the one after it is diffed against, so a gap costs the
+  // curve nothing but its own step.
+  let previousText: string | null = null;
+  let previous: TimelineRevision | null = null;
+
+  for (const [index, entry] of ordered.entries()) {
+    const text = entry.text;
+
+    if (text === null) {
+      missingCount += 1;
+      revisions.push({
+        sha: entry.sha,
+        date: entry.date,
+        message: entry.message,
+        authorName: entry.authorName,
+        index,
+        words: previous?.words ?? 0,
+        characters: previous?.characters ?? 0,
+        lines: previous?.lines ?? 0,
+        added: 0,
+        removed: 0,
+        wordDelta: 0,
+        missing: true,
+      });
+      // `previous` intentionally stays where it was: the next readable
+      // revision should be compared with the last readable one, not with a row
+      // whose numbers were copied from somewhere else.
+      continue;
+    }
+
+    const words = countWords(text);
+    const { added, removed } =
+      previousText === null
+        ? // The first readable revision has nothing before it. Counting its
+          // whole body as additions is what `git log --stat` shows for a file's
+          // first commit, and it makes the opening spike of a replay honest.
+          { added: lineCount(text), removed: 0 }
+        : diffStats(diffLines(previousText, text));
+
+    const row: TimelineRevision = {
+      sha: entry.sha,
+      date: entry.date,
+      message: entry.message,
+      authorName: entry.authorName,
+      index,
+      words,
+      characters: text.length,
+      lines: lineCount(text),
+      added,
+      removed,
+      wordDelta: previous === null ? words : words - previous.words,
+      missing: false,
+    };
+
+    revisions.push(row);
+    maxWords = Math.max(maxWords, words);
+    maxChurn = Math.max(maxChurn, added + removed);
+    previousText = text;
+    previous = row;
+  }
+
+  const first = revisions[0];
+  const last = revisions[revisions.length - 1];
+
+  return {
+    revisions,
+    maxWords: Math.max(1, maxWords),
+    maxChurn: Math.max(1, maxChurn),
+    spanMs: first && last ? Math.max(0, timeOf(last.date) - timeOf(first.date)) : 0,
+    netWords: first && last ? last.words - first.words : 0,
+    missingCount,
+  };
+}
+
+export interface SparklineGeometry {
+  /** `d` for a stroked path along the top of the series. */
+  line: string;
+  /** `d` for the same series closed to the baseline, to fill underneath. */
+  area: string;
+  /** Where each revision sits, so the panel can put a marker on it. */
+  points: { x: number; y: number }[];
+}
+
+/**
+ * Turns a series into SVG path geometry.
+ *
+ * Points are spread evenly rather than by timestamp. A note written in a burst
+ * three years ago and touched once last week would otherwise pile thirty
+ * revisions into two pixels and leave the rest of the chart empty — the
+ * scrubber steps commit by commit, so the chart is drawn commit by commit to
+ * match it.
+ */
+export function sparkline(
+  values: readonly number[],
+  width: number,
+  height: number,
+  max?: number,
+): SparklineGeometry {
+  const points: { x: number; y: number }[] = [];
+  if (values.length === 0 || width <= 0 || height <= 0) {
+    return { line: "", area: "", points };
+  }
+
+  const ceiling = Math.max(1, max ?? Math.max(...values));
+  const step = values.length === 1 ? 0 : width / (values.length - 1);
+
+  for (const [index, value] of values.entries()) {
+    // A single revision has nowhere to travel, so it is centred instead of
+    // pinned to the left edge where it would read as the start of a line.
+    const x = values.length === 1 ? width / 2 : index * step;
+    const ratio = Math.min(1, Math.max(0, value / ceiling));
+    points.push({ x: round(x), y: round(height - ratio * height) });
+  }
+
+  const line = points
+    .map((point, index) => `${index === 0 ? "M" : "L"}${point.x} ${point.y}`)
+    .join(" ");
+  const firstPoint = points[0]!;
+  const lastPoint = points[points.length - 1]!;
+  const area = `${line} L${lastPoint.x} ${round(height)} L${firstPoint.x} ${round(height)} Z`;
+
+  return { line, area, points };
+}
+
+function round(value: number): number {
+  // Two decimals is finer than any display can resolve and keeps the `d`
+  // attribute from filling with floating-point noise.
+  return Math.round(value * 100) / 100;
+}


### PR DESCRIPTION
Two features and the entry points that make them findable. Three commits, one story: a note's commit list tells you *that* it changed thirty times, and neither the list nor a diff answers the question you actually have re-reading your own notes months later — **when did I learn this, and do I still believe it?**

## What's in here

**1. Replay how this was written** (`625f5476`)
A scrubber that types and untypes the note through its real revisions, with a sparkline of its length over time underneath — so you can see where you wrote in bursts and where you deleted a section wholesale.

**2. Its own way in** (`8184753d`)
The replay originally shipped buried as a second tab in the history dialog. Its name never appeared on screen until you were already inside it. Now it has a properties-panel button and a command-palette entry keyed on the words people actually type (*replay, time travel, timeline, scrubber, watch, playback, evolution*).

**3. Git blame for prose** (`6f484e49`)
Every paragraph with its date in the margin, shaded by age, so a paragraph untouched since March is visibly different from one added last week. Point at (or Tab to) one and a card names the commit, the author, and **what else that commit touched** — the part that turns "12 March" into "during the AD engagement."

Designed findable from the start this time: panel button, palette entry, third tab, Getting started, and in-app help.

## How blame is computed

GitHub's REST API has no blame endpoint and this app is REST throughout, so it's computed client-side: walk revisions oldest to newest, diff each against the one before, and every surviving line keeps the commit that introduced it. The inputs are the revision texts the replay already caches, so **the two features share one fetch** — switching tabs costs nothing.

Line-level blame is the right computation and the wrong unit to show, so lines are grouped into blank-line-separated blocks. The paragraph is what a reader points at.

## Honest about its limits

- A line already present in the oldest readable revision is marked **"at or before"** rather than claiming a date we can't support.
- History now reads **100 deep** rather than GitHub's default 30 — every revision blame can't see becomes another hedged line. Still one request.
- An unreadable revision is **skipped** rather than treated as an empty file, which would blame the whole note on the commit after the gap.
- While older revisions are still arriving, the view says so, and says attribution will move earlier as they land.
- Without an auth token, "what else this commit touched" degrades to a quiet message rather than an error.

## Verification

`pnpm check` green end to end, **exit 0**: prettier, 8 typecheck tasks, eslint, **1041 tests across 71 files**, `next build`.

**+3973 / −59** across 28 files, of which **148 tests are new**.

Driven in a browser against a temporary preview route (removed before commit). Four bugs found that way and fixed here rather than shipped:

1. The commit card printed **"3/12/2026 (3/12/2026)"** — relative time falls back to an absolute date past a month. Added `relativeAge`, which returns null instead of repeating it.
2. The card **changed height between hovers**, shoving the text out from under the cursor. It now holds a minimum height in both states.
3. The gutter left prose **two words wide at 375px**. It narrows below `sm`, dropping the SHA — which the card names anyway.
4. `Number(null)` is `0`, not `NaN` — an absent `limit` would have **clamped history to a single commit**. Caught by a test, now covered by one.

Two eslint errors fixed properly rather than suppressed, both setState-in-effect: the commit lookup is now tagged with the SHA it belongs to and read back through the current one, so there's no reset render and no window where one commit's files sit under another's name.

## Reviewing it

Both features need a signed-in GitHub repo and a note with several commits — they're gated on the note having history, so there's no demo path signed out. Start with **blame**: it explains itself without being touched, since the dates are visible before you point at anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)