### PR TITLE
fix(publish): put the repository chooser where it is needed, and say what to set for the sandbox

### DIFF
--- a/apps/web/src/app/api/run/route.test.ts
+++ b/apps/web/src/app/api/run/route.test.ts
@@ -100,7 +100,10 @@ describe("POST /api/run — what it refuses", () => {
     const { status, body } = await post({ language: "bash", code: "echo hi" });
 
     expect(status).toBe(503);
-    expect(body.error.message).toMatch(/not configured/i);
+    // Naming the variables, because whoever sees this can usually set them.
+    expect(body.error.message).toMatch(/VERCEL_TOKEN/);
+    expect(body.error.message).toMatch(/VERCEL_TEAM_ID/);
+    expect(body.error.message).toMatch(/VERCEL_PROJECT_ID/);
   });
 
   it("accepts OIDC alone, which is how it authenticates on Vercel", async () => {

--- a/apps/web/src/app/api/run/route.ts
+++ b/apps/web/src/app/api/run/route.ts
@@ -105,10 +105,13 @@ export async function POST(request: NextRequest) {
 
     const credentials = sandboxCredentials();
     if (!credentials) {
+      // Naming the variables matters: this is a deployment-configuration
+      // problem, and the person who hits it is usually the person who can fix
+      // it. A message that only says "not configured" sends them to the source.
       throw new ApiError(
         503,
         "unavailable",
-        "Running blocks needs a sandbox, which this deployment is not configured for.",
+        "Running blocks needs a Vercel Sandbox. Set VERCEL_TOKEN, VERCEL_TEAM_ID and VERCEL_PROJECT_ID for local development — on Vercel it authenticates itself.",
       );
     }
 

--- a/apps/web/src/components/PublishDialog.test.tsx
+++ b/apps/web/src/components/PublishDialog.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Note, Workspace } from "@forkleaf/types";
+import { PublishDialog } from "./PublishDialog";
+
+vi.mock("@/lib/gateway", () => ({
+  ApiGatewayError: class extends Error {},
+  publishNote: vi.fn(),
+  unpublishNote: vi.fn(),
+}));
+
+vi.mock("@forkleaf/exporter", () => ({ toHtml: () => "<html></html>" }));
+
+afterEach(cleanup);
+
+const NOTES = { owner: "me", repo: "forkleaf-notes", branch: "main", directory: "" };
+
+function workspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: "me/forkleaf-notes@main:",
+    name: "notes",
+    repo: NOTES,
+    isDefault: false,
+    isLocal: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    lastOpenedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const note = {
+  id: "n1",
+  path: "recon.md",
+  content: "# Recon\n\nSome prose.",
+  frontmatter: {},
+} as unknown as Note;
+
+function view(props: Partial<React.ComponentProps<typeof PublishDialog>> = {}) {
+  return render(
+    <PublishDialog
+      note={note}
+      workspace={workspace()}
+      published={undefined}
+      onSetTarget={vi.fn()}
+      onChanged={vi.fn()}
+      onClose={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe("PublishDialog — choosing where pages go", () => {
+  it("offers the choice before anything has been published", async () => {
+    // The bug this pins: the chooser first rendered only in the published
+    // view, so a private notebook — which cannot publish at all on a free
+    // plan — could never reach the one control that fixes that.
+    view();
+
+    expect(screen.getByText("Pages go to")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /use another repository/i })).toBeTruthy();
+  });
+
+  it("names the notes' own repository as the default", () => {
+    view();
+    expect(screen.getByText("me/forkleaf-notes")).toBeTruthy();
+  });
+
+  it("says when pages go somewhere else", () => {
+    view({
+      workspace: workspace({
+        publishRepo: { owner: "me", repo: "site", branch: "main", directory: "" },
+      }),
+    });
+
+    expect(screen.getByText("me/site")).toBeTruthy();
+    expect(screen.getByText(/not the repository your notes are in/i)).toBeTruthy();
+  });
+
+  it("records a repository that was typed in", async () => {
+    const onSetTarget = vi.fn();
+    view({ onSetTarget });
+
+    fireEvent.click(screen.getByRole("button", { name: /use another repository/i }));
+    fireEvent.change(screen.getByLabelText(/repository to publish into/i), {
+      target: { value: "me/site" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(onSetTarget).toHaveBeenCalledWith(
+        expect.objectContaining({ owner: "me", repo: "site", directory: "" }),
+      ),
+    );
+  });
+
+  it("refuses something that is not an owner/repository name", async () => {
+    const onSetTarget = vi.fn();
+    view({ onSetTarget });
+
+    fireEvent.click(screen.getByRole("button", { name: /use another repository/i }));
+    fireEvent.change(screen.getByLabelText(/repository to publish into/i), {
+      target: { value: "not a repo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(screen.getByText(/not an owner\/repository name/i)).toBeTruthy());
+    expect(onSetTarget).not.toHaveBeenCalled();
+  });
+
+  it("clears the target when the box is emptied", async () => {
+    const onSetTarget = vi.fn();
+    view({
+      onSetTarget,
+      workspace: workspace({
+        publishRepo: { owner: "me", repo: "site", branch: "main", directory: "" },
+      }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /change/i }));
+    fireEvent.change(screen.getByLabelText(/repository to publish into/i), {
+      target: { value: "  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(onSetTarget).toHaveBeenCalledWith(null));
+  });
+
+  it("does not offer the control when the caller cannot store the choice", () => {
+    view({ onSetTarget: undefined });
+
+    expect(screen.getByText("Pages go to")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /use another repository/i })).toBeNull();
+  });
+
+  it("points at the fix when GitHub refuses for want of a paid plan", async () => {
+    const { publishNote } = await import("@/lib/gateway");
+    vi.mocked(publishNote).mockRejectedValue(
+      Object.assign(
+        new Error("Your current plan does not support GitHub Pages for this repository."),
+        {
+          name: "ApiGatewayError",
+        },
+      ),
+    );
+
+    view();
+    fireEvent.click(screen.getByRole("button", { name: /^publish$/i }));
+
+    // GitHub's own message is accurate and says nothing about what to do next.
+    await waitFor(() => expect(screen.getByText(/choose a public repository/i)).toBeTruthy());
+  });
+});

--- a/apps/web/src/components/PublishDialog.tsx
+++ b/apps/web/src/components/PublishDialog.tsx
@@ -185,6 +185,66 @@ export function PublishDialog({
     window.setTimeout(() => setCopied(false), 1600);
   }, [page]);
 
+  /**
+   * Where pages go, and how to change it.
+   *
+   * Rendered in both states of this dialog on purpose. It first lived only in
+   * the published view, which put it exactly out of reach of the person who
+   * needs it most: a private notebook cannot publish at all on a free plan, so
+   * the one control that fixes that sat behind a publish that could never
+   * succeed.
+   */
+  const targetChooser = (
+    <div className="space-y-1.5 rounded-lg border border-[var(--fl-border)] px-3 py-2.5">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <span className="text-[12px] text-[var(--fl-muted)]">Pages go to</span>
+        {onSetTarget && !editingTarget && (
+          <button
+            type="button"
+            onClick={() => setEditingTarget(true)}
+            className="text-[12px] text-[var(--fl-muted)] underline-offset-2 hover:text-[var(--fl-text)] hover:underline"
+          >
+            {split ? "Change" : "Use another repository"}
+          </button>
+        )}
+      </div>
+
+      {editingTarget ? (
+        <div className="space-y-1.5">
+          <div className="flex gap-2">
+            <input
+              value={targetDraft}
+              onChange={(event) => setTargetDraft(event.target.value)}
+              placeholder={`${workspace.repo.owner}/my-public-site`}
+              aria-label="Repository to publish into"
+              className="min-w-0 flex-1 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2.5 py-1.5 font-mono text-[12.5px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
+            />
+            <button type="button" onClick={() => void saveTarget()} className="fl-btn">
+              Save
+            </button>
+          </div>
+          {/* Says what clearing it does, because an empty box that means
+                  "go back to the default" is otherwise a guess. */}
+          <p className="text-[11.5px] text-[var(--fl-muted)]">
+            Leave it empty to publish into {describeTarget(workspace.repo)} alongside your notes.
+          </p>
+          {targetError && <p className="text-[12px] text-[var(--fl-danger)]">{targetError}</p>}
+        </div>
+      ) : (
+        <p className="font-mono text-[12.5px] text-[var(--fl-text)]">
+          {describeTarget(target)}
+          {split && (
+            <span className="ml-2 font-sans text-[11.5px] text-[var(--fl-muted)]">
+              not the repository your notes are in
+            </span>
+          )}
+        </p>
+      )}
+
+      {warning && <p className="text-[11.5px] leading-snug text-[var(--fl-muted)]">{warning}</p>}
+    </div>
+  );
+
   // ── Published ───────────────────────────────────────────────────────────
 
   if (page) {
@@ -225,59 +285,7 @@ export function PublishDialog({
             </p>
           )}
 
-          <div className="space-y-1.5 rounded-lg border border-[var(--fl-border)] px-3 py-2.5">
-            <div className="flex flex-wrap items-baseline justify-between gap-2">
-              <span className="text-[12px] text-[var(--fl-muted)]">Pages go to</span>
-              {onSetTarget && !editingTarget && (
-                <button
-                  type="button"
-                  onClick={() => setEditingTarget(true)}
-                  className="text-[12px] text-[var(--fl-muted)] underline-offset-2 hover:text-[var(--fl-text)] hover:underline"
-                >
-                  {split ? "Change" : "Use another repository"}
-                </button>
-              )}
-            </div>
-
-            {editingTarget ? (
-              <div className="space-y-1.5">
-                <div className="flex gap-2">
-                  <input
-                    value={targetDraft}
-                    onChange={(event) => setTargetDraft(event.target.value)}
-                    placeholder={`${workspace.repo.owner}/my-public-site`}
-                    aria-label="Repository to publish into"
-                    className="min-w-0 flex-1 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2.5 py-1.5 font-mono text-[12.5px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
-                  />
-                  <button type="button" onClick={() => void saveTarget()} className="fl-btn">
-                    Save
-                  </button>
-                </div>
-                {/* Says what clearing it does, because an empty box that means
-                    "go back to the default" is otherwise a guess. */}
-                <p className="text-[11.5px] text-[var(--fl-muted)]">
-                  Leave it empty to publish into {describeTarget(workspace.repo)} alongside your
-                  notes.
-                </p>
-                {targetError && (
-                  <p className="text-[12px] text-[var(--fl-danger)]">{targetError}</p>
-                )}
-              </div>
-            ) : (
-              <p className="font-mono text-[12.5px] text-[var(--fl-text)]">
-                {describeTarget(target)}
-                {split && (
-                  <span className="ml-2 font-sans text-[11.5px] text-[var(--fl-muted)]">
-                    not the repository your notes are in
-                  </span>
-                )}
-              </p>
-            )}
-
-            {warning && (
-              <p className="text-[11.5px] leading-snug text-[var(--fl-muted)]">{warning}</p>
-            )}
-          </div>
+          {targetChooser}
 
           {error && (
             <p role="alert" className="text-[13px] leading-relaxed text-[var(--fl-danger)]">
@@ -339,15 +347,28 @@ export function PublishDialog({
           unpublishing deletes the file.
         </p>
 
+        {targetChooser}
+
         <div className="rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-2.5 text-[12.5px] text-[var(--fl-muted)]">
           Anyone with the link will be able to read this note. Publishing from a private repository
-          needs a paid GitHub plan; GitHub will say so if that applies to yours.
+          needs a paid GitHub plan — point this at a public repository above and your notes stay
+          private.
         </div>
 
         {error && (
-          <p role="alert" className="text-[13px] leading-relaxed text-[var(--fl-danger)]">
-            {error}
-          </p>
+          <div role="alert" className="space-y-1">
+            <p className="text-[13px] leading-relaxed text-[var(--fl-danger)]">{error}</p>
+            {/* GitHub's refusal is accurate and says nothing about what to do
+                next. The fix is one control above this message, so it is worth
+                naming rather than leaving to be discovered. */}
+            {/pages|plan/i.test(error) && !split && (
+              <p className="text-[12.5px] leading-relaxed text-[var(--fl-muted)]">
+                Pages needs a paid plan for a private repository. Choose a public repository under
+                &ldquo;Pages go to&rdquo; above and this note is published there instead — the notes
+                themselves stay where they are.
+              </p>
+            )}
+          </div>
         )}
 
         <div className="flex items-center justify-end gap-2">


### PR DESCRIPTION
Two problems reported from a real screen.

## The bug: the chooser was unreachable

The control for pointing pages at a public repository only rendered in the dialog's **published** view. That is exactly out of reach of the person it was built for — a private notebook cannot publish at all on a free plan, so the one control that fixes that sat behind a publish that could never succeed.

The reported dialog showed *"Your current plan does not support GitHub Pages for this repository"* with no way forward. That is the feature failing at precisely the case it exists for.

It now renders in **both** states of the dialog, extracted once so the two cannot drift apart.

Two smaller things the same report surfaced:

- **GitHub's refusal says nothing about what to do next.** When a publish fails for want of a plan and pages are still going to the notes' own repository, the message now names the fix — which is one control above it on screen.
- The standing note about private repositories only said a paid plan is needed. It now says what to do instead.

## Not a bug: the sandbox message

`Running blocks needs a sandbox, which this deployment is not configured for` is the honest 503 from feature 3 — the feature works, the deployment has no sandbox credentials. But the message was true and useless. It now names **`VERCEL_TOKEN`, `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID`**, because whoever sees it is usually the person who can set them. On Vercel it authenticates itself via OIDC and none are needed.

## Verification

`pnpm check` **exit 0** — prettier, 8 typecheck tasks, eslint, **1417 tests across 86 files**, `next build`.

**8 new tests**, and the first one is the bug: the chooser present before anything is published — the regression that would have caught this. Plus the default repository named, a chosen one shown as not being where the notes are, a typed repository recorded, a malformed one refused without calling the handler, an emptied box clearing the target, no control offered when the caller cannot store the choice, and the paid-plan refusal pointing at the fix.

A build failure during this work was the dev server holding `.next` open, not the code.

**Not verified in a browser:** the dialog needs a connected repository and I am signed out locally. That is the same gap that let the original bug through, which is why the regression test exists rather than a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)