### PR TITLE
fix: a way out of "nothing to propose", archives that exist, and insert-menu entries

### DIFF
--- a/apps/web/src/app/api/capture/route.test.ts
+++ b/apps/web/src/app/api/capture/route.test.ts
@@ -230,12 +230,62 @@ describe("POST /api/capture — the archived copy", () => {
     expect((await post({ url: "https://example.com/a" })).body.archiveUrl).toMatch(/^https:/);
   });
 
-  it("says there is no snapshot when there is none", async () => {
-    serve({ archive: () => wayback(null) });
+  it("asks for a snapshot to be taken when none exists", async () => {
+    // A citation with no archived copy is an address and a timestamp, which is
+    // what this feature was supposed to improve on.
+    let asked = false;
+    const mock = vi.fn().mockImplementation((input: URL | string) => {
+      const url = String(input);
+      if (url.includes("web.archive.org/save/")) {
+        asked = true;
+        return Promise.resolve(new Response("", { status: 200 }));
+      }
+      if (url.includes("archive.org")) {
+        return Promise.resolve(
+          asked
+            ? wayback({ available: true, url: "http://web.archive.org/web/1/x" })
+            : wayback(null),
+        );
+      }
+      return Promise.resolve(page("<title>A page</title>"));
+    });
+    vi.stubGlobal("fetch", mock);
+
     const { body } = await post({ url: "https://example.com/a" });
 
+    expect(asked).toBe(true);
+    expect(body.archiveUrl).toBe("https://web.archive.org/web/1/x");
+  });
+
+  it("does not ask for one when the archive already has it", async () => {
+    const mock = vi.fn().mockImplementation((input: URL | string) => {
+      const url = String(input);
+      if (url.includes("archive.org")) {
+        return Promise.resolve(wayback({ available: true, url: "http://web.archive.org/web/1/x" }));
+      }
+      return Promise.resolve(page("<title>A page</title>"));
+    });
+    vi.stubGlobal("fetch", mock);
+
+    await post({ url: "https://example.com/a" });
+
+    expect(mock.mock.calls.some(([u]) => String(u).includes("/save/"))).toBe(false);
+  });
+
+  it("still returns the capture when archiving fails outright", async () => {
+    const mock = vi.fn().mockImplementation((input: URL | string) => {
+      const url = String(input);
+      if (url.includes("/save/")) return Promise.reject(new Error("rate limited"));
+      if (url.includes("archive.org")) return Promise.resolve(wayback(null));
+      return Promise.resolve(page("<title>A page</title>"));
+    });
+    vi.stubGlobal("fetch", mock);
+
+    const { status, body } = await post({ url: "https://example.com/a" });
+
+    expect(status).toBe(200);
+    expect(body.title).toBe("A page");
     expect(body.archiveUrl).toBeNull();
-    expect(body.archivedAt).toBeNull();
   });
 
   it("treats an unavailable snapshot as no snapshot", async () => {

--- a/apps/web/src/app/api/capture/route.ts
+++ b/apps/web/src/app/api/capture/route.ts
@@ -28,6 +28,14 @@ const MAX_REDIRECTS = 5;
 const RATE_LIMIT = { name: "capture", limit: 20, windowMs: 5 * 60_000 };
 
 /**
+ * Room for the archive request, which is the slow half.
+ *
+ * The default ceiling is shorter than Save Page Now takes, which would kill
+ * the request mid-archive and report it to the reader as a network error.
+ */
+export const maxDuration = 60;
+
+/**
  * Fetches a URL, re-checking the address at every redirect.
  *
  * `redirect: "manual"` rather than letting fetch follow them: a public URL
@@ -102,13 +110,48 @@ interface Snapshot {
   archivedAt: string | null;
 }
 
+/** How long to wait on Save Page Now before giving up on it. */
+const ARCHIVE_TIMEOUT_MS = 25_000;
+
+/**
+ * Asks archive.org to take a snapshot now, and waits for it.
+ *
+ * Only reached when no snapshot exists, because that is the case where the
+ * citation is worth nothing: an address, a timestamp, and a link that dies
+ * with the page. Save Page Now is slow and rate limited, which is why it is
+ * not the first thing tried — but a capture that ends with "no archived copy"
+ * has not done the one job the feature exists for.
+ *
+ * Failure here is not an error. The capture still returns, and the citation
+ * says plainly that nothing was archived.
+ */
+async function requestSnapshot(url: string): Promise<Snapshot> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ARCHIVE_TIMEOUT_MS);
+
+  try {
+    await fetch(`https://web.archive.org/save/${url}`, {
+      method: "GET",
+      signal: controller.signal,
+      headers: { "user-agent": "ForkLeaf/1.0 (+https://github.com/praneeth132006/ForkLeaf)" },
+      redirect: "follow",
+    });
+
+    // Asked and answered separately: Save Page Now's own response body is not
+    // a stable contract, while the availability API is.
+    return await findSnapshot(url, controller.signal);
+  } catch {
+    return { archiveUrl: null, archivedAt: null };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /**
  * The nearest snapshot archive.org already holds.
  *
- * Only asks — it does not request that a new one be taken. Save Page Now is
- * slow, heavily rate limited, and would make every capture wait on a third
- * party's queue. What comes back is honest either way: a snapshot from three
- * years ago is labelled with its date, and no snapshot says so.
+ * Asked first because it is fast and usually enough. When it comes back empty
+ * the caller asks for one to be made.
  */
 async function findSnapshot(url: string, signal: AbortSignal): Promise<Snapshot> {
   try {
@@ -170,12 +213,17 @@ export async function POST(request: NextRequest) {
 
     try {
       // Together: neither is worth failing the other over.
-      const [page, snapshot] = await Promise.all([
+      const [page, existing] = await Promise.all([
         fetchChecked(url, controller.signal)
           .then((response) => (response && response.ok ? readTitle(response) : null))
           .catch(() => null),
         findSnapshot(url.toString(), controller.signal),
       ]);
+
+      // A citation whose archived copy does not exist is an address and a
+      // timestamp — which is what the feature was supposed to improve on. So
+      // when there is no snapshot, ask for one before giving up.
+      const snapshot = existing.archiveUrl ? existing : await requestSnapshot(url.toString());
 
       return {
         url: url.toString(),

--- a/apps/web/src/components/ProposeChangesDialog.tsx
+++ b/apps/web/src/components/ProposeChangesDialog.tsx
@@ -41,6 +41,15 @@ export interface ProposeChangesDialogProps {
    * continued editing keeps landing on the same pull request.
    */
   onSwitchBranch: (branch: string, repo?: { owner: string; repo: string }) => void | Promise<void>;
+  /**
+   * Turns auto-save off, so edits queue up instead of landing on the branch.
+   *
+   * Passed in because the only way out of "there is nothing to propose" is to
+   * stop committing straight to the base branch, and sending somebody to hunt
+   * for a control in the status bar to do it is not a way out, it is a
+   * scavenger hunt.
+   */
+  onUseManualSaving?: () => void | Promise<void>;
 }
 
 type Stage = "form" | "working" | "done";
@@ -66,6 +75,7 @@ export function ProposeChangesDialog({
   onProposed,
   onClose,
   onSwitchBranch,
+  onUseManualSaving,
 }: ProposeChangesDialogProps) {
   const [branches, setBranches] = useState<BranchSummaryDto[] | null>(null);
   const [base, setBase] = useState(workspace.repo.branch);
@@ -254,10 +264,19 @@ export function ProposeChangesDialog({
                 <span className="font-mono">{base}</span> does not have yet.
               </p>
               <p className="mt-2 text-[var(--fl-muted)]">
-                To propose work instead of committing it directly: set auto-save to{" "}
-                <strong className="font-medium text-[var(--fl-text)]">Manual</strong> in the status
-                bar at the bottom, make your edits, then come back here.
+                To propose work instead of committing it directly, stop auto-saving first. Then edit
+                the note and come back — those edits become the pull request.
               </p>
+
+              {onUseManualSaving && (
+                <button
+                  type="button"
+                  onClick={() => void onUseManualSaving()}
+                  className="fl-btn fl-btn-primary mt-3 w-full"
+                >
+                  Stop auto-saving and let me propose changes
+                </button>
+              )}
             </div>
           )}
 

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -763,6 +763,46 @@ export function EditorWorkspace() {
    * Everything here is reachable by mouse somewhere else too — the palette is a
    * faster route to existing actions, not a second place where features live.
    */
+  /**
+   * The two actions that belong in the "/" menu and the toolbar but cannot
+   * live in the editor package: one has to list the repository, the other has
+   * to fetch a web page. Gated exactly as their panel buttons are.
+   */
+  const editorExtras = useMemo(() => {
+    const list: { id: string; label: string; hint: string; icon: React.ReactNode }[] = [];
+
+    if (workspace && !workspace.isLocal) {
+      list.push({
+        id: "link-file",
+        label: "Link a file",
+        hint: "A file in this repository, pinned to the revision you read",
+        icon: (
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
+            <path d="M9 1.5H4a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V5.5Z" />
+            <path d="M9 1.5v4h4" />
+          </svg>
+        ),
+      });
+    }
+
+    if (user) {
+      list.push({
+        id: "capture",
+        label: "Web source",
+        hint: "A page with its address, the time you read it, and an archived copy",
+        icon: (
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
+            <path d="M4 2h6a1 1 0 0 1 1 1v5.5" />
+            <path d="M4 2v11l3-2.2" strokeLinecap="round" />
+            <circle cx="11" cy="11" r="3.2" />
+          </svg>
+        ),
+      });
+    }
+
+    return list;
+  }, [workspace, user]);
+
   const commands = useMemo<Command[]>(() => {
     const list: Command[] = [
       {
@@ -1386,6 +1426,8 @@ export function EditorWorkspace() {
             {note ? (
               <MarkdownEditor
                 key={note.id}
+                extraActions={editorExtras}
+                onExtraAction={(id) => setDialog(id === "link-file" ? "link-file" : "capture")}
                 value={note.content}
                 onChange={notebook.saveNote}
                 mode={mode}
@@ -1636,6 +1678,10 @@ export function EditorWorkspace() {
           onProposed={notebook.discardPending}
           onClose={() => setDialog(null)}
           onSwitchBranch={notebook.switchBranch}
+          onUseManualSaving={() => {
+            notebook.setSyncMode("manual");
+            setNotice("Auto-save is off. Edit the note, then open Propose changes again.");
+          }}
         />
       )}
 

--- a/packages/editor/src/MarkdownEditor.tsx
+++ b/packages/editor/src/MarkdownEditor.tsx
@@ -17,10 +17,21 @@ import { insertActionsFor, runRichAction, runSourceAction } from "./insert-actio
 import { isolateCurrentLine } from "./isolate-line";
 import { ImageDialog } from "./ui/ImageDialog";
 import { LinkDialog } from "./ui/LinkDialog";
+import type { InsertAction } from "./EditorToolbar";
 import type { ImageBridge } from "./images";
 import type { LinkBridge } from "./links";
 
 export interface MarkdownEditorProps {
+  /**
+   * Actions the app adds to the "/" menu and the toolbar.
+   *
+   * The editor shows them and reports which was chosen; it does not know how
+   * to run them. That is the point — linking a repository file needs the
+   * repository, which is not the editor's to have.
+   */
+  extraActions?: InsertAction[];
+  /** Told which app-supplied action was chosen. */
+  onExtraAction?: (id: string) => void;
   value: string;
   onChange: (markdown: string) => void;
   mode: EditorViewMode;
@@ -67,6 +78,8 @@ const MODES: { value: EditorViewMode; label: string; hint: string }[] = [
  * whether you are in rich text or staring at raw markdown.
  */
 export function MarkdownEditor({
+  extraActions,
+  onExtraAction,
   value,
   onChange,
   mode,
@@ -263,13 +276,20 @@ export function MarkdownEditor({
 
   const runAction = useCallback(
     (id: string) => {
+      // An app-supplied action is the app's to run; the editor only knows it
+      // was chosen.
+      if (extraActions?.some((action) => action.id === id)) {
+        onExtraAction?.(id);
+        return;
+      }
+
       if (isRich) {
         if (tiptap) runRichAction(tiptap, id, actionContext);
       } else {
         runSourceAction(sourceHandle.current, id, actionContext);
       }
     },
-    [isRich, tiptap, actionContext],
+    [isRich, tiptap, actionContext, extraActions, onExtraAction],
   );
 
   const applyLink = useCallback(
@@ -310,7 +330,18 @@ export function MarkdownEditor({
 
   // Rich text and raw Markdown can hold different things, so the toolbar shows
   // only what the surface underneath it can actually apply.
-  const actions = useMemo(() => insertActionsFor(isRich ? "rich" : "source"), [isRich]);
+  /**
+   * The surface's own actions, plus any the app supplies.
+   *
+   * Some things worth reaching from the "/" menu and the toolbar need more
+   * than the editor has: linking a repository file has to list the
+   * repository, and capturing a page has to fetch it. Those live in the app,
+   * so it hands them over here and gets told by id when one is chosen.
+   */
+  const actions = useMemo(
+    () => [...insertActionsFor(isRich ? "rich" : "source"), ...(extraActions ?? [])],
+    [isRich, extraActions],
+  );
 
   const resolveImageSrc = images?.resolve;
 


### PR DESCRIPTION
Three problems, all reported from using the app.

## 1. You could not open a pull request at all

The propose dialog said *"there is nothing to propose yet"*, explained that auto-save had already pushed everything to `main`, and then told you to go find a control in the status bar, switch it, come back, and try again.

That is not a way out — it is a scavenger hunt, and it was the only path to a feature the app advertises.

**There is now a button in that dialog that does it:** *"Stop auto-saving and let me propose changes"*. One press, with a note saying what to do next. The explanation got shorter because the button says most of it.

## 2. A citation with no archived copy is worthless

Capture asked archive.org *whether* a snapshot existed and, when none did, wrote "no archived copy — this link may not outlive the page" and called it done. Honest, and useless: an address and a timestamp is exactly what this feature was meant to improve on. That is the screenshot that prompted this.

**It now asks archive.org to take one.** Save Page Now is slow and rate limited, which is why it is not tried first — but reaching the end of a capture with nothing archived means the one job did not get done.

If the request fails the capture still returns, and the citation still says plainly that nothing was archived. `maxDuration` is raised for that route, because the default ceiling is shorter than Save Page Now takes and would have killed the request mid-archive and reported it as a network error.

## 3. Linking a file was in the wrong place

It was in the properties panel — the wrong side of the screen from the sentence you are writing. Both it and capturing a page are now in the **`/` menu** and the toolbar's **More** section, where you insert things.

Neither can live in the editor package — one has to list a repository, the other has to fetch a web page — so the editor now takes actions from the app, shows them, and reports which was chosen. It does not learn how to run them, which is the point.

## Verification

`pnpm check` **exit 0** — prettier, 8 typecheck tasks, eslint, **1446 tests across 89 files**, `next build`.

Two mistakes of my own on the way, both caught by tooling rather than by me: a prop wired to a memo that had not been written yet (eslint, unused value), and a local action type with `hint` optional where the editor's is required (typecheck).

**Not verified in a browser:** all three need a connected repository and a signed-in session; this machine is signed out. The archive behaviour is covered by three new tests, including the request being made only when no snapshot exists.

## Still true, and not something I can change

GitHub will not serve Pages from a **private** repository on a free plan. The one-click *"Create …-site and publish there"* button (merged in #44, live now) makes the way around it one press — it creates a public repo and points publishing at it. If that button is not showing for you, tell me and I will look at why rather than guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)