### PR TITLE
fix(publish): the button that says "and publish there" now publishes there

### DIFF
--- a/apps/web/src/components/PublishDialog.test.tsx
+++ b/apps/web/src/components/PublishDialog.test.tsx
@@ -11,6 +11,14 @@ vi.mock("@/lib/gateway", () => ({
   unpublishNote: vi.fn(),
 }));
 
+vi.stubGlobal(
+  "fetch",
+  vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ owner: "me", repo: "forkleaf-notes-site", created: true }),
+  }),
+);
+
 vi.mock("@forkleaf/exporter", () => ({ toHtml: () => "<html></html>" }));
 
 afterEach(cleanup);
@@ -132,6 +140,38 @@ describe("PublishDialog — choosing where pages go", () => {
 
     expect(screen.getByText("Pages go to")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /use another repository/i })).toBeNull();
+  });
+
+  it("creates the public repository and publishes into it, in one press", async () => {
+    // The button says "and publish there". Setting the target and leaving the
+    // reader looking at the same failure is how this looked broken.
+    const { publishNote } = await import("@/lib/gateway");
+    vi.mocked(publishNote).mockResolvedValue({
+      url: "https://me.github.io/forkleaf-notes-site/recon.html",
+      siteUrl: "https://me.github.io/forkleaf-notes-site",
+      status: "building",
+      path: "docs/recon.html",
+    });
+
+    const onSetTarget = vi.fn();
+    view({ onSetTarget });
+
+    fireEvent.click(screen.getByRole("button", { name: /create .*-site and publish there/i }));
+
+    await waitFor(() =>
+      expect(onSetTarget).toHaveBeenCalledWith(
+        expect.objectContaining({ owner: "me", repo: "forkleaf-notes-site" }),
+      ),
+    );
+
+    // Into the repository it just made, not the one the closure still holds.
+    await waitFor(() =>
+      expect(publishNote).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repo: expect.objectContaining({ repo: "forkleaf-notes-site" }),
+        }),
+      ),
+    );
   });
 
   it("points at the fix when GitHub refuses for want of a paid plan", async () => {

--- a/apps/web/src/components/PublishDialog.tsx
+++ b/apps/web/src/components/PublishDialog.tsx
@@ -85,7 +85,58 @@ export function PublishDialog({
 
   const warning = useMemo(() => targetWarning(target, workspace.repo), [target, workspace.repo]);
 
+  const title = useMemo(() => deriveTitle(note.content, note.frontmatter.title, note.path), [note]);
+  const slug = useMemo(
+    () => slugifyFilename(stripExtension(note.path.split("/").pop() ?? "note")),
+    [note.path],
+  );
+
   const [creating, setCreating] = useState(false);
+
+  const [stage, setStage] = useState<Stage>("idle");
+  const [step, setStep] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{ url: string | null; status: string | null } | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  /**
+   * Publishes into a named repository.
+   *
+   * Takes the repository rather than reading `target` from the closure,
+   * because the one caller that matters most has just changed it: creating the
+   * public site repository and then publishing into `target` would publish
+   * into the old one, since state does not update until the next render.
+   */
+  const publishTo = useCallback(
+    async (repo: RepoRef) => {
+      setStage("working");
+      setError(null);
+
+      try {
+        setStep("Rendering the page…");
+        const html = await toHtml(note.content, note.frontmatter, {
+          format: "html",
+          title,
+          includeFrontmatter: false,
+          renderDiagrams: true,
+          theme: "light",
+        });
+
+        setStep("Committing it to your repository…");
+        const result = await publishNote({ repo, slug, html, title });
+
+        setResult({ url: result.url, status: result.status });
+        setStage("idle");
+        await onChanged?.();
+      } catch (problem) {
+        setError(messageFor(problem));
+        setStage("idle");
+      }
+    },
+    [note, title, slug, onChanged],
+  );
+
+  const publish = useCallback(() => publishTo(target), [publishTo, target]);
 
   /**
    * Makes the public repository and points publishing at it, in one go.
@@ -114,19 +165,26 @@ export function PublishDialog({
         return;
       }
 
-      await onSetTarget({
+      const created: RepoRef = {
         owner: String(body.owner),
         repo: String(body.repo),
         branch: "main",
         directory: "",
-      });
+      };
+
+      await onSetTarget(created);
       setEditingTarget(false);
+
+      // The button says "and publish there", so it publishes there. Setting
+      // the target and leaving the reader looking at the same failure, with a
+      // second button to find, is how this looked broken the first time.
+      await publishTo(created);
     } catch {
       setTargetError("Could not reach GitHub to create the repository.");
     } finally {
       setCreating(false);
     }
-  }, [onSetTarget, workspace.repo.repo]);
+  }, [onSetTarget, workspace.repo.repo, publishTo]);
 
   const saveTarget = useCallback(async () => {
     if (!onSetTarget) return;
@@ -150,18 +208,6 @@ export function PublishDialog({
     setTargetError(null);
   }, [onSetTarget, targetDraft]);
 
-  const title = useMemo(() => deriveTitle(note.content, note.frontmatter.title, note.path), [note]);
-  const slug = useMemo(
-    () => slugifyFilename(stripExtension(note.path.split("/").pop() ?? "note")),
-    [note.path],
-  );
-
-  const [stage, setStage] = useState<Stage>("idle");
-  const [step, setStep] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<{ url: string | null; status: string | null } | null>(null);
-  const [copied, setCopied] = useState(false);
-
   /**
    * What to show: what this dialog just did, else what was already true.
    *
@@ -179,32 +225,6 @@ export function PublishDialog({
     () => result ?? (published ? { url: published.url, status: "built" as string | null } : null),
     [result, published],
   );
-
-  const publish = useCallback(async () => {
-    setStage("working");
-    setError(null);
-
-    try {
-      setStep("Rendering the page…");
-      const html = await toHtml(note.content, note.frontmatter, {
-        format: "html",
-        title,
-        includeFrontmatter: false,
-        renderDiagrams: true,
-        theme: "light",
-      });
-
-      setStep("Committing it to your repository…");
-      const result = await publishNote({ repo: target, slug, html, title });
-
-      setResult({ url: result.url, status: result.status });
-      setStage("idle");
-      await onChanged?.();
-    } catch (problem) {
-      setError(messageFor(problem));
-      setStage("idle");
-    }
-  }, [note, title, slug, target, onChanged]);
 
   const unpublish = useCallback(async () => {
     setStage("working");


### PR DESCRIPTION
Your screenshot showed the bug exactly: **"Published"**, the page committed to `docs/untitled-note-4.html`, the *"Create praneeth132006/forkleaf-notes-site and publish there"* button sitting right there — and the same red **"Your current plan does not support GitHub Pages for this repository"** underneath it.

## What was wrong

The button created the public repository, pointed publishing at it, and **stopped**. You were left looking at the same failure you pressed it to escape, with a second button to find. The label promised something the code did not do, which is why it read as broken rather than half-finished.

It now creates the repository, points publishing at it, **and publishes**, in one press.

## Why it did not

A closure. `publish` read the target from component state, and state does not update until the next render — so publishing straight after setting it would have published into the *old* repository anyway. Publishing now takes the repository explicitly, and the caller that just created one passes it in.

Reordering the component to allow that tripped two React Compiler rules, and both were real: a callback reading state declared below it, and memoisation that could no longer be preserved. My reordering, not the rules being fussy.

## What this does not change

GitHub still will not serve Pages from a **private** repository on a free plan. That is their limit. This makes the way around it actually work in one press instead of three.

## Verification

`pnpm check` **exit 0** — prettier, 8 typecheck tasks, eslint, **1447 tests across 89 files**, `next build`. Re-run after the rebase.

**1 new test**: the repository created, the target set to it, and the page published *into the repository just made* rather than the one the closure still held — the bug itself.

**Not verified in a browser:** the dialog needs a connected repository and a signed-in session; this machine is signed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)