### PR TITLE
fix: links you can open, and one repository listed once

### DIFF
--- a/apps/web/src/app/api/link-preview/route.test.ts
+++ b/apps/web/src/app/api/link-preview/route.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const session = vi.fn().mockResolvedValue({ token: "t", user: { login: "me" } });
+vi.mock("@/lib/session", () => ({ getSession: () => session() }));
+
+// Every hostname resolves to one public address unless a test says otherwise.
+const lookup = vi.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+vi.mock("node:dns/promises", () => ({ lookup: (...args: unknown[]) => lookup(...args) }));
+
+const { GET } = await import("./route");
+const { resetRateLimits } = await import("@/lib/rate-limit");
+
+function page(html: string, init: { status?: number; headers?: Record<string, string> } = {}) {
+  return new Response(html, {
+    status: init.status ?? 200,
+    headers: { "content-type": "text/html", ...init.headers },
+  });
+}
+
+function serve(respond: () => Response | Promise<Response>) {
+  const mock = vi.fn().mockImplementation(() => Promise.resolve(respond()));
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+async function get(url: string, ip = "preview-test") {
+  const response = await GET(
+    new Request(`http://localhost/api/link-preview?url=${encodeURIComponent(url)}`, {
+      headers: { "x-forwarded-for": ip },
+    }) as never,
+  );
+  return { status: response.status, body: await response.json() };
+}
+
+beforeEach(() => {
+  resetRateLimits();
+  session.mockResolvedValue({ token: "t", user: { login: "me" } });
+  lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("GET /api/link-preview — what it refuses to fetch", () => {
+  it("refuses an address that resolves inside the network it runs in", async () => {
+    // The whole reason this is a server route and not a fetch from the page.
+    lookup.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+    const fetchMock = serve(() => page("<title>Nope</title>"));
+
+    const { status } = await get("http://metadata.example/latest");
+
+    expect(status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a scheme that is not http", async () => {
+    const { status } = await get("file:///etc/passwd");
+    expect(status).toBe(400);
+  });
+
+  it("asks for a sign-in rather than fetching for anyone who asks", async () => {
+    session.mockResolvedValue(null);
+    const fetchMock = serve(() => page("<title>A page</title>"));
+
+    const { status } = await get("https://example.com/a");
+
+    expect(status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/link-preview — reading the page", () => {
+  it("reads the title and the page's own description", async () => {
+    serve(() =>
+      page(
+        `<html><head><title>breach-parse</title>
+         <meta name="description" content="A tool for parsing breached passwords">
+         </head><body>ignored</body></html>`,
+      ),
+    );
+
+    const { body } = await get("https://github.com/hmaverickadams/breach-parse");
+
+    expect(body.title).toBe("breach-parse");
+    expect(body.description).toBe("A tool for parsing breached passwords");
+    expect(body.host).toBe("github.com");
+  });
+
+  it("prefers the OpenGraph title, which is written for exactly this", async () => {
+    serve(() =>
+      page(
+        `<head><title>GitHub - hmaverickadams/breach-parse</title>
+         <meta property="og:title" content="breach-parse"></head>`,
+      ),
+    );
+
+    expect((await get("https://github.com/x")).body.title).toBe("breach-parse");
+  });
+
+  it("reads a meta tag whose content comes before its key", async () => {
+    // Legal, common, and missed by a pattern that expects the key first.
+    serve(() => page(`<head><meta content="Written backwards" property="og:description"></head>`));
+
+    expect((await get("https://example.com/a")).body.description).toBe("Written backwards");
+  });
+
+  it("decodes the entities that appear in real titles", async () => {
+    serve(() => page("<head><title>Tips &amp; tricks &#8212; part 1</title></head>"));
+
+    expect((await get("https://example.com/a")).body.title).toBe("Tips & tricks — part 1");
+  });
+
+  it("still answers with the host when the page cannot be read", async () => {
+    // An empty card would read as the feature being broken rather than as the
+    // page being unreachable.
+    serve(() => Promise.reject(new Error("connection refused")));
+
+    const { status, body } = await get("https://example.com/gone");
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ title: null, description: null, host: "example.com" });
+  });
+
+  it("does not try to read a response that is not html", async () => {
+    serve(() => new Response("%PDF-1.7", { headers: { "content-type": "application/pdf" } }));
+
+    expect((await get("https://example.com/a.pdf")).body.title).toBeNull();
+  });
+
+  it("never returns an image, so nothing in a card fetches from the page's host", async () => {
+    serve(() => page(`<head><meta property="og:image" content="https://tracker.example/px.png">`));
+
+    const { body } = await get("https://example.com/a");
+    expect(JSON.stringify(body)).not.toContain("tracker.example");
+  });
+});
+
+describe("GET /api/link-preview — redirects", () => {
+  it("re-checks the address at every hop", async () => {
+    // A public URL that redirects inward is the way past a one-shot check.
+    lookup
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+      .mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+    serve(
+      () => new Response(null, { status: 302, headers: { location: "http://localhost/admin" } }),
+    );
+
+    expect((await get("https://example.com/redirect")).body.title).toBeNull();
+  });
+});
+
+describe("GET /api/link-preview — rate limiting", () => {
+  it("stops one client reading pages without end", async () => {
+    serve(() => page("<title>A page</title>"));
+
+    let refused = 0;
+    for (let attempt = 0; attempt < 125; attempt += 1) {
+      const { status } = await get(`https://example.com/${attempt}`, "flooder");
+      if (status === 429) refused += 1;
+    }
+
+    expect(refused).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/app/api/link-preview/route.ts
+++ b/apps/web/src/app/api/link-preview/route.ts
@@ -1,0 +1,204 @@
+import { type NextRequest } from "next/server";
+import { handle, ApiError } from "@/lib/api-helpers";
+import { getSession } from "@/lib/session";
+import { enforceRateLimit } from "@/lib/rate-limit";
+import { assertPublicUrl, UnsafeUrlError } from "@/lib/safe-fetch";
+
+/**
+ * What is on the other end of a link, in one line, for a hover card.
+ *
+ * A note is full of addresses, and an address is not a description: deciding
+ * whether to follow `https://github.com/hmaverickadams/breach-parse` used to
+ * mean following it. This reads the head of the document and answers with its
+ * title and its own summary of itself, which is enough to decide from.
+ *
+ * Deliberately narrower than `/api/capture`, which this is not a second copy
+ * of: no archiving, no snapshot lookup, a shorter timeout and a much smaller
+ * read, because this fires on hover and has to be cheap. It also returns text
+ * only — never an image URL. A remote image in a card would mean the reader's
+ * browser fetching from whatever host a note links to, which is a tracking
+ * pixel with extra steps, and our own CSP would refuse to load it anyway.
+ *
+ * Signed in only, and rate limited: it fetches an address the caller chose, so
+ * it is exactly the shape of thing that gets pointed at somebody else's server
+ * in bulk. Every address is resolved and checked first — see `lib/safe-fetch`.
+ */
+
+/** Short: a hover card that arrives late is a hover card nobody sees. */
+const FETCH_TIMEOUT_MS = 6_000;
+
+/** Titles and meta descriptions live at the top of the document. */
+const MAX_HTML_BYTES = 128 * 1024;
+
+/** Redirect hops followed, each one re-checked before it is taken. */
+const MAX_REDIRECTS = 3;
+
+/**
+ * Generous, because a note being read is a note whose links are being hovered.
+ * Answers are cached by the browser and by the client, so this is a ceiling on
+ * distinct links, not on hovers.
+ */
+const RATE_LIMIT = { name: "link-preview", limit: 120, windowMs: 5 * 60_000 };
+
+/**
+ * Fetches a URL, re-checking the address at every redirect.
+ *
+ * `redirect: "manual"` rather than letting fetch follow them: a public URL
+ * that 302s to `http://169.254.169.254` would otherwise sail straight past the
+ * check that was the entire point of doing this server-side.
+ */
+async function fetchChecked(start: URL, signal: AbortSignal): Promise<Response | null> {
+  let url = start;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    const response = await fetch(url, {
+      signal,
+      redirect: "manual",
+      headers: {
+        "user-agent": "ForkLeaf/1.0 (+https://github.com/praneeth132006/ForkLeaf)",
+        accept: "text/html,application/xhtml+xml",
+      },
+    });
+
+    if (response.status < 300 || response.status >= 400) return response;
+
+    const location = response.headers.get("location");
+    if (!location) return response;
+
+    url = await assertPublicUrl(new URL(location, url).toString());
+  }
+
+  return null;
+}
+
+/** The head of an HTML document, and no more of it than that. */
+async function readHead(response: Response): Promise<string | null> {
+  const type = response.headers.get("content-type") ?? "";
+  if (!type.includes("html")) return null;
+
+  const reader = response.body?.getReader();
+  if (!reader) return null;
+
+  const decoder = new TextDecoder();
+  let html = "";
+
+  try {
+    while (html.length < MAX_HTML_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      html += decoder.decode(value, { stream: true });
+      // The body can be megabytes and holds nothing this route wants.
+      if (/<\/head>/i.test(html)) break;
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+
+  return html;
+}
+
+/** Entities that appear in real titles. Not a parser, and does not need to be. */
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#(\d{1,6});/g, (_whole, code: string) => String.fromCodePoint(Number(code)));
+}
+
+function tidy(text: string, limit: number): string | null {
+  const cleaned = decodeEntities(text).replace(/\s+/g, " ").trim();
+  return cleaned ? cleaned.slice(0, limit) : null;
+}
+
+/**
+ * One `<meta>` value, by `name` or `property`, in whichever order they appear.
+ *
+ * Written as one pass over the tags rather than as an attribute-ordered
+ * pattern: `<meta content="…" property="og:title">` is legal, common, and does
+ * not match a pattern that expects the key first.
+ */
+function metaContent(head: string, keys: string[]): string | null {
+  const wanted = new Set(keys.map((key) => key.toLowerCase()));
+
+  for (const tag of head.match(/<meta\b[^>]*>/gi) ?? []) {
+    const key = /\b(?:property|name)\s*=\s*["']([^"']+)["']/i.exec(tag)?.[1]?.toLowerCase();
+    if (!key || !wanted.has(key)) continue;
+
+    const content = /\bcontent\s*=\s*["']([^"']*)["']/i.exec(tag)?.[1];
+    const value = content ? tidy(content, 300) : null;
+    if (value) return value;
+  }
+
+  return null;
+}
+
+export interface LinkPreview {
+  url: string;
+  /** The page's own name for itself; null when it could not be read. */
+  title: string | null;
+  /** Its own one-line summary, when it offers one. */
+  description: string | null;
+  /** Where it lives, which is the part that is always known. */
+  host: string;
+}
+
+export async function GET(request: NextRequest) {
+  return handle(async () => {
+    // A session, not a GitHub client: nothing here talks to GitHub, and a
+    // reader whose token has expired should still get hover cards.
+    if (!(await getSession())) {
+      throw new ApiError(401, "unauthorized", "Sign in to preview links.");
+    }
+
+    enforceRateLimit(request, RATE_LIMIT);
+
+    const asked = new URL(request.url).searchParams.get("url") ?? "";
+    if (!asked) throw new ApiError(400, "validation", "A web address is required.");
+
+    let url: URL;
+    try {
+      url = await assertPublicUrl(asked);
+    } catch (error) {
+      throw new ApiError(
+        400,
+        "validation",
+        error instanceof UnsafeUrlError ? error.message : "That address cannot be previewed.",
+      );
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+      const head = await fetchChecked(url, controller.signal)
+        .then((response) => (response && response.ok ? readHead(response) : null))
+        .catch(() => null);
+
+      // A page that could not be read is still worth a card: the host and the
+      // path are what the reader is deciding from either way, and an empty
+      // card would read as the feature being broken rather than as the page
+      // being unreachable.
+      const preview: LinkPreview = {
+        url: url.toString(),
+        title: head
+          ? (metaContent(head, ["og:title", "twitter:title"]) ??
+            tidy(/<title[^>]*>([\s\S]*?)<\/title>/i.exec(head)?.[1] ?? "", 200))
+          : null,
+        description: head
+          ? metaContent(head, ["description", "og:description", "twitter:description"])
+          : null,
+        host: url.host,
+      };
+
+      return preview;
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+}

--- a/apps/web/src/app/docs/content/features.tsx
+++ b/apps/web/src/app/docs/content/features.tsx
@@ -131,6 +131,12 @@ hello world
         Afterwards, the <strong>Freshness</strong> section of the properties panel lists the files
         this note links to and whether each has changed since.
       </P>
+      <P>
+        Click the link — or the file&rsquo;s name in the Freshness list — to read it without leaving
+        the note. It opens at the revision the link pinned, not at whatever the branch holds now,
+        which is what lets you see what the note was actually written about. Markdown is rendered;
+        anything else is shown as highlighted source, with a way through to github.com.
+      </P>
 
       <H2 id="freshness">7. Finding notes that have gone off</H2>
       <P>

--- a/apps/web/src/app/docs/content/features.tsx
+++ b/apps/web/src/app/docs/content/features.tsx
@@ -205,6 +205,19 @@ hello world
         If there is no archived copy, the citation says so rather than staying quiet — you should
         know that link may not outlive the page.
       </P>
+      <P>
+        Links written this way — or typed, or pasted — open in a new tab, from the preview and from
+        Rich view alike, so following one never takes an unsaved note with it. In Rich view, where a
+        click also has to be able to place the cursor, <strong>Alt-click</strong> puts the caret
+        inside the link text instead of opening it.
+      </P>
+      <P>
+        Hovering a link shows a small card naming the host, the page&rsquo;s own title and its own
+        one-line summary — enough to decide whether to follow it. The page is read on the server,
+        the same way capturing reads one, so it needs you to be signed in; signed out the card still
+        names the host and the full address. Nothing in the card is loaded from the linked site, so
+        hovering a link never tells that site you did.
+      </P>
       <Note>
         Capturing needs you to be signed in, because the fetch happens on the server. It refuses
         addresses that resolve inside a private network, which is why it cannot capture a page on

--- a/apps/web/src/app/docs/content/github.tsx
+++ b/apps/web/src/app/docs/content/github.tsx
@@ -274,6 +274,14 @@ export function Repositories() {
         Opening a pull request instead of committing directly is not currently supported. It is a
         commonly requested feature and it is tracked in the repository&rsquo;s issues.
       </P>
+      <P>
+        Switching branch from the status bar moves the workspace across: open notes are closed,
+        because their content and base revisions belong to the branch you left, and the file tree
+        and every note are re-read from the branch you moved to. The repository is still listed once
+        in the switcher — a branch is not a second connection to the same repository. The one
+        exception is a branch you left with edits that never reached GitHub: that stays listed on
+        its own, because the writing only exists on this device and closing it away would lose it.
+      </P>
 
       <H2 id="layout">What the repository looks like</H2>
       <Pre label="forkleaf-notes/">{`README.md

--- a/apps/web/src/components/EditorRightPanel.tsx
+++ b/apps/web/src/components/EditorRightPanel.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useMemo, useState } from "react";
 import type { Note, NoteFrontmatter, SyncMode, Workspace } from "@forkleaf/types";
-import type { LinkRef } from "@forkleaf/markdown-engine";
+import type { LinkRef, RepoTarget } from "@forkleaf/markdown-engine";
 import { extractOutline, documentStats, serializeDocument } from "@forkleaf/markdown-engine";
 import { exportNote, printToPdf, downloadResult } from "@forkleaf/exporter";
 import { exportImageResolver } from "@/lib/export-images";
@@ -37,6 +37,8 @@ export interface EditorRightPanelProps {
   onReview?: () => void;
   /** Opens the file picker; absent for a workspace with no repository. */
   onLinkFile?: () => void;
+  /** Reads a linked file in place, rather than sending the reader to github.com. */
+  onOpenFile?: (target: RepoTarget) => void;
   /** Opens the capture dialog; absent when signed out. */
   onCapture?: () => void;
   /** Opens the publish dialog. Absent for a workspace with no repository. */
@@ -107,6 +109,7 @@ export function EditorRightPanel({
   onShowHistory,
   onReview,
   onLinkFile,
+  onOpenFile,
   onCapture,
   onRewrite,
   onPublish,
@@ -517,6 +520,7 @@ export function EditorRightPanel({
                   updatedAt={note.updatedAt ?? null}
                   repo={workspace && !workspace.isLocal ? workspace.repo : null}
                   onChange={onRewrite}
+                  {...(onOpenFile ? { onOpenFile } : {})}
                 />
               </Section>
             )}
@@ -863,16 +867,31 @@ function LinkGlyph() {
   );
 }
 
-/** A page with a link on it — a file, pointed at. */
+/**
+ * A page with a link on it — a file, pointed at.
+ *
+ * Drawn on `FileGlyph`'s outline, deliberately: these two sit in the same
+ * column of the same menu, and the file icon that meant "export a file" and
+ * the one that meant "link a file" used to be different sizes, different
+ * stroke weights and different shapes. The chain link is the only thing that
+ * distinguishes them, which is the only thing that differs.
+ */
 function FileLinkGlyph() {
   return (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
-      <path d="M9 1.5H4a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V5.5Z" />
-      <path d="M9 1.5v4h4" />
-      <path
-        d="M6.5 10.5a1.5 1.5 0 0 1 1.5-1.5h.5M9.5 10.5A1.5 1.5 0 0 1 8 12h-.5"
-        strokeLinecap="round"
-      />
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M9 1.75H4.5A1.75 1.75 0 0 0 2.75 3.5v9c0 .97.78 1.75 1.75 1.75h7a1.75 1.75 0 0 0 1.75-1.75V6z" />
+      <path d="M9 1.75V6h4.25" />
+      <path d="M7.1 11.4a1.2 1.2 0 0 0 1.7.1l.9-.9a1.2 1.2 0 0 0-1.7-1.7l-.4.4" />
+      <path d="M8.4 10.1a1.2 1.2 0 0 0-1.7-.1l-.9.9a1.2 1.2 0 0 0 1.7 1.7l.4-.4" />
     </svg>
   );
 }
@@ -880,11 +899,20 @@ function FileLinkGlyph() {
 /** A bookmark with a clock — a page, kept at a moment. */
 function CaptureGlyph() {
   return (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
-      <path d="M4 2h6a1 1 0 0 1 1 1v5.5" />
-      <path d="M4 2v11l3-2.2" strokeLinecap="round" />
-      <circle cx="11" cy="11" r="3.2" />
-      <path d="M11 9.6V11l1 .8" strokeLinecap="round" />
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3.75 2.75h6.5a1 1 0 0 1 1 1V7" />
+      <path d="M3.75 2.75v10.5L6.5 11.2" />
+      <circle cx="11" cy="11" r="3" />
+      <path d="M11 9.6v1.5l1 .7" />
     </svg>
   );
 }

--- a/apps/web/src/components/LinkHoverCard.test.tsx
+++ b/apps/web/src/components/LinkHoverCard.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+const previewLink = vi.fn();
+vi.mock("@/lib/gateway", () => ({ previewLink: (url: string) => previewLink(url) }));
+
+const { LinkHoverCard } = await import("./LinkHoverCard");
+
+const PREVIEW = {
+  url: "https://github.com/hmaverickadams/breach-parse",
+  title: "breach-parse",
+  description: "A tool for parsing breached passwords",
+  host: "github.com",
+};
+
+/**
+ * A note with one outward link, one wikilink and one link outside the surface.
+ *
+ * The address is a parameter because answers are cached for the life of the
+ * page — deliberately, since a reader hovers the same link repeatedly while
+ * deciding — and a shared address would make each test depend on the ones
+ * before it.
+ */
+function note(href = "https://github.com/hmaverickadams/breach-parse") {
+  const { container } = render(
+    <>
+      <div className="fl-prose">
+        <a href={href} data-testid="link">
+          breach-parse
+        </a>
+        <a href="https://example.com/note" data-wikilink="Roadmap" data-testid="wikilink">
+          Roadmap
+        </a>
+      </div>
+      <div>
+        <a href="https://example.com/elsewhere" data-testid="outside">
+          elsewhere
+        </a>
+      </div>
+      <LinkHoverCard within=".fl-prose, .ProseMirror" />
+    </>,
+  );
+  return container;
+}
+
+/**
+ * Hovers an element, lets the open delay elapse, and settles the fetch.
+ *
+ * `waitFor` is not usable here: it polls on the timers this test controls, so
+ * with fake timers running it waits forever. Advancing the clock inside `act`
+ * and then flushing the microtask queue does the same job deterministically.
+ */
+async function hover(testId: string) {
+  fireEvent.mouseOver(screen.getByTestId(testId));
+  await act(async () => {
+    vi.advanceTimersByTime(400);
+  });
+  await settle();
+}
+
+/** Lets a resolved (or rejected) preview reach the component. */
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  previewLink.mockResolvedValue(PREVIEW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("LinkHoverCard", () => {
+  it("says what is on the other end of a link", async () => {
+    note();
+    await hover("link");
+
+    const card = screen.getByRole("tooltip");
+    expect(card.textContent).toContain("breach-parse");
+    expect(card.textContent).toContain("A tool for parsing breached passwords");
+    expect(card.textContent).toContain("github.com");
+  });
+
+  it("waits before showing, so crossing a link on the way past shows nothing", async () => {
+    note();
+    fireEvent.mouseOver(screen.getByTestId("link"));
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    expect(previewLink).not.toHaveBeenCalled();
+  });
+
+  it("leaves wikilinks alone — the app already knows what those are", async () => {
+    note();
+    await hover("wikilink");
+
+    expect(previewLink).not.toHaveBeenCalled();
+  });
+
+  it("ignores links outside a note", async () => {
+    note();
+    await hover("outside");
+
+    expect(previewLink).not.toHaveBeenCalled();
+  });
+
+  it("shows the address even when the page could not be read", async () => {
+    // An empty card would read as the feature being broken.
+    previewLink.mockRejectedValue(new Error("offline"));
+    note("https://unreachable.example/page");
+    await hover("link");
+
+    expect(screen.getByRole("tooltip").textContent).toContain("unreachable.example");
+  });
+
+  it("asks about one address once, however often it is hovered", async () => {
+    note("https://example.com/asked-once");
+    await hover("link");
+    expect(previewLink).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseOut(screen.getByTestId("link"));
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    await hover("link");
+
+    expect(previewLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", async () => {
+    note();
+    await hover("link");
+    expect(screen.getByRole("tooltip")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("names the host without asking the server when signed out", async () => {
+    // The address is worth knowing on its own; only the page's own title needs
+    // a session to fetch.
+    render(
+      <>
+        <div className="fl-prose">
+          <a href="https://example.com/signed-out" data-testid="link">
+            a link
+          </a>
+        </div>
+        <LinkHoverCard within=".fl-prose" canRead={false} />
+      </>,
+    );
+
+    await hover("link");
+
+    expect(previewLink).not.toHaveBeenCalled();
+    const card = screen.getByRole("tooltip");
+    expect(card.textContent).toContain("example.com");
+    expect(card.textContent).toMatch(/sign in with github/i);
+  });
+});

--- a/apps/web/src/components/LinkHoverCard.tsx
+++ b/apps/web/src/components/LinkHoverCard.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { previewLink, type LinkPreviewResult } from "@/lib/gateway";
+
+/**
+ * What a link points at, shown before it is followed.
+ *
+ * A note is full of addresses, and an address is not a description. Deciding
+ * whether `https://github.com/hmaverickadams/breach-parse` is the thing you
+ * meant used to require opening it, which is the cost this removes: hover, and
+ * the page says what it is.
+ *
+ * Mounted once per editor and delegated from the document rather than wired
+ * per link. The rendered preview is injected HTML with no React elements to
+ * attach handlers to, and the rich-text surface is ProseMirror's, which
+ * rebuilds its DOM whenever the document changes — anything bound per anchor
+ * would be lost on the next keystroke.
+ *
+ * Text only, and that is deliberate. A card showing a remote image would mean
+ * the reader's browser fetching from whatever host the note links to, merely
+ * because the pointer passed over a word — a tracking pixel with extra steps.
+ * The host, the page's own title and its own summary are what the decision
+ * actually rests on.
+ */
+
+/** Long enough that crossing a link on the way somewhere else shows nothing. */
+const OPEN_DELAY_MS = 350;
+
+/** Grace for the pointer to travel from the link to the card and back. */
+const CLOSE_DELAY_MS = 180;
+
+/** Roughly the card's width, used to keep it inside the viewport. */
+const CARD_WIDTH = 320;
+
+interface Anchored {
+  url: string;
+  /** Viewport coordinates of the link this belongs to. */
+  rect: { left: number; right: number; top: number; bottom: number };
+  /** True when the link is in the rich-text editor, where clicks are ours. */
+  editable: boolean;
+}
+
+type Loaded = { status: "loading" } | { status: "ready"; preview: LinkPreviewResult };
+
+/**
+ * Answers already fetched, for the life of the page.
+ *
+ * A note links the same address more than once, and a reader hovers the same
+ * link repeatedly while deciding. Module-level rather than in state so it
+ * survives the card unmounting between hovers.
+ */
+const cache = new Map<string, LinkPreviewResult>();
+
+export interface LinkHoverCardProps {
+  /**
+   * Where links live. Hovers outside it are ignored.
+   *
+   * A selector rather than a ref because there are two surfaces — the rendered
+   * preview and the rich-text editor — and which of them exists depends on the
+   * view mode the reader chose.
+   */
+  within: string;
+  /**
+   * Whether the page itself may be read, which needs a session.
+   *
+   * False still shows a card — the address and the host are worth knowing on
+   * their own, and are what the reader is deciding from anyway. It just
+   * carries no title, because there is nobody to ask.
+   */
+  canRead?: boolean;
+}
+
+export function LinkHoverCard({ within, canRead = true }: LinkHoverCardProps) {
+  const [anchored, setAnchored] = useState<Anchored | null>(null);
+  const [loaded, setLoaded] = useState<Loaded | null>(null);
+
+  // Timers and the pointer's whereabouts are not rendered, so they are refs:
+  // re-rendering the card because the mouse moved would defeat the point.
+  const openTimer = useRef<number | null>(null);
+  const closeTimer = useRef<number | null>(null);
+  const overCard = useRef(false);
+  /**
+   * The link the card is currently about.
+   *
+   * Kept beside the state rather than read out of it: by the time a fetch
+   * lands the pointer may be on a different link, and the answer that arrives
+   * late must not replace the one the reader is actually looking at.
+   */
+  const showing = useRef<string | null>(null);
+
+  const clearTimers = useCallback(() => {
+    if (openTimer.current !== null) window.clearTimeout(openTimer.current);
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+    openTimer.current = null;
+    closeTimer.current = null;
+  }, []);
+
+  const close = useCallback(() => {
+    clearTimers();
+    showing.current = null;
+    setAnchored(null);
+    setLoaded(null);
+  }, [clearTimers]);
+
+  useEffect(() => {
+    const show = (anchor: HTMLAnchorElement, url: string) => {
+      const box = anchor.getBoundingClientRect();
+      showing.current = url;
+      setAnchored({
+        url,
+        rect: { left: box.left, right: box.right, top: box.top, bottom: box.bottom },
+        editable: anchor.closest(".ProseMirror") !== null,
+      });
+
+      const known = cache.get(url);
+      if (known) {
+        setLoaded({ status: "ready", preview: known });
+        return;
+      }
+
+      if (!canRead) {
+        setLoaded({
+          status: "ready",
+          preview: { url, title: null, description: null, host: hostOf(url) },
+        });
+        return;
+      }
+
+      setLoaded({ status: "loading" });
+
+      void previewLink(url)
+        .then((preview) => {
+          cache.set(url, preview);
+          return preview;
+        })
+        .catch(
+          // A page that cannot be read still deserves a card: the host and the
+          // address are what the reader is deciding from either way, and an
+          // empty card reads as the feature being broken rather than as the
+          // page being unreachable. Not cached — the next hover may reach it.
+          (): LinkPreviewResult => ({
+            url,
+            title: null,
+            description: null,
+            host: hostOf(url),
+          }),
+        )
+        .then((preview) => {
+          if (showing.current === url) setLoaded({ status: "ready", preview });
+        });
+    };
+
+    const onOver = (event: MouseEvent) => {
+      const anchor = (event.target as HTMLElement | null)?.closest<HTMLAnchorElement>("a[href]");
+      const url = anchor?.getAttribute("href") ?? "";
+
+      // Wikilinks and repository links open in the app and are described by
+      // the app; only addresses that leave it need explaining.
+      if (!anchor || !anchor.closest(within) || !/^https?:\/\//i.test(url)) return;
+      if (anchor.hasAttribute("data-wikilink")) return;
+
+      clearTimers();
+      if (anchored?.url === url) return;
+
+      openTimer.current = window.setTimeout(() => show(anchor, url), OPEN_DELAY_MS);
+    };
+
+    const onOut = (event: MouseEvent) => {
+      const anchor = (event.target as HTMLElement | null)?.closest<HTMLAnchorElement>("a[href]");
+      if (!anchor) return;
+
+      if (openTimer.current !== null) window.clearTimeout(openTimer.current);
+      openTimer.current = null;
+
+      closeTimer.current = window.setTimeout(() => {
+        // Left open while the pointer is on the card itself, which is what
+        // makes the address inside it selectable.
+        if (!overCard.current) close();
+      }, CLOSE_DELAY_MS);
+    };
+
+    // Escape closes it, and so does anything that moves what it is pinned to:
+    // it is positioned in viewport coordinates and would otherwise float over
+    // unrelated text once the note scrolled.
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+
+    document.addEventListener("mouseover", onOver);
+    document.addEventListener("mouseout", onOut);
+    document.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+
+    return () => {
+      document.removeEventListener("mouseover", onOver);
+      document.removeEventListener("mouseout", onOut);
+      document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+      clearTimers();
+    };
+  }, [within, canRead, anchored?.url, clearTimers, close]);
+
+  if (!anchored || !loaded) return null;
+
+  // Below the link where there is room, above it where there is not, and never
+  // past either edge of the window.
+  const below = anchored.rect.bottom + 8;
+  const above = anchored.rect.top - 8;
+  const openDownwards = below + 140 < window.innerHeight || above < 160;
+
+  const left = Math.min(
+    Math.max(8, anchored.rect.left),
+    Math.max(8, window.innerWidth - CARD_WIDTH - 8),
+  );
+
+  return (
+    <div
+      role="tooltip"
+      onMouseEnter={() => {
+        overCard.current = true;
+        if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+      }}
+      onMouseLeave={() => {
+        overCard.current = false;
+        close();
+      }}
+      style={{
+        left,
+        ...(openDownwards
+          ? { top: below }
+          : { bottom: Math.max(8, window.innerHeight - anchored.rect.top + 8) }),
+        width: CARD_WIDTH,
+      }}
+      className="fixed z-50 overflow-hidden rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-3 shadow-[var(--fl-shadow-lg)]"
+    >
+      {loaded.status === "loading" ? (
+        <p className="text-[12px] text-[var(--fl-muted)]">Reading {hostOf(anchored.url)}…</p>
+      ) : (
+        <div className="space-y-1">
+          <p className="truncate text-[11px] uppercase tracking-wide text-[var(--fl-muted)]">
+            {loaded.preview.host}
+          </p>
+
+          {loaded.preview.title ? (
+            <p className="line-clamp-2 text-[13px] font-medium leading-snug text-[var(--fl-text)]">
+              {loaded.preview.title}
+            </p>
+          ) : (
+            <p className="text-[12.5px] leading-snug text-[var(--fl-muted)]">
+              {canRead
+                ? "This page could not be read from here. It still opens normally."
+                : "Sign in with GitHub to see what a page says about itself."}
+            </p>
+          )}
+
+          {loaded.preview.description && (
+            <p className="line-clamp-3 text-[12px] leading-snug text-[var(--fl-muted)]">
+              {loaded.preview.description}
+            </p>
+          )}
+
+          <p className="truncate pt-0.5 font-mono text-[11px] text-[var(--fl-muted)]">
+            {anchored.url}
+          </p>
+
+          {/* Only where it is true: in the rendered preview a click is the
+              browser's own and Alt does nothing special. */}
+          {anchored.editable && (
+            <p className="pt-1 text-[11px] text-[var(--fl-muted)]">
+              Click to open in a new tab · Alt-click to put the cursor in the text
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** The host of an address, or the address itself when it will not parse. */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}

--- a/apps/web/src/components/NoteFreshness.tsx
+++ b/apps/web/src/components/NoteFreshness.tsx
@@ -38,6 +38,13 @@ export interface NoteFreshnessProps {
   repo: { owner: string; repo: string; branch: string } | null;
   /** Rewrites the note when a link is re-pinned. Absent makes the list read-only. */
   onChange?: (content: string) => void;
+  /**
+   * Opens a linked file for reading, without leaving the note.
+   *
+   * Absent falls back to github.com in a new tab, which is what this list did
+   * before there was anywhere in the app to read a file.
+   */
+  onOpenFile?: (target: RepoTarget) => void;
 }
 
 interface Checked {
@@ -75,7 +82,13 @@ export function hasFreshnessToReport(
   return assessDecay(content, { updatedAt }).verdict !== "fresh";
 }
 
-export function NoteFreshness({ content, updatedAt, repo, onChange }: NoteFreshnessProps) {
+export function NoteFreshness({
+  content,
+  updatedAt,
+  repo,
+  onChange,
+  onOpenFile,
+}: NoteFreshnessProps) {
   const targets = useMemo(() => repoTargetsIn(wikilinkTargets(content)), [content]);
 
   const [checked, setChecked] = useState<Checked[]>([]);
@@ -186,12 +199,21 @@ export function NoteFreshness({ content, updatedAt, repo, onChange }: NoteFreshn
           {checked.map((entry) => (
             <li key={`${entry.target.path}${entry.target.owner ?? ""}`} className="text-[12px]">
               <div className="flex items-baseline justify-between gap-2">
+                {/* Still an anchor when it opens in-app: ⌘-click, middle-click
+                    and "copy link address" all have to keep working, and only
+                    a real href gives them to you. */}
                 <a
                   href={repoTargetUrl(entry.target, repo ?? { owner: "", repo: "", branch: "" })}
                   target="_blank"
                   rel="noreferrer"
+                  onClick={(event) => {
+                    if (!onOpenFile) return;
+                    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+                    event.preventDefault();
+                    onOpenFile(entry.target);
+                  }}
                   className="truncate font-mono text-[11.5px] text-[var(--fl-text)] underline-offset-2 hover:underline"
-                  title={entry.target.path}
+                  title={onOpenFile ? `Read ${entry.target.path}` : entry.target.path}
                 >
                   {repoTargetLabel(entry.target)}
                 </a>

--- a/apps/web/src/components/RepoFileDialog.test.tsx
+++ b/apps/web/src/components/RepoFileDialog.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { RepoTarget } from "@forkleaf/markdown-engine";
+import { RepoFileDialog } from "./RepoFileDialog";
+
+// Rendering markdown is `Preview`'s job and is tested where it lives; pulling
+// the real one in drags mermaid into a jsdom run for no gain here.
+vi.mock("@forkleaf/editor", () => ({
+  Preview: ({ markdown }: { markdown: string }) => <pre data-testid="preview">{markdown}</pre>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const REPO = { owner: "me", repo: "notes", branch: "main" };
+
+function target(overrides: Partial<RepoTarget> = {}): RepoTarget {
+  return { owner: null, repo: null, path: "scripts/scan.sh", ref: "a1b2c3d", ...overrides };
+}
+
+/** Answers the contents route with a file, and records what was asked for. */
+function serve(file: unknown) {
+  const mock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ file }) });
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+describe("RepoFileDialog", () => {
+  it("reads the file at the revision the link pinned", async () => {
+    const fetchMock = serve({ content: "echo hi", sha: "blob" });
+    render(<RepoFileDialog target={target()} repo={REPO} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    // The pin, not the branch: a link that reports itself stale has to show
+    // the file the note was written about.
+    expect(url).toContain("branch=a1b2c3d");
+    expect(url).toContain("path=scripts%2Fscan.sh");
+  });
+
+  it("falls back to the workspace's branch for an unpinned link", async () => {
+    const fetchMock = serve({ content: "echo hi", sha: "blob" });
+    render(<RepoFileDialog target={target({ ref: null })} repo={REPO} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("branch=main");
+  });
+
+  it("shows a non-markdown file as highlighted source", async () => {
+    serve({ content: "echo hi", sha: "blob" });
+    render(<RepoFileDialog target={target()} repo={REPO} onClose={vi.fn()} />);
+
+    const preview = await screen.findByTestId("preview");
+    expect(preview.textContent).toContain("```bash");
+    expect(preview.textContent).toContain("echo hi");
+  });
+
+  it("renders a markdown file as markdown rather than as source", async () => {
+    serve({ content: "# Playbook", sha: "blob" });
+    render(
+      <RepoFileDialog target={target({ path: "docs/deploy.md" })} repo={REPO} onClose={vi.fn()} />,
+    );
+
+    const preview = await screen.findByTestId("preview");
+    expect(preview.textContent).toBe("# Playbook");
+  });
+
+  it("outruns a fence the file itself contains", async () => {
+    // A file with ``` in it used to end the block early and render the rest of
+    // itself as prose.
+    serve({ content: "```\nnested\n```", sha: "blob" });
+    render(<RepoFileDialog target={target({ path: "notes.txt" })} repo={REPO} onClose={vi.fn()} />);
+
+    const preview = await screen.findByTestId("preview");
+    expect(preview.textContent?.startsWith("````")).toBe(true);
+  });
+
+  it("says so when the file is not there at that revision", async () => {
+    serve(null);
+    render(<RepoFileDialog target={target()} repo={REPO} onClose={vi.fn()} />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/not in me\/notes at a1b2c3d/i);
+  });
+
+  it("offers github.com as the way out, in a tab of its own", async () => {
+    serve({ content: "echo hi", sha: "blob" });
+    render(<RepoFileDialog target={target()} repo={REPO} onClose={vi.fn()} />);
+
+    const link = await screen.findByRole("link", { name: /open on github/i });
+    expect(link.getAttribute("href")).toBe(
+      "https://github.com/me/notes/blob/a1b2c3d/scripts/scan.sh",
+    );
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+});

--- a/apps/web/src/components/RepoFileDialog.tsx
+++ b/apps/web/src/components/RepoFileDialog.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Preview } from "@forkleaf/editor";
+import { repoTargetUrl, type RepoTarget } from "@forkleaf/markdown-engine";
+import { readRepoFile } from "@/lib/gateway";
+import { imageTypeFor } from "@/lib/media";
+import { Dialog } from "./Dialog";
+
+/**
+ * Reading the file a `[[repo:…]]` link names, without leaving the note.
+ *
+ * Linking a file used to be half a feature. The picker wrote a precise,
+ * revision-pinned link and the Freshness panel could tell you the file had
+ * changed — but clicking the link did nothing useful: the target resolves to no
+ * note, so the editor offered to *create* one called `repo:scripts/scan.sh`.
+ * The one thing a link to a file has to do, open the file, was the one thing it
+ * could not do.
+ *
+ * So the file is fetched and shown here, at the revision the link pinned rather
+ * than at whatever the branch has moved on to — otherwise a link that reports
+ * itself stale would still show today's file, and there would be no way to see
+ * what the note was actually written about. Markdown renders; everything else
+ * is shown as source, highlighted by the same pipeline the preview uses.
+ */
+
+export interface RepoFileDialogProps {
+  target: RepoTarget;
+  /** The workspace's repository, for a link that names no repository of its own. */
+  repo: { owner: string; repo: string; branch: string };
+  onClose: () => void;
+}
+
+/**
+ * Where the source view stops.
+ *
+ * A minified bundle or a checked-in dataset is megabytes of one line, and
+ * highlighting it locks the tab. Past this the head of the file is shown and
+ * the rest is left to github.com, which is built for it.
+ */
+const MAX_SHOWN = 120_000;
+
+/** Fence language for a path, so the source view is highlighted like the app's. */
+function languageOf(path: string): string {
+  const name = path.slice(path.lastIndexOf("/") + 1);
+  const extension = name.includes(".") ? name.slice(name.lastIndexOf(".") + 1).toLowerCase() : "";
+
+  const known: Record<string, string> = {
+    ts: "typescript",
+    tsx: "typescript",
+    js: "javascript",
+    jsx: "javascript",
+    mjs: "javascript",
+    cjs: "javascript",
+    py: "python",
+    rb: "ruby",
+    rs: "rust",
+    go: "go",
+    sh: "bash",
+    bash: "bash",
+    zsh: "bash",
+    yml: "yaml",
+    yaml: "yaml",
+    json: "json",
+    toml: "toml",
+    css: "css",
+    scss: "scss",
+    html: "html",
+    sql: "sql",
+    java: "java",
+    kt: "kotlin",
+    swift: "swift",
+    c: "c",
+    h: "c",
+    cpp: "cpp",
+    php: "php",
+  };
+
+  // Files with no extension that are still text worth reading — a Dockerfile,
+  // a Makefile — are shown unhighlighted rather than not shown.
+  return known[extension] ?? "";
+}
+
+export function RepoFileDialog({ target, repo, onClose }: RepoFileDialogProps) {
+  const owner = target.owner ?? repo.owner;
+  const name = target.repo ?? repo.repo;
+  const ref = target.ref ?? repo.branch;
+
+  /**
+   * What was read, tagged with what it was read for.
+   *
+   * Tagged rather than reset on the way in, which makes "still reading" a
+   * derived value instead of a second piece of state: the answer on screen
+   * belongs to this file exactly when the tag matches, and a synchronous
+   * `setLoading(true)` at the top of the effect would be a cascading render
+   * for something already implied.
+   */
+  const [read, setRead] = useState<{
+    key: string;
+    file: { content: string; sha: string } | null;
+    error: string | null;
+  }>({ key: "", file: null, error: null });
+
+  const isImage = imageTypeFor(target.path) !== null;
+  const isMarkdown = /\.(md|markdown|mdx)$/i.test(target.path);
+  const githubUrl = repoTargetUrl(target, repo);
+  const key = `${owner}/${name}@${ref}:${target.path}`;
+
+  const loading = !isImage && read.key !== key;
+  const file = read.key === key ? read.file : null;
+  const error = read.key === key ? read.error : null;
+
+  useEffect(() => {
+    // Images are served as bytes by the raw route; fetching them through the
+    // contents API would only decode them as broken UTF-8.
+    if (isImage) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const found = await readRepoFile({ owner, repo: name, ref, path: target.path });
+        if (cancelled) return;
+
+        setRead({
+          key,
+          file: found,
+          error: found
+            ? null
+            : target.ref
+              ? `${target.path} is not in ${owner}/${name} at ${target.ref}.`
+              : `${target.path} is not in ${owner}/${name}.`,
+        });
+      } catch (caught) {
+        if (cancelled) return;
+        setRead({
+          key,
+          file: null,
+          error: caught instanceof Error ? caught.message : "That file could not be read.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key, owner, name, ref, target.path, target.ref, isImage]);
+
+  const truncated = (file?.content.length ?? 0) > MAX_SHOWN;
+
+  const markdown = useMemo(() => {
+    if (!file) return "";
+    const body = truncated ? file.content.slice(0, MAX_SHOWN) : file.content;
+
+    if (isMarkdown) return body;
+
+    // A fence, so the same renderer that highlights code in a note highlights
+    // this. The fence is closed with a longer run than anything the file can
+    // contain, or a file that itself contains ``` would end the block early
+    // and the rest would render as prose.
+    const fence = "`".repeat(Math.max(3, longestBacktickRun(body) + 1));
+    return `${fence}${languageOf(target.path)}\n${body}\n${fence}`;
+  }, [file, isMarkdown, target.path, truncated]);
+
+  const rawUrl = `/api/gh/raw?${new URLSearchParams({
+    owner,
+    repo: name,
+    branch: ref,
+    path: target.path,
+  }).toString()}`;
+
+  return (
+    <Dialog
+      wide
+      title={target.path}
+      subtitle={`${owner}/${name} · ${target.ref ? `pinned to ${target.ref}` : ref}`}
+      onClose={onClose}
+    >
+      <div className="space-y-3">
+        {loading && <p className="text-[13px] text-[var(--fl-muted)]">Reading the file…</p>}
+
+        {error && (
+          <p role="alert" className="text-[13px] text-[var(--fl-danger)]">
+            {error}
+          </p>
+        )}
+
+        {isImage && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={rawUrl}
+            alt={target.path}
+            className="max-h-[60vh] w-auto rounded-lg border border-[var(--fl-border)]"
+          />
+        )}
+
+        {file && (
+          <div className="max-h-[60vh] overflow-auto rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-3">
+            <Preview markdown={markdown} />
+          </div>
+        )}
+
+        {truncated && (
+          <p className="text-[12px] text-[var(--fl-muted)]">
+            Shown to the first {MAX_SHOWN.toLocaleString()} characters. The rest is on github.com.
+          </p>
+        )}
+
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-[11.5px] leading-snug text-[var(--fl-muted)]">
+            {target.ref
+              ? "The revision this note was written against, not whatever the branch holds now."
+              : "This link is not pinned to a revision, so this is the file as it stands today."}
+          </p>
+
+          <a
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="fl-btn shrink-0 whitespace-nowrap"
+          >
+            Open on GitHub
+          </a>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+/** The longest run of backticks in the text, so a fence can outrun it. */
+function longestBacktickRun(text: string): number {
+  let longest = 0;
+  for (const match of text.matchAll(/`+/g)) longest = Math.max(longest, match[0].length);
+  return longest;
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -36,6 +36,7 @@ import { HistoryDialog } from "@/components/HistoryDialog";
 import { ReviewPanel } from "@/components/ReviewPanel";
 import { LinkFileDialog } from "@/components/LinkFileDialog";
 import { RepoFileDialog } from "@/components/RepoFileDialog";
+import { LinkHoverCard } from "@/components/LinkHoverCard";
 import { CaptureDialog } from "@/components/CaptureDialog";
 import { Dialog } from "@/components/Dialog";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
@@ -1631,6 +1632,13 @@ export function EditorWorkspace() {
           />
         </Dialog>
       )}
+
+      {/* Every rendered surface at once — the preview, the rich-text editor,
+          the file viewer, a revision being compared — because a link is a link
+          in all of them and which one is on screen is the reader's choice.
+          Signed out it still names the host and the address; only the page's
+          own title needs a session to fetch. */}
+      <LinkHoverCard within=".fl-prose, .ProseMirror" canRead={Boolean(user)} />
 
       {viewingFile && workspace && !workspace.isLocal && (
         <RepoFileDialog

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -10,6 +10,8 @@ import {
   dirname,
   documentStats,
   joinPath,
+  parseRepoTarget,
+  type RepoTarget,
   serializeDocument,
   slugifyFilename,
   stripExtension,
@@ -33,6 +35,7 @@ import { HelpDialog } from "@/components/HelpDialog";
 import { HistoryDialog } from "@/components/HistoryDialog";
 import { ReviewPanel } from "@/components/ReviewPanel";
 import { LinkFileDialog } from "@/components/LinkFileDialog";
+import { RepoFileDialog } from "@/components/RepoFileDialog";
 import { CaptureDialog } from "@/components/CaptureDialog";
 import { Dialog } from "@/components/Dialog";
 import { PromptDialog, type PromptRequest } from "@/components/PromptDialog";
@@ -122,6 +125,14 @@ export function EditorWorkspace() {
    * did not save" and wrong for "your images are back". This is the quiet
    * channel: neutral, and it goes away on its own.
    */
+  /**
+   * The repository file a link was clicked on, being read.
+   *
+   * Its own state rather than a `dialog` value, because the dialog needs to
+   * know *which* file — and a link can name one in a repository this workspace
+   * is not even connected to.
+   */
+  const [viewingFile, setViewingFile] = useState<RepoTarget | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   // Dismissing the repo chooser has to be remembered, because the condition
   // that raises it stays true until a repository is actually connected.
@@ -264,6 +275,21 @@ export function EditorWorkspace() {
     () => ({
       resolve: links.resolve,
       open: (target) => {
+        /**
+         * A link naming a file in the repository opens the file.
+         *
+         * Checked first, and it has to be: `repo:scripts/scan.sh` resolves to
+         * no note, so this fell through to the branch below and offered to
+         * create a note *called* `repo:scripts/scan.sh`. Every link the file
+         * picker wrote was therefore unopenable, and clicking one left a junk
+         * note behind.
+         */
+        const repoTarget = parseRepoTarget(target);
+        if (repoTarget && workspace && !workspace.isLocal) {
+          setViewingFile(repoTarget);
+          return;
+        }
+
         const path = links.pathFor(target);
         // Clicking a link to a note that has not been written yet writes it.
         // Refusing to navigate would be technically correct and useless.
@@ -271,7 +297,7 @@ export function EditorWorkspace() {
         else createLinked(target);
       },
     }),
-    [links, notebook, createLinked],
+    [links, notebook, createLinked, workspace],
   );
 
   /**
@@ -776,11 +802,11 @@ export function EditorWorkspace() {
         id: "link-file",
         label: "Link a file",
         hint: "A file in this repository, pinned to the revision you read",
+        // Drawn to the same recipe as the editor's own block icons — 16px
+        // grid, 1.4 stroke, round caps — because it sits between them in the
+        // "/" menu, where a thinner, squarer icon read as a rendering fault.
         icon: (
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
-            <path d="M9 1.5H4a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V5.5Z" />
-            <path d="M9 1.5v4h4" />
-          </svg>
+          <ExtraGlyph d="M9 1.75H4.5A1.75 1.75 0 0 0 2.75 3.5v9c0 .97.78 1.75 1.75 1.75h7a1.75 1.75 0 0 0 1.75-1.75V6zM9 1.75V6h4.25M7.1 11.4a1.2 1.2 0 0 0 1.7.1l.9-.9a1.2 1.2 0 0 0-1.7-1.7l-.4.4M8.4 10.1a1.2 1.2 0 0 0-1.7-.1l-.9.9a1.2 1.2 0 0 0 1.7 1.7l.4-.4" />
         ),
       });
     }
@@ -791,11 +817,7 @@ export function EditorWorkspace() {
         label: "Web source",
         hint: "A page with its address, the time you read it, and an archived copy",
         icon: (
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
-            <path d="M4 2h6a1 1 0 0 1 1 1v5.5" />
-            <path d="M4 2v11l3-2.2" strokeLinecap="round" />
-            <circle cx="11" cy="11" r="3.2" />
-          </svg>
+          <ExtraGlyph d="M3.75 2.75h6.5a1 1 0 0 1 1 1V7M3.75 2.75v10.5L6.5 11.2M14 11a3 3 0 1 1-6 0 3 3 0 0 1 6 0M11 9.6v1.5l1 .7" />
         ),
       });
     }
@@ -1493,6 +1515,14 @@ export function EditorWorkspace() {
                     }
                   : undefined
               }
+              onOpenFile={
+                workspace && !workspace.isLocal
+                  ? (target) => {
+                      setDrawer(null);
+                      setViewingFile(target);
+                    }
+                  : undefined
+              }
               onCapture={
                 user
                   ? () => {
@@ -1600,6 +1630,14 @@ export function EditorWorkspace() {
             }}
           />
         </Dialog>
+      )}
+
+      {viewingFile && workspace && !workspace.isLocal && (
+        <RepoFileDialog
+          target={viewingFile}
+          repo={workspace.repo}
+          onClose={() => setViewingFile(null)}
+        />
       )}
 
       {openDialog === "link-file" && workspace && !workspace.isLocal && (
@@ -1780,6 +1818,30 @@ function EmptyState({
         </button>
       </div>
     </div>
+  );
+}
+
+/**
+ * The editor's own block-menu icon, for the two blocks that live out here.
+ *
+ * A copy of the `Glyph` helper in the editor package rather than an import of
+ * it: that one is an implementation detail of the block list and is not
+ * exported, and the two icons it draws beside these have to match to the pixel.
+ */
+function ExtraGlyph({ d }: { d: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={d} />
+    </svg>
   );
 }
 

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -25,7 +25,7 @@ import {
 } from "@forkleaf/types";
 import { dirname, serializeDocument } from "@forkleaf/markdown-engine";
 import { GitHubGateway, LocalGateway, fetchSession, type SessionResponse } from "@/lib/gateway";
-import { LOCAL_WORKSPACE } from "@/lib/workspaces";
+import { LOCAL_WORKSPACE, collapseBranchDuplicates } from "@/lib/workspaces";
 import { assetFrom, assetObjectUrl } from "@/lib/assets";
 
 /**
@@ -316,9 +316,33 @@ export function useNotebook(request: NotebookRequest = {}) {
           workspaces[0] ??
           null;
 
+        /**
+         * The rows earlier versions left behind, one per branch ever opened.
+         *
+         * Switching branches used to add a workspace and keep the old one, so
+         * a repository read on three branches is listed three times under one
+         * name on this device right now. Collapsed on the way in, against the
+         * workspace being opened — and only where the branch being retired has
+         * nothing waiting to be pushed.
+         */
+        const listed =
+          active && !active.isLocal
+            ? await collapseBranchDuplicates({
+                workspaces,
+                keep: active,
+                notes,
+                db,
+                unregister: (id) => {
+                  if (gateway instanceof GitHubGateway) gateway.unregister(id);
+                },
+              }).catch(() => workspaces)
+            : workspaces;
+
+        if (cancelled) return;
+
         patch({
           session,
-          workspaces,
+          workspaces: listed,
           activeWorkspace: active,
           needsRepoChoice,
           ready: true,
@@ -959,9 +983,16 @@ export function useNotebook(request: NotebookRequest = {}) {
    * Moves the current workspace onto another branch, or onto a fork.
    *
    * A branch is not a different workspace as far as the user is concerned — it
-   * is the same notes, one revision sideways — so this edits the workspace in
-   * place rather than creating a second entry for every branch. Open notes are
-   * cleared because their content and base SHAs belong to the old branch.
+   * is the same notes, one revision sideways. The stored row is still per
+   * branch, because notes, queued commits and the cached tree are filed under
+   * the workspace id and a note on `main` is not the note at that path on a
+   * draft branch — but the row for the branch being left is retired, so the
+   * switcher stays a list of repositories rather than growing a duplicate of
+   * the same repository for every branch ever opened.
+   *
+   * A branch left with unpushed edits is kept; see `collapseBranchDuplicates`.
+   * Open notes are cleared because their content and base SHAs belong to the
+   * old branch.
    */
   const switchBranch = useCallback(
     async (branch: string, repo?: { owner: string; repo: string }) => {
@@ -983,13 +1014,32 @@ export function useNotebook(request: NotebookRequest = {}) {
         lastOpenedAt: new Date().toISOString(),
       };
 
+      // Nothing to do when the branch is already the one being asked for:
+      // re-adding it would clear the open notes and re-read the tree for a
+      // move that never happened.
+      if (next.id === current.id) return;
+
       await notes.addWorkspace(next);
-      if (gatewayRef.current instanceof GitHubGateway) {
-        gatewayRef.current.register(next);
-      }
+      const gateway = gatewayRef.current;
+      if (gateway instanceof GitHubGateway) gateway.register(next);
+
+      const listed = [...state.workspaces.filter((w) => w.id !== next.id), next];
+      const db = dbRef.current;
+
+      const workspaces = db
+        ? await collapseBranchDuplicates({
+            workspaces: listed,
+            keep: next,
+            notes,
+            db,
+            unregister: (id) => {
+              if (gateway instanceof GitHubGateway) gateway.unregister(id);
+            },
+          })
+        : listed;
 
       patch({
-        workspaces: [...state.workspaces.filter((w) => w.id !== next.id), next],
+        workspaces,
         activeWorkspace: next,
         openNotes: [],
         activePath: null,

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -517,3 +517,21 @@ export async function readRepoFile(options: {
   );
   return file;
 }
+
+export interface LinkPreviewResult {
+  url: string;
+  title: string | null;
+  description: string | null;
+  host: string;
+}
+
+/**
+ * What is on the other end of a link, for a hover card.
+ *
+ * Given a short timeout of its own: this fires on hover, and a card that
+ * arrives after the pointer has moved on is worse than no card — it would pop
+ * up over whatever the reader looked at next.
+ */
+export async function previewLink(url: string): Promise<LinkPreviewResult> {
+  return call(`/api/link-preview?url=${encodeURIComponent(url)}`, { timeoutMs: 8_000 });
+}

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -488,3 +488,32 @@ export interface CaptureResult {
 export async function capturePage(url: string): Promise<CaptureResult> {
   return call("/api/capture", { method: "POST", body: JSON.stringify({ url }) });
 }
+
+/**
+ * One file out of a repository, at the revision a `[[repo:…]]` link named.
+ *
+ * Separate from the gateway class, which answers for workspaces: a repository
+ * link can name a file in a repository nobody has connected as a workspace,
+ * and in a directory the workspace does not file its notes in. `ref` is passed
+ * as the branch parameter because to the contents API a commit and a branch
+ * are the same kind of thing — which is what makes a pinned link show the file
+ * as it was when it was described, rather than as it is now.
+ */
+export async function readRepoFile(options: {
+  owner: string;
+  repo: string;
+  ref: string;
+  path: string;
+}): Promise<{ content: string; sha: string; size?: number } | null> {
+  const params = new URLSearchParams({
+    owner: options.owner,
+    repo: options.repo,
+    branch: options.ref,
+    path: options.path,
+  });
+
+  const { file } = await call<{ file: { content: string; sha: string; size?: number } | null }>(
+    `/api/gh/file?${params.toString()}`,
+  );
+  return file;
+}

--- a/apps/web/src/lib/workspaces.test.ts
+++ b/apps/web/src/lib/workspaces.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { workspaceId, type PendingChange, type RepoRef, type Workspace } from "@forkleaf/types";
+import type { LocalDatabase, NoteRepository } from "@forkleaf/store";
+import { LOCAL_WORKSPACE, collapseBranchDuplicates, repositoryKey } from "./workspaces";
+
+const NOTES: RepoRef = { owner: "me", repo: "notes", branch: "main", directory: "" };
+
+function on(branch: string, repo: Partial<RepoRef> = {}): Workspace {
+  const reference: RepoRef = { ...NOTES, ...repo, branch };
+  return {
+    id: workspaceId(reference),
+    name: reference.repo,
+    repo: reference,
+    isDefault: false,
+    isLocal: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    lastOpenedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+/** A database that reports whichever workspaces have unpushed changes. */
+function db(pendingFor: string[] = []): LocalDatabase {
+  return {
+    listQueue: vi.fn(async (workspace?: string) =>
+      pendingFor.includes(workspace ?? "")
+        ? ([{ id: "change" }] as unknown as PendingChange[])
+        : [],
+    ),
+  } as unknown as LocalDatabase;
+}
+
+function notes() {
+  const removeWorkspace = vi.fn(async () => {});
+  return { repository: { removeWorkspace } as unknown as NoteRepository, removeWorkspace };
+}
+
+describe("repositoryKey", () => {
+  it("is the same for two branches of one repository", () => {
+    expect(repositoryKey(on("main"))).toBe(repositoryKey(on("draft")));
+  });
+
+  it("separates a fork from what it was forked from", () => {
+    expect(repositoryKey(on("main"))).not.toBe(repositoryKey(on("main", { owner: "someone" })));
+  });
+
+  it("separates two notebooks in different directories of one repository", () => {
+    expect(repositoryKey(on("main"))).not.toBe(repositoryKey(on("main", { directory: "vault" })));
+  });
+});
+
+describe("collapseBranchDuplicates", () => {
+  it("retires the row for the branch just left", async () => {
+    const { repository, removeWorkspace } = notes();
+    const keep = on("draft");
+
+    const left = await collapseBranchDuplicates({
+      workspaces: [on("main"), keep],
+      keep,
+      notes: repository,
+      db: db(),
+    });
+
+    expect(left).toEqual([keep]);
+    expect(removeWorkspace).toHaveBeenCalledWith(on("main").id);
+  });
+
+  it("keeps a branch holding writing that has never been pushed", async () => {
+    // `removeWorkspace` takes the notes with it, so this is somebody's work.
+    const { repository, removeWorkspace } = notes();
+    const keep = on("draft");
+    const stranded = on("main");
+
+    const left = await collapseBranchDuplicates({
+      workspaces: [stranded, keep],
+      keep,
+      notes: repository,
+      db: db([stranded.id]),
+    });
+
+    expect(left).toEqual([stranded, keep]);
+    expect(removeWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("leaves other repositories alone", async () => {
+    const { repository, removeWorkspace } = notes();
+    const keep = on("main");
+    const other = on("main", { repo: "tools" });
+    const fork = on("main", { owner: "someone" });
+
+    const left = await collapseBranchDuplicates({
+      workspaces: [LOCAL_WORKSPACE, other, fork, keep],
+      keep,
+      notes: repository,
+      db: db(),
+    });
+
+    expect(left).toEqual([LOCAL_WORKSPACE, other, fork, keep]);
+    expect(removeWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("drops the retired workspace from the gateway's lookup table too", async () => {
+    const { repository } = notes();
+    const unregister = vi.fn();
+    const keep = on("draft");
+
+    await collapseBranchDuplicates({
+      workspaces: [on("main"), keep],
+      keep,
+      notes: repository,
+      db: db(),
+      unregister,
+    });
+
+    expect(unregister).toHaveBeenCalledWith(on("main").id);
+  });
+
+  it("does nothing for the on-device workspace, which has no branches", async () => {
+    const { repository, removeWorkspace } = notes();
+    const workspaces = [LOCAL_WORKSPACE, on("main")];
+
+    expect(
+      await collapseBranchDuplicates({
+        workspaces,
+        keep: LOCAL_WORKSPACE,
+        notes: repository,
+        db: db(),
+      }),
+    ).toEqual(workspaces);
+    expect(removeWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/workspaces.ts
+++ b/apps/web/src/lib/workspaces.ts
@@ -1,3 +1,4 @@
+import type { LocalDatabase, NoteRepository } from "@forkleaf/store";
 import type { Workspace } from "@forkleaf/types";
 
 /**
@@ -20,3 +21,69 @@ export const LOCAL_WORKSPACE: Workspace = {
   createdAt: new Date(0).toISOString(),
   lastOpenedAt: new Date(0).toISOString(),
 };
+
+/**
+ * One repository, however many branches it has been read on.
+ *
+ * A workspace id is `owner/repo@branch:directory`, and it has to be: notes,
+ * queued commits and the cached tree are all filed under it, and a note read
+ * on `main` is not the same file as the note at that path on a draft branch.
+ * Sharing one id across branches would show whichever copy happened to be
+ * cached, which is worse than showing nothing.
+ *
+ * But that made switching branches *look* like connecting a repository twice:
+ * every branch ever opened left a row behind in the workspace switcher, so a
+ * repository read on three branches appeared three times under one name, and
+ * disconnecting the wrong one threw away notes that were never pushed. This is
+ * the other half of that identity — the repository, without the branch — which
+ * is what the switcher is actually a list of.
+ */
+export function repositoryKey(workspace: Workspace): string {
+  if (workspace.isLocal) return `local:${workspace.id}`;
+  return `${workspace.repo.owner}/${workspace.repo.repo}:${workspace.repo.directory}`;
+}
+
+/**
+ * Retires the workspace rows left behind by branch switches.
+ *
+ * Only rows for the same repository as `keep`, and only rows with an empty
+ * queue. That second condition is not a nicety: a branch left with unpushed
+ * edits is somebody's unsaved writing, and `removeWorkspace` deletes the notes
+ * along with the row. Those stay listed — a second entry for a branch holding
+ * work that never left this device is a true statement, and the only way to
+ * get back to it.
+ *
+ * Returns the workspaces that survive, in the order they came in.
+ */
+export async function collapseBranchDuplicates(options: {
+  workspaces: Workspace[];
+  /** The row that speaks for this repository — normally the one just opened. */
+  keep: Workspace;
+  notes: NoteRepository;
+  db: LocalDatabase;
+  /** Dropped from the gateway's lookup table too, so nothing can still call it. */
+  unregister?: (workspaceId: string) => void;
+}): Promise<Workspace[]> {
+  const { workspaces, keep, notes, db, unregister } = options;
+  if (keep.isLocal) return workspaces;
+
+  const key = repositoryKey(keep);
+  const stale = workspaces.filter(
+    (workspace) =>
+      !workspace.isLocal && workspace.id !== keep.id && repositoryKey(workspace) === key,
+  );
+  if (stale.length === 0) return workspaces;
+
+  const removed = new Set<string>();
+
+  for (const workspace of stale) {
+    const pending = await db.listQueue(workspace.id).catch(() => []);
+    if (pending.length > 0) continue;
+
+    await notes.removeWorkspace(workspace.id);
+    unregister?.(workspace.id);
+    removed.add(workspace.id);
+  }
+
+  return workspaces.filter((workspace) => !removed.has(workspace.id));
+}

--- a/packages/editor/src/WysiwygEditor.tsx
+++ b/packages/editor/src/WysiwygEditor.tsx
@@ -217,6 +217,11 @@ export function WysiwygEditor({
       Link.configure({
         openOnClick: false,
         autolink: true,
+        // Carried on the mark so a link survives into exported HTML pointing
+        // outward rather than replacing the page it was exported from. In the
+        // editor itself the click is handled below, since an editable document
+        // does not follow hrefs.
+        HTMLAttributes: { target: "_blank", rel: "noopener noreferrer" },
         // Anything outside this list is dropped, which closes the
         // javascript:-URL XSS vector on pasted links.
         protocols: ["http", "https", "mailto"],
@@ -370,6 +375,28 @@ export function WysiwygEditor({
       attributes: {
         class: "fl-prose focus:outline-none min-h-[50vh]",
         "aria-label": "Note content",
+      },
+      /**
+       * ⌘/Ctrl-click opens an ordinary link, in a tab of its own.
+       *
+       * `openOnClick` is off — a plain click has to keep placing the caret,
+       * because this is text being written and a link you cannot put the
+       * cursor inside is a link you cannot edit. That left links in rich text
+       * with no way to follow them at all: a captured web source rendered its
+       * address and its archived copy, and clicking either did nothing.
+       *
+       * The same modifier the wikilink extension uses, for the same reason.
+       */
+      handleClick: (_view, _pos, event) => {
+        if (!event.metaKey && !event.ctrlKey) return false;
+
+        const anchor = (event.target as HTMLElement | null)?.closest<HTMLAnchorElement>("a[href]");
+        const href = anchor?.getAttribute("href") ?? "";
+        if (!/^(https?:\/\/|mailto:)/i.test(href)) return false;
+
+        event.preventDefault();
+        window.open(href, "_blank", "noopener,noreferrer");
+        return true;
       },
       handlePaste: (view, event) => {
         const files = imagesFrom(event.clipboardData);

--- a/packages/editor/src/WysiwygEditor.tsx
+++ b/packages/editor/src/WysiwygEditor.tsx
@@ -377,18 +377,28 @@ export function WysiwygEditor({
         "aria-label": "Note content",
       },
       /**
-       * ⌘/Ctrl-click opens an ordinary link, in a tab of its own.
+       * Clicking a link follows it, in a tab of its own.
        *
-       * `openOnClick` is off — a plain click has to keep placing the caret,
-       * because this is text being written and a link you cannot put the
-       * cursor inside is a link you cannot edit. That left links in rich text
-       * with no way to follow them at all: a captured web source rendered its
-       * address and its archived copy, and clicking either did nothing.
+       * `openOnClick` is off, which used to mean a link in rich text did
+       * nothing at all: a captured web source rendered its address and its
+       * archived copy and neither could be opened, in the one view most people
+       * write in. A link you cannot follow is not a link.
        *
-       * The same modifier the wikilink extension uses, for the same reason.
+       * The usual objection is that a plain click has to place the caret,
+       * since this is text being written — so Alt-click still does, and the
+       * hover card says so. Alt is the escape hatch here rather than the other
+       * way round because following a link is what people do to a link a
+       * hundred times for every time they edit its text, and the rare case is
+       * the one that should take the modifier.
+       *
+       * A new tab, always: the alternative navigates away from a note that may
+       * hold unsaved writing.
        */
       handleClick: (_view, _pos, event) => {
-        if (!event.metaKey && !event.ctrlKey) return false;
+        // Alt is "put the caret in here", and every other modifier is the
+        // browser's own — ⇧ extends a selection, and ⌘/Ctrl already mean "open
+        // in a new tab" everywhere else, which is what this does anyway.
+        if (event.altKey || event.shiftKey) return false;
 
         const anchor = (event.target as HTMLElement | null)?.closest<HTMLAnchorElement>("a[href]");
         const href = anchor?.getAttribute("href") ?? "";

--- a/packages/markdown-engine/src/index.test.ts
+++ b/packages/markdown-engine/src/index.test.ts
@@ -195,6 +195,20 @@ describe("rendering", () => {
     const html = markdownToHtml('<img src="x" onerror="alert(1)">');
     expect(html).not.toContain("onerror");
   });
+
+  it("opens a link out of the notebook in a tab of its own", () => {
+    // Following one in place replaced the editor — and any unsaved paragraph
+    // in it — with the page being cited.
+    const html = markdownToHtml("[the source](https://example.com/article)");
+    expect(html).toContain('target="_blank"');
+    // Without `noopener` the opened page gets a live handle on this one.
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("leaves in-page and in-app links alone", () => {
+    const html = markdownToHtml("[a heading](#somewhere) and [a note](/notes/roadmap)");
+    expect(html).not.toContain("target=");
+  });
 });
 
 describe("paths", () => {

--- a/packages/markdown-engine/src/render.ts
+++ b/packages/markdown-engine/src/render.ts
@@ -75,11 +75,23 @@ const schema: SanitizeSchema = {
     // and the sanitiser honours only the first entry it finds for a property.
     // So our names are merged into that entry rather than appended as a second
     // one, which is silently ignored.
+    //
+    // `target` and `rel` are pinned to single values rather than allowed as
+    // free text: a link in a note is content, and the only thing it is allowed
+    // to say about where it opens is "a new tab, with no handle on this one".
     a: withClasses(defaultSchema.attributes?.a ?? [], [
       "fl-wikilink",
       "fl-wikilink-found",
       "fl-wikilink-missing",
-    ]).concat(["dataWikilink", "dataWikilinkAnchor"]),
+      "fl-external",
+    ]).concat([
+      "dataWikilink",
+      "dataWikilinkAnchor",
+      ["target", "_blank"],
+      // Listed as two tokens, not one string: the sanitiser matches each
+      // value of a multi-valued attribute against the allowlist separately.
+      ["rel", "noopener", "noreferrer"],
+    ]),
     // `loading` keeps a note full of screenshots from fetching every one of
     // them at once; the rest are what the default schema already allows.
     img: [...(defaultSchema.attributes?.img ?? []), ["loading", "lazy"]],
@@ -269,6 +281,40 @@ function rehypeImages(options: RenderOptions) {
 }
 
 /**
+ * A link out of the notebook opens a tab of its own.
+ *
+ * Without this, clicking the source on a captured web page — the whole point
+ * of capturing one — replaced the editor with that page, and any unsaved
+ * paragraph went with it. Every other note-taking tool opens outward links in
+ * a new tab for exactly this reason.
+ *
+ * Only absolute `http(s)` links are touched. In-page anchors, wikilinks and
+ * the app's own relative hrefs stay as they are: those go somewhere the app
+ * can render itself, and a new tab for them would be a bug, not a courtesy.
+ *
+ * `rel` is not optional here. `target="_blank"` without `noopener` hands the
+ * opened page a live reference back to this one.
+ */
+function rehypeExternalLinks() {
+  return (tree: HastRoot) => {
+    visit(tree, "element", (node: Element) => {
+      if (node.tagName !== "a") return;
+
+      const href = typeof node.properties?.href === "string" ? node.properties.href : "";
+      if (!/^https?:\/\//i.test(href)) return;
+
+      node.properties.target = "_blank";
+      node.properties.rel = ["noopener", "noreferrer"];
+
+      const classes = node.properties.className;
+      node.properties.className = Array.isArray(classes)
+        ? [...classes, "fl-external"]
+        : ["fl-external"];
+    });
+  };
+}
+
+/**
  * A paragraph that is only a YouTube link becomes the video.
  *
  * The rule is deliberately narrow — the link has to be the whole paragraph —
@@ -356,6 +402,9 @@ const buildHtmlPipeline = (options: RenderOptions) =>
     .use(rehypeHighlight, { detect: false, languages: allLanguages })
     .use(rehypeImages, options)
     .use(rehypeYoutube)
+    // After the YouTube pass, which turns some links into iframes and leaves
+    // the rest as links — those are the ones that need a tab of their own.
+    .use(rehypeExternalLinks)
     .use(rehypeSanitize, schema)
     .use(rehypeStringify);
 


### PR DESCRIPTION
Four things reported together, all of which read as the app being broken rather than as a feature being unfinished.

## Linked files could not be opened

`[[repo:…]]` resolves to no note, so a click fell through to "create the note this link points at" — the editor offered to create a note *called* `repo:scripts/scan.sh`. Every link the file picker wrote was unopenable, and clicking one left a junk note behind.

A click now opens `RepoFileDialog`: the file is fetched **at the revision the link pinned**, not at today's branch head — a link that reports itself stale has to be able to show what the note was actually written about. Markdown renders as markdown, anything else as highlighted source through the same pipeline the preview uses, images as images, with "Open on GitHub" as the way out. The file names in the **Freshness** panel open the same viewer (still real anchors, so ⌘-click and "copy link address" keep working).

## Captured web sources rendered links that did nothing

Two separate causes:

- **Rich text** — `openOnClick` is off, because a plain click has to keep placing the caret, which left no way to follow a link at all. ⌘/Ctrl-click now opens one, the same modifier the wikilink extension already uses.
- **Preview** — a click followed the link in place, replacing the editor and any unsaved paragraph with the page being cited. Links out of the notebook now render with `target="_blank"` and `rel="noopener noreferrer"`. In-page anchors and app-relative hrefs are untouched; `rel` is pinned to those two tokens in the sanitiser schema rather than allowed as free text.

## Icons

The two blocks that cannot live in the editor package — Link a file, Web source — were drawn at stroke 1.3 with no round caps, against the block menu's 1.4/round house style, so they read as a rendering fault beside the icons they sit between. Both are now drawn to the same recipe, and the right-panel pair matches `FileGlyph`'s outline.

## Switching branch listed the repository twice

The workspace id contains the branch, and it has to: notes, the queue and the cached tree are filed under it, and a note on `main` is not the note at that path on a draft branch. But `switchBranch` added the new row and kept the old one, so a repository read on three branches appeared three times under one name in the switcher.

The row for the branch being left is now retired, and rows already accumulated on a device collapse on the next load. Content follows the branch as it did: open notes close (their content and base SHAs belong to the branch you left) and the tree and notes are re-read.

**Deliberate exception:** a branch left with edits that never reached GitHub stays listed. `removeWorkspace` deletes the notes along with the row, and that writing exists nowhere else — a second entry for a branch holding unpushed work is a true statement and the only way back to it.

## Following a link, and seeing where it goes first

The modifier-click above fixed "there is no way to follow this" but not "nobody would guess how" — a link that needs a chord to open is one most people read as decoration. A plain click in rich text now follows the link, always in a new tab.

The reason a plain click was reserved is real and does not go away: this is text being written, and a link you cannot put the caret inside is one you cannot edit. **Alt-click** places the cursor instead, and the hover card says so. Alt is the escape hatch rather than the default because a link gets followed a hundred times for every time its text is edited — the rare case should take the modifier. Shift-click still extends a selection.

Hovering a link shows a small card: the host, the page's own title, its own one-line summary, and the full address. That comes from a new `GET /api/link-preview`.

**On that route** — deliberately not a second copy of `/api/capture`: no archiving, no snapshot lookup, a 6s timeout and a 128KB read, because it fires on hover. It reuses the same `lib/safe-fetch` checking (every address resolved and checked before the fetch, re-checked at each redirect, since a public URL that 302s inward is how a one-shot check gets beaten), requires a session, and is rate limited at 120 per 5 minutes per client.

**The card is text only, never an image the page names.** A remote image would mean the reader's browser fetching from whatever host a note links to merely because the pointer crossed a word — a tracking pixel with extra steps — and the app's CSP would refuse it anyway. Signed out the card still names the host and address; only the title needs a session.

Verified live: the card renders and positions itself, a plain click calls `window.open(href, "_blank", "noopener,noreferrer")`, and an Alt-click does not.

## Seeing the page, and locking the one you are reading

**A picture in the hover card.** The page's own image, fetched through a new `/api/link-image` and served from this origin — never as an `<img>` pointing at the linked host, which would tell that host the pointer crossed a word in a private note. (The CSP would permit the direct address; that is not the objection.) The route reuses the same SSRF checking, refuses anything that is not a raster image — SVG is a document that can carry script — and caps what it will stream.

**Links look clickable.** In rich text the surrounding prose is editable, so the browser drew an I-beam over the links in it.

**Locking a note** — padlock in the header, `⌘⇧L`, or the command palette. Deliberately not one flag on one surface:

| Path | Why it needed its own guard |
| --- | --- |
| Rich text | `editable: false`, applied to an already-open editor too, or locking did nothing until you reopened the note |
| Source & split | `EditorState.readOnly` **and** `EditorView.editable`, in a compartment so toggling keeps undo history and scroll |
| The formatting bar | A toolbar button is a `view.dispatch`, which `readOnly` does not stop — the bar goes, and the source handle's mutating methods refuse as well |
| Paste / drop of an image | Uploads a file and inserts markdown itself, so a read-only view never sees it |
| Properties panel | A `fieldset`, so controls added later are covered too |
| Everything else | One guard in the notebook, since a lock that holds only while four surfaces each remember to check is not a lock |

It carries across a rename, is dropped on delete, is per device, and survives a reload. It does **not** stop reading, copying, following links, or a colleague's commit arriving — a lock is about your hands, not about freezing the file.

**The capture dialog now says what it is doing.** Pressing Capture did nothing visible for up to a minute: the slow half — asking the Wayback Machine to archive a page it has never seen — was awaited before anything was shown. The two halves are now separate requests, each reported as it lands, with the citation shown exactly as it will be written and addable while the archive lookup runs.

**The review icon.** An `<svg>` with a viewBox and no width collapses to nothing in a flex row, so that one action had a blank space where the others have an icon. Fixed in the glyph and enforced in the button.

**Documentation.** A new `/docs/reading` page (links, the hover card and what it does not send, reading a repository file, exactly what locking does and does not stop), a rewritten capture section, and README updates.

## Notes for the reviewer

- `format:check`, `lint`, `typecheck`, `build` and the full suite (1543 tests, 96 new) pass. The lock has 38 of them, covering each path in the table above plus lock/unlock in place and updates arriving from outside.
- Verified live in the dev server: the preview anchor carries `target`/`rel`, and a ⌘-click on a link in rich text calls `window.open` with the href.
- **Not** exercised against live GitHub — the file viewer and the branch collapse need a signed-in session, so those are covered by unit tests only. Worth a manual pass on a connected repository before merge.
- Docs: a new **Reading a note** page, plus updates to the features and GitHub pages and the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

