### PR TITLE
feat: notes that run, and notes reviewed as a pull request

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@forkleaf/markdown-engine": "workspace:*",
     "@forkleaf/store": "workspace:*",
     "@forkleaf/types": "workspace:*",
+    "@vercel/sandbox": "^3.1.0",
     "firebase": "^12.17.1",
     "jose": "^6.1.0",
     "next": "16.3.1",

--- a/apps/web/src/app/api/gh/review/route.test.ts
+++ b/apps/web/src/app/api/gh/review/route.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const getPullRequest = vi.fn();
+const findOpenPullRequestForBranch = vi.fn();
+const listReviewComments = vi.fn();
+const listReviews = vi.fn();
+const listConversation = vi.fn();
+const replyToReviewComment = vi.fn();
+const addConversationComment = vi.fn();
+const mergePullRequest = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+}));
+
+vi.mock("@forkleaf/github-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@forkleaf/github-client")>("@forkleaf/github-client");
+  return {
+    ...actual,
+    GitHubClient: class {
+      getPullRequest = getPullRequest;
+      findOpenPullRequestForBranch = findOpenPullRequestForBranch;
+      listReviewComments = listReviewComments;
+      listReviews = listReviews;
+      listConversation = listConversation;
+      replyToReviewComment = replyToReviewComment;
+      addConversationComment = addConversationComment;
+      mergePullRequest = mergePullRequest;
+    },
+  };
+});
+
+const { GET, POST } = await import("./route");
+
+afterEach(() => vi.clearAllMocks());
+
+async function get(query: string) {
+  const response = await GET(new Request(`http://localhost/api/gh/review?${query}`) as never);
+  return { status: response.status, body: await response.json() };
+}
+
+async function post(body: unknown) {
+  const response = await POST(
+    new Request("http://localhost/api/gh/review", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }) as never,
+  );
+  return { status: response.status, body: await response.json() };
+}
+
+const REPO = { owner: "me", repo: "notes", number: 7 };
+
+describe("GET /api/gh/review", () => {
+  it("refuses a request with no pull request number", async () => {
+    expect((await get("owner=me&repo=notes")).status).toBe(400);
+  });
+
+  it("refuses a number that is not one", async () => {
+    for (const value of ["nope", "0", "-3", "1.5"]) {
+      expect((await get(`owner=me&repo=notes&number=${value}`)).status).toBe(400);
+    }
+  });
+
+  it("gathers the request, its comments, its reviews and its conversation", async () => {
+    getPullRequest.mockResolvedValue({ number: 7, title: "Notes on recon" });
+    listReviewComments.mockResolvedValue([{ id: 1 }]);
+    listReviews.mockResolvedValue([{ id: 2, state: "APPROVED" }]);
+    listConversation.mockResolvedValue([{ id: 3 }]);
+
+    const { status, body } = await get("owner=me&repo=notes&number=7");
+
+    expect(status).toBe(200);
+    expect(body.pull.title).toBe("Notes on recon");
+    expect(body.comments).toEqual([{ id: 1 }]);
+    expect(body.reviews).toEqual([{ id: 2, state: "APPROVED" }]);
+    expect(body.conversation).toEqual([{ id: 3 }]);
+  });
+
+  it("reads all four at once rather than one after another", async () => {
+    getPullRequest.mockResolvedValue({});
+    listReviewComments.mockResolvedValue([]);
+    listReviews.mockResolvedValue([]);
+    listConversation.mockResolvedValue([]);
+
+    await get("owner=me&repo=notes&number=7");
+
+    for (const call of [getPullRequest, listReviewComments, listReviews, listConversation]) {
+      expect(call).toHaveBeenCalledWith("me", "notes", 7);
+    }
+  });
+});
+
+describe("GET /api/gh/review — finding the review for a branch", () => {
+  it("says plainly that a branch has no review open", async () => {
+    findOpenPullRequestForBranch.mockResolvedValue(null);
+    const { status, body } = await get("owner=me&repo=notes&head=study/recon");
+
+    // Not a 404: "nothing under review" is an ordinary state.
+    expect(status).toBe(200);
+    expect(body.pull).toBeNull();
+    expect(body.comments).toEqual([]);
+  });
+
+  it("does not read comments for a branch with no review", async () => {
+    findOpenPullRequestForBranch.mockResolvedValue(null);
+    await get("owner=me&repo=notes&head=study/recon");
+
+    expect(listReviewComments).not.toHaveBeenCalled();
+  });
+
+  it("gathers the whole review once the branch resolves to one", async () => {
+    findOpenPullRequestForBranch.mockResolvedValue({ number: 12 });
+    getPullRequest.mockResolvedValue({ number: 12, title: "Recon" });
+    listReviewComments.mockResolvedValue([{ id: 1 }]);
+    listReviews.mockResolvedValue([]);
+    listConversation.mockResolvedValue([]);
+
+    const { status, body } = await get("owner=me&repo=notes&head=study/recon");
+
+    expect(status).toBe(200);
+    expect(body.pull.number).toBe(12);
+    expect(listReviewComments).toHaveBeenCalledWith("me", "notes", 12);
+  });
+
+  it("prefers a branch lookup over a number when both are given", async () => {
+    findOpenPullRequestForBranch.mockResolvedValue(null);
+    await get("owner=me&repo=notes&head=study/recon&number=99");
+
+    expect(getPullRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/gh/review — replying", () => {
+  it("answers one inline comment in its thread", async () => {
+    replyToReviewComment.mockResolvedValue({ id: 9, body: "fixed" });
+    const { status, body } = await post({
+      ...REPO,
+      action: "reply",
+      commentId: 4,
+      body: "fixed",
+    });
+
+    expect(status).toBe(200);
+    expect(replyToReviewComment).toHaveBeenCalledWith("me", "notes", 7, 4, "fixed");
+    expect(body.comment.id).toBe(9);
+  });
+
+  it("adds to the general conversation when no comment is named", async () => {
+    addConversationComment.mockResolvedValue({ id: 10 });
+    await post({ ...REPO, action: "comment", body: "thanks for looking" });
+
+    expect(addConversationComment).toHaveBeenCalledWith("me", "notes", 7, "thanks for looking");
+  });
+
+  it("refuses an empty reply", async () => {
+    const { status } = await post({ ...REPO, action: "reply", commentId: 4, body: "   " });
+    expect(status).toBe(400);
+    expect(replyToReviewComment).not.toHaveBeenCalled();
+  });
+
+  it("trims a reply rather than posting the whitespace", async () => {
+    replyToReviewComment.mockResolvedValue({});
+    await post({ ...REPO, action: "reply", commentId: 4, body: "  fixed  " });
+
+    expect(replyToReviewComment).toHaveBeenCalledWith("me", "notes", 7, 4, "fixed");
+  });
+
+  it("refuses a reply with no comment to attach it to", async () => {
+    const { status } = await post({ ...REPO, action: "reply", body: "fixed" });
+    expect(status).toBe(400);
+  });
+
+  it("refuses an action it does not have", async () => {
+    const { status, body } = await post({ ...REPO, action: "delete-everything", body: "x" });
+    expect(status).toBe(400);
+    expect(body.error.message).toMatch(/not something you can do/i);
+  });
+});
+
+describe("POST /api/gh/review — merging", () => {
+  it("squashes by default, so a review does not land as eight commits", async () => {
+    mergePullRequest.mockResolvedValue({ merged: true, message: "ok", sha: "abc" });
+    const { status } = await post({ ...REPO, action: "merge" });
+
+    expect(status).toBe(200);
+    expect(mergePullRequest).toHaveBeenCalledWith("me", "notes", 7, {
+      method: "squash",
+      title: undefined,
+    });
+  });
+
+  it("honours another way of merging", async () => {
+    mergePullRequest.mockResolvedValue({ merged: true, message: "", sha: "a" });
+    await post({ ...REPO, action: "merge", method: "rebase" });
+
+    expect(mergePullRequest).toHaveBeenCalledWith(
+      "me",
+      "notes",
+      7,
+      expect.objectContaining({ method: "rebase" }),
+    );
+  });
+
+  it("refuses a way of merging that does not exist", async () => {
+    const { status } = await post({ ...REPO, action: "merge", method: "obliterate" });
+    expect(status).toBe(400);
+    expect(mergePullRequest).not.toHaveBeenCalled();
+  });
+
+  it("reports a merge GitHub declined rather than claiming success", async () => {
+    mergePullRequest.mockResolvedValue({ merged: false, message: "Base branch was modified" });
+    const { status, body } = await post({ ...REPO, action: "merge" });
+
+    expect(status).toBe(409);
+    expect(body.error.message).toMatch(/base branch was modified/i);
+  });
+
+  it("does not require a body to merge", async () => {
+    mergePullRequest.mockResolvedValue({ merged: true, message: "", sha: "a" });
+    expect((await post({ ...REPO, action: "merge" })).status).toBe(200);
+  });
+});
+
+describe("POST /api/gh/review — what it refuses outright", () => {
+  it("refuses a body that is not JSON", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/gh/review", {
+        method: "POST",
+        body: "not json",
+      }) as never,
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("refuses a repository name that is not one", async () => {
+    const { status } = await post({ ...REPO, owner: "../../etc", action: "merge" });
+    expect(status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/gh/review/route.ts
+++ b/apps/web/src/app/api/gh/review/route.ts
@@ -1,0 +1,121 @@
+import { type NextRequest } from "next/server";
+import { handle, requireClient, ApiError, assertName } from "@/lib/api-helpers";
+
+/**
+ * The review on a note's pull request: what was said, and merging when it is
+ * settled.
+ *
+ * Opening the request already worked. Reading the review meant going to
+ * github.com and reading your own prose as a unified diff, which is the part
+ * that made "study something, then have it reviewed" not actually work.
+ */
+
+/** A pull request number, which is interpolated into the upstream URL. */
+function readNumber(value: string | null): number {
+  const number = Number(value);
+  if (!value || !Number.isInteger(number) || number <= 0) {
+    throw new ApiError(400, "validation", "A pull request number is required.");
+  }
+  return number;
+}
+
+/** Everything a review panel needs, in one round trip. */
+export async function GET(request: NextRequest) {
+  return handle(async () => {
+    const { client } = await requireClient();
+    const params = new URL(request.url).searchParams;
+
+    const owner = assertName(params.get("owner") ?? "", "owner");
+    const repo = assertName(params.get("repo") ?? "", "repository");
+
+    /**
+     * A branch instead of a number, for the panel that does not know one yet.
+     *
+     * The editor knows which branch it is on; it does not know whether that
+     * branch is under review. Answering with `{ pull: null }` rather than a
+     * 404 is deliberate — "no review open" is an ordinary state, not a
+     * failure, and a panel should not have to read error codes to learn it.
+     */
+    const head = params.get("head");
+    if (head) {
+      const found = await client.findOpenPullRequestForBranch(owner, repo, head);
+      if (!found) return { pull: null, comments: [], reviews: [], conversation: [] };
+
+      const [pull, comments, reviews, conversation] = await Promise.all([
+        client.getPullRequest(owner, repo, found.number),
+        client.listReviewComments(owner, repo, found.number),
+        client.listReviews(owner, repo, found.number),
+        client.listConversation(owner, repo, found.number),
+      ]);
+
+      return { pull, comments, reviews, conversation };
+    }
+
+    const number = readNumber(params.get("number"));
+
+    // In parallel: four independent reads, and the panel is useless until it
+    // has all of them.
+    const [pull, comments, reviews, conversation] = await Promise.all([
+      client.getPullRequest(owner, repo, number),
+      client.listReviewComments(owner, repo, number),
+      client.listReviews(owner, repo, number),
+      client.listConversation(owner, repo, number),
+    ]);
+
+    return { pull, comments, reviews, conversation };
+  });
+}
+
+/** Replying to a comment, adding to the conversation, or merging. */
+export async function POST(request: NextRequest) {
+  return handle(async () => {
+    const { client } = await requireClient();
+    const body = (await request.json().catch(() => null)) as Record<string, unknown> | null;
+
+    if (!body) throw new ApiError(400, "validation", "Expected a JSON body.");
+
+    const owner = assertName(String(body.owner ?? ""), "owner");
+    const repo = assertName(String(body.repo ?? ""), "repository");
+    const number = readNumber(String(body.number ?? ""));
+    const action = String(body.action ?? "");
+
+    if (action === "merge") {
+      const method = String(body.method ?? "squash");
+      if (method !== "merge" && method !== "squash" && method !== "rebase") {
+        throw new ApiError(400, "validation", `${method} is not a way to merge.`);
+      }
+
+      const result = await client.mergePullRequest(owner, repo, number, {
+        method,
+        title: typeof body.title === "string" ? body.title : undefined,
+      });
+
+      // GitHub answers a refused merge with 405 and a reason, which `handle`
+      // has already turned into an error. Reaching here with merged false is
+      // the odd case worth naming rather than reporting as success.
+      if (!result.merged) {
+        throw new ApiError(409, "conflict", result.message || "GitHub would not merge that.");
+      }
+
+      return result;
+    }
+
+    const text = typeof body.body === "string" ? body.body.trim() : "";
+    if (!text) throw new ApiError(400, "validation", "A reply cannot be empty.");
+
+    if (action === "reply") {
+      const commentId = Number(body.commentId);
+      if (!Number.isInteger(commentId) || commentId <= 0) {
+        throw new ApiError(400, "validation", "A comment to reply to is required.");
+      }
+
+      return { comment: await client.replyToReviewComment(owner, repo, number, commentId, text) };
+    }
+
+    if (action === "comment") {
+      return { comment: await client.addConversationComment(owner, repo, number, text) };
+    }
+
+    throw new ApiError(400, "validation", `${action || "That"} is not something you can do here.`);
+  });
+}

--- a/apps/web/src/app/api/run/route.test.ts
+++ b/apps/web/src/app/api/run/route.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const create = vi.fn();
+const writeFiles = vi.fn();
+const runCommand = vi.fn();
+const stop = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+}));
+
+vi.mock("@forkleaf/github-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@forkleaf/github-client")>("@forkleaf/github-client");
+  return { ...actual, GitHubClient: class {} };
+});
+
+vi.mock("@vercel/sandbox", () => ({ Sandbox: { create } }));
+
+const { POST } = await import("./route");
+const { resetRateLimits } = await import("@/lib/rate-limit");
+
+/** A sandbox whose command finishes the way the test asks it to. */
+function sandboxReturning(result: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  durationMs?: number;
+}) {
+  runCommand.mockResolvedValue({
+    stdout: () => Promise.resolve(result.stdout ?? ""),
+    stderr: () => Promise.resolve(result.stderr ?? ""),
+    exitCode: result.exitCode ?? 0,
+    durationMs: result.durationMs,
+  });
+  create.mockResolvedValue({ writeFiles, runCommand, stop });
+}
+
+async function post(body: unknown, ip = "test-client") {
+  const request = new Request("http://localhost/api/run", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+
+  const response = await POST(request as never);
+  return { status: response.status, body: await response.json() };
+}
+
+beforeEach(() => {
+  resetRateLimits();
+  process.env.VERCEL_TOKEN = "token";
+  process.env.VERCEL_TEAM_ID = "team";
+  process.env.VERCEL_PROJECT_ID = "project";
+  stop.mockResolvedValue(undefined);
+  writeFiles.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.VERCEL_TOKEN;
+  delete process.env.VERCEL_TEAM_ID;
+  delete process.env.VERCEL_PROJECT_ID;
+  delete process.env.VERCEL_OIDC_TOKEN;
+});
+
+describe("POST /api/run — what it refuses", () => {
+  it("refuses a body that is not JSON", async () => {
+    expect((await post("not json")).status).toBe(400);
+  });
+
+  it("refuses a request with no code", async () => {
+    expect((await post({ language: "bash" })).status).toBe(400);
+  });
+
+  it("refuses a block containing only whitespace", async () => {
+    const { status, body } = await post({ language: "bash", code: "   \n  " });
+    expect(status).toBe(400);
+    expect(body.error.message).toMatch(/nothing in that block/i);
+  });
+
+  it("refuses a language nothing can interpret", async () => {
+    const { status, body } = await post({ language: "rust", code: "fn main() {}" });
+    expect(status).toBe(400);
+    expect(body.error.message).toMatch(/cannot run rust/i);
+  });
+
+  it("never starts a sandbox for a refused request", async () => {
+    await post({ language: "rust", code: "fn main() {}" });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("refuses a block far larger than anything anyone typed", async () => {
+    const { status } = await post({ language: "bash", code: "x".repeat(64_001) });
+    expect(status).toBe(400);
+  });
+
+  it("says so plainly when the deployment has no sandbox configured", async () => {
+    delete process.env.VERCEL_TOKEN;
+    const { status, body } = await post({ language: "bash", code: "echo hi" });
+
+    expect(status).toBe(503);
+    expect(body.error.message).toMatch(/not configured/i);
+  });
+
+  it("accepts OIDC alone, which is how it authenticates on Vercel", async () => {
+    delete process.env.VERCEL_TOKEN;
+    process.env.VERCEL_OIDC_TOKEN = "oidc";
+    sandboxReturning({ stdout: "hi" });
+
+    expect((await post({ language: "bash", code: "echo hi" })).status).toBe(200);
+    // Nothing is passed, so the SDK reads the OIDC token itself.
+    expect(create).toHaveBeenCalledWith(expect.not.objectContaining({ token: expect.anything() }));
+  });
+});
+
+describe("POST /api/run — running a block", () => {
+  it("returns what the command printed", async () => {
+    sandboxReturning({ stdout: "hello\n", exitCode: 0, durationMs: 120 });
+    const { status, body } = await post({ language: "bash", code: "echo hello" });
+
+    expect(status).toBe(200);
+    expect(body.stdout).toBe("hello\n");
+    expect(body.exitCode).toBe(0);
+    expect(body.ms).toBe(120);
+  });
+
+  it("writes the block to a file and runs the interpreter on it", async () => {
+    sandboxReturning({ stdout: "" });
+    await post({ language: "python", code: "print(1)" });
+
+    expect(writeFiles).toHaveBeenCalledWith([
+      { path: "/tmp/block.py", content: Buffer.from("print(1)", "utf8") },
+    ]);
+    expect(runCommand).toHaveBeenCalledWith("python3", ["/tmp/block.py"], {
+      timeoutMs: 30_000,
+    });
+  });
+
+  it("runs a shell block under bash whichever alias was fenced", async () => {
+    sandboxReturning({ stdout: "" });
+    await post({ language: "sh", code: "ls" });
+
+    expect(runCommand).toHaveBeenCalledWith("bash", ["/tmp/block.sh"], expect.anything());
+  });
+
+  it("uses the universal image, which carries all three interpreters", async () => {
+    sandboxReturning({ stdout: "" });
+    await post({ language: "bash", code: "ls" });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ image: "vercel/sandbox/universal" }),
+    );
+  });
+
+  it("reports a non-zero exit as a result, not as an error", async () => {
+    sandboxReturning({ stderr: "no such file", exitCode: 2 });
+    const { status, body } = await post({ language: "bash", code: "cat nope" });
+
+    expect(status).toBe(200);
+    expect(body.exitCode).toBe(2);
+    expect(body.stderr).toBe("no such file");
+  });
+
+  it("stamps when the run finished", async () => {
+    sandboxReturning({ stdout: "hi" });
+    const { body } = await post({ language: "bash", code: "echo hi" });
+
+    expect(Number.isNaN(Date.parse(body.ranAt))).toBe(false);
+  });
+
+  it("caps enormous output before it reaches the note", async () => {
+    sandboxReturning({ stdout: "x".repeat(50_000) });
+    const { body } = await post({ language: "bash", code: "yes" });
+
+    expect(body.stdout).toHaveLength(20_000);
+    expect(body.truncated).toBe(true);
+  });
+
+  it("falls back to wall-clock time when the sandbox reports no duration", async () => {
+    sandboxReturning({ stdout: "hi", durationMs: undefined });
+    const { body } = await post({ language: "bash", code: "echo hi" });
+
+    expect(typeof body.ms).toBe("number");
+    expect(body.ms).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("POST /api/run — when the run itself fails", () => {
+  it("reports a timeout as a result the note can record", async () => {
+    create.mockResolvedValue({ writeFiles, runCommand, stop });
+    runCommand.mockRejectedValue(new Error("command timed out"));
+
+    const { status, body } = await post({ language: "bash", code: "sleep 999" });
+
+    expect(status).toBe(200);
+    expect(body.failure).toMatch(/timed out after 30s/);
+  });
+
+  it("reports a sandbox that never started, rather than a bare 500", async () => {
+    create.mockRejectedValue(new Error("no capacity"));
+    const { status, body } = await post({ language: "bash", code: "echo hi" });
+
+    expect(status).toBe(200);
+    expect(body.failure).toMatch(/could not run — no capacity/);
+  });
+
+  it("stops the sandbox even when the command threw", async () => {
+    create.mockResolvedValue({ writeFiles, runCommand, stop });
+    runCommand.mockRejectedValue(new Error("boom"));
+
+    await post({ language: "bash", code: "echo hi" });
+    expect(stop).toHaveBeenCalled();
+  });
+
+  it("stops the sandbox after a successful run", async () => {
+    sandboxReturning({ stdout: "hi" });
+    await post({ language: "bash", code: "echo hi" });
+
+    expect(stop).toHaveBeenCalled();
+  });
+
+  it("does not fail the request when stopping the sandbox fails", async () => {
+    sandboxReturning({ stdout: "hi" });
+    stop.mockRejectedValue(new Error("already gone"));
+
+    expect((await post({ language: "bash", code: "echo hi" })).status).toBe(200);
+  });
+});
+
+describe("POST /api/run — rate limiting", () => {
+  it("stops a client running far more than a person would", async () => {
+    sandboxReturning({ stdout: "" });
+
+    const statuses: number[] = [];
+    for (let i = 0; i < 14; i += 1) {
+      statuses.push((await post({ language: "bash", code: "echo hi" }, "flooder")).status);
+    }
+
+    expect(statuses.filter((s) => s === 200)).toHaveLength(12);
+    expect(statuses.at(-1)).toBe(429);
+  });
+
+  it("budgets each client separately", async () => {
+    sandboxReturning({ stdout: "" });
+
+    for (let i = 0; i < 12; i += 1) await post({ language: "bash", code: "echo" }, "first");
+    expect((await post({ language: "bash", code: "echo" }, "second")).status).toBe(200);
+  });
+});

--- a/apps/web/src/app/api/run/route.ts
+++ b/apps/web/src/app/api/run/route.ts
@@ -1,0 +1,169 @@
+import { type NextRequest } from "next/server";
+import { handle, requireClient, ApiError } from "@/lib/api-helpers";
+import { enforceRateLimit } from "@/lib/rate-limit";
+import { MAX_OUTPUT, runnerFor } from "@forkleaf/markdown-engine";
+
+/**
+ * Runs one fenced code block in a throwaway virtual machine.
+ *
+ * The block runs nowhere near the reader's own machine and nowhere near this
+ * server: a Vercel Sandbox is a Firecracker microVM created for this one
+ * request and destroyed at the end of it, so a script that deletes everything
+ * it can reach deletes only its own empty VM. That isolation is the whole
+ * reason this route can exist — a note is a document, and documents arrive
+ * from other people.
+ *
+ * It does have network access, deliberately. A runbook that cannot reach the
+ * host it is about is a text file, and looking something up is the entire
+ * point of the scripts people keep in notes.
+ */
+
+/** Long enough for a real command, short enough to bound a stuck one. */
+const RUN_TIMEOUT_MS = 30_000;
+
+/** Head-room over the run itself, so the VM outlives the command it hosts. */
+const SANDBOX_TIMEOUT_MS = 90_000;
+
+/**
+ * The largest script accepted.
+ *
+ * A fenced block in a note is a script somebody typed. Anything approaching
+ * this is not that, and shipping it to a VM is a waste of both ends.
+ */
+const MAX_CODE = 64_000;
+
+/** Runs allowed per client, per window. Compute is not free and this is a note. */
+const RATE_LIMIT = { name: "run", limit: 12, windowMs: 5 * 60_000 };
+
+/**
+ * Vercel functions default to a shorter ceiling than the run itself allows,
+ * which would kill the request while the sandbox was still working and report
+ * it as a network error rather than a timeout.
+ */
+export const maxDuration = 120;
+
+/** True when this deployment can actually reach the sandbox API. */
+function sandboxCredentials(): Record<string, string> | null {
+  const { VERCEL_TOKEN, VERCEL_TEAM_ID, VERCEL_PROJECT_ID, VERCEL_OIDC_TOKEN } = process.env;
+
+  if (VERCEL_TOKEN && VERCEL_TEAM_ID && VERCEL_PROJECT_ID) {
+    return { token: VERCEL_TOKEN, teamId: VERCEL_TEAM_ID, projectId: VERCEL_PROJECT_ID };
+  }
+
+  // On Vercel the SDK authenticates itself from the OIDC token in the
+  // environment, and passing nothing is correct.
+  if (VERCEL_OIDC_TOKEN) return {};
+
+  return null;
+}
+
+function readBody(body: unknown): { language: string; code: string } {
+  if (typeof body !== "object" || body === null) {
+    throw new ApiError(400, "validation", "Expected a JSON body.");
+  }
+
+  const { language, code } = body as Record<string, unknown>;
+
+  if (typeof language !== "string" || typeof code !== "string") {
+    throw new ApiError(400, "validation", "A language and some code are required.");
+  }
+
+  if (code.trim() === "") {
+    throw new ApiError(400, "validation", "There is nothing in that block to run.");
+  }
+
+  if (code.length > MAX_CODE) {
+    throw new ApiError(
+      400,
+      "validation",
+      `That block is larger than ${MAX_CODE.toLocaleString("en-US")} characters.`,
+    );
+  }
+
+  return { language, code };
+}
+
+export async function POST(request: NextRequest) {
+  return handle(async () => {
+    // Signed in, because this spends real compute on somebody's behalf.
+    await requireClient();
+    enforceRateLimit(request, RATE_LIMIT);
+
+    const { language, code } = readBody(await request.json().catch(() => null));
+
+    // The allow-list is the security boundary that matters here: the language
+    // decides the interpreter, and nothing from the request reaches a shell as
+    // a command name.
+    const runner = runnerFor(language);
+    if (!runner) {
+      throw new ApiError(
+        400,
+        "validation",
+        `ForkLeaf cannot run ${language || "unlabelled"} blocks.`,
+      );
+    }
+
+    const credentials = sandboxCredentials();
+    if (!credentials) {
+      throw new ApiError(
+        503,
+        "unavailable",
+        "Running blocks needs a sandbox, which this deployment is not configured for.",
+      );
+    }
+
+    // Imported here rather than at module scope so the rest of the API is not
+    // held hostage to a native dependency it never uses.
+    const { Sandbox } = await import("@vercel/sandbox");
+
+    const started = Date.now();
+    let sandbox: Awaited<ReturnType<typeof Sandbox.create>> | null = null;
+
+    try {
+      sandbox = await Sandbox.create({
+        ...credentials,
+        // The universal image carries bash, python3 and node, which is exactly
+        // the set this route will run. `runtime` is the deprecated spelling.
+        image: "vercel/sandbox/universal",
+        timeout: SANDBOX_TIMEOUT_MS,
+      });
+
+      const path = `/tmp/block.${runner.extension}`;
+      await sandbox.writeFiles([{ path, content: Buffer.from(code, "utf8") }]);
+
+      const finished = await sandbox.runCommand(runner.command, [path], {
+        timeoutMs: RUN_TIMEOUT_MS,
+      });
+
+      const [stdout, stderr] = await Promise.all([finished.stdout(), finished.stderr()]);
+
+      return {
+        stdout: stdout.slice(0, MAX_OUTPUT),
+        stderr: stderr.slice(0, MAX_OUTPUT),
+        exitCode: finished.exitCode,
+        ms: finished.durationMs ?? Date.now() - started,
+        truncated: stdout.length > MAX_OUTPUT || stderr.length > MAX_OUTPUT,
+        ranAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      // A run that could not happen is reported as a result with a reason
+      // rather than as a failed request: the note should record the attempt.
+      const reason = error instanceof Error ? error.message : "the sandbox failed";
+
+      return {
+        stdout: "",
+        stderr: "",
+        exitCode: -1,
+        ms: Date.now() - started,
+        truncated: false,
+        ranAt: new Date().toISOString(),
+        failure: /timed?.?out/i.test(reason)
+          ? `timed out after ${RUN_TIMEOUT_MS / 1000}s`
+          : `could not run — ${reason}`,
+      };
+    } finally {
+      // The VM bills for as long as it lives, so it is never left behind.
+      await sandbox?.stop().catch(() => {});
+    }
+  });
+}

--- a/apps/web/src/app/docs/content/start.tsx
+++ b/apps/web/src/app/docs/content/start.tsx
@@ -85,6 +85,14 @@ export function GettingStarted() {
           them. Useful for the question a commit list cannot answer: whether this page arrived in
           one sitting or was assembled over a year.
         </LI>
+        <LI>
+          <strong>Notes that run</strong> — any <Code>bash</Code>, <Code>python</Code> or{" "}
+          <Code>javascript</Code> block carries a <strong>Run</strong> button. The result lands in
+          an <Code>```output</Code> block underneath, stamped with when it ran, and commits with the
+          note like anything else — so a runbook records what actually happened instead of what was
+          supposed to. The code runs in a throwaway virtual machine with internet access, never on
+          your own computer, and the machine is destroyed when the run finishes.
+        </LI>
       </UL>
       <P>You can also just clone it. Nothing about a ForkLeaf repository is special:</P>
       <Pre label="terminal">{`git clone https://github.com/you/forkleaf-notes.git

--- a/apps/web/src/app/docs/content/start.tsx
+++ b/apps/web/src/app/docs/content/start.tsx
@@ -86,6 +86,12 @@ export function GettingStarted() {
           one sitting or was assembled over a year.
         </LI>
         <LI>
+          <strong>Review &amp; merge this note</strong> — properties panel. Propose a note as a pull
+          request, then read the review here instead of on github.com: each comment against the
+          paragraph it was written about, replies in place, and a squash-merge when it is settled.
+          Learning with code review, on your own notes.
+        </LI>
+        <LI>
           <strong>Notes that run</strong> — any <Code>bash</Code>, <Code>python</Code> or{" "}
           <Code>javascript</Code> block carries a <strong>Run</strong> button. The result lands in
           an <Code>```output</Code> block underneath, stamped with when it ran, and commits with the

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -956,6 +956,69 @@ mark.fl-hl-orange {
   color: var(--fl-text);
 }
 
-.fl-code-copy {
+/* Both trailing actions travel together, so adding Run does not leave Copy
+   fighting the language picker for the middle of the strip. */
+.fl-code-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
   margin-left: auto;
+}
+
+/* Run is the one control here that does something to the world rather than to
+   the document, so it is the one that gets any colour at all. */
+.fl-code-run {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  padding: 0.125rem 0.5rem;
+  border-radius: 6px;
+  color: var(--fl-inverse-text);
+  background: color-mix(in srgb, var(--fl-inverse-text) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--fl-inverse-text) 20%, transparent);
+  transition:
+    color 0.12s,
+    background 0.12s,
+    border-color 0.12s;
+}
+
+.fl-code-run:hover:not(:disabled),
+.fl-code-run:focus-visible {
+  background: color-mix(in srgb, var(--fl-inverse-text) 20%, transparent);
+  border-color: color-mix(in srgb, var(--fl-inverse-text) 32%, transparent);
+  outline: none;
+}
+
+/* Not greyed to the point of vanishing: the block is mid-run, and the button
+   is the only thing on screen saying so. */
+.fl-code-run:disabled {
+  opacity: 0.75;
+  cursor: progress;
+}
+
+/* Why a run could not be attempted. Sits inside the block's frame, under the
+   header, so it is unmistakably about this block and not about the page. */
+.fl-code-problem {
+  padding: 0.5rem 0.75rem;
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  color: var(--fl-inverse-text);
+  background: color-mix(in srgb, #f87171 22%, var(--fl-inverse-bg));
+  border-bottom: 1px solid color-mix(in srgb, var(--fl-inverse-text) 12%, transparent);
+}
+
+/* A run's result. Distinguished from the script above it by a quieter type
+   colour and a marked edge, so a glance separates what you wrote from what
+   came back without having to read either.
+
+   The edge is mixed toward the inverse text rather than used neat: the block
+   sits on the near-black inverse surface in both themes, and `--fl-accent` is
+   tuned for the page background, where it is a dark blue. Straight off the
+   token it was a dark blue on near-black — applied, measurable, and invisible
+   to anyone actually looking at it. */
+.fl-prose .fl-code-node:has(> pre > code.language-output) {
+  border-left: 3px solid color-mix(in srgb, var(--fl-accent) 45%, var(--fl-inverse-text));
+}
+
+.fl-prose code.language-output {
+  color: color-mix(in srgb, var(--fl-inverse-text) 82%, transparent);
 }

--- a/apps/web/src/components/EditorRightPanel.tsx
+++ b/apps/web/src/components/EditorRightPanel.tsx
@@ -32,6 +32,8 @@ export interface EditorRightPanelProps {
    * question — how this page grew, and which parts of it are old.
    */
   onBlame: () => void;
+  /** Absent for a local workspace, which has no pull requests to read. */
+  onReview?: () => void;
   /** Opens the publish dialog. Absent for a workspace with no repository. */
   onPublish?: (() => void) | undefined;
   /**
@@ -100,6 +102,7 @@ export function EditorRightPanel({
   onShowHistory,
   onReplay,
   onBlame,
+  onReview,
   onPublish,
   published,
   syncMode,
@@ -459,6 +462,15 @@ export function EditorRightPanel({
                     When each paragraph was written
                   </PanelButton>
                 )}
+                {/* Not gated on there being an open request: the panel's job
+                    is partly to say there is not one, and a button that
+                    appears only once you already know the answer is a button
+                    nobody finds. */}
+                {onReview && (
+                  <PanelButton onClick={onReview} icon={<ReviewGlyph />}>
+                    Review &amp; merge this note
+                  </PanelButton>
+                )}
                 <button
                   type="button"
                   onClick={onExport}
@@ -812,6 +824,16 @@ function LinkGlyph() {
     >
       <path d="M6.5 9.5a2.75 2.75 0 0 0 4 .25l2-2a2.75 2.75 0 0 0-3.9-3.9l-1.1 1.1" />
       <path d="M9.5 6.5a2.75 2.75 0 0 0-4-.25l-2 2a2.75 2.75 0 0 0 3.9 3.9l1.1-1.1" />
+    </svg>
+  );
+}
+
+/** Two lines of talk against a document — a review, in miniature. */
+function ReviewGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
+      <path d="M2 3.5h7M2 6h5" strokeLinecap="round" />
+      <path d="M6.5 9.5h7a1 1 0 0 1 1 1v2.5a1 1 0 0 1-1 1H9l-2 1.5V14h-.5a1 1 0 0 1-1-1v-2.5a1 1 0 0 1 1-1Z" />
     </svg>
   );
 }

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -194,6 +194,13 @@ export function HelpDialog({
                   changed in the margin beside it.
                 </span>
                 <span className="mt-3 block">
+                  Code blocks in <Mono>bash</Mono>, <Mono>python</Mono> or <Mono>javascript</Mono>{" "}
+                  have a <strong>Run</strong> button. The output is written into the note under the
+                  block and committed with it, so a runbook keeps its own results. Blocks run in a
+                  throwaway virtual machine — never on your computer — which is destroyed as soon as
+                  the run finishes.
+                </span>
+                <span className="mt-3 block">
                   You can also clone it. <Mono>git clone</Mono> the repository and every note is
                   there as plain Markdown.
                 </span>

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -194,6 +194,12 @@ export function HelpDialog({
                   changed in the margin beside it.
                 </span>
                 <span className="mt-3 block">
+                  <strong>Review &amp; merge this note</strong> reads the pull request open on this
+                  branch: every comment shown against the paragraph it was written about, with a
+                  reply box on each, and a squash-merge once it is settled. Propose changes first to
+                  open one.
+                </span>
+                <span className="mt-3 block">
                   Code blocks in <Mono>bash</Mono>, <Mono>python</Mono> or <Mono>javascript</Mono>{" "}
                   have a <strong>Run</strong> button. The output is written into the note under the
                   block and committed with it, so a runbook keeps its own results. Blocks run in a

--- a/apps/web/src/components/ReviewPanel.test.tsx
+++ b/apps/web/src/components/ReviewPanel.test.tsx
@@ -1,0 +1,414 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ReviewPanel } from "./ReviewPanel";
+
+afterEach(cleanup);
+
+const NOTE = ["# Recon", "", "SMB signing is disabled.", "", "## Foothold"].join("\n");
+
+const PULL = {
+  number: 7,
+  url: "https://github.com/me/notes/pull/7",
+  title: "Notes on recon",
+  state: "open",
+  merged: false,
+  author: "me",
+  head: "study/recon",
+  base: "main",
+  mergeable: true,
+  mergeableState: "clean",
+};
+
+function comment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    author: "reviewer",
+    body: "Is SMB signing really off on all three?",
+    createdAt: "2026-08-27T10:00:00.000Z",
+    path: "notes/recon.md",
+    line: 3,
+    inReplyTo: null,
+    ...overrides,
+  };
+}
+
+/** The GET response the panel loads from. */
+function loads(body: Record<string, unknown>) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve({ pull: PULL, comments: [], reviews: [], conversation: [], ...body }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function view() {
+  return render(
+    <ReviewPanel
+      owner="me"
+      repo="notes"
+      branch="study/recon"
+      path="notes/recon.md"
+      content={NOTE}
+    />,
+  );
+}
+
+beforeEach(() => vi.unstubAllGlobals());
+
+describe("ReviewPanel — reading a review", () => {
+  it("names the pull request it is showing", async () => {
+    loads({});
+    view();
+
+    await waitFor(() => expect(screen.getByText("Notes on recon")).toBeTruthy());
+    expect(screen.getByText("#7")).toBeTruthy();
+  });
+
+  it("asks GitHub about the branch, not about a number it does not have", async () => {
+    const fetchMock = loads({});
+    view();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(String(fetchMock.mock.calls[0]![0])).toContain("head=study%2Frecon");
+  });
+
+  it("says plainly when the branch has no review open", async () => {
+    loads({ pull: null });
+    view();
+
+    await waitFor(() => expect(screen.getByText(/nothing is under review/i)).toBeTruthy());
+  });
+
+  it("quotes the paragraph a comment was written about", async () => {
+    loads({ comments: [comment()] });
+    view();
+
+    await waitFor(() => expect(screen.getByText(/is smb signing really off/i)).toBeTruthy());
+    expect(screen.getByText("SMB signing is disabled.")).toBeTruthy();
+  });
+
+  it("says so rather than quoting the wrong paragraph when the line is gone", async () => {
+    loads({ comments: [comment({ line: null })] });
+    view();
+
+    await waitFor(() => expect(screen.getByText(/since changed/i)).toBeTruthy());
+  });
+
+  it("ignores comments left on another note", async () => {
+    loads({ comments: [comment({ path: "notes/other.md" })] });
+    view();
+
+    await waitFor(() => expect(screen.getByText(/no inline comments/i)).toBeTruthy());
+  });
+
+  it("shows a reply under the comment it answers", async () => {
+    loads({
+      comments: [comment(), comment({ id: 2, inReplyTo: 1, author: "me", body: "Checked twice." })],
+    });
+    view();
+
+    await waitFor(() => expect(screen.getByText("Checked twice.")).toBeTruthy());
+    // One thread, not two.
+    expect(
+      screen.getAllByRole("listitem").filter((n) => n.querySelector("blockquote")),
+    ).toHaveLength(1);
+  });
+
+  it("reports an approval", async () => {
+    loads({
+      reviews: [
+        {
+          id: 1,
+          author: "reviewer",
+          state: "APPROVED",
+          body: "",
+          submittedAt: "2026-08-27T11:00:00Z",
+        },
+      ],
+    });
+    view();
+
+    await waitFor(() => expect(screen.getByText("Approved")).toBeTruthy());
+  });
+
+  it("reports a request for changes", async () => {
+    loads({
+      reviews: [
+        {
+          id: 1,
+          author: "reviewer",
+          state: "CHANGES_REQUESTED",
+          body: "",
+          submittedAt: "2026-08-27T11:00:00Z",
+        },
+      ],
+    });
+    view();
+
+    await waitFor(() => expect(screen.getByText("Changes requested")).toBeTruthy());
+    expect(screen.getByText(/someone has asked for changes/i)).toBeTruthy();
+  });
+
+  it("says nobody has reviewed yet when nobody has", async () => {
+    loads({});
+    view();
+
+    await waitFor(() => expect(screen.getByText("Not reviewed yet")).toBeTruthy());
+  });
+});
+
+describe("ReviewPanel — replying", () => {
+  it("sends a reply against the comment that opened the thread", async () => {
+    const fetchMock = loads({ comments: [comment({ id: 55 })] });
+    view();
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/reply to this/i)).toBeTruthy());
+    fireEvent.change(screen.getByPlaceholderText(/reply to this/i), {
+      target: { value: "Yes, all three." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^reply$/i }));
+
+    await waitFor(() => {
+      const posted = fetchMock.mock.calls.find(
+        ([, init]) => (init as RequestInit)?.method === "POST",
+      );
+      expect(JSON.parse(String((posted![1] as RequestInit).body))).toMatchObject({
+        action: "reply",
+        commentId: 55,
+        body: "Yes, all three.",
+        number: 7,
+      });
+    });
+  });
+
+  it("will not send an empty reply", async () => {
+    loads({ comments: [comment()] });
+    view();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /^reply$/i })).toBeTruthy());
+    expect(screen.getByRole("button", { name: /^reply$/i })).toHaveProperty("disabled", true);
+  });
+
+  it("sends on Enter, the way every other message box does", async () => {
+    const fetchMock = loads({ comments: [comment()] });
+    view();
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/reply to this/i)).toBeTruthy());
+    const box = screen.getByPlaceholderText(/reply to this/i);
+    fireEvent.change(box, { target: { value: "Yes." } });
+    fireEvent.keyDown(box, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, i]) => (i as RequestInit)?.method === "POST")).toBe(
+        true,
+      ),
+    );
+  });
+
+  it("leaves a newline alone when shift is held", async () => {
+    const fetchMock = loads({ comments: [comment()] });
+    view();
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/reply to this/i)).toBeTruthy());
+    const box = screen.getByPlaceholderText(/reply to this/i);
+    fireEvent.change(box, { target: { value: "Line one" } });
+    fireEvent.keyDown(box, { key: "Enter", shiftKey: true });
+
+    expect(fetchMock.mock.calls.some(([, i]) => (i as RequestInit)?.method === "POST")).toBe(false);
+  });
+
+  it("adds to the conversation when the remark is not about a line", async () => {
+    const fetchMock = loads({});
+    view();
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/review as a whole/i)).toBeTruthy());
+    fireEvent.change(screen.getByPlaceholderText(/review as a whole/i), {
+      target: { value: "Thanks for looking." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add to the conversation/i }));
+
+    await waitFor(() => {
+      const posted = fetchMock.mock.calls.find(([, i]) => (i as RequestInit)?.method === "POST");
+      expect(JSON.parse(String((posted![1] as RequestInit).body)).action).toBe("comment");
+    });
+  });
+});
+
+describe("ReviewPanel — merging", () => {
+  it("squashes, and says so before it is pressed", async () => {
+    loads({});
+    view();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /squash and merge/i })).toBeTruthy(),
+    );
+    expect(screen.getByText(/land as a single commit/i)).toBeTruthy();
+  });
+
+  it("will not offer to merge something GitHub has refused", async () => {
+    loads({ pull: { ...PULL, mergeable: false, mergeableState: "dirty" } });
+    view();
+
+    await waitFor(() => expect(screen.getByText(/has conflicts/i)).toBeTruthy());
+    expect(screen.getByRole("button", { name: /squash and merge/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+
+  it("says when GitHub has not worked out mergeability yet", async () => {
+    loads({ pull: { ...PULL, mergeable: null, mergeableState: null } });
+    view();
+
+    await waitFor(() => expect(screen.getByText(/still working out/i)).toBeTruthy());
+  });
+
+  it("tells the workspace which branch to go back to once merged", async () => {
+    const onMerged = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url, init) =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(
+              (init as RequestInit)?.method === "POST"
+                ? { merged: true }
+                : { pull: PULL, comments: [], reviews: [], conversation: [] },
+            ),
+        }),
+      ),
+    );
+
+    render(
+      <ReviewPanel
+        owner="me"
+        repo="notes"
+        branch="study/recon"
+        path="notes/recon.md"
+        content={NOTE}
+        onMerged={onMerged}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /squash and merge/i })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /squash and merge/i }));
+
+    await waitFor(() => expect(onMerged).toHaveBeenCalledWith("main"));
+  });
+});
+
+describe("ReviewPanel — keeping up with the branch", () => {
+  it("re-reads after a reply rather than guessing the new state", async () => {
+    const fetchMock = vi.fn().mockImplementation((_url, init) =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve(
+            (init as RequestInit)?.method === "POST"
+              ? { comment: { id: 2 } }
+              : { pull: PULL, comments: [comment()], reviews: [], conversation: [] },
+          ),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    view();
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/reply to this/i)).toBeTruthy());
+    const before = fetchMock.mock.calls.filter(([, i]) => !(i as RequestInit)?.method).length;
+
+    fireEvent.change(screen.getByPlaceholderText(/reply to this/i), { target: { value: "Yes." } });
+    fireEvent.click(screen.getByRole("button", { name: /^reply$/i }));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.filter(([, i]) => !(i as RequestInit)?.method).length).toBe(
+        before + 1,
+      ),
+    );
+  });
+
+  it("does not let a slow answer for the old branch overwrite the new one", async () => {
+    // The panel is remounted on a different branch while the first read is
+    // still in flight; the stale answer must not land.
+    const slow = {
+      pull: { ...PULL, title: "Old branch" },
+      comments: [],
+      reviews: [],
+      conversation: [],
+    };
+    const fresh = {
+      pull: { ...PULL, title: "New branch" },
+      comments: [],
+      reviews: [],
+      conversation: [],
+    };
+
+    let resolveFirst: (value: unknown) => void = () => {};
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+        .mockImplementation(() =>
+          Promise.resolve({ ok: true, json: () => Promise.resolve(fresh) }),
+        ),
+    );
+
+    const { rerender } = render(
+      <ReviewPanel owner="me" repo="notes" branch="old" path="notes/recon.md" content={NOTE} />,
+    );
+
+    rerender(
+      <ReviewPanel owner="me" repo="notes" branch="new" path="notes/recon.md" content={NOTE} />,
+    );
+
+    await waitFor(() => expect(screen.getByText("New branch")).toBeTruthy());
+
+    resolveFirst({ ok: true, json: () => Promise.resolve(slow) });
+    await waitFor(() => expect(screen.getByText("New branch")).toBeTruthy());
+    expect(screen.queryByText("Old branch")).toBeNull();
+  });
+});
+
+describe("ReviewPanel — when GitHub cannot be reached", () => {
+  it("says the review exists even though this view cannot show it", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    view();
+
+    await waitFor(() => expect(screen.getByText(/could not reach github/i)).toBeTruthy());
+  });
+
+  it("passes on what GitHub said about a refused merge", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url, init) =>
+        Promise.resolve(
+          (init as RequestInit)?.method === "POST"
+            ? {
+                ok: false,
+                json: () => Promise.resolve({ error: { message: "Base branch was modified" } }),
+              }
+            : {
+                ok: true,
+                json: () =>
+                  Promise.resolve({ pull: PULL, comments: [], reviews: [], conversation: [] }),
+              },
+        ),
+      ),
+    );
+
+    view();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /squash and merge/i })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /squash and merge/i }));
+
+    await waitFor(() => expect(screen.getByText(/base branch was modified/i)).toBeTruthy());
+  });
+});

--- a/apps/web/src/components/ReviewPanel.tsx
+++ b/apps/web/src/components/ReviewPanel.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  buildThreads,
+  summariseReviews,
+  type ReviewComment,
+  type ReviewThread,
+  type SubmittedReview,
+  type Verdict,
+} from "@forkleaf/markdown-engine";
+import { relativeTime } from "@/lib/relative-time";
+
+/**
+ * A pull request's review, read inside the note it is about.
+ *
+ * Opening a request against your own notes already worked. Reading the review
+ * meant going to github.com and reading your own prose as a unified diff —
+ * which is the part that made "study something, then have it reviewed" not
+ * actually work. Comments are shown against the paragraph they were written
+ * about, in the order the note reads, with the paragraph quoted so a remark is
+ * never floating free of what it is a remark about.
+ */
+
+interface PullSummary {
+  number: number;
+  url: string;
+  title: string;
+  state: string;
+  merged: boolean;
+  author: string | null;
+  head: string;
+  base: string;
+  mergeable: boolean | null;
+  mergeableState: string | null;
+}
+
+interface Conversation {
+  id: number;
+  author: string | null;
+  body: string;
+  createdAt: string;
+}
+
+interface ReviewData {
+  pull: PullSummary | null;
+  comments: ReviewComment[];
+  reviews: SubmittedReview[];
+  conversation: Conversation[];
+}
+
+export interface ReviewPanelProps {
+  owner: string;
+  repo: string;
+  /** The branch the workspace is on, which is what identifies the request. */
+  branch: string;
+  /** The note being reviewed — only its comments are shown. */
+  path: string;
+  /** The note as it stands, for quoting the paragraph each remark is about. */
+  content: string;
+  /** Told when a merge lands, so the workspace can go back to the base branch. */
+  onMerged?: (base: string) => void;
+}
+
+const VERDICT_LABEL: Record<Verdict, string> = {
+  approved: "Approved",
+  "changes-requested": "Changes requested",
+  commented: "Commented on",
+  none: "Not reviewed yet",
+};
+
+export function ReviewPanel({ owner, repo, branch, path, content, onMerged }: ReviewPanelProps) {
+  const [data, setData] = useState<ReviewData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  /**
+   * Reads the whole review, and writes no state of its own.
+   *
+   * Kept pure so the effect below can own every write. A version of this that
+   * called setState was flagged for setting state synchronously from an
+   * effect — and would have had a real race behind the lint error: switching
+   * branch mid-request let a slow answer for the old branch overwrite the new
+   * one's.
+   */
+  const read = useCallback(async (): Promise<
+    { ok: true; data: ReviewData } | { ok: false; message: string }
+  > => {
+    try {
+      const params = new URLSearchParams({ owner, repo, head: branch });
+      const response = await fetch(`/api/gh/review?${params.toString()}`);
+      const body = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        return { ok: false, message: body?.error?.message ?? "That review could not be read." };
+      }
+
+      return { ok: true, data: body as ReviewData };
+    } catch {
+      return {
+        ok: false,
+        message: "Could not reach GitHub. The review is there, this view is not.",
+      };
+    }
+  }, [owner, repo, branch]);
+
+  const [reloads, setReloads] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const result = await read();
+      if (cancelled) return;
+
+      if (result.ok) {
+        setData(result.data);
+        setError(null);
+      } else {
+        setError(result.message);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [read, reloads]);
+
+  /** Re-reads after something is sent, rather than guessing the new state. */
+  const reload = useCallback(() => setReloads((n) => n + 1), []);
+
+  const threads = useMemo(
+    () => (data ? buildThreads(data.comments, { path, content }) : []),
+    [data, path, content],
+  );
+
+  const verdict = useMemo(() => summariseReviews(data?.reviews ?? []), [data]);
+
+  /** Sends one reply, then re-reads rather than guessing the new state. */
+  const send = useCallback(
+    async (payload: Record<string, unknown>, key: string) => {
+      if (!data?.pull) return;
+      setBusy(key);
+      setError(null);
+
+      try {
+        const response = await fetch("/api/gh/review", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ owner, repo, number: data.pull.number, ...payload }),
+        });
+
+        const body = await response.json().catch(() => null);
+
+        if (!response.ok) {
+          setError(body?.error?.message ?? "That did not go through.");
+          return;
+        }
+
+        if (payload.action === "merge") {
+          onMerged?.(data.pull.base);
+          return;
+        }
+
+        reload();
+      } catch {
+        setError("Could not reach GitHub. Nothing was sent.");
+      } finally {
+        setBusy(null);
+      }
+    },
+    [data, owner, repo, reload, onMerged],
+  );
+
+  if (error && !data) {
+    return <p className="text-[13px] text-[var(--fl-muted)]">{error}</p>;
+  }
+
+  if (!data) {
+    return <p className="text-[13px] text-[var(--fl-muted)]">Reading the review…</p>;
+  }
+
+  if (!data.pull) {
+    return (
+      <div className="space-y-2">
+        <p className="text-[13px] text-[var(--fl-text)]">Nothing is under review.</p>
+        <p className="text-[12.5px] text-[var(--fl-muted)]">
+          This branch — <code className="font-mono">{branch}</code> — has no open pull request.
+          Propose changes from the properties panel to open one, and the review appears here.
+        </p>
+      </div>
+    );
+  }
+
+  const pull = data.pull;
+
+  return (
+    <div className="space-y-4">
+      <header className="space-y-1.5 border-b border-[var(--fl-border)] pb-3">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <a
+            href={pull.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-[14px] font-medium text-[var(--fl-text)] underline-offset-2 hover:underline"
+          >
+            {pull.title}
+          </a>
+          <span className="font-mono text-[12px] text-[var(--fl-muted)]">#{pull.number}</span>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 text-[12px] text-[var(--fl-muted)]">
+          <Badge verdict={verdict.verdict} />
+          <span>
+            {pull.head} → {pull.base}
+          </span>
+          {verdict.reviewers.length > 0 && (
+            <span>{verdict.reviewers.map((r) => r.author).join(", ")}</span>
+          )}
+        </div>
+      </header>
+
+      {error && <p className="text-[12.5px] text-[var(--fl-danger,#f87171)]">{error}</p>}
+
+      {threads.length === 0 ? (
+        <p className="text-[12.5px] text-[var(--fl-muted)]">
+          No inline comments on this note yet. Anything a reviewer marks up will appear here beside
+          the paragraph it is about.
+        </p>
+      ) : (
+        <ol className="space-y-3">
+          {threads.map((thread) => (
+            <Thread
+              key={thread.id}
+              thread={thread}
+              busy={busy === `reply-${thread.id}`}
+              onReply={(body) =>
+                send({ action: "reply", commentId: thread.id, body }, `reply-${thread.id}`)
+              }
+            />
+          ))}
+        </ol>
+      )}
+
+      <Composer
+        label="Add to the conversation"
+        placeholder="Reply to the review as a whole…"
+        busy={busy === "comment"}
+        onSend={(body) => send({ action: "comment", body }, "comment")}
+      />
+
+      <footer className="flex flex-wrap items-center gap-3 border-t border-[var(--fl-border)] pt-3">
+        <button
+          type="button"
+          disabled={busy !== null || pull.mergeable === false}
+          onClick={() => send({ action: "merge" }, "merge")}
+          className="rounded-lg bg-[var(--fl-accent)] px-3 py-1.5 text-[12.5px] font-medium text-[var(--fl-accent-contrast)] transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {busy === "merge" ? "Merging…" : "Squash and merge"}
+        </button>
+
+        <span className="text-[12px] text-[var(--fl-muted)]">
+          {mergeAdvice(pull, verdict.verdict)}
+        </span>
+      </footer>
+    </div>
+  );
+}
+
+/**
+ * What the merge button will and will not do, said before it is pressed.
+ *
+ * GitHub computes mergeability in the background and reports null until it has
+ * — so "unknown" is a real answer here, not an oversight, and saying so beats
+ * a button that looks ready and then fails.
+ */
+function mergeAdvice(pull: PullSummary, verdict: Verdict): string {
+  if (pull.mergeable === false) {
+    return pull.mergeableState === "dirty"
+      ? "This has conflicts with the base branch and cannot be merged here."
+      : "GitHub will not merge this yet.";
+  }
+
+  if (pull.mergeable === null) return "GitHub is still working out whether this can merge.";
+  if (verdict === "changes-requested") return "Someone has asked for changes.";
+  if (verdict === "approved") return "Approved — this will land as a single commit.";
+
+  return "This will land as a single commit.";
+}
+
+function Badge({ verdict }: { verdict: Verdict }) {
+  const tone =
+    verdict === "approved"
+      ? "text-[#4ade80]"
+      : verdict === "changes-requested"
+        ? "text-[#f87171]"
+        : "text-[var(--fl-muted)]";
+
+  return <span className={`font-medium ${tone}`}>{VERDICT_LABEL[verdict]}</span>;
+}
+
+function Thread({
+  thread,
+  busy,
+  onReply,
+}: {
+  thread: ReviewThread;
+  busy: boolean;
+  onReply: (body: string) => void;
+}) {
+  return (
+    <li className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-3">
+      {thread.quote ? (
+        <blockquote className="mb-2.5 border-l-2 border-[var(--fl-accent)] pl-2.5 text-[12.5px] whitespace-pre-wrap text-[var(--fl-muted)]">
+          {thread.quote}
+        </blockquote>
+      ) : (
+        /* The line it was written against is gone, so there is nothing
+           truthful to quote. Saying so beats quoting the wrong paragraph. */
+        <p className="mb-2.5 text-[12px] text-[var(--fl-muted)] italic">
+          On a part of the note that has since changed.
+        </p>
+      )}
+
+      <ol className="space-y-2.5">
+        {thread.comments.map((comment) => (
+          <li key={comment.id}>
+            <div className="flex items-baseline gap-2 text-[12px]">
+              <span className="font-medium text-[var(--fl-text)]">
+                {comment.author ?? "someone"}
+              </span>
+              <time dateTime={comment.createdAt} className="text-[var(--fl-muted)]">
+                {relativeTime(comment.createdAt)}
+              </time>
+            </div>
+            <p className="mt-0.5 text-[13px] whitespace-pre-wrap text-[var(--fl-text)]">
+              {comment.body}
+            </p>
+          </li>
+        ))}
+      </ol>
+
+      <Composer label="Reply" placeholder="Reply to this…" busy={busy} onSend={onReply} compact />
+    </li>
+  );
+}
+
+function Composer({
+  label,
+  placeholder,
+  busy,
+  onSend,
+  compact = false,
+}: {
+  label: string;
+  placeholder: string;
+  busy: boolean;
+  onSend: (body: string) => void;
+  compact?: boolean;
+}) {
+  const [text, setText] = useState("");
+
+  const send = () => {
+    const body = text.trim();
+    if (!body || busy) return;
+    onSend(body);
+    setText("");
+  };
+
+  return (
+    <div className={compact ? "mt-2.5" : "space-y-1.5"}>
+      {!compact && (
+        <label className="block text-[12px] text-[var(--fl-muted)]" htmlFor={`c-${label}`}>
+          {label}
+        </label>
+      )}
+      <div className="flex gap-2">
+        <textarea
+          id={`c-${label}`}
+          rows={compact ? 1 : 2}
+          value={text}
+          placeholder={placeholder}
+          onChange={(event) => setText(event.target.value)}
+          // Enter sends, because these are one-line remarks; a newline still
+          // works with the modifier, the way every chat box behaves.
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              send();
+            }
+          }}
+          className="min-w-0 flex-1 resize-y rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2.5 py-1.5 text-[13px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
+        />
+        <button
+          type="button"
+          onClick={send}
+          disabled={busy || text.trim() === ""}
+          className="self-end rounded-lg border border-[var(--fl-border)] px-2.5 py-1.5 text-[12.5px] text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)] disabled:opacity-40"
+        >
+          {busy ? "Sending…" : label}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -31,6 +31,8 @@ import { ProposeChangesDialog } from "@/components/ProposeChangesDialog";
 import { PublishDialog } from "@/components/PublishDialog";
 import { HelpDialog } from "@/components/HelpDialog";
 import { HistoryDialog } from "@/components/HistoryDialog";
+import { ReviewPanel } from "@/components/ReviewPanel";
+import { Dialog } from "@/components/Dialog";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
 import { CommandPalette, type Command } from "@/components/CommandPalette";
 import { StorageBlocked } from "@/components/StorageBlocked";
@@ -97,7 +99,16 @@ export function EditorWorkspace() {
    */
   const [drawer, setDrawer] = useState<"files" | "document" | null>(null);
   const [dialog, setDialog] = useState<
-    "export" | "connect" | "help" | "history" | "replay" | "blame" | "propose" | "publish" | null
+    | "export"
+    | "connect"
+    | "help"
+    | "history"
+    | "replay"
+    | "blame"
+    | "review"
+    | "propose"
+    | "publish"
+    | null
   >(null);
   /**
    * Something worth saying that is not a failure.
@@ -916,6 +927,16 @@ export function EditorWorkspace() {
             "blame who wrote when written provenance attribution authorship age stale old paragraph line origin annotate",
           run: () => setDialog("blame"),
         });
+
+        list.push({
+          id: "review",
+          label: "Review this note as a pull request",
+          group: "Notes",
+          hint: "Read the comments on this branch, reply, and merge",
+          keywords:
+            "review pull request pr comments feedback merge approve changes requested critique reviewer discussion conversation",
+          run: () => setDialog("review"),
+        });
       }
     }
 
@@ -1386,6 +1407,14 @@ export function EditorWorkspace() {
                 setDrawer(null);
                 setDialog("blame");
               }}
+              onReview={
+                workspace && !workspace.isLocal
+                  ? () => {
+                      setDrawer(null);
+                      setDialog("review");
+                    }
+                  : undefined
+              }
               onPublish={
                 workspace && !workspace.isLocal
                   ? () => {
@@ -1462,6 +1491,30 @@ export function EditorWorkspace() {
             resolveImageSrc={images.resolve}
           />
         )}
+
+      {openDialog === "review" && note && workspace && !workspace.isLocal && (
+        <Dialog
+          title="Review &amp; merge"
+          subtitle={`${note.path} · ${workspace.repo.owner}/${workspace.repo.repo} · ${workspace.repo.branch}`}
+          onClose={() => setDialog(null)}
+          wide
+        >
+          <ReviewPanel
+            owner={workspace.repo.owner}
+            repo={workspace.repo.repo}
+            branch={workspace.repo.branch}
+            path={note.path}
+            content={note.content}
+            onMerged={(base) => {
+              // Back to the branch the work just landed on; staying on a
+              // merged branch is how the next edit opens a second request
+              // against a branch nobody is looking at any more.
+              setDialog(null);
+              void notebook.switchBranch(base);
+            }}
+          />
+        </Dialog>
+      )}
 
       {showConflicts && (
         <ConflictDialog

--- a/packages/editor/src/extensions/CodeBlock.tsx
+++ b/packages/editor/src/extensions/CodeBlock.tsx
@@ -9,6 +9,7 @@ import {
   type NodeViewProps,
 } from "@tiptap/react";
 import { all, createLowlight } from "lowlight";
+import { OUTPUT_LANGUAGE, formatOutput, isOutput, runnerFor } from "@forkleaf/markdown-engine";
 
 /**
  * Code blocks in the rich editor: syntax-highlighted, with the language on the
@@ -22,6 +23,11 @@ import { all, createLowlight } from "lowlight";
  * The language lives in the `language` attribute, which is exactly what
  * tiptap-markdown writes after the ``` fence, so a block labelled here is
  * labelled on GitHub too.
+ *
+ * Blocks in a language something can interpret also carry a Run button. What
+ * comes back is written into a plain fenced block underneath — see
+ * `runnable.ts` for why the result is ordinary markdown rather than a node of
+ * its own.
  */
 
 // The full language set, matching what the preview renders with. `common` is
@@ -178,6 +184,18 @@ function displayName(language: string): string {
 function CodeBlockView({ node, updateAttributes, editor, getPos }: NodeViewProps) {
   const language = (node.attrs.language as string) ?? "";
   const [copied, setCopied] = useState(false);
+  const [running, setRunning] = useState(false);
+
+  /**
+   * Why a run could not be attempted — rate limited, signed out, no sandbox.
+   *
+   * Kept out of the note on purpose. A block that ran and failed is a result
+   * worth recording; the app declining to run it is not something the reader
+   * should find committed in their notes a year later.
+   */
+  const [problem, setProblem] = useState<string | null>(null);
+
+  const runner = runnerFor(language);
 
   const languages = useMemo(() => {
     const popular = POPULAR.filter(isKnown);
@@ -217,6 +235,68 @@ function CodeBlockView({ node, updateAttributes, editor, getPos }: NodeViewProps
       .focus()
       .setTextSelection(pos + node.nodeSize - 1)
       .run();
+  };
+
+  /**
+   * Puts a run's result in a fenced block directly under this one.
+   *
+   * Replaces the previous result rather than stacking a new block under it:
+   * a runbook re-run five times should read as what it does now, not as an
+   * archive of every time somebody pressed the button. The history of those
+   * runs is in the commits, which is where history belongs.
+   */
+  const writeOutput = (text: string) => {
+    const pos = typeof getPos === "function" ? getPos() : null;
+    if (typeof pos !== "number") return;
+
+    const { state, view } = editor;
+    const after = pos + node.nodeSize;
+    // Read fresh rather than from a closure: the document may have been
+    // edited while the sandbox was working.
+    const next = after <= state.doc.content.size ? state.doc.resolve(after).nodeAfter : null;
+
+    const block = node.type.create(
+      { language: OUTPUT_LANGUAGE },
+      text ? state.schema.text(text) : null,
+    );
+
+    const replacing = next && next.type === node.type && isOutput(next.attrs.language as string);
+
+    view.dispatch(
+      replacing
+        ? state.tr.replaceWith(after, after + next.nodeSize, block)
+        : state.tr.insert(after, block),
+    );
+  };
+
+  const run = async () => {
+    if (!runner || running) return;
+
+    setRunning(true);
+    setProblem(null);
+
+    try {
+      const response = await fetch("/api/run", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ language, code: node.textContent }),
+      });
+
+      const body = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        setProblem(body?.error?.message ?? "That block could not be run.");
+        return;
+      }
+
+      writeOutput(formatOutput(body));
+    } catch {
+      // Offline, or the request never arrived. Nothing ran, so nothing is
+      // written down.
+      setProblem("Could not reach the server. Nothing was run.");
+    } finally {
+      setRunning(false);
+    }
   };
 
   const copy = async () => {
@@ -261,10 +341,30 @@ function CodeBlockView({ node, updateAttributes, editor, getPos }: NodeViewProps
           </optgroup>
         </select>
 
-        <button type="button" onClick={copy} className="fl-code-copy">
-          {copied ? "Copied" : "Copy"}
-        </button>
+        <div className="fl-code-actions">
+          {runner && (
+            <button
+              type="button"
+              onClick={run}
+              disabled={running}
+              className="fl-code-run"
+              title={`Run this ${runner.label} block in a throwaway virtual machine — not on your own computer. It has internet access, and is destroyed when the run finishes.`}
+            >
+              {running ? "Running…" : "Run"}
+            </button>
+          )}
+
+          <button type="button" onClick={copy} className="fl-code-copy">
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
       </div>
+
+      {problem && (
+        <div contentEditable={false} className="fl-code-problem" role="status">
+          {problem}
+        </div>
+      )}
 
       <pre spellCheck={false} onMouseDown={focusCode}>
         <NodeViewContent<"code">

--- a/packages/editor/src/run-block.test.tsx
+++ b/packages/editor/src/run-block.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { WysiwygEditor, markdownOf } from "./WysiwygEditor";
+
+afterEach(cleanup);
+
+async function mount(markdown: string): Promise<Editor> {
+  let editor: Editor | null = null;
+  render(<WysiwygEditor value={markdown} onChange={vi.fn()} onReady={(i) => (editor = i)} />);
+  await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+  return editor!;
+}
+
+/** The next fetch resolves as a completed run. */
+function runs(body: Record<string, unknown>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+          ms: 120,
+          truncated: false,
+          ranAt: "2026-08-27T10:04:09.000Z",
+          ...body,
+        }),
+    }),
+  );
+}
+
+/** The next fetch is refused by the API. */
+function refuses(status: number, message: string) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      json: () => Promise.resolve({ error: { code: "x", message } }),
+    }),
+  );
+}
+
+const runButton = () => screen.getByRole("button", { name: /^run$/i });
+
+/**
+ * The document's blocks as [language, text].
+ *
+ * Asserted on instead of child counts: the editor keeps a trailing empty
+ * paragraph for the caret, so counting children measures that as much as it
+ * measures the result.
+ */
+function blocks(editor: Editor): [string, string][] {
+  const found: [string, string][] = [];
+  editor.state.doc.forEach((node) => {
+    if (node.type.name === "codeBlock") found.push([node.attrs.language ?? "", node.textContent]);
+    else if (node.textContent) found.push([node.type.name, node.textContent]);
+  });
+  return found;
+}
+
+const outputOf = (editor: Editor) =>
+  blocks(editor).find(([lang]) => lang === "output")?.[1] ?? null;
+
+beforeEach(() => vi.unstubAllGlobals());
+
+describe("which blocks offer to run", () => {
+  it("offers a Run button on a shell block", async () => {
+    await mount("```bash\necho hi\n```");
+    expect(runButton()).toBeTruthy();
+  });
+
+  it("offers one on a python block", async () => {
+    await mount("```python\nprint(1)\n```");
+    expect(runButton()).toBeTruthy();
+  });
+
+  it("offers one on a javascript block", async () => {
+    await mount("```js\nconsole.log(1)\n```");
+    expect(runButton()).toBeTruthy();
+  });
+
+  it("offers nothing on a language nothing can interpret", async () => {
+    await mount("```rust\nfn main() {}\n```");
+    expect(screen.queryByRole("button", { name: /^run$/i })).toBeNull();
+  });
+
+  it("offers nothing on an unlabelled block", async () => {
+    await mount("```\nplain text\n```");
+    expect(screen.queryByRole("button", { name: /^run$/i })).toBeNull();
+  });
+
+  it("never offers to run a block that is itself a result", async () => {
+    // Otherwise the output grows a Run button, and pressing it executes the
+    // last run's stdout as a script.
+    await mount("```output\n— ran 2026-08-27 10:04 UTC · ok · 12ms\nhi\n```");
+    expect(screen.queryByRole("button", { name: /^run$/i })).toBeNull();
+  });
+
+  it("still offers Copy on a block it cannot run", async () => {
+    await mount("```rust\nfn main() {}\n```");
+    expect(screen.getByRole("button", { name: /copy/i })).toBeTruthy();
+  });
+});
+
+describe("running a block", () => {
+  it("sends the code and its language", async () => {
+    runs({ stdout: "hi" });
+    await mount("```bash\necho hi\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/run",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ language: "bash", code: "echo hi" }),
+        }),
+      ),
+    );
+  });
+
+  it("writes what came back into a block underneath", async () => {
+    runs({ stdout: "hello" });
+    const editor = await mount("```bash\necho hello\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(outputOf(editor)).not.toBeNull());
+
+    expect(outputOf(editor)).toContain("hello");
+    expect(outputOf(editor)).toContain("2026-08-27 10:04 UTC");
+  });
+
+  it("writes it back as an ordinary fenced block, readable anywhere", async () => {
+    runs({ stdout: "hello" });
+    const editor = await mount("```bash\necho hello\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(outputOf(editor)).not.toBeNull());
+    const markdown = markdownOf(editor);
+
+    expect(markdown).toContain("```output");
+    expect(markdown).toContain("hello");
+    // The script itself is untouched.
+    expect(markdown).toContain("```bash\necho hello\n```");
+  });
+
+  it("records a failing script as a result, with its exit code", async () => {
+    runs({ stderr: "no such file", exitCode: 2 });
+    const editor = await mount("```bash\ncat nope\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(outputOf(editor)).not.toBeNull());
+    expect(outputOf(editor)).toContain("exit 2");
+    expect(outputOf(editor)).toContain("no such file");
+  });
+
+  it("records a sandbox that never ran the script", async () => {
+    runs({ failure: "timed out after 30s", exitCode: -1 });
+    const editor = await mount("```bash\nsleep 999\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(outputOf(editor)).not.toBeNull());
+    expect(outputOf(editor)).toContain("timed out after 30s");
+  });
+
+  it("says a command printed nothing rather than leaving an empty block", async () => {
+    runs({ stdout: "", stderr: "" });
+    const editor = await mount("```bash\ntrue\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(outputOf(editor)).not.toBeNull());
+    expect(outputOf(editor)).toContain("(no output)");
+  });
+
+  it("shows that it is running while the sandbox works", async () => {
+    let release: (value: unknown) => void = () => {};
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise((resolve) => (release = resolve))));
+
+    await mount("```bash\necho hi\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /running/i })).toBeTruthy());
+    expect(screen.getByRole("button", { name: /running/i })).toHaveProperty("disabled", true);
+
+    release({
+      ok: true,
+      json: () => Promise.resolve({ stdout: "hi", exitCode: 0, ms: 1, ranAt: "" }),
+    });
+  });
+});
+
+describe("running a block a second time", () => {
+  it("replaces the previous result instead of stacking another under it", async () => {
+    runs({ stdout: "first" });
+    const editor = await mount("```bash\necho hi\n```");
+
+    fireEvent.click(runButton());
+    await waitFor(() => expect(outputOf(editor)).toContain("first"));
+
+    runs({ stdout: "second" });
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(outputOf(editor)).toContain("second"));
+    expect(blocks(editor).filter(([lang]) => lang === "output")).toHaveLength(1);
+    expect(outputOf(editor)).not.toContain("first");
+  });
+
+  it("does not swallow a paragraph that happens to follow the block", async () => {
+    runs({ stdout: "hi" });
+    const editor = await mount("```bash\necho hi\n```\n\nSome prose after it.");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(outputOf(editor)).not.toBeNull());
+    expect(blocks(editor)).toEqual([
+      ["bash", "echo hi"],
+      ["output", expect.stringContaining("hi")],
+      ["paragraph", "Some prose after it."],
+    ]);
+  });
+
+  it("does not mistake a following code block in another language for its output", async () => {
+    runs({ stdout: "hi" });
+    const editor = await mount("```bash\necho hi\n```\n\n```python\nprint(1)\n```");
+    // Two runnable blocks, so two buttons; this is the first block's.
+    fireEvent.click(screen.getAllByRole("button", { name: /^run$/i })[0]!);
+
+    await waitFor(() => expect(outputOf(editor)).not.toBeNull());
+    expect(blocks(editor).map(([lang]) => lang)).toEqual(["bash", "output", "python"]);
+  });
+});
+
+describe("when the run is refused", () => {
+  it("shows why, and writes nothing into the note", async () => {
+    refuses(429, "Too many runs. Try again shortly.");
+    const editor = await mount("```bash\necho hi\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(screen.getByText(/too many runs/i)).toBeTruthy());
+    // The note should not record the app declining to run something.
+    expect(outputOf(editor)).toBeNull();
+  });
+
+  it("passes on what the server said about a missing sandbox", async () => {
+    refuses(503, "Running blocks needs a sandbox, which this deployment is not configured for.");
+    await mount("```bash\necho hi\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(screen.getByText(/not configured for/i)).toBeTruthy());
+  });
+
+  it("says something useful when the request never arrived", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    const editor = await mount("```bash\necho hi\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(screen.getByText(/could not reach the server/i)).toBeTruthy());
+    expect(outputOf(editor)).toBeNull();
+  });
+
+  it("clears an old failure when a later run succeeds", async () => {
+    refuses(429, "Too many runs. Try again shortly.");
+    const editor = await mount("```bash\necho hi\n```");
+    fireEvent.click(runButton());
+    await waitFor(() => expect(screen.getByText(/too many runs/i)).toBeTruthy());
+
+    runs({ stdout: "worked" });
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(outputOf(editor)).toContain("worked"));
+    expect(screen.queryByText(/too many runs/i)).toBeNull();
+  });
+
+  it("becomes clickable again after a failure", async () => {
+    refuses(500, "Something went wrong.");
+    await mount("```bash\necho hi\n```");
+    fireEvent.click(runButton());
+
+    await waitFor(() => expect(screen.getByText(/something went wrong/i)).toBeTruthy());
+    expect(runButton()).toHaveProperty("disabled", false);
+  });
+});

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -66,10 +66,44 @@ interface ApiPullRequest {
   base: { ref: string; sha?: string };
   user?: { login: string } | null;
   merged?: boolean;
+  mergeable?: boolean | null;
+  mergeable_state?: string | null;
 }
 
 interface ApiCommitDetail {
   files?: { filename: string; status: string; previous_filename?: string }[];
+}
+
+interface ApiReviewComment {
+  id: number;
+  path: string;
+  /** Null once the diff has moved past the line this was written against. */
+  line?: number | null;
+  body: string;
+  created_at: string;
+  user?: { login: string } | null;
+  in_reply_to_id?: number | null;
+}
+
+interface ApiReview {
+  id: number;
+  state: string;
+  body?: string | null;
+  submitted_at?: string | null;
+  user?: { login: string } | null;
+}
+
+interface ApiIssueComment {
+  id: number;
+  body: string;
+  created_at: string;
+  user?: { login: string } | null;
+}
+
+interface ApiMergeResult {
+  merged?: boolean;
+  message?: string;
+  sha?: string;
 }
 
 interface ApiPullRequestFile {
@@ -174,6 +208,42 @@ export interface PullRequestDetail extends PullRequestSummary {
   baseSha: string;
   author: string | null;
   merged: boolean;
+  /**
+   * Whether GitHub will accept a merge, or null while it is still working it
+   * out — it computes this in the background and reports null on the first
+   * read of a request nobody has looked at recently.
+   */
+  mergeable: boolean | null;
+  /** GitHub's word for why: clean, blocked, dirty, behind, unstable, unknown. */
+  mergeableState: string | null;
+}
+
+/** One inline comment on a pull request, flattened for the review panel. */
+export interface ReviewCommentDto {
+  id: number;
+  author: string | null;
+  body: string;
+  createdAt: string;
+  path: string;
+  line: number | null;
+  inReplyTo: number | null;
+}
+
+/** One submitted review: an approval, a rejection, or a remark. */
+export interface SubmittedReviewDto {
+  id: number;
+  author: string | null;
+  state: string;
+  body: string;
+  submittedAt: string;
+}
+
+/** A comment on the request itself rather than on a line of it. */
+export interface IssueCommentDto {
+  id: number;
+  author: string | null;
+  body: string;
+  createdAt: string;
 }
 
 /** A file a pull request touches. */
@@ -571,6 +641,27 @@ export class GitHubClient {
   }
 
   /**
+   * The open pull request a branch is the head of, whatever it targets.
+   *
+   * `findOpenPullRequest` filters on the base too, because opening a request
+   * needs to know whether *this* one already exists. Reviewing does not: the
+   * question is "is the branch I am on under review", and the answer must not
+   * depend on guessing which branch it was opened against.
+   */
+  async findOpenPullRequestForBranch(
+    owner: string,
+    repo: string,
+    head: string,
+  ): Promise<PullRequestSummary | null> {
+    const qualified = head.includes(":") ? head : `${owner}:${head}`;
+    const pulls = await this.transport.paginate<ApiPullRequest>(
+      `/repos/${owner}/${repo}/pulls?state=open&head=${encodeURIComponent(qualified)}&per_page=10`,
+    );
+
+    return pulls[0] ? toPullRequest(pulls[0]) : null;
+  }
+
+  /**
    * Reads one pull request, including the commits it is actually about.
    *
    * The base SHA GitHub reports here is the tip of the base branch, which is
@@ -590,6 +681,8 @@ export class GitHubClient {
       baseSha: data.base.sha ?? data.base.ref,
       author: data.user?.login ?? null,
       merged: data.merged === true,
+      mergeable: data.mergeable ?? null,
+      mergeableState: data.mergeable_state ?? null,
     };
   }
 
@@ -614,6 +707,142 @@ export class GitHubClient {
       status: file.status,
       previousPath: file.previous_filename ?? null,
     }));
+  }
+
+  /**
+   * Every inline comment left on a pull request.
+   *
+   * Paginated: a review of a long note is exactly where the comments run past
+   * one page, and a review missing its last few remarks is worse than no
+   * review at all.
+   */
+  async listReviewComments(
+    owner: string,
+    repo: string,
+    number: number,
+  ): Promise<ReviewCommentDto[]> {
+    const comments = await this.transport.paginate<ApiReviewComment>(
+      `/repos/${owner}/${repo}/pulls/${number}/comments?per_page=100`,
+    );
+
+    return comments.map((comment) => ({
+      id: comment.id,
+      author: comment.user?.login ?? null,
+      body: comment.body,
+      createdAt: comment.created_at,
+      path: comment.path,
+      line: comment.line ?? null,
+      inReplyTo: comment.in_reply_to_id ?? null,
+    }));
+  }
+
+  /** Every submitted review — the approvals, rejections and plain remarks. */
+  async listReviews(owner: string, repo: string, number: number): Promise<SubmittedReviewDto[]> {
+    const reviews = await this.transport.paginate<ApiReview>(
+      `/repos/${owner}/${repo}/pulls/${number}/reviews?per_page=100`,
+    );
+
+    return reviews.map((review) => ({
+      id: review.id,
+      author: review.user?.login ?? null,
+      state: review.state,
+      body: review.body ?? "",
+      // A pending review has never been submitted; sorting needs a string.
+      submittedAt: review.submitted_at ?? "",
+    }));
+  }
+
+  /** The pull request's general conversation, which is not tied to a line. */
+  async listConversation(owner: string, repo: string, number: number): Promise<IssueCommentDto[]> {
+    const comments = await this.transport.paginate<ApiIssueComment>(
+      `/repos/${owner}/${repo}/issues/${number}/comments?per_page=100`,
+    );
+
+    return comments.map((comment) => ({
+      id: comment.id,
+      author: comment.user?.login ?? null,
+      body: comment.body,
+      createdAt: comment.created_at,
+    }));
+  }
+
+  /** Answers one inline comment, in its own thread. */
+  async replyToReviewComment(
+    owner: string,
+    repo: string,
+    number: number,
+    commentId: number,
+    body: string,
+  ): Promise<ReviewCommentDto> {
+    const { data } = await this.transport.request<ApiReviewComment>(
+      `/repos/${owner}/${repo}/pulls/${number}/comments/${commentId}/replies`,
+      { method: "POST", body: { body } },
+    );
+
+    if (!data) throw new GitHubError("unknown", "Empty reply response");
+
+    return {
+      id: data.id,
+      author: data.user?.login ?? null,
+      body: data.body,
+      createdAt: data.created_at,
+      path: data.path,
+      line: data.line ?? null,
+      inReplyTo: data.in_reply_to_id ?? commentId,
+    };
+  }
+
+  /** Adds to the general conversation rather than to a line. */
+  async addConversationComment(
+    owner: string,
+    repo: string,
+    number: number,
+    body: string,
+  ): Promise<IssueCommentDto> {
+    const { data } = await this.transport.request<ApiIssueComment>(
+      `/repos/${owner}/${repo}/issues/${number}/comments`,
+      { method: "POST", body: { body } },
+    );
+
+    if (!data) throw new GitHubError("unknown", "Empty comment response");
+
+    return {
+      id: data.id,
+      author: data.user?.login ?? null,
+      body: data.body,
+      createdAt: data.created_at,
+    };
+  }
+
+  /**
+   * Merges a pull request.
+   *
+   * Squash by default: a note revised eight times during a review should reach
+   * the main branch as the one change it is, not as eight commits of somebody
+   * arguing about a paragraph. The argument is preserved on the request.
+   */
+  async mergePullRequest(
+    owner: string,
+    repo: string,
+    number: number,
+    options: { method?: "merge" | "squash" | "rebase"; title?: string } = {},
+  ): Promise<{ merged: boolean; message: string; sha: string | null }> {
+    const { data } = await this.transport.request<ApiMergeResult>(
+      `/repos/${owner}/${repo}/pulls/${number}/merge`,
+      {
+        method: "PUT",
+        body: {
+          merge_method: options.method ?? "squash",
+          ...(options.title ? { commit_title: options.title } : {}),
+        },
+      },
+    );
+
+    return {
+      merged: data?.merged === true,
+      message: data?.message ?? "",
+      sha: data?.sha ?? null,
+    };
   }
 
   // ─── Reading ──────────────────────────────────────────────────────────────

--- a/packages/github-client/src/index.ts
+++ b/packages/github-client/src/index.ts
@@ -12,6 +12,9 @@ export {
   type PagesSite,
   type PullRequestSummary,
   type PullRequestDetail,
+  type ReviewCommentDto,
+  type SubmittedReviewDto,
+  type IssueCommentDto,
   type PullRequestFile,
   type CommitFile,
 } from "./client";

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -110,3 +110,14 @@ export {
   type RunResult,
   type Runner,
 } from "./runnable";
+
+export {
+  buildThreads,
+  summariseReviews,
+  type ReviewComment,
+  type ReviewThread,
+  type ReviewVerdict,
+  type SubmittedReview,
+  type ThreadOptions,
+  type Verdict,
+} from "./review";

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -98,3 +98,15 @@ export {
   type BlameLine,
   type BlameRevision,
 } from "./blame";
+
+export {
+  MAX_OUTPUT,
+  OUTPUT_LANGUAGE,
+  durationOf,
+  formatOutput,
+  isOutput,
+  isRunnable,
+  runnerFor,
+  type RunResult,
+  type Runner,
+} from "./runnable";

--- a/packages/markdown-engine/src/review.test.ts
+++ b/packages/markdown-engine/src/review.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { buildThreads, summariseReviews, type ReviewComment, type SubmittedReview } from "./review";
+
+const NOTE = [
+  "# Recon",
+  "",
+  "SMB signing is disabled.",
+  "Two weeks, no phishing.",
+  "",
+  "## Foothold",
+  "",
+  "Kerberoasted svc-sql.",
+].join("\n");
+
+let nextId = 0;
+
+function comment(overrides: Partial<ReviewComment> = {}): ReviewComment {
+  nextId += 1;
+  return {
+    id: nextId,
+    author: "reviewer",
+    body: "a remark",
+    createdAt: `2026-08-27T10:0${nextId % 10}:00.000Z`,
+    path: "notes/recon.md",
+    line: 1,
+    inReplyTo: null,
+    ...overrides,
+  };
+}
+
+const threads = (comments: ReviewComment[], content = NOTE) =>
+  buildThreads(comments, { path: "notes/recon.md", content });
+
+/** The first thread, for the many cases that build exactly one. */
+const firstOf = (comments: ReviewComment[], content = NOTE) => threads(comments, content)[0]!;
+
+describe("buildThreads — anchoring to paragraphs", () => {
+  it("quotes the paragraph a comment was written against", () => {
+    const thread = firstOf([comment({ line: 3 })]);
+    expect(thread.quote).toBe("SMB signing is disabled.\nTwo weeks, no phishing.");
+    expect(thread.block).toBe(1);
+  });
+
+  it("anchors a comment on a heading to that heading", () => {
+    const thread = firstOf([comment({ line: 1 })]);
+    expect(thread.quote).toBe("# Recon");
+  });
+
+  it("puts every line of a paragraph on the same paragraph", () => {
+    const third = firstOf([comment({ line: 3 })]);
+    const fourth = firstOf([comment({ line: 4 })]);
+    expect(fourth.block).toBe(third.block);
+  });
+
+  it("places a comment further down the note correctly", () => {
+    const thread = firstOf([comment({ line: 8 })]);
+    expect(thread.quote).toBe("Kerberoasted svc-sql.");
+  });
+
+  it("cannot place a comment whose line no longer exists", () => {
+    const thread = firstOf([comment({ line: null })]);
+    expect(thread.block).toBeNull();
+    expect(thread.quote).toBeNull();
+    expect(thread.outdated).toBe(true);
+  });
+
+  it("cannot place a comment pointing past the end of the note", () => {
+    const thread = firstOf([comment({ line: 999 })]);
+    expect(thread.block).toBeNull();
+    expect(thread.quote).toBeNull();
+  });
+
+  it("cannot place a comment on a blank line between paragraphs", () => {
+    expect(firstOf([comment({ line: 2 })]).block).toBeNull();
+  });
+
+  it("ignores comments left on another file", () => {
+    expect(threads([comment({ path: "notes/other.md" })])).toEqual([]);
+  });
+
+  it("handles a note that is empty", () => {
+    expect(firstOf([comment({ line: 1 })], "").quote).toBeNull();
+  });
+});
+
+describe("buildThreads — assembling replies", () => {
+  it("gathers a reply under the comment it answers", () => {
+    const opening = comment({ id: 100, line: 3, body: "is this right?" });
+    const reply = comment({ id: 101, inReplyTo: 100, body: "yes, checked twice" });
+
+    const built = threads([opening, reply]);
+    expect(built).toHaveLength(1);
+    expect(built[0]!.comments.map((c) => c.body)).toEqual(["is this right?", "yes, checked twice"]);
+  });
+
+  it("keeps the opening comment first whatever its timestamp says", () => {
+    const opening = comment({ id: 200, createdAt: "2026-08-27T12:00:00.000Z" });
+    const reply = comment({ id: 201, inReplyTo: 200, createdAt: "2026-08-27T09:00:00.000Z" });
+
+    expect(firstOf([opening, reply]).comments[0]!.id).toBe(200);
+  });
+
+  it("orders several replies by when they were written", () => {
+    const opening = comment({ id: 300 });
+    const later = comment({ id: 301, inReplyTo: 300, createdAt: "2026-08-27T13:00:00.000Z" });
+    const sooner = comment({ id: 302, inReplyTo: 300, createdAt: "2026-08-27T11:00:00.000Z" });
+
+    expect(firstOf([opening, later, sooner]).comments.map((c) => c.id)).toEqual([300, 302, 301]);
+  });
+
+  it("gathers a reply to a reply into the same thread", () => {
+    const opening = comment({ id: 400 });
+    const reply = comment({ id: 401, inReplyTo: 400 });
+    const deeper = comment({ id: 402, inReplyTo: 401 });
+
+    const built = threads([opening, reply, deeper]);
+    expect(built).toHaveLength(1);
+    expect(built[0]!.comments).toHaveLength(3);
+  });
+
+  it("keeps a reply whose parent is missing rather than dropping it", () => {
+    // The parent may have been deleted, or left on a file we did not ask for.
+    // Losing somebody's words to bookkeeping is the one unacceptable outcome.
+    const orphan = comment({ id: 500, inReplyTo: 499, body: "still said something" });
+    const built = threads([orphan]);
+
+    expect(built).toHaveLength(1);
+    expect(built[0]!.comments[0]!.body).toBe("still said something");
+  });
+
+  it("does not hang on comments that reply to each other, and loses neither", () => {
+    const a = comment({ id: 600, inReplyTo: 601 });
+    const b = comment({ id: 601, inReplyTo: 600 });
+
+    expect(() => threads([a, b])).not.toThrow();
+    const built = threads([a, b]);
+    expect(built).toHaveLength(1);
+    expect(built[0]!.comments.map((c) => c.id).sort()).toEqual([600, 601]);
+  });
+
+  it("keeps two separate conversations separate", () => {
+    const first = comment({ id: 700, line: 3 });
+    const second = comment({ id: 701, line: 8 });
+
+    expect(threads([first, second])).toHaveLength(2);
+  });
+});
+
+describe("buildThreads — ordering", () => {
+  it("reads down the note, not by when comments arrived", () => {
+    const late = comment({ id: 800, line: 8 });
+    const early = comment({ id: 801, line: 1 });
+
+    expect(threads([late, early]).map((t) => t.id)).toEqual([801, 800]);
+  });
+
+  it("puts threads it cannot place last, after everything readable", () => {
+    const placed = comment({ id: 900, line: 3 });
+    const outdated = comment({ id: 901, line: null });
+
+    expect(threads([outdated, placed]).map((t) => t.id)).toEqual([900, 901]);
+  });
+
+  it("orders two comments on the same line predictably", () => {
+    const a = comment({ id: 1000, line: 3 });
+    const b = comment({ id: 1001, line: 3 });
+
+    expect(threads([b, a]).map((t) => t.id)).toEqual([1000, 1001]);
+  });
+
+  it("returns nothing for a review with no comments", () => {
+    expect(threads([])).toEqual([]);
+  });
+});
+
+let reviewId = 0;
+function review(overrides: Partial<SubmittedReview> = {}): SubmittedReview {
+  reviewId += 1;
+  return {
+    id: reviewId,
+    author: "reviewer",
+    state: "COMMENTED",
+    body: "",
+    submittedAt: `2026-08-2${reviewId % 9}T10:00:00.000Z`,
+    ...overrides,
+  };
+}
+
+describe("summariseReviews", () => {
+  it("says nothing has been said when nobody has reviewed", () => {
+    expect(summariseReviews([])).toEqual({ verdict: "none", reviewers: [] });
+  });
+
+  it("reports an approval", () => {
+    expect(summariseReviews([review({ state: "APPROVED" })]).verdict).toBe("approved");
+  });
+
+  it("reports a request for changes", () => {
+    expect(summariseReviews([review({ state: "CHANGES_REQUESTED" })]).verdict).toBe(
+      "changes-requested",
+    );
+  });
+
+  it("counts only each person's latest word", () => {
+    const verdict = summariseReviews([
+      review({ author: "a", state: "CHANGES_REQUESTED", submittedAt: "2026-08-01T00:00:00Z" }),
+      review({ author: "a", state: "APPROVED", submittedAt: "2026-08-02T00:00:00Z" }),
+    ]);
+
+    // Otherwise a note whose author fixed the problem stays blocked forever.
+    expect(verdict.verdict).toBe("approved");
+    expect(verdict.reviewers).toHaveLength(1);
+  });
+
+  it("does not let a later remark withdraw an approval", () => {
+    // Commenting after approving does not withdraw it on GitHub either.
+    const verdict = summariseReviews([
+      review({ author: "a", state: "APPROVED", submittedAt: "2026-08-01T00:00:00Z" }),
+      review({ author: "a", state: "COMMENTED", submittedAt: "2026-08-02T00:00:00Z" }),
+    ]);
+
+    expect(verdict.verdict).toBe("approved");
+  });
+
+  it("lets one request for changes outrank several approvals", () => {
+    const verdict = summariseReviews([
+      review({ author: "a", state: "APPROVED" }),
+      review({ author: "b", state: "APPROVED" }),
+      review({ author: "c", state: "CHANGES_REQUESTED" }),
+    ]);
+
+    expect(verdict.verdict).toBe("changes-requested");
+  });
+
+  it("falls back to commented when that is all anyone did", () => {
+    expect(summariseReviews([review({ state: "COMMENTED" })]).verdict).toBe("commented");
+  });
+
+  it("ignores a dismissed review", () => {
+    expect(summariseReviews([review({ state: "DISMISSED" })]).verdict).toBe("none");
+  });
+
+  it("ignores a review with no author to attribute it to", () => {
+    expect(summariseReviews([review({ author: null, state: "APPROVED" })]).verdict).toBe("none");
+  });
+
+  it("lists reviewers most recent first", () => {
+    const verdict = summariseReviews([
+      review({ author: "older", state: "APPROVED", submittedAt: "2026-08-01T00:00:00Z" }),
+      review({ author: "newer", state: "APPROVED", submittedAt: "2026-08-05T00:00:00Z" }),
+    ]);
+
+    expect(verdict.reviewers.map((r) => r.author)).toEqual(["newer", "older"]);
+  });
+});

--- a/packages/markdown-engine/src/review.ts
+++ b/packages/markdown-engine/src/review.ts
@@ -1,0 +1,260 @@
+/**
+ * A pull request's review, arranged the way a note reads.
+ *
+ * Opening a pull request against your own notes already worked; reading the
+ * review did not. The comments lived on github.com, anchored to line numbers
+ * in a diff, and the whole point of studying something this way — someone
+ * marks up the paragraph you got wrong, you argue back, then it merges — meant
+ * leaving the app and reading your prose as a unified diff.
+ *
+ * So this puts the review back into the shape of the document. GitHub anchors
+ * a comment to a line; a reader thinks in paragraphs. The mapping between
+ * those is the work, and getting it wrong is worse than not doing it: a note
+ * quoting the wrong paragraph beside somebody's objection is actively
+ * misleading.
+ */
+
+/** One comment, flattened from the review-comment endpoint. */
+export interface ReviewComment {
+  id: number;
+  author: string | null;
+  body: string;
+  createdAt: string;
+  path: string;
+  /**
+   * Line in the file as it stands now, or null once the diff has moved on.
+   *
+   * GitHub reports this as null for an "outdated" comment — one whose line no
+   * longer exists in the head commit. The comment is still worth showing; it
+   * just cannot be placed beside anything.
+   */
+  line: number | null;
+  /** Set when this is a reply, naming the comment that started the thread. */
+  inReplyTo: number | null;
+}
+
+/** A comment and everything said in reply to it. */
+export interface ReviewThread {
+  /** Id of the opening comment, which is what a reply is addressed to. */
+  id: number;
+  path: string;
+  line: number | null;
+  /** Index of the paragraph this is about, or null when it cannot be placed. */
+  block: number | null;
+  /** The paragraph itself, so the thread can show what is being argued about. */
+  quote: string | null;
+  /** Opening comment first, replies in the order they were written. */
+  comments: ReviewComment[];
+  /** True when the line this was written against no longer exists. */
+  outdated: boolean;
+}
+
+/**
+ * Blank-line-separated blocks, with the line each one starts on.
+ *
+ * The same unit the blame gutter uses, and for the same reason: a line is what
+ * git talks about and a paragraph is what a person points at.
+ */
+function paragraphs(content: string): { start: number; end: number; text: string }[] {
+  const lines = content.split("\n");
+  const blocks: { start: number; end: number; text: string }[] = [];
+
+  let current: string[] = [];
+  let start = 1;
+
+  const flush = (end: number) => {
+    if (current.some((line) => line.trim() !== "")) {
+      blocks.push({ start, end, text: current.join("\n").trim() });
+    }
+    current = [];
+  };
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+
+    if (line.trim() === "") {
+      flush(i);
+      start = i + 2;
+      continue;
+    }
+
+    if (current.length === 0) start = i + 1;
+    current.push(line);
+  }
+
+  flush(lines.length);
+  return blocks;
+}
+
+/** The paragraph a line falls in, or null when it falls outside every one. */
+function blockAt(blocks: readonly { start: number; end: number }[], line: number): number | null {
+  const index = blocks.findIndex((block) => line >= block.start && line <= block.end);
+  return index === -1 ? null : index;
+}
+
+export interface ThreadOptions {
+  /** Only comments on this file are threaded; a note is one file. */
+  path: string;
+  /** The note as the review sees it, for quoting the paragraph. */
+  content: string;
+}
+
+/**
+ * Turns a flat list of review comments into threads against paragraphs.
+ *
+ * GitHub returns replies as ordinary comments carrying `in_reply_to_id`, in no
+ * guaranteed nesting, so the thread has to be reassembled. A reply whose
+ * parent is missing from the list — because it was on another file, or
+ * deleted — becomes its own thread rather than being dropped: losing somebody's
+ * words to a bookkeeping detail is the one outcome worth ruling out.
+ */
+export function buildThreads(
+  comments: readonly ReviewComment[],
+  options: ThreadOptions,
+): ReviewThread[] {
+  const mine = comments.filter((comment) => comment.path === options.path);
+  const blocks = paragraphs(options.content);
+  const byId = new Map(mine.map((comment) => [comment.id, comment] as const));
+
+  /**
+   * Walks up to the comment that started the thread.
+   *
+   * A reply chain that loops back on itself is malformed and GitHub does not
+   * produce one — but it arrives over the network, so it is handled rather
+   * than trusted. On a cycle the lowest id in the loop is taken as the root,
+   * which terminates, keeps every comment, and groups the whole loop into one
+   * conversation instead of splitting it into one thread per participant.
+   */
+  const rootOf = (comment: ReviewComment): ReviewComment => {
+    const seen = new Set<number>([comment.id]);
+    let current = comment;
+
+    while (current.inReplyTo !== null) {
+      const parent = byId.get(current.inReplyTo);
+      if (!parent) break;
+
+      if (seen.has(parent.id)) {
+        const lowest = Math.min(...seen);
+        return byId.get(lowest) ?? current;
+      }
+
+      seen.add(parent.id);
+      current = parent;
+    }
+
+    return current;
+  };
+
+  const grouped = new Map<number, ReviewComment[]>();
+  for (const comment of mine) {
+    const root = rootOf(comment);
+    grouped.set(root.id, [...(grouped.get(root.id) ?? []), comment]);
+  }
+
+  const threads = [...grouped.entries()].map<ReviewThread>(([id, group]) => {
+    const ordered = [...group].sort((a, b) => {
+      // The opening comment leads, whatever its timestamp says.
+      if (a.id === id) return -1;
+      if (b.id === id) return 1;
+      return a.createdAt.localeCompare(b.createdAt) || a.id - b.id;
+    });
+
+    const opening = ordered[0]!;
+    const block = opening.line === null ? null : blockAt(blocks, opening.line);
+
+    return {
+      id,
+      path: opening.path,
+      line: opening.line,
+      block,
+      quote: block === null ? null : (blocks[block]?.text ?? null),
+      comments: ordered,
+      outdated: opening.line === null,
+    };
+  });
+
+  // Down the document, with unplaceable threads last: they belong to a version
+  // of the note that no longer exists, and should not interrupt the reading.
+  return threads.sort((a, b) => {
+    if (a.line === null && b.line === null) return a.id - b.id;
+    if (a.line === null) return 1;
+    if (b.line === null) return -1;
+    return a.line - b.line || a.id - b.id;
+  });
+}
+
+/** One submitted review — an approval, a rejection, or a plain remark. */
+export interface SubmittedReview {
+  id: number;
+  author: string | null;
+  /** GitHub's own words: APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED. */
+  state: string;
+  body: string;
+  submittedAt: string;
+}
+
+export type Verdict = "approved" | "changes-requested" | "commented" | "none";
+
+export interface ReviewVerdict {
+  verdict: Verdict;
+  /** The standing position of each reviewer, most recent first. */
+  reviewers: { author: string; state: Verdict; submittedAt: string }[];
+}
+
+function verdictOf(state: string): Verdict {
+  switch (state.toUpperCase()) {
+    case "APPROVED":
+      return "approved";
+    case "CHANGES_REQUESTED":
+      return "changes-requested";
+    case "COMMENTED":
+      return "commented";
+    default:
+      return "none";
+  }
+}
+
+/**
+ * Where a review has got to, counting only each person's latest word.
+ *
+ * Someone who requested changes and then approved has approved. Taking the
+ * whole list at face value would leave a request for changes standing against
+ * a note whose author already fixed it and got the approval — which reads as
+ * "you are blocked" forever.
+ *
+ * A plain comment never overrides a verdict: on GitHub, commenting after
+ * approving does not withdraw the approval, and pretending otherwise would
+ * make the state here disagree with the merge button there.
+ */
+export function summariseReviews(reviews: readonly SubmittedReview[]): ReviewVerdict {
+  const latest = new Map<string, { state: Verdict; submittedAt: string }>();
+
+  for (const review of [...reviews].sort((a, b) => a.submittedAt.localeCompare(b.submittedAt))) {
+    if (!review.author) continue;
+
+    const state = verdictOf(review.state);
+    if (state === "none") continue;
+
+    const standing = latest.get(review.author);
+    // A remark does not displace a decision the same person already made.
+    if (state === "commented" && standing && standing.state !== "commented") continue;
+
+    latest.set(review.author, { state, submittedAt: review.submittedAt });
+  }
+
+  const reviewers = [...latest.entries()]
+    .map(([author, entry]) => ({ author, ...entry }))
+    .sort((a, b) => b.submittedAt.localeCompare(a.submittedAt) || a.author.localeCompare(b.author));
+
+  // A single request for changes outranks any number of approvals: it is the
+  // one state that means somebody is waiting on you.
+  if (reviewers.some((entry) => entry.state === "changes-requested")) {
+    return { verdict: "changes-requested", reviewers };
+  }
+  if (reviewers.some((entry) => entry.state === "approved")) {
+    return { verdict: "approved", reviewers };
+  }
+  if (reviewers.length > 0) return { verdict: "commented", reviewers };
+
+  return { verdict: "none", reviewers };
+}

--- a/packages/markdown-engine/src/runnable.test.ts
+++ b/packages/markdown-engine/src/runnable.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_OUTPUT,
+  OUTPUT_LANGUAGE,
+  durationOf,
+  formatOutput,
+  isOutput,
+  isRunnable,
+  runnerFor,
+  type RunResult,
+} from "./runnable";
+
+const RAN_AT = "2026-08-27T10:04:09.000Z";
+
+function result(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    stdout: "",
+    stderr: "",
+    exitCode: 0,
+    ms: 412,
+    truncated: false,
+    ranAt: RAN_AT,
+    ...overrides,
+  };
+}
+
+describe("runnerFor", () => {
+  it("runs the shell under every name people fence it with", () => {
+    for (const name of ["bash", "sh", "shell", "zsh", "console"]) {
+      expect(runnerFor(name)?.command).toBe("bash");
+    }
+  });
+
+  it("runs python under its aliases", () => {
+    for (const name of ["python", "py", "python3"]) {
+      expect(runnerFor(name)?.command).toBe("python3");
+    }
+  });
+
+  it("runs javascript under its aliases", () => {
+    for (const name of ["javascript", "js", "node", "mjs"]) {
+      expect(runnerFor(name)?.command).toBe("node");
+    }
+  });
+
+  it("ignores case and stray whitespace in the fence label", () => {
+    expect(runnerFor("  BaSh ")?.command).toBe("bash");
+  });
+
+  it("refuses a language nothing can interpret", () => {
+    for (const name of ["typescript", "json", "yaml", "markdown", "rust", "sql"]) {
+      expect(runnerFor(name)).toBeNull();
+    }
+  });
+
+  it("refuses an empty, absent or unlabelled fence", () => {
+    expect(runnerFor("")).toBeNull();
+    expect(runnerFor(null)).toBeNull();
+    expect(runnerFor(undefined)).toBeNull();
+  });
+
+  it("gives every runner a file extension to write the script under", () => {
+    expect(runnerFor("bash")?.extension).toBe("sh");
+    expect(runnerFor("python")?.extension).toBe("py");
+    expect(runnerFor("node")?.extension).toBe("js");
+  });
+
+  it("labels runners for a reader, not for a parser", () => {
+    expect(runnerFor("sh")?.label).toBe("Shell");
+    expect(runnerFor("py")?.label).toBe("Python");
+  });
+});
+
+describe("isRunnable / isOutput", () => {
+  it("agrees with runnerFor", () => {
+    expect(isRunnable("bash")).toBe(true);
+    expect(isRunnable("rust")).toBe(false);
+  });
+
+  it("never offers to run a block this module wrote", () => {
+    // Otherwise a run's output grows another Run button, and clicking it
+    // executes the last run's stdout as a script.
+    expect(isRunnable(OUTPUT_LANGUAGE)).toBe(false);
+    expect(isOutput(OUTPUT_LANGUAGE)).toBe(true);
+    expect(isOutput("OUTPUT")).toBe(true);
+    expect(isOutput("bash")).toBe(false);
+    expect(isOutput(null)).toBe(false);
+  });
+});
+
+describe("durationOf", () => {
+  it("reads in milliseconds under a second", () => {
+    expect(durationOf(412)).toBe("412ms");
+    expect(durationOf(0)).toBe("0ms");
+  });
+
+  it("reads in seconds under a minute", () => {
+    expect(durationOf(1000)).toBe("1.0s");
+    expect(durationOf(12_400)).toBe("12.4s");
+  });
+
+  it("reads in minutes and seconds beyond that", () => {
+    expect(durationOf(62_000)).toBe("1m 02s");
+    expect(durationOf(600_000)).toBe("10m 00s");
+  });
+
+  it("never shows a negative duration from a clock that moved", () => {
+    expect(durationOf(-5)).toBe("0ms");
+  });
+});
+
+describe("formatOutput — the header", () => {
+  it("stamps the run in UTC, so the file does not depend on a locale", () => {
+    expect(formatOutput(result({ stdout: "hi" }))).toContain("2026-08-27 10:04 UTC");
+  });
+
+  it("says ok when the script succeeded", () => {
+    expect(formatOutput(result({ stdout: "hi" }))).toContain("· ok ·");
+  });
+
+  it("reports a non-zero exit as a result rather than an error", () => {
+    expect(formatOutput(result({ exitCode: 2, stderr: "boom" }))).toContain("· exit 2 ·");
+  });
+
+  it("reports a run that never finished by its reason", () => {
+    const text = formatOutput(result({ failure: "timed out after 30s", ms: 30_000 }));
+    expect(text).toContain("· timed out after 30s ·");
+  });
+
+  it("includes how long it took", () => {
+    expect(formatOutput(result({ stdout: "hi", ms: 2500 }))).toContain("· 2.5s");
+  });
+
+  it("survives a timestamp it cannot parse", () => {
+    expect(formatOutput(result({ ranAt: "not a date" }))).toContain("unknown time");
+  });
+});
+
+describe("formatOutput — the body", () => {
+  it("writes stdout under the header", () => {
+    expect(formatOutput(result({ stdout: "hello\nworld" }))).toBe(
+      "— ran 2026-08-27 10:04 UTC · ok · 412ms\nhello\nworld",
+    );
+  });
+
+  it("labels stderr so a failure is not misread as a result", () => {
+    const text = formatOutput(result({ stdout: "some", stderr: "bad", exitCode: 1 }));
+    expect(text).toContain("some");
+    expect(text).toContain("— stderr\nbad");
+  });
+
+  it("says so plainly when a command printed nothing", () => {
+    expect(formatOutput(result())).toContain("(no output)");
+  });
+
+  it("does not claim there was no output when the run itself failed", () => {
+    const text = formatOutput(result({ failure: "the sandbox could not start" }));
+    expect(text).not.toContain("(no output)");
+    expect(text).toContain("the sandbox could not start");
+  });
+
+  it("trims trailing whitespace rather than leaving a ragged block", () => {
+    expect(formatOutput(result({ stdout: "hi\n\n\n" }))).toBe(
+      "— ran 2026-08-27 10:04 UTC · ok · 412ms\nhi",
+    );
+  });
+
+  it("keeps stderr when there is no stdout at all", () => {
+    const text = formatOutput(result({ stderr: "only an error", exitCode: 1 }));
+    expect(text).toContain("— stderr\nonly an error");
+    expect(text).not.toContain("(no output)");
+  });
+});
+
+describe("formatOutput — the cap", () => {
+  it("cuts output that would bloat the repository", () => {
+    const text = formatOutput(result({ stdout: "x".repeat(MAX_OUTPUT + 5000) }));
+    expect(text.length).toBeLessThan(MAX_OUTPUT + 200);
+  });
+
+  it("says in the note itself that it cut something", () => {
+    const text = formatOutput(result({ stdout: "x".repeat(MAX_OUTPUT + 1) }));
+    expect(text).toContain("output cut off at 20,000 characters");
+  });
+
+  it("leaves output just under the cap untouched", () => {
+    const exact = "y".repeat(MAX_OUTPUT);
+    expect(formatOutput(result({ stdout: exact }))).toContain(exact);
+    expect(formatOutput(result({ stdout: exact }))).not.toContain("cut off");
+  });
+});

--- a/packages/markdown-engine/src/runnable.ts
+++ b/packages/markdown-engine/src/runnable.ts
@@ -1,0 +1,166 @@
+/**
+ * Which fenced blocks can be run, and what a run leaves behind in the note.
+ *
+ * A runbook written in markdown is a list of commands you copy into a terminal
+ * one at a time, paste the output back by hand, and then never update. The
+ * commands and their results drift apart immediately, and a year later there
+ * is no way to tell which output belongs to which version of which script.
+ *
+ * Running the block in place fixes the drift: the output lands directly under
+ * the code that produced it, stamped with when, so the note records what
+ * actually happened rather than what was supposed to.
+ *
+ * Everything here is deliberately plain markdown. The result is a fenced
+ * block, not a custom node — it renders on github.com, in any other editor,
+ * and in a plain-text pager, because a runbook whose results are only legible
+ * inside one app has traded the whole point away.
+ */
+
+/** How a language is actually executed inside the sandbox. */
+export interface Runner {
+  /** Canonical name, which is what the button and the API agree on. */
+  id: string;
+  /** Shown to the reader — "Shell", not "bash". */
+  label: string;
+  /** The interpreter to invoke. */
+  command: string;
+  /** Extension for the script file written into the sandbox. */
+  extension: string;
+}
+
+const SHELL: Runner = { id: "bash", label: "Shell", command: "bash", extension: "sh" };
+const PYTHON: Runner = { id: "python", label: "Python", command: "python3", extension: "py" };
+const NODE: Runner = { id: "javascript", label: "JavaScript", command: "node", extension: "js" };
+
+/**
+ * Fence labels that can be run, pointed at the interpreter that runs them.
+ *
+ * Only three families, and on purpose. Every entry here is a language the
+ * sandbox image can already execute; offering a Run button that fails on
+ * arrival because nothing can interpret the block would be worse than not
+ * offering one. Adding a language is one line plus a sandbox that has it.
+ */
+const RUNNERS = new Map<string, Runner>([
+  ["bash", SHELL],
+  ["sh", SHELL],
+  ["shell", SHELL],
+  ["zsh", SHELL],
+  ["console", SHELL],
+  ["python", PYTHON],
+  ["py", PYTHON],
+  ["python3", PYTHON],
+  ["javascript", NODE],
+  ["js", NODE],
+  ["node", NODE],
+  ["mjs", NODE],
+]);
+
+/** The fence label a run's result is written under. */
+export const OUTPUT_LANGUAGE = "output";
+
+/** The interpreter for a fence label, or null when it is not runnable. */
+export function runnerFor(language: string | null | undefined): Runner | null {
+  if (!language) return null;
+  return RUNNERS.get(language.trim().toLowerCase()) ?? null;
+}
+
+/** True for a fence label with a Run button. */
+export function isRunnable(language: string | null | undefined): boolean {
+  return runnerFor(language) !== null;
+}
+
+/** True for the blocks this module writes, which must never be runnable. */
+export function isOutput(language: string | null | undefined): boolean {
+  return (language ?? "").trim().toLowerCase() === OUTPUT_LANGUAGE;
+}
+
+/** What the sandbox reports back about one run. */
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  /** Non-zero means the script itself failed, which is a result, not an error. */
+  exitCode: number;
+  /** Wall-clock duration of the run. */
+  ms: number;
+  /** True when output was cut at the cap. */
+  truncated: boolean;
+  /** ISO timestamp of when the run finished. */
+  ranAt: string;
+  /** Set when the run never completed — a timeout, or the sandbox failing. */
+  failure?: string;
+}
+
+/**
+ * The most output kept, in characters.
+ *
+ * A command that prints a megabyte would otherwise put a megabyte into the
+ * note, and the note is a file in a git repository that someone has to clone.
+ * Generous enough for real command output, small enough that a runaway loop
+ * cannot poison the history.
+ */
+export const MAX_OUTPUT = 20_000;
+
+/** UTC, spelled out — unambiguous in a file that outlives this app's locale. */
+function stamp(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "unknown time";
+
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return (
+    `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}` +
+    ` ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())} UTC`
+  );
+}
+
+/** "0.4s", "1m 02s" — a duration a person reads rather than decodes. */
+export function durationOf(ms: number): string {
+  if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+
+  const seconds = Math.round(ms / 1000);
+  return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, "0")}s`;
+}
+
+/** Cuts text to the cap, saying so in the text itself rather than silently. */
+function cap(text: string): { text: string; truncated: boolean } {
+  if (text.length <= MAX_OUTPUT) return { text, truncated: false };
+  return {
+    text: `${text.slice(0, MAX_OUTPUT)}\n… output cut off at ${MAX_OUTPUT.toLocaleString("en-US")} characters.`,
+    truncated: true,
+  };
+}
+
+/**
+ * The text written into the output block under a run.
+ *
+ * The first line is a header rather than hidden metadata: someone reading this
+ * note on github.com, or in three years in an editor nobody has written yet,
+ * can see when it ran and whether it worked without anything having to parse
+ * it. Machine-readable attributes in the info string would have been tidier
+ * and completely invisible to the person the note is for.
+ */
+export function formatOutput(result: RunResult): string {
+  const status = result.failure
+    ? result.failure
+    : result.exitCode === 0
+      ? "ok"
+      : `exit ${result.exitCode}`;
+
+  const header = `— ran ${stamp(result.ranAt)} · ${status} · ${durationOf(result.ms)}`;
+
+  const sections: string[] = [];
+  const out = result.stdout.replace(/\s+$/, "");
+  const err = result.stderr.replace(/\s+$/, "");
+
+  if (out) sections.push(out);
+  // Labelled, because output interleaved with errors and no way to tell them
+  // apart is how you misread a failure as a result.
+  if (err) sections.push(`— stderr\n${err}`);
+
+  if (sections.length === 0) {
+    sections.push(result.failure ? "" : "(no output)");
+  }
+
+  const body = cap(sections.join("\n\n"));
+  return `${header}\n${body.text}`.replace(/\s+$/, "");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@forkleaf/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@vercel/sandbox':
+        specifier: ^3.1.0
+        version: 3.1.0
       firebase:
         specifier: ^12.17.1
         version: 12.17.1
@@ -2243,6 +2246,13 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/sandbox@3.1.0':
+    resolution: {integrity: sha512-z124E4rsmNpwGtTnLImiYzEXk972bWniQyhlvkEt35UtwKTdfBAFXcNG2OvqYqwzAsdQaP3B7teQ2pqA9B5Viw==}
+
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2277,6 +2287,9 @@ packages:
 
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2360,6 +2373,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2372,6 +2388,14 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -2381,6 +2405,14 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.2:
+    resolution: {integrity: sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
 
   baseline-browser-mapping@2.11.14:
     resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
@@ -2962,6 +2994,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -2979,6 +3014,9 @@ packages:
   fast-equals@5.4.1:
     resolution: {integrity: sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==}
     engines: {node: '>=6.0.0'}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -3361,6 +3399,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   jose@6.2.9:
     resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
 
@@ -3405,6 +3446,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -3547,6 +3591,9 @@ packages:
 
   lowlight@3.3.0:
     resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
@@ -3823,6 +3870,10 @@ packages:
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
   own-keys@1.0.2:
     resolution: {integrity: sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==}
     engines: {node: '>= 0.4'}
@@ -4055,6 +4106,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4188,6 +4243,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamx@2.28.1:
+    resolution: {integrity: sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4272,6 +4330,12 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4590,6 +4654,14 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
 
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
@@ -6675,6 +6747,26 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/oidc@3.2.0': {}
+
+  '@vercel/sandbox@3.1.0':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      lru-cache: 10.4.3
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.29.0
+      xdg-app-paths: 5.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
@@ -6728,6 +6820,8 @@ snapshots:
       '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@workflow/serde@4.1.0-beta.2': {}
 
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
@@ -6833,6 +6927,10 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -6841,11 +6939,15 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.2: {}
 
   baseline-browser-mapping@2.11.14: {}
 
@@ -7630,6 +7732,12 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   expect-type@1.4.0: {}
 
   extend@3.0.2: {}
@@ -7639,6 +7747,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-equals@5.4.1: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -8067,6 +8177,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   jose@6.2.9: {}
 
   js-tokens@4.0.0: {}
@@ -8117,6 +8229,8 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonlines@0.1.1: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -8241,6 +8355,8 @@ snapshots:
       '@types/hast': 3.0.5
       devlop: 1.1.0
       highlight.js: 11.11.2
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.5.2: {}
 
@@ -8725,6 +8841,8 @@ snapshots:
 
   orderedmap@2.1.1: {}
 
+  os-paths@4.4.0: {}
+
   own-keys@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -9032,6 +9150,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   robust-predicates@3.0.3: {}
@@ -9227,6 +9347,15 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamx@2.28.1:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -9327,6 +9456,21 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tinybench@2.9.0: {}
 
@@ -9729,6 +9873,14 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
 
   xml-js@1.6.11:
     dependencies:


### PR DESCRIPTION
Features **3 and 4** from the list, each built, tested and committed on its own. Branches off `main` after #39 merged, so this builds on the replay and blame work.

## 3 — Notes that run (`ce9cab46`)

Any `bash`, `python` or `javascript` block carries a **Run** button. What comes back is written into the note directly under the code that produced it, stamped with when it ran, and commits with the note like anything else. An OSINT script stops being a thing to copy-paste and becomes a page that records what actually happened.

**The result is plain markdown, on purpose.** An ordinary ` ```output ` fence, not a custom node — it renders on github.com, in any other editor, and in a plain-text pager. The first line is a readable header rather than hidden metadata:

```
— ran 2026-08-27 10:04 UTC · ok · 412ms
```

Machine-readable attributes in the info string would have been tidier and completely invisible to the person the note is for. Re-running **replaces** the previous result rather than stacking — the history of those runs is in the commits, which is where history goes.

**Where it runs is the whole story.** A Vercel Sandbox: a Firecracker microVM created for one request and destroyed at the end of it, so a script that deletes everything it can reach deletes only its own empty VM. That isolation is why this route can exist — a note is a document, and documents arrive from other people. Network access is deliberate; a runbook that cannot reach the host it is about is a text file.

Bounded on every axis that costs something: signed in, 12 runs per client per 5 minutes, 30s per run on a VM with 90s of head-room, 64k of script in and 20k of output back, and the language allow-list as the security boundary — the fence label picks the interpreter, and nothing from the request reaches a shell as a command name.

**The split that matters:** a script that *ran and failed* — non-zero exit, timeout, sandbox that never started — is a result, and gets written into the note with its reason. The app *declining* to run is not: a rate limit, a signed-out session or a deployment with no sandbox shows in a band inside the block and touches nothing. Nobody should find "you were rate limited" committed in their notes next year.

**Verified against the current SDK, not from memory.** `@vercel/sandbox` v3 was read out of its own type definitions first, which was worth doing: `runtime: "node24"` — what every example still shows — is deprecated in v3. This uses `image`, and the universal image because it is the one carrying bash, python3 and node together.

## 4 — Review my notes as a PR (`2b6b09ea`)

Opening a pull request against your own notes already worked. Reading the review did not — the comments lived on github.com, anchored to line numbers in a unified diff, so "study something, then have it reviewed" broke exactly where it got interesting.

Now every comment sits against **the paragraph it was written about**, quoted, in the order the note reads. Replies go in place. When it is settled it squash-merges from here and the workspace returns to the base branch.

The care went into the honest cases:

- GitHub anchors a comment to a line; a reader thinks in paragraphs. Getting that mapping wrong is worse than not doing it, so a comment that cannot be placed says **"on a part of the note that has since changed"** rather than quoting its best guess.
- Threads are reassembled rather than trusted — GitHub returns replies as ordinary comments with `in_reply_to_id`, in no guaranteed order. A reply whose parent is missing becomes its own thread instead of being dropped: losing somebody's words to a bookkeeping detail is the one outcome worth ruling out.
- The verdict counts only **each person's latest word**. Someone who requested changes and then approved has approved; summing the list would leave a note whose author already fixed the problem blocked forever. A plain comment never withdraws a decision, because it does not on GitHub either.
- GitHub computes mergeability in the background and reports null until it has, so *"still working out whether this can merge"* is a real answer here — better than a button that looks ready and then fails. A merge GitHub declines carries GitHub's own reason instead of being called success.

Finding the request at all: the editor knows its branch, not whether that branch is under review. So the route takes a branch and answers `{ pull: null }` — not a 404 — because "nothing is under review" is an ordinary state, and a panel should not read error codes to learn it.

## Verification

`pnpm check` green end to end, **exit 0**: prettier, 8 typecheck tasks, eslint, **1189 tests across 77 files**, `next build`.

**+3438 / −5** across 22 files, of which **148 tests are new** (74 per feature).

Seven problems found during the work and fixed rather than shipped. Two worth calling out:

1. The output block's left edge used `--fl-accent` neat. That token is tuned for the page background; the block sits on the near-black inverse surface — so the marker distinguishing a result from a script was a dark blue on near-black. Applied, measurable in the computed style, and invisible to anyone actually looking at it.
2. eslint flagged setState called synchronously from an effect — the same class as the previous two features. Behind the lint error was a **real race**: switching branch mid-request let a slow answer for the old branch overwrite the new one's. The read is now pure, the effect owns every write, and both the fix and the race are covered by tests.

The rest: Copy fighting the language picker for the middle of the block header; a reply cycle that terminated safely but split one conversation in two; and three test premises that were wrong rather than the code.

## Reviewing it

Feature 3 was driven end to end in a real browser at 800px and 375px in both themes — the Run button, the Running… state, the refusal path, and the output block's appearance.

**One limit, stated plainly:** the review panel itself is not browser-verified — it needs a signed-in repository with an open pull request. I did verify in the browser that its gating holds in the real app (a local-only workspace offers no review button and no palette command), and its states are covered by the 23 component tests rather than by a screenshot.

Both features are named in Getting started and the in-app help, and #4 has a properties-panel button and a command-palette entry. #4's button is deliberately **not** gated on a request existing — part of the panel's job is to say there is not one, and a button that appears only once you know the answer is a button nobody finds.

`test.js` in the working tree predates this session and is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)