### PR TITLE
fix(ux): make the features usable — pickers instead of syntax, one history button, one-click publishing, and real docs

### DIFF
--- a/apps/web/src/app/api/gh/site-repo/route.ts
+++ b/apps/web/src/app/api/gh/site-repo/route.ts
@@ -1,0 +1,50 @@
+import { type NextRequest } from "next/server";
+import { handle, requireClient, ApiError, assertName } from "@/lib/api-helpers";
+import { enforceRateLimit } from "@/lib/rate-limit";
+
+/**
+ * Creates the public repository a private notebook publishes into.
+ *
+ * The alternative was telling somebody with a private notebook to go to
+ * github.com, make a repository, come back, and type its name — four steps
+ * outside the app to work around a limit they did not choose. GitHub will not
+ * serve Pages from a private repository on a free plan, and nothing here can
+ * change that; what it can do is make the way around it one click.
+ *
+ * Always public, and not negotiable through the request: a private target
+ * would hit exactly the same wall, so creating one would be building the
+ * problem again with an extra step.
+ */
+export async function POST(request: NextRequest) {
+  return handle(async () => {
+    const { client, login } = await requireClient();
+    enforceRateLimit(request, { name: "site-repo", limit: 5, windowMs: 10 * 60_000 });
+
+    const body = (await request.json().catch(() => null)) as { name?: unknown } | null;
+    const name = assertName(String(body?.name ?? ""), "repository name");
+
+    const existing = await client.getRepo(login, name);
+    if (existing) {
+      // Reusing one the reader already has beats refusing, but a private one
+      // cannot serve pages — saying which is the difference between a fix and
+      // a second dead end.
+      if (existing.private) {
+        throw new ApiError(
+          409,
+          "conflict",
+          `${login}/${name} already exists and is private, so GitHub will not serve pages from it either. Pick another name, or make that repository public on GitHub.`,
+        );
+      }
+
+      return { owner: existing.owner, repo: existing.name, created: false };
+    }
+
+    const created = await client.createRepo({
+      name,
+      description: "Pages published from my ForkLeaf notes",
+      private: false,
+    });
+
+    return { owner: created.owner, repo: created.name, created: true };
+  });
+}

--- a/apps/web/src/app/docs/content/features.tsx
+++ b/apps/web/src/app/docs/content/features.tsx
@@ -1,0 +1,210 @@
+import { Code, H2, H3, Lead, LI, Note, OL, P, Pre, UL } from "@/components/prose";
+
+/**
+ * How to actually use the eight features that use git for something.
+ *
+ * A separate page because they share a shape: each one uses the fact that
+ * every note is a commit in a repository you own, and each one is invisible
+ * until somebody tells you where the button is. The rest of the docs describe
+ * what the app is; this one is a set of instructions.
+ */
+export function Features() {
+  return (
+    <>
+      <Lead>
+        Eight things ForkLeaf can do because your notes are commits in a repository you own. Each
+        one below says exactly where the button is.
+      </Lead>
+
+      <Note>
+        Everything on this page except capturing a page needs a connected GitHub repository, and
+        most need a note with more than one commit — there is no history to read on a note you saved
+        once. Sign in and edit a note a few times before trying them.
+      </Note>
+
+      <H2 id="history">1–3. History, replay, and who wrote what</H2>
+      <P>
+        Open the <strong>properties panel</strong> (the panel toggle at the top right of the
+        editor), find <strong>History, replay &amp; who wrote what</strong>, and click it. One
+        window, three tabs across the top:
+      </P>
+      <UL>
+        <LI>
+          <strong>Changes</strong> — every commit that has touched this note, and a side-by-side
+          diff of any two. <strong>Restore this version</strong> writes an old version back as a new
+          commit, so nothing is lost.
+        </LI>
+        <LI>
+          <strong>Replay</strong> — a scrubber. Drag it and the note types and untypes itself
+          through its real revisions. The chart underneath is its length over time, so you can see
+          where you wrote in bursts and where you deleted a section.
+        </LI>
+        <LI>
+          <strong>Who wrote what</strong> — every paragraph with its date in the margin, shaded by
+          age. Point at a paragraph and a card names the commit, the author, and what else that
+          commit changed that day. That last part is the useful one: it turns &ldquo;12 March&rdquo;
+          into &ldquo;the day I was doing the AD engagement&rdquo;.
+        </LI>
+      </UL>
+      <P>
+        In the command palette (<Code>⌘K</Code> / <Code>Ctrl-K</Code>) each tab has its own entry —
+        type <Code>replay</Code>, <Code>blame</Code> or <Code>history</Code> to open straight onto
+        it.
+      </P>
+
+      <H2 id="run">4. Running a code block</H2>
+      <P>
+        Write a fenced block and set its language to <Code>bash</Code>, <Code>python</Code> or{" "}
+        <Code>javascript</Code> — either type the language after the opening fence, or pick it from
+        the dropdown on the block itself. A <strong>Run</strong> button appears in the block&rsquo;s
+        header.
+      </P>
+      <P>
+        Press it. The output is written into an <Code>output</Code> block directly underneath,
+        stamped with when it ran, and committed with the note like any other edit:
+      </P>
+      <Pre label="in your note">{`\`\`\`python
+print("hello world")
+\`\`\`
+
+\`\`\`output
+— ran 2026-08-27 11:09 UTC · ok · 34ms
+hello world
+\`\`\``}</Pre>
+      <P>
+        Running it again replaces that block rather than adding another. The old results are in the
+        commit history, which is where history belongs.
+      </P>
+      <H3>Where the code runs</H3>
+      <P>
+        In a throwaway virtual machine that is created for the one run and destroyed afterwards —
+        never on your computer, and never on the server. It does have internet access, because a
+        runbook that cannot reach the host it is about is a text file.
+      </P>
+      <Note>
+        This needs a sandbox to be configured. On your own machine, set <Code>VERCEL_TOKEN</Code>,{" "}
+        <Code>VERCEL_TEAM_ID</Code> and <Code>VERCEL_PROJECT_ID</Code> in{" "}
+        <Code>apps/web/.env.local</Code>. On a deployment, set the same three in your hosting
+        project&rsquo;s environment variables — a local <Code>.env.local</Code> never reaches a
+        deployment. Without them, the Run button says so rather than failing quietly.
+      </Note>
+
+      <H2 id="review">5. Reviewing a note as a pull request</H2>
+      <OL>
+        <LI>
+          Write something, then open <strong>Propose changes</strong> in the properties panel. That
+          puts your edits on a branch and opens a pull request.
+        </LI>
+        <LI>Have someone comment on it — on github.com, or yourself, or a bot.</LI>
+        <LI>
+          Back in ForkLeaf, open <strong>Review &amp; merge this note</strong> in the properties
+          panel.
+        </LI>
+      </OL>
+      <P>
+        Each comment appears against <em>the paragraph it was written about</em>, quoted, with a
+        reply box. When it is settled, <strong>Squash and merge</strong> lands it as a single commit
+        and puts you back on the main branch.
+      </P>
+      <P>
+        If the branch you are on has no pull request open, the panel says so rather than looking
+        broken.
+      </P>
+
+      <H2 id="repo-links">6. Linking a note to a file</H2>
+      <P>
+        A note describing a script and the script itself drift apart silently. Linking them means
+        the note can tell you when the file has moved on.
+      </P>
+      <P>
+        In the properties panel, click <strong>Link a file from this repository</strong>. Filter,
+        click a file, done — the link is inserted and the file&rsquo;s current revision is recorded
+        for you:
+      </P>
+      <Pre label="what gets inserted">{`[[repo:scripts/scan.sh@a1b2c3d]]`}</Pre>
+      <P>
+        You can write one by hand if you prefer — <Code>[[repo:path/to/file]]</Code> for this
+        repository, <Code>[[repo:owner/name:path/to/file]]</Code> for another — but the picker is
+        there because the <Code>@a1b2c3d</Code> part is a commit you have no way of knowing while
+        writing, and it is the half that makes the feature work.
+      </P>
+      <P>
+        Afterwards, the <strong>Freshness</strong> section of the properties panel lists the files
+        this note links to and whether each has changed since.
+      </P>
+
+      <H2 id="freshness">7. Finding notes that have gone off</H2>
+      <P>
+        The <strong>Freshness</strong> section appears in the properties panel on its own. It weighs
+        what the note claims — version numbers, CVEs, dates, sentences hanging on the word
+        &ldquo;currently&rdquo; — against how long it has been since you touched it, and against any
+        linked file that has changed.
+      </P>
+      <P>
+        It never says a note is wrong. It says it is worth re-reading, and always shows why, so you
+        can disagree at a glance. A note with nothing datable in it is never called stale however
+        old it is: prose about how you think does not expire.
+      </P>
+
+      <H2 id="publish">8. Publishing a page from private notes</H2>
+      <P>
+        Publishing renders a note to a single self-contained HTML page, commits it to a{" "}
+        <Code>docs/</Code> folder, and lets GitHub Pages serve it. Open{" "}
+        <strong>Publish as a page</strong> in the properties panel.
+      </P>
+      <H3>If your notes repository is private</H3>
+      <P>
+        GitHub will not serve Pages from a private repository on a free plan. Nothing in ForkLeaf
+        can change that — but it can publish somewhere else. In the publish dialog, under{" "}
+        <strong>Pages go to</strong>:
+      </P>
+      <UL>
+        <LI>
+          Click <strong>Create …-site and publish there</strong>. ForkLeaf makes a public repository
+          named after your notes repository and points publishing at it. One click.
+        </LI>
+        <LI>
+          Or click <strong>Use another repository</strong> and type the <Code>owner/name</Code> of a
+          public repository you already have.
+        </LI>
+      </UL>
+      <P>
+        Your notes stay in the private repository. Only the rendered page is public. Leave the box
+        empty to go back to publishing alongside your notes.
+      </P>
+
+      <H2 id="capture">9. Capturing a web page as a source</H2>
+      <P>
+        A note that cites a page has a hole in it waiting to open: the page moves, the site is sold,
+        the post is deleted, and the citation becomes a dead link that still looks sourced.
+      </P>
+      <OL>
+        <LI>
+          Properties panel → <strong>Capture a web page as a source</strong>.
+        </LI>
+        <LI>
+          Paste the address and press <strong>Capture</strong>.
+        </LI>
+        <LI>
+          It shows what it found — the page title, and whether the Wayback Machine has an archived
+          copy and how old it is.
+        </LI>
+        <LI>
+          Press <strong>Add to this note</strong>.
+        </LI>
+      </OL>
+      <P>The citation is written at the end of the note as an ordinary blockquote:</P>
+      <Pre label="in your note">{`> **Source** — [The article](https://example.com/article)
+> Read 2026-08-27 10:04 UTC · [archived copy](https://web.archive.org/…) from 2024-03-15 12:00 UTC`}</Pre>
+      <P>
+        If there is no archived copy, the citation says so rather than staying quiet — you should
+        know that link may not outlive the page.
+      </P>
+      <Note>
+        Capturing needs you to be signed in, because the fetch happens on the server. It refuses
+        addresses that resolve inside a private network, which is why it cannot capture a page on
+        your own machine or an intranet.
+      </Note>
+    </>
+  );
+}

--- a/apps/web/src/app/docs/content/index.tsx
+++ b/apps/web/src/app/docs/content/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { GettingStarted, HowItWorks } from "./start";
 import { Editor, Diagrams, Properties, Export, Shortcuts } from "./writing";
+import { Features } from "./features";
 import { SigningIn, Repositories, Sync, Conflicts } from "./github";
 import { Plans, PrivacyAndData, Security } from "./account";
 import { SelfHosting, Firebase, Troubleshooting, Faq } from "./running";
@@ -21,6 +22,7 @@ export const DOC_CONTENT: Record<string, () => React.JSX.Element> = {
   properties: Properties,
   export: Export,
   shortcuts: Shortcuts,
+  features: Features,
   "signing-in": SigningIn,
   repositories: Repositories,
   sync: Sync,

--- a/apps/web/src/app/docs/nav.ts
+++ b/apps/web/src/app/docs/nav.ts
@@ -64,6 +64,12 @@ export const DOC_SECTIONS: DocSection[] = [
         title: "Keyboard shortcuts",
         summary: "Every shortcut in the app, in one table.",
       },
+      {
+        slug: "features",
+        title: "What notes-as-commits gets you",
+        summary:
+          "Replay, blame, runnable blocks, review as a pull request, links to files, freshness, publishing from a private notebook, and capturing sources — with where each button is.",
+      },
     ],
   },
   {

--- a/apps/web/src/components/CaptureDialog.test.tsx
+++ b/apps/web/src/components/CaptureDialog.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CaptureDialog } from "./CaptureDialog";
+
+const capturePage = vi.fn();
+vi.mock("@/lib/gateway", () => ({ capturePage: (...a: unknown[]) => capturePage(...a) }));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const RESULT = {
+  url: "https://example.com/a",
+  title: "The article",
+  capturedAt: "2026-08-27T10:04:09.000Z",
+  archiveUrl: "https://web.archive.org/web/20240315120000/https://example.com/a",
+  archivedAt: "2024-03-15T12:00:00.000Z",
+  titleFromUrl: false,
+};
+
+function view(onInsert = vi.fn()) {
+  render(<CaptureDialog onInsert={onInsert} onClose={vi.fn()} />);
+  return onInsert;
+}
+
+const type = (value: string) =>
+  fireEvent.change(screen.getByLabelText(/address to capture/i), { target: { value } });
+
+describe("CaptureDialog", () => {
+  it("refuses something that is not a web address, without asking the server", async () => {
+    view();
+    type("not a url");
+    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+
+    await waitFor(() => expect(screen.getByText(/not a web address/i)).toBeTruthy());
+    expect(capturePage).not.toHaveBeenCalled();
+  });
+
+  it("shows what it found before anything is written down", async () => {
+    capturePage.mockResolvedValue(RESULT);
+    view();
+    type("https://example.com/a");
+    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+
+    await waitFor(() => expect(screen.getByText("The article")).toBeTruthy());
+    expect(screen.getByText(/an archived copy exists/i)).toBeTruthy();
+  });
+
+  it("says plainly when there is no archived copy", async () => {
+    // This changes what the citation is worth and used to be invisible.
+    capturePage.mockResolvedValue({ ...RESULT, archiveUrl: null, archivedAt: null });
+    view();
+    type("https://example.com/a");
+    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+
+    await waitFor(() => expect(screen.getByText(/no snapshot of this page/i)).toBeTruthy());
+  });
+
+  it("says when the title is only the address", async () => {
+    capturePage.mockResolvedValue({ ...RESULT, titleFromUrl: true });
+    view();
+    type("https://example.com/a");
+    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+
+    await waitFor(() => expect(screen.getByText(/could not be read/i)).toBeTruthy());
+  });
+
+  it("writes nothing until the reader says so", async () => {
+    capturePage.mockResolvedValue(RESULT);
+    const onInsert = view();
+    type("https://example.com/a");
+    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+
+    await waitFor(() => expect(screen.getByText("The article")).toBeTruthy());
+    expect(onInsert).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /add to this note/i }));
+    await waitFor(() => expect(onInsert).toHaveBeenCalled());
+    expect(String(onInsert.mock.calls[0]![0])).toContain("> **Source** — [The article]");
+  });
+
+  it("captures on Enter, without reaching for the button", async () => {
+    capturePage.mockResolvedValue(RESULT);
+    view();
+    type("https://example.com/a");
+    fireEvent.keyDown(screen.getByLabelText(/address to capture/i), { key: "Enter" });
+
+    await waitFor(() => expect(capturePage).toHaveBeenCalledWith("https://example.com/a"));
+  });
+
+  it("passes on why a capture failed", async () => {
+    capturePage.mockRejectedValue(new Error("That address is inside a private network."));
+    view();
+    type("https://example.com/a");
+    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+
+    await waitFor(() => expect(screen.getByText(/private network/i)).toBeTruthy());
+  });
+});

--- a/apps/web/src/components/CaptureDialog.tsx
+++ b/apps/web/src/components/CaptureDialog.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { formatSource, isCapturable, type CapturedSource } from "@forkleaf/markdown-engine";
+import { capturePage, type CaptureResult } from "@/lib/gateway";
+import { Dialog } from "./Dialog";
+
+/**
+ * Capturing a page, with the result shown before it is written down.
+ *
+ * This was a bare text prompt: paste a URL, press enter, and a citation
+ * appeared at the end of the note with no indication of what had been found —
+ * whether the title was read or guessed from the address, whether an archived
+ * copy exists, or how old that copy is. All three change what the citation is
+ * worth, and all three were invisible until you went looking in the note.
+ *
+ * So the capture happens first and is shown, and inserting it is a separate
+ * decision. The honest failure — a page with no snapshot — is stated plainly
+ * here rather than discovered later.
+ */
+
+export interface CaptureDialogProps {
+  /** Appends the finished citation to the note. */
+  onInsert: (markdown: string) => Promise<void> | void;
+  onClose: () => void;
+}
+
+export function CaptureDialog({ onInsert, onClose }: CaptureDialogProps) {
+  const [url, setUrl] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [found, setFound] = useState<CaptureResult | null>(null);
+
+  const capture = useCallback(async () => {
+    const trimmed = url.trim();
+
+    if (!isCapturable(trimmed)) {
+      setError("That is not a web address — it needs to start with http:// or https://.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    setFound(null);
+
+    try {
+      setFound(await capturePage(trimmed));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "That page could not be captured.");
+    } finally {
+      setBusy(false);
+    }
+  }, [url]);
+
+  const insert = useCallback(async () => {
+    if (!found) return;
+    await onInsert(formatSource(found as CapturedSource));
+    onClose();
+  }, [found, onInsert, onClose]);
+
+  return (
+    <Dialog
+      title="Capture a web page"
+      subtitle="Its address, when you read it, and a copy that outlives it"
+      onClose={onClose}
+    >
+      <div className="space-y-3">
+        <div className="flex gap-2">
+          <input
+            autoFocus
+            value={url}
+            onChange={(event) => setUrl(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                void capture();
+              }
+            }}
+            placeholder="https://example.com/the-article"
+            aria-label="Address to capture"
+            className="min-w-0 flex-1 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-2 text-[13px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
+          />
+          <button
+            type="button"
+            onClick={() => void capture()}
+            disabled={busy || url.trim() === ""}
+            className="fl-btn shrink-0 disabled:opacity-40"
+          >
+            {busy ? "Reading…" : "Capture"}
+          </button>
+        </div>
+
+        {error && <p className="text-[13px] text-[var(--fl-danger)]">{error}</p>}
+
+        {found && (
+          <div className="space-y-2 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-3">
+            <p className="text-[13px] font-medium text-[var(--fl-text)]">{found.title}</p>
+            <p className="truncate font-mono text-[11.5px] text-[var(--fl-muted)]">{found.url}</p>
+
+            {/* All three of these change what the citation is worth, and all
+                three used to be invisible until you looked in the note. */}
+            {found.titleFromUrl && (
+              <p className="text-[12px] text-[var(--fl-muted)]">
+                The page itself could not be read, so its address stands in for a title.
+              </p>
+            )}
+
+            <p className="text-[12px] text-[var(--fl-muted)]">
+              {found.archiveUrl ? (
+                <>
+                  An archived copy exists
+                  {found.archivedAt
+                    ? ` from ${new Date(found.archivedAt).toLocaleDateString()}`
+                    : ""}
+                  . It will still be readable if this page disappears.
+                </>
+              ) : (
+                <>
+                  The Wayback Machine has no snapshot of this page. The citation will say so — this
+                  link may not outlive the page.
+                </>
+              )}
+            </p>
+
+            <div className="flex justify-end pt-1">
+              <button type="button" onClick={() => void insert()} className="fl-btn fl-btn-primary">
+                Add to this note
+              </button>
+            </div>
+          </div>
+        )}
+
+        {!found && !busy && (
+          <p className="text-[11.5px] leading-snug text-[var(--fl-muted)]">
+            The address, the time you read it, and a link to an archived copy are written into the
+            note as an ordinary blockquote, and committed with it like any other edit.
+          </p>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/Dialog.tsx
+++ b/apps/web/src/components/Dialog.tsx
@@ -7,6 +7,15 @@ export interface DialogProps {
   onClose: () => void;
   children: React.ReactNode;
   wide?: boolean;
+  /**
+   * Holds the window at a fixed height instead of fitting its contents.
+   *
+   * For dialogs whose tabs differ wildly in size. A window that resizes as you
+   * switch between them moves the tabs out from under the cursor and makes the
+   * whole page jump, which reads as the app breaking rather than as the
+   * content changing.
+   */
+  steady?: boolean;
   /** Optional line under the title, for orientation. */
   subtitle?: string;
 }
@@ -16,7 +25,14 @@ export interface DialogProps {
  * Escape closes it, focus is trapped inside while it is open, and focus returns
  * to whatever opened it on close.
  */
-export function Dialog({ title, subtitle, onClose, children, wide = false }: DialogProps) {
+export function Dialog({
+  title,
+  subtitle,
+  onClose,
+  children,
+  wide = false,
+  steady = false,
+}: DialogProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const previouslyFocused = useRef<HTMLElement | null>(null);
 
@@ -101,7 +117,7 @@ export function Dialog({ title, subtitle, onClose, children, wide = false }: Dia
         tabIndex={-1}
         className={`flex max-h-[85vh] w-full flex-col overflow-hidden rounded-2xl border border-[var(--fl-border)] bg-[var(--fl-surface)] shadow-[var(--fl-shadow-lg)] ${
           wide ? "max-w-3xl" : "max-w-md"
-        }`}
+        } ${steady ? "h-[85vh]" : ""}`}
       >
         <div className="flex shrink-0 items-start justify-between gap-3 border-b border-[var(--fl-border)] px-5 py-3.5">
           <div className="min-w-0">

--- a/apps/web/src/components/EditorRightPanel.test.tsx
+++ b/apps/web/src/components/EditorRightPanel.test.tsx
@@ -22,8 +22,6 @@ const LOCAL = { isLocal: true } as Workspace;
 
 function panel(workspace: Workspace | null = CONNECTED) {
   const onShowHistory = vi.fn();
-  const onReplay = vi.fn();
-  const onBlame = vi.fn();
 
   render(
     <EditorRightPanel
@@ -34,8 +32,6 @@ function panel(workspace: Workspace | null = CONNECTED) {
       onFrontmatterChange={vi.fn()}
       onExport={vi.fn()}
       onShowHistory={onShowHistory}
-      onReplay={onReplay}
-      onBlame={onBlame}
       syncMode="auto"
       onSyncNow={vi.fn()}
       links={{
@@ -50,53 +46,43 @@ function panel(workspace: Workspace | null = CONNECTED) {
     />,
   );
 
-  return { onShowHistory, onReplay, onBlame };
+  return { onShowHistory };
 }
 
 /**
  * The properties panel is where somebody goes looking for what they can do
- * with the note in front of them, which makes it the one place the replay has
- * to be named. It shipped reachable only as a tab inside the history dialog —
- * two steps past anywhere its name appears — so these guard the way in, not
- * just the thing at the end of it.
+ * with the note in front of them, which makes it the one place history has to
+ * be named.
+ *
+ * Replay and blame each had their own button here when they were built,
+ * because each had shipped buried in a tab nobody opened. Three buttons
+ * opening three tabs of one window turned out to be the opposite mistake, so
+ * there is one now and the tabs do the choosing. These guard that there is
+ * still exactly one obvious way in.
  */
 describe("EditorRightPanel actions", () => {
-  it("offers the replay by name, next to history", () => {
+  it("offers one way into history, naming all three things it holds", () => {
     panel();
-    const replay = screen.getByRole("button", { name: /replay how this was written/i });
-    const history = screen.getByRole("button", { name: /history & commits/i });
-    expect(replay).toBeTruthy();
-    // Adjacent, so finding one finds the other.
-    expect(history.compareDocumentPosition(replay) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const button = screen.getByRole("button", { name: /history, replay & who wrote what/i });
+    expect(button).toBeTruthy();
   });
 
-  it("opens the replay when that button is pressed", () => {
-    const { onReplay, onShowHistory } = panel();
-    fireEvent.click(screen.getByRole("button", { name: /replay how this was written/i }));
-    expect(onReplay).toHaveBeenCalledTimes(1);
-    expect(onShowHistory).not.toHaveBeenCalled();
+  it("opens it when pressed", () => {
+    const { onShowHistory } = panel();
+    fireEvent.click(screen.getByRole("button", { name: /history, replay & who wrote what/i }));
+    expect(onShowHistory).toHaveBeenCalledTimes(1);
   });
 
-  it("offers the blame view by name, beside the replay", () => {
+  it("does not repeat replay and blame as buttons of their own", () => {
+    // They are tabs inside the window this opens; a button per tab made the
+    // reader choose before they could look.
     panel();
-    const blame = screen.getByRole("button", { name: /when each paragraph was written/i });
-    const replay = screen.getByRole("button", { name: /replay how this was written/i });
-    expect(blame).toBeTruthy();
-    expect(replay.compareDocumentPosition(blame) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  });
-
-  it("opens the blame view when that button is pressed", () => {
-    const { onBlame, onReplay, onShowHistory } = panel();
-    fireEvent.click(screen.getByRole("button", { name: /when each paragraph was written/i }));
-    expect(onBlame).toHaveBeenCalledTimes(1);
-    expect(onReplay).not.toHaveBeenCalled();
-    expect(onShowHistory).not.toHaveBeenCalled();
-  });
-
-  it("hides all three when there is no repository to read history from", () => {
-    panel(LOCAL);
     expect(screen.queryByRole("button", { name: /replay how this was written/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /when each paragraph was written/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /history & commits/i })).toBeNull();
+  });
+
+  it("hides it when there is no repository to read history from", () => {
+    panel(LOCAL);
+    expect(screen.queryByRole("button", { name: /history, replay & who wrote what/i })).toBeNull();
   });
 });

--- a/apps/web/src/components/EditorRightPanel.tsx
+++ b/apps/web/src/components/EditorRightPanel.tsx
@@ -37,6 +37,10 @@ export interface EditorRightPanelProps {
   onRewrite?: (content: string) => void;
   /** Absent for a local workspace, which has no pull requests to read. */
   onReview?: () => void;
+  /** Opens the file picker; absent for a workspace with no repository. */
+  onLinkFile?: () => void;
+  /** Opens the capture dialog; absent when signed out. */
+  onCapture?: () => void;
   /** Opens the publish dialog. Absent for a workspace with no repository. */
   onPublish?: (() => void) | undefined;
   /**
@@ -106,6 +110,8 @@ export function EditorRightPanel({
   onReplay,
   onBlame,
   onReview,
+  onLinkFile,
+  onCapture,
   onRewrite,
   onPublish,
   published,
@@ -473,6 +479,20 @@ export function EditorRightPanel({
                 {onReview && (
                   <PanelButton onClick={onReview} icon={<ReviewGlyph />}>
                     Review &amp; merge this note
+                  </PanelButton>
+                )}
+                {/* Both of these were reachable only from the command palette,
+                    which meant knowing they existed before you could find
+                    them. They insert into the note, so they belong beside the
+                    other things you can do to it. */}
+                {onLinkFile && (
+                  <PanelButton onClick={onLinkFile} icon={<FileLinkGlyph />}>
+                    Link a file from this repository
+                  </PanelButton>
+                )}
+                {onCapture && (
+                  <PanelButton onClick={onCapture} icon={<CaptureGlyph />}>
+                    Capture a web page as a source
                   </PanelButton>
                 )}
                 <button
@@ -847,6 +867,32 @@ function LinkGlyph() {
     >
       <path d="M6.5 9.5a2.75 2.75 0 0 0 4 .25l2-2a2.75 2.75 0 0 0-3.9-3.9l-1.1 1.1" />
       <path d="M9.5 6.5a2.75 2.75 0 0 0-4-.25l-2 2a2.75 2.75 0 0 0 3.9 3.9l1.1-1.1" />
+    </svg>
+  );
+}
+
+/** A page with a link on it — a file, pointed at. */
+function FileLinkGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
+      <path d="M9 1.5H4a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V5.5Z" />
+      <path d="M9 1.5v4h4" />
+      <path
+        d="M6.5 10.5a1.5 1.5 0 0 1 1.5-1.5h.5M9.5 10.5A1.5 1.5 0 0 1 8 12h-.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+/** A bookmark with a clock — a page, kept at a moment. */
+function CaptureGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
+      <path d="M4 2h6a1 1 0 0 1 1 1v5.5" />
+      <path d="M4 2v11l3-2.2" strokeLinecap="round" />
+      <circle cx="11" cy="11" r="3.2" />
+      <path d="M11 9.6V11l1 .8" strokeLinecap="round" />
     </svg>
   );
 }

--- a/apps/web/src/components/EditorRightPanel.tsx
+++ b/apps/web/src/components/EditorRightPanel.tsx
@@ -25,14 +25,12 @@ export interface EditorRightPanelProps {
    * only reachable by opening history and noticing a second tab, which is a
    * place nobody looks for something they have never heard of.
    */
-  onReplay: () => void;
   /**
    * Opens the per-paragraph attribution view.
    *
    * Beside the replay, because they answer the two halves of the same
    * question — how this page grew, and which parts of it are old.
    */
-  onBlame: () => void;
   /** Rewrites the note, for re-pinning a repository link. */
   onRewrite?: (content: string) => void;
   /** Absent for a local workspace, which has no pull requests to read. */
@@ -107,8 +105,6 @@ export function EditorRightPanel({
   onFrontmatterChange,
   onExport,
   onShowHistory,
-  onReplay,
-  onBlame,
   onReview,
   onLinkFile,
   onCapture,
@@ -454,22 +450,18 @@ export function EditorRightPanel({
                     {published ? "Published as a page" : "Publish as a page"}
                   </PanelButton>
                 )}
-                {/* Named for the thing it shows. "Version history" is accurate
-                    and is not what anybody searches for — every save here is a
-                    git commit, and people go looking for the word "commits". */}
+                {/* One way in, not three.
+                    Replay and blame each got their own button when they were
+                    built, because each had been buried in a tab nobody opened.
+                    Three buttons opening three tabs of the same window is the
+                    opposite mistake: the panel repeats what the window already
+                    shows, and the reader has to decide before they can look.
+                    The tabs are labelled and visible, so the choice belongs
+                    there — the panel just opens it. The command palette still
+                    reaches each tab directly, which costs no space here. */}
                 {hasHistory && (
                   <PanelButton onClick={onShowHistory} icon={<HistoryGlyph />}>
-                    History &amp; commits
-                  </PanelButton>
-                )}
-                {hasHistory && (
-                  <PanelButton onClick={onReplay} icon={<ReplayGlyph />}>
-                    Replay how this was written
-                  </PanelButton>
-                )}
-                {hasHistory && (
-                  <PanelButton onClick={onBlame} icon={<BlameGlyph />}>
-                    When each paragraph was written
+                    History, replay &amp; who wrote what
                   </PanelButton>
                 )}
                 {/* Not gated on there being an open request: the panel's job
@@ -903,44 +895,6 @@ function ReviewGlyph() {
     <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
       <path d="M2 3.5h7M2 6h5" strokeLinecap="round" />
       <path d="M6.5 9.5h7a1 1 0 0 1 1 1v2.5a1 1 0 0 1-1 1H9l-2 1.5V14h-.5a1 1 0 0 1-1-1v-2.5a1 1 0 0 1 1-1Z" />
-    </svg>
-  );
-}
-
-/** Lines of text with a marked margin — the blame gutter, in miniature. */
-function BlameGlyph() {
-  return (
-    <svg
-      viewBox="0 0 16 16"
-      aria-hidden="true"
-      className="h-3.5 w-3.5"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-    >
-      <path d="M2.25 3.5v9" strokeWidth="2" />
-      <path d="M5.5 4h8.25M5.5 7h8.25M5.5 10h5.5M5.5 13h7" />
-    </svg>
-  );
-}
-
-/** A play head over a rising line — the replay's own chart, in miniature. */
-function ReplayGlyph() {
-  return (
-    <svg
-      viewBox="0 0 16 16"
-      aria-hidden="true"
-      className="h-3.5 w-3.5"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M1.75 11.5 5 8l2.5 2 4.75-5.5" />
-      <path d="M1.75 14.25h12.5" />
-      <circle cx="12.25" cy="4.5" r="1.4" fill="currentColor" stroke="none" />
     </svg>
   );
 }

--- a/apps/web/src/components/HistoryDialog.tsx
+++ b/apps/web/src/components/HistoryDialog.tsx
@@ -163,6 +163,9 @@ export function HistoryDialog({
             : "Version history"
       }
       subtitle={`${note.path} · ${workspace.repo.owner}/${workspace.repo.repo}`}
+      // Three tabs whose contents differ hugely in height; without this the
+      // window resized under the cursor every time you switched.
+      steady
       onClose={onClose}
       wide
     >

--- a/apps/web/src/components/LinkFileDialog.test.tsx
+++ b/apps/web/src/components/LinkFileDialog.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Workspace } from "@forkleaf/types";
+import { LinkFileDialog } from "./LinkFileDialog";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const workspace = {
+  id: "me/notes@main:",
+  name: "notes",
+  repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
+  isDefault: false,
+  isLocal: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastOpenedAt: "2026-01-01T00:00:00.000Z",
+} as Workspace;
+
+/** Answers the tree listing, then the revision lookup. */
+function serve(tree: unknown, head: unknown = { sha: "a1b2c3d4e5f6", exists: true }) {
+  const mock = vi
+    .fn()
+    .mockImplementation((url: string) =>
+      Promise.resolve(
+        String(url).includes("file-head")
+          ? { ok: true, json: () => Promise.resolve(head) }
+          : { ok: true, json: () => Promise.resolve(tree) },
+      ),
+    );
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+function view(onInsert = vi.fn()) {
+  render(<LinkFileDialog workspace={workspace} onInsert={onInsert} onClose={vi.fn()} />);
+  return onInsert;
+}
+
+const TREE = {
+  tree: [{ path: "scripts/scan.sh" }, { path: "README.md" }, { path: "node_modules/x.js" }],
+};
+
+beforeEach(() => serve(TREE));
+
+describe("LinkFileDialog", () => {
+  it("lists the repository's files", async () => {
+    view();
+    await waitFor(() => expect(screen.getByText("scripts/scan.sh")).toBeTruthy());
+    expect(screen.getByText("README.md")).toBeTruthy();
+  });
+
+  it("leaves out the folders nobody documents", async () => {
+    view();
+    await waitFor(() => expect(screen.getByText("README.md")).toBeTruthy());
+    expect(screen.queryByText("node_modules/x.js")).toBeNull();
+  });
+
+  it("filters as you type, so a big repository stays usable", async () => {
+    view();
+    await waitFor(() => expect(screen.getByText("README.md")).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText(/filter files/i), { target: { value: "scan" } });
+    expect(screen.getByText("scripts/scan.sh")).toBeTruthy();
+    expect(screen.queryByText("README.md")).toBeNull();
+  });
+
+  it("says when nothing matches", async () => {
+    view();
+    await waitFor(() => expect(screen.getByText("README.md")).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText(/filter files/i), { target: { value: "zzz" } });
+    expect(screen.getByText(/nothing matches/i)).toBeTruthy();
+  });
+
+  it("pins the revision for you — the part a person cannot do", async () => {
+    const onInsert = view();
+    await waitFor(() => expect(screen.getByText("scripts/scan.sh")).toBeTruthy());
+    fireEvent.click(screen.getByText("scripts/scan.sh"));
+
+    await waitFor(() => expect(onInsert).toHaveBeenCalledWith("[[repo:scripts/scan.sh@a1b2c3d]]"));
+  });
+
+  it("still inserts a link when the revision cannot be looked up", async () => {
+    // Half the feature beats none of it; it just cannot report staleness yet.
+    serve(TREE, {});
+    const onInsert = view();
+
+    await waitFor(() => expect(screen.getByText("scripts/scan.sh")).toBeTruthy());
+    fireEvent.click(screen.getByText("scripts/scan.sh"));
+
+    await waitFor(() => expect(onInsert).toHaveBeenCalledWith("[[repo:scripts/scan.sh]]"));
+  });
+
+  it("says so when the repository cannot be listed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: { message: "Repository not found." } }),
+      }),
+    );
+    view();
+
+    await waitFor(() => expect(screen.getByText(/repository not found/i)).toBeTruthy());
+  });
+
+  it("says so when GitHub cannot be reached at all", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    view();
+
+    await waitFor(() => expect(screen.getByText(/could not reach github/i)).toBeTruthy());
+  });
+});

--- a/apps/web/src/components/LinkFileDialog.tsx
+++ b/apps/web/src/components/LinkFileDialog.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Workspace } from "@forkleaf/types";
+import { formatRepoTarget } from "@forkleaf/markdown-engine";
+import { Dialog } from "./Dialog";
+
+/**
+ * Picking a file to link, instead of typing a link to a file.
+ *
+ * The `[[repo:owner/name:path@a1b2c3d]]` syntax is precise, survives in plain
+ * markdown, and is completely unreasonable to expect anybody to type. Worse,
+ * the useful half — pinning the revision you read the file at, which is what
+ * lets the note tell you later that the file moved — requires knowing a commit
+ * SHA you have no way of knowing while writing.
+ *
+ * So: a list of the files in the repository, a filter box, and one click. The
+ * revision is looked up and pinned automatically, because that is the part a
+ * person cannot do and the machine can.
+ */
+
+export interface LinkFileDialogProps {
+  workspace: Workspace;
+  /** Inserts the finished `[[repo:…]]` link into the note. */
+  onInsert: (link: string) => void;
+  onClose: () => void;
+}
+
+/** Files that are not worth offering as documentation targets. */
+const IGNORED = /(^|\/)(\.git|node_modules|\.next|dist|build|coverage)(\/|$)/;
+
+export function LinkFileDialog({ workspace, onInsert, onClose }: LinkFileDialogProps) {
+  const [paths, setPaths] = useState<string[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+  const [pinning, setPinning] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const params = new URLSearchParams({
+          owner: workspace.repo.owner,
+          repo: workspace.repo.repo,
+          branch: workspace.repo.branch,
+          all: "1",
+        });
+
+        const response = await fetch(`/api/gh/tree?${params.toString()}`);
+        const body = await response.json().catch(() => null);
+        if (cancelled) return;
+
+        if (!response.ok) {
+          setError(body?.error?.message ?? "That repository's files could not be listed.");
+          return;
+        }
+
+        const found: string[] = (body?.tree ?? body?.paths ?? [])
+          .map((node: unknown) =>
+            typeof node === "string" ? node : ((node as { path?: string })?.path ?? ""),
+          )
+          .filter((path: string) => path && !IGNORED.test(path));
+
+        setPaths(found.sort((a, b) => a.localeCompare(b)));
+      } catch {
+        setError("Could not reach GitHub to list the files.");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspace.repo.owner, workspace.repo.repo, workspace.repo.branch]);
+
+  const shown = useMemo(() => {
+    if (!paths) return [];
+    const needle = filter.trim().toLowerCase();
+    const matched = needle ? paths.filter((path) => path.toLowerCase().includes(needle)) : paths;
+    // Capped: a repository can hold thousands of files and nobody scrolls past
+    // the first screen — they type instead.
+    return matched.slice(0, 200);
+  }, [paths, filter]);
+
+  /**
+   * Pins the file's current revision, then inserts the link.
+   *
+   * A link that fails to pin is still inserted, unpinned: the reader wanted a
+   * link to a file, and refusing to give them one because the revision lookup
+   * failed would be trading the whole feature for half of it. It just cannot
+   * report staleness until something pins it.
+   */
+  const choose = useCallback(
+    async (path: string) => {
+      setPinning(path);
+
+      let ref: string | null = null;
+      try {
+        const params = new URLSearchParams({
+          owner: workspace.repo.owner,
+          repo: workspace.repo.repo,
+          branch: workspace.repo.branch,
+          path,
+        });
+        const response = await fetch(`/api/gh/file-head?${params.toString()}`);
+        const body = await response.json().catch(() => null);
+        if (response.ok && body?.sha) ref = String(body.sha).slice(0, 7);
+      } catch {
+        // Left unpinned; see above.
+      }
+
+      onInsert(`[[${formatRepoTarget({ owner: null, repo: null, path, ref })}]]`);
+      setPinning(null);
+      onClose();
+    },
+    [workspace.repo, onInsert, onClose],
+  );
+
+  return (
+    <Dialog
+      title="Link a file"
+      subtitle={`A file in ${workspace.repo.owner}/${workspace.repo.repo}, pinned to its current revision`}
+      onClose={onClose}
+    >
+      <div className="space-y-3">
+        <input
+          autoFocus
+          value={filter}
+          onChange={(event) => setFilter(event.target.value)}
+          placeholder="Filter by name or folder…"
+          aria-label="Filter files"
+          className="w-full rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-2 text-[13px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
+        />
+
+        {error && <p className="text-[13px] text-[var(--fl-danger)]">{error}</p>}
+
+        {!paths && !error && (
+          <p className="text-[13px] text-[var(--fl-muted)]">Reading the repository…</p>
+        )}
+
+        {paths && shown.length === 0 && (
+          <p className="text-[13px] text-[var(--fl-muted)]">
+            {filter.trim()
+              ? `Nothing matches “${filter.trim()}”.`
+              : "This repository has no files."}
+          </p>
+        )}
+
+        {shown.length > 0 && (
+          <ul className="max-h-80 divide-y divide-[var(--fl-border)] overflow-y-auto rounded-lg border border-[var(--fl-border)]">
+            {shown.map((path) => (
+              <li key={path}>
+                <button
+                  type="button"
+                  disabled={pinning !== null}
+                  onClick={() => void choose(path)}
+                  className="flex w-full items-baseline justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-[var(--fl-elevated)] disabled:opacity-50"
+                >
+                  <span className="truncate font-mono text-[12.5px] text-[var(--fl-text)]">
+                    {path}
+                  </span>
+                  {pinning === path && (
+                    <span className="shrink-0 text-[11.5px] text-[var(--fl-muted)]">pinning…</span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <p className="text-[11.5px] leading-snug text-[var(--fl-muted)]">
+          The link records the revision the file is at now. When it changes, the Freshness panel
+          says so — which is what turns a paragraph describing a script into one you can trust.
+        </p>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/PublishDialog.tsx
+++ b/apps/web/src/components/PublishDialog.tsx
@@ -85,6 +85,49 @@ export function PublishDialog({
 
   const warning = useMemo(() => targetWarning(target, workspace.repo), [target, workspace.repo]);
 
+  const [creating, setCreating] = useState(false);
+
+  /**
+   * Makes the public repository and points publishing at it, in one go.
+   *
+   * The alternative was four steps on github.com and a name typed back in, to
+   * work around a limit the reader did not choose. Named after the notes
+   * repository, so months later it is obvious which notebook it belongs to.
+   */
+  const createSiteRepo = useCallback(async () => {
+    if (!onSetTarget) return;
+
+    setCreating(true);
+    setTargetError(null);
+
+    try {
+      const response = await fetch("/api/gh/site-repo", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: `${workspace.repo.repo}-site` }),
+      });
+
+      const body = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        setTargetError(body?.error?.message ?? "That repository could not be created.");
+        return;
+      }
+
+      await onSetTarget({
+        owner: String(body.owner),
+        repo: String(body.repo),
+        branch: "main",
+        directory: "",
+      });
+      setEditingTarget(false);
+    } catch {
+      setTargetError("Could not reach GitHub to create the repository.");
+    } finally {
+      setCreating(false);
+    }
+  }, [onSetTarget, workspace.repo.repo]);
+
   const saveTarget = useCallback(async () => {
     if (!onSetTarget) return;
 
@@ -242,6 +285,22 @@ export function PublishDialog({
       )}
 
       {warning && <p className="text-[11.5px] leading-snug text-[var(--fl-muted)]">{warning}</p>}
+
+      {/* The way out, offered rather than described. Only while pages still go
+          to the notes' own repository — once they do not, this is solved and
+          the button would be noise. */}
+      {onSetTarget && !split && (
+        <button
+          type="button"
+          onClick={() => void createSiteRepo()}
+          disabled={creating}
+          className="w-full rounded-lg border border-[var(--fl-border)] px-2.5 py-1.5 text-[12px] text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)] disabled:opacity-50"
+        >
+          {creating
+            ? "Creating…"
+            : `Create ${workspace.repo.owner}/${workspace.repo.repo}-site and publish there`}
+        </button>
+      )}
     </div>
   );
 

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -1431,14 +1431,6 @@ export function EditorWorkspace() {
                 setDrawer(null);
                 setDialog("history");
               }}
-              onReplay={() => {
-                setDrawer(null);
-                setDialog("replay");
-              }}
-              onBlame={() => {
-                setDrawer(null);
-                setDialog("blame");
-              }}
               onReview={
                 workspace && !workspace.isLocal
                   ? () => {

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -29,11 +29,11 @@ import { ExportDialog } from "@/components/ExportDialog";
 import { ConnectRepoDialog } from "@/components/ConnectRepoDialog";
 import { ProposeChangesDialog } from "@/components/ProposeChangesDialog";
 import { PublishDialog } from "@/components/PublishDialog";
-import { formatSource, isCapturable } from "@forkleaf/markdown-engine";
-import { capturePage } from "@/lib/gateway";
 import { HelpDialog } from "@/components/HelpDialog";
 import { HistoryDialog } from "@/components/HistoryDialog";
 import { ReviewPanel } from "@/components/ReviewPanel";
+import { LinkFileDialog } from "@/components/LinkFileDialog";
+import { CaptureDialog } from "@/components/CaptureDialog";
 import { Dialog } from "@/components/Dialog";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
 import { CommandPalette, type Command } from "@/components/CommandPalette";
@@ -108,6 +108,8 @@ export function EditorWorkspace() {
     | "replay"
     | "blame"
     | "review"
+    | "link-file"
+    | "capture"
     | "propose"
     | "publish"
     | null
@@ -887,47 +889,9 @@ export function EditorWorkspace() {
           hint: "Records the address, when you read it, and an archived copy",
           keywords:
             "capture clip source citation cite provenance archive wayback snapshot reference url link web page bookmark",
-          run: () =>
-            setPrompt({
-              title: "Capture a web page",
-              label: "Address",
-              confirmLabel: "Capture",
-              body: "The address, the moment you read it, and an archived copy are written into this note as an ordinary blockquote — so the citation still means something after the page is gone.",
-              onConfirm: async (value) => {
-                const url = value.trim();
-                if (!isCapturable(url)) {
-                  setNotice("That is not a web address ForkLeaf can capture.");
-                  return;
-                }
-
-                try {
-                  const source = await capturePage(url);
-                  // Written through the same save path as any edit, so it is
-                  // committed like anything else the note contains.
-                  const current = notebook.note;
-                  if (!current) return;
-
-                  const separator = current.content.endsWith("\n") ? "\n" : "\n\n";
-                  await notebook.saveNote(
-                    `${current.content}${separator}${formatSource(source)}\n`,
-                  );
-
-                  setNotice(
-                    source.archiveUrl
-                      ? "Captured, with an archived copy."
-                      : "Captured. The archive has no snapshot of that page yet.",
-                  );
-                } catch (error) {
-                  setNotice(
-                    error instanceof Error ? error.message : "That page could not be captured.",
-                  );
-                }
-              },
-            }),
+          run: () => setDialog("capture"),
         });
-      }
 
-      if (localFiles.supported) {
         list.push({
           id: "save-file-as",
           label: "Save this note to a file…",
@@ -980,6 +944,16 @@ export function EditorWorkspace() {
           keywords:
             "blame who wrote when written provenance attribution authorship age stale old paragraph line origin annotate",
           run: () => setDialog("blame"),
+        });
+
+        list.push({
+          id: "link-file",
+          label: "Link a file from this repository…",
+          group: "Notes",
+          hint: "Pick a file; the revision you read it at is pinned for you",
+          keywords:
+            "link file repo repository script code pin revision reference document describes attach",
+          run: () => setDialog("link-file"),
         });
 
         list.push({
@@ -1473,6 +1447,22 @@ export function EditorWorkspace() {
                     }
                   : undefined
               }
+              onLinkFile={
+                workspace && !workspace.isLocal
+                  ? () => {
+                      setDrawer(null);
+                      setDialog("link-file");
+                    }
+                  : undefined
+              }
+              onCapture={
+                user
+                  ? () => {
+                      setDrawer(null);
+                      setDialog("capture");
+                    }
+                  : undefined
+              }
               onPublish={
                 workspace && !workspace.isLocal
                   ? () => {
@@ -1572,6 +1562,35 @@ export function EditorWorkspace() {
             }}
           />
         </Dialog>
+      )}
+
+      {openDialog === "link-file" && workspace && !workspace.isLocal && (
+        <LinkFileDialog
+          workspace={workspace}
+          onClose={() => setDialog(null)}
+          onInsert={(link) => {
+            const current = notebook.note;
+            if (!current) return;
+            // Appended rather than inserted at the caret: the editor owns the
+            // selection and this dialog has taken focus away from it.
+            const separator = current.content.endsWith("\n") ? "" : "\n";
+            void notebook.saveNote(`${current.content}${separator}\n${link}\n`);
+            setNotice("Link added to the end of this note.");
+          }}
+        />
+      )}
+
+      {openDialog === "capture" && user && (
+        <CaptureDialog
+          onClose={() => setDialog(null)}
+          onInsert={async (markdown) => {
+            const current = notebook.note;
+            if (!current) return;
+            const separator = current.content.endsWith("\n") ? "" : "\n";
+            await notebook.saveNote(`${current.content}${separator}\n${markdown}\n`);
+            setNotice("Source added to the end of this note.");
+          }}
+        />
       )}
 
       {showConflicts && (


### PR DESCRIPTION
Everything here came from actually using the app and reporting what broke. Two commits.

**Why a new PR:** these two commits were pushed to the `fix/publish-target-reachable` branch *after* #43 had already merged, so they were stranded. Rebased onto current `main`.

## `a255a0be` — pickers instead of syntax

Both of these features worked and neither was usable.

**Link a file.** Writing `[[repo:owner/name:path@a1b2c3d]]` by hand is unreasonable, and the useful half is *impossible* — pinning the revision you read the file at means knowing a commit SHA while you are writing prose. That pin is the whole point; it is what later lets the note say the file has moved on.

There is now a picker: the repository's files, a filter box, one click. The revision is looked up and pinned automatically, because that is the part a person cannot do and the machine can. Build output and dependency folders are left out.

A file whose revision cannot be read is still linked, unpinned — half the feature beats none of it.

**Capture a page.** This was a bare text prompt. Paste a URL, press enter, and a citation appeared at the end of the note with no sign of what was found — whether the title was read or guessed from the address, whether an archived copy exists, or how old it is. All three change what the citation is worth and all three were invisible until you went looking.

The capture now happens first and is **shown**, and adding it is a separate decision. "The Wayback Machine has no snapshot of this page" is said before you commit it.

**Both were command-palette only**, which means knowing they exist before you can find them. Both now have a button in the properties panel.

## `641d262c` — one history button, a steady window, one-click publishing, docs

**Three buttons → one.** Replay and blame each got their own panel button when they were built, because each had shipped buried in a tab nobody opened. Three buttons opening three tabs of the same window is the opposite mistake: the panel repeats what the window already shows, and the reader has to choose before they are allowed to look. One button now; the tabs do the choosing. The palette still opens each tab directly.

**A window that stops resizing.** The three history tabs differ hugely in height, so switching resized the dialog under the cursor and moved the tabs away from it. That reads as the app breaking. The dialog takes a `steady` height now.

**Publishing from a private notebook, in one click.** GitHub will not serve Pages from a private repository on a free plan and nothing here can change that — but "choose a public repository" meant four steps on github.com and a name typed back in, to work around a limit the reader did not choose. There is now a button that creates it: a public repo named after the notes repo, pointed at, in one press. An existing repo by that name is reused — unless it is private, which is said plainly rather than being the same dead end with an extra step.

**Documented properly.** New page, `/docs/features` — "What notes-as-commits gets you" — walking through all nine features with where each button is, what gets written into the note, and what each needs before it works. Including that **a local `.env.local` never reaches a deployment**, which is the reason runnable blocks appeared broken.

## Verification

`pnpm check` **exit 0** — prettier, 8 typecheck tasks, eslint, **1431 tests across 88 files**, `next build`. Re-run after the rebase, not just before it.

- 15 new tests for the two dialogs (7 capture, 8 file picker).
- The four panel tests that guarded the old three buttons now guard the one, and one asserts replay and blame are **not** repeated as buttons of their own — the mistake this fixes.
- Removing the buttons left their props and glyphs unused; eslint caught it and they are deleted, not suppressed.
- A build failed once for "No space left on device" — the disk was at 100% with 416MB free, of which `.turbo` was 11GB. Cleared, not worked around.

**Not verified in a browser:** the two dialogs and the publish chooser need a connected repository and a signed-in session, and this machine is signed out. That blind spot is what hid these problems in the first place, so the tests stand in for a screenshot rather than my word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)