### PR TITLE
feat: see where a link goes, and lock the note you are reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ ForkLeaf has none.
 
 - [Why this exists](#why-this-exists)
 - [Features](#features)
-  - [Writing](#writing) · [Links](#links-between-notes) · [Search](#search) ·
+  - [Writing](#writing) · [Links](#links-between-notes) · [Reading](#reading) ·
+    [Search](#search) ·
     [Diagrams](#diagrams) · [Sync](#sync) · [History and review](#history-and-review) ·
     [Dashboard](#dashboard) · [Workspaces](#workspaces) ·
     [On your desktop](#on-your-desktop) · [Publishing](#publishing) ·
@@ -74,6 +75,35 @@ your notes at all:
   `[[q3-roadmap]]` and `[[Q3 roadmap]]` reach the same note.
 - **Linking ahead of yourself is normal.** A link to a note you haven't written
   is drawn muted rather than broken, and clicking it writes the note.
+
+### Reading
+
+A notebook is read far more often than it is written, and reading has its own
+set of problems.
+
+- **Links open, in a new tab.** One click, from the rendered preview and from
+  rich text alike — following a link never navigates away from a note holding
+  writing that hasn't reached GitHub yet. In rich text, `Alt`-click puts the
+  cursor in the link text instead, because that is the rarer of the two things
+  you do to a link.
+- **Hover a link and a card says where it goes**: the host, the page's own
+  title, its own one-line description, the picture it offers of itself, and the
+  full address. Enough to decide without opening it.
+- **The card doesn't tell the site you looked.** The page is read by ForkLeaf's
+  server, and even the picture is fetched server-side and served back from this
+  origin — no request from your browser, no referrer, no address. Addresses that
+  resolve inside a private network are refused outright.
+- **`[[repo:path/to/file]]` opens the file, in place.** Markdown renders,
+  anything else is shown as highlighted source, images as images — at the
+  revision the link pinned, not at whatever the branch has moved on to. That is
+  what lets a note that reports itself stale still show you what it was written
+  about.
+- **Lock a note against editing.** The padlock in the header, or `⌘⇧L`. A note
+  you read constantly is a note whose text is one stray keystroke from being
+  quietly edited and committed; locking stops typing, the formatting bar, the
+  `/` menu, pasted images, undo, and the properties panel — while leaving
+  reading, copying, links and incoming changes from GitHub exactly as they were.
+  Locks are per device, survive a reload, and carry across a rename.
 
 ### Search
 
@@ -142,6 +172,10 @@ blocks, so they render on github.com and anywhere else Mermaid is supported.
 - **Propose changes.** For a repository you cannot push to, ForkLeaf forks it,
   commits to a branch and opens a pull request — so contributing a documentation
   fix is the same gesture as editing a note.
+- **Capture a web page as a source.** A citation that records the address, the
+  moment you read it, and a link to an archived copy — asking the Wayback
+  Machine to make one if none exists. Written into the note as an ordinary
+  blockquote, so it stays readable anywhere markdown is.
 
 ### Dashboard
 
@@ -218,6 +252,7 @@ Export one note, or the whole workspace at once.
 | `⌘S`     | Save now rather than waiting for autosave            |
 | `⌘⇧N`    | New note                                             |
 | `⌘⇧E`    | Export                                               |
+| `⌘⇧L`    | Lock or unlock the note against editing              |
 | `⌘⇧?`    | Help and the full shortcut list                      |
 
 The complete table, including the rich-text and source-mode bindings, is on the
@@ -335,13 +370,13 @@ The app ships its own documentation site at `/docs`, covering every page below.
 Run `pnpm dev` and open <http://localhost:3000/docs>, or read it on the hosted
 instance.
 
-| Section             | Pages                                                      |
-| ------------------- | ---------------------------------------------------------- |
-| Start here          | Getting started · How ForkLeaf works                       |
-| Writing             | The editor · Diagrams · Properties · Exporting · Shortcuts |
-| GitHub              | Signing in · Repositories · Syncing · Conflicts            |
-| Account             | What it costs · Your data · Security model                 |
-| Running it yourself | Self-hosting · Firebase setup · Troubleshooting · FAQ      |
+| Section             | Pages                                                                       |
+| ------------------- | --------------------------------------------------------------------------- |
+| Start here          | Getting started · How ForkLeaf works                                        |
+| Writing             | The editor · Diagrams · Properties · Reading a note · Exporting · Shortcuts |
+| GitHub              | Signing in · Repositories · Syncing · Conflicts                             |
+| Account             | What it costs · Your data · Security model                                  |
+| Running it yourself | Self-hosting · Firebase setup · Troubleshooting · FAQ                       |
 
 Architecture notes live in [docs/architecture.md](docs/architecture.md), and the
 deployment guide in [docs/self-hosting.md](docs/self-hosting.md).

--- a/apps/web/src/app/api/capture/route.ts
+++ b/apps/web/src/app/api/capture/route.ts
@@ -192,10 +192,26 @@ export async function POST(request: NextRequest) {
     await requireClient();
     enforceRateLimit(request, RATE_LIMIT);
 
-    const body = (await request.json().catch(() => null)) as { url?: unknown } | null;
+    const body = (await request.json().catch(() => null)) as {
+      url?: unknown;
+      want?: unknown;
+    } | null;
     if (!body || typeof body.url !== "string") {
       throw new ApiError(400, "validation", "A web address is required.");
     }
+
+    /**
+     * Which half of the work to do.
+     *
+     * Both, by default, which is what this route always did. The dialog asks
+     * for them separately because they take wildly different amounts of time:
+     * reading a page is a second, and asking the Wayback Machine to make a
+     * snapshot that does not exist yet can take most of a minute. Doing them
+     * in one request meant pressing "Capture" and watching nothing happen for
+     * forty seconds, which reads as broken however honest the eventual answer
+     * is.
+     */
+    const want = body.want === "page" || body.want === "archive" ? body.want : "both";
 
     let url: URL;
     try {
@@ -214,16 +230,21 @@ export async function POST(request: NextRequest) {
     try {
       // Together: neither is worth failing the other over.
       const [page, existing] = await Promise.all([
-        fetchChecked(url, controller.signal)
-          .then((response) => (response && response.ok ? readTitle(response) : null))
-          .catch(() => null),
-        findSnapshot(url.toString(), controller.signal),
+        want === "archive"
+          ? Promise.resolve(null)
+          : fetchChecked(url, controller.signal)
+              .then((response) => (response && response.ok ? readTitle(response) : null))
+              .catch(() => null),
+        want === "page"
+          ? Promise.resolve({ archiveUrl: null, archivedAt: null })
+          : findSnapshot(url.toString(), controller.signal),
       ]);
 
       // A citation whose archived copy does not exist is an address and a
       // timestamp — which is what the feature was supposed to improve on. So
       // when there is no snapshot, ask for one before giving up.
-      const snapshot = existing.archiveUrl ? existing : await requestSnapshot(url.toString());
+      const snapshot =
+        want === "page" || existing.archiveUrl ? existing : await requestSnapshot(url.toString());
 
       return {
         url: url.toString(),

--- a/apps/web/src/app/api/link-image/route.test.ts
+++ b/apps/web/src/app/api/link-image/route.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const session = vi.fn().mockResolvedValue({ token: "t", user: { login: "me" } });
+vi.mock("@/lib/session", () => ({ getSession: () => session() }));
+
+// Every hostname resolves to one public address unless a test says otherwise.
+const lookup = vi.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+vi.mock("node:dns/promises", () => ({ lookup: (...args: unknown[]) => lookup(...args) }));
+
+const { GET } = await import("./route");
+const { resetRateLimits } = await import("@/lib/rate-limit");
+
+/** A response carrying `bytes` as an image of the given type. */
+function image(type = "image/png", bytes = new Uint8Array([1, 2, 3, 4])) {
+  return new Response(bytes, {
+    headers: { "content-type": type, "content-length": String(bytes.byteLength) },
+  });
+}
+
+function serve(respond: () => Response | Promise<Response>) {
+  const mock = vi.fn().mockImplementation(() => Promise.resolve(respond()));
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+async function get(url: string, ip = "image-test") {
+  const response = await GET(
+    new Request(`http://localhost/api/link-image?url=${encodeURIComponent(url)}`, {
+      headers: { "x-forwarded-for": ip },
+    }) as never,
+  );
+  return response;
+}
+
+beforeEach(() => {
+  resetRateLimits();
+  session.mockResolvedValue({ token: "t", user: { login: "me" } });
+  lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("GET /api/link-image", () => {
+  it("serves the bytes from our own origin", async () => {
+    serve(() => image());
+
+    const response = await get("https://cdn.example/cover.png");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("refuses an address inside the network the server runs in", async () => {
+    lookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+    const fetchMock = serve(() => image());
+
+    expect((await get("http://internal.example/secret.png")).status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("re-checks the address at every redirect", async () => {
+    lookup
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+      .mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+    serve(() => new Response(null, { status: 302, headers: { location: "http://localhost/x" } }));
+
+    expect((await get("https://cdn.example/cover.png")).status).toBe(400);
+  });
+
+  it("refuses to serve an SVG, which is a document that can carry script", async () => {
+    serve(() => image("image/svg+xml"));
+
+    expect((await get("https://cdn.example/cover.svg")).status).toBe(415);
+  });
+
+  it("refuses anything that is not an image at all", async () => {
+    serve(() => new Response("<html>", { headers: { "content-type": "text/html" } }));
+
+    expect((await get("https://cdn.example/page")).status).toBe(415);
+  });
+
+  it("refuses an image that declares itself too large", async () => {
+    serve(
+      () =>
+        new Response(new Uint8Array([1]), {
+          headers: { "content-type": "image/png", "content-length": String(9 * 1024 * 1024) },
+        }),
+    );
+
+    expect((await get("https://cdn.example/huge.png")).status).toBe(413);
+  });
+
+  it("stops reading an image that lied about its size", async () => {
+    // No content-length, and more bytes than the cap allows.
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let chunk = 0; chunk < 5; chunk += 1) {
+          controller.enqueue(new Uint8Array(600 * 1024));
+        }
+        controller.close();
+      },
+    });
+
+    serve(() => new Response(body, { headers: { "content-type": "image/png" } }));
+
+    expect((await get("https://cdn.example/liar.png")).status).toBe(413);
+  });
+
+  it("does not fetch for someone who is not signed in", async () => {
+    session.mockResolvedValue(null);
+    const fetchMock = serve(() => image());
+
+    expect((await get("https://cdn.example/cover.png")).status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("answers a page that has gone with a 404 rather than an error page", async () => {
+    serve(() => new Response("gone", { status: 404 }));
+
+    expect((await get("https://cdn.example/missing.png")).status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/link-image/route.ts
+++ b/apps/web/src/app/api/link-image/route.ts
@@ -1,0 +1,157 @@
+import { type NextRequest } from "next/server";
+import { getSession } from "@/lib/session";
+import { enforceRateLimit } from "@/lib/rate-limit";
+import { ApiError } from "@/lib/api-helpers";
+import { assertPublicUrl } from "@/lib/safe-fetch";
+
+/**
+ * The picture a linked page offers of itself, served from our own origin.
+ *
+ * A hover card that says what a page is called is a decent answer to "is this
+ * the right link"; seeing the page is a better one. What makes that awkward is
+ * that the picture lives on the linked site, and putting its address straight
+ * into an `<img>` would mean the reader's browser connecting there — with a
+ * referrer and an IP address — merely because the pointer crossed a word in a
+ * note. The CSP would permit it; that is not the objection. Hovering a link
+ * should not tell the other end that you did.
+ *
+ * So the bytes come through here instead, exactly as repository images do:
+ * one request from our server, and a same-origin image for the page. The
+ * linked site sees this server, once, and never the reader.
+ *
+ * The address is resolved and checked before anything is fetched, the response
+ * has to actually be a raster image, and it is capped — an image proxy that
+ * will stream anything, at any size, is a bandwidth amplifier with a URL bar.
+ */
+
+/** Hover-speed: an image that arrives after the card is gone is wasted. */
+const FETCH_TIMEOUT_MS = 6_000;
+
+/** Bigger than any thumbnail needs to be, small enough to be harmless. */
+const MAX_BYTES = 2 * 1024 * 1024;
+
+/** Redirect hops followed, each one re-checked before it is taken. */
+const MAX_REDIRECTS = 3;
+
+const RATE_LIMIT = { name: "link-image", limit: 120, windowMs: 5 * 60_000 };
+
+/**
+ * What may be served back.
+ *
+ * A closed list of raster formats. SVG is deliberately absent: it is a
+ * document that can carry script, and serving one from our own origin is
+ * precisely the hole this route otherwise closes.
+ */
+const ALLOWED = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"]);
+
+async function fetchChecked(start: URL, signal: AbortSignal): Promise<Response | null> {
+  let url = start;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    const response = await fetch(url, {
+      signal,
+      redirect: "manual",
+      headers: {
+        "user-agent": "ForkLeaf/1.0 (+https://github.com/praneeth132006/ForkLeaf)",
+        accept: "image/*",
+      },
+    });
+
+    if (response.status < 300 || response.status >= 400) return response;
+
+    const location = response.headers.get("location");
+    if (!location) return response;
+
+    url = await assertPublicUrl(new URL(location, url).toString());
+  }
+
+  return null;
+}
+
+/** Reads at most `MAX_BYTES`, and gives up rather than buffering more. */
+async function readCapped(response: Response): Promise<Uint8Array | null> {
+  const declared = Number(response.headers.get("content-length") ?? "0");
+  if (declared > MAX_BYTES) return null;
+
+  const reader = response.body?.getReader();
+  if (!reader) return null;
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      total += value.byteLength;
+      // A server that lies about content-length, or does not send one.
+      if (total > MAX_BYTES) return null;
+      chunks.push(value);
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+
+  const bytes = new Uint8Array(total);
+  let at = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, at);
+    at += chunk.byteLength;
+  }
+
+  return bytes;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    // Plain responses rather than the JSON envelope: this route answers with
+    // image bytes, and an `<img>` that gets JSON just shows a broken image.
+    if (!(await getSession())) return new Response("Sign in required", { status: 401 });
+
+    enforceRateLimit(request, RATE_LIMIT);
+
+    const asked = new URL(request.url).searchParams.get("url") ?? "";
+    if (!asked) throw new ApiError(400, "validation", "An image address is required.");
+
+    const url = await assertPublicUrl(asked);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+      const response = await fetchChecked(url, controller.signal);
+      if (!response?.ok) return new Response("Not found", { status: 404 });
+
+      const type = (response.headers.get("content-type") ?? "").split(";")[0]?.trim() ?? "";
+      if (!ALLOWED.has(type)) return new Response("Not an image", { status: 415 });
+
+      const bytes = await readCapped(response);
+      if (!bytes) return new Response("Too large", { status: 413 });
+
+      // Copied into a plain ArrayBuffer, which is what `Response` accepts.
+      return new Response(bytes.buffer.slice(0) as ArrayBuffer, {
+        headers: {
+          "Content-Type": type,
+          "Content-Length": String(bytes.byteLength),
+          // Private, because it was fetched for one signed-in reader; an hour,
+          // because the same card is opened repeatedly while reading a note.
+          "Cache-Control": "private, max-age=3600",
+          // Belt and braces: these bytes came from somewhere else entirely.
+          "Content-Security-Policy": "default-src 'none'; sandbox",
+          "X-Content-Type-Options": "nosniff",
+        },
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return new Response(error.message, { status: error.status });
+    }
+    // Anything else — an unreachable host, a refused address, a timeout — is
+    // "there is no picture", which the card is built to survive.
+    return new Response("Could not be fetched", { status: 400 });
+  }
+}

--- a/apps/web/src/app/api/link-preview/route.test.ts
+++ b/apps/web/src/app/api/link-preview/route.test.ts
@@ -129,11 +129,37 @@ describe("GET /api/link-preview — reading the page", () => {
     expect((await get("https://example.com/a.pdf")).body.title).toBeNull();
   });
 
-  it("never returns an image, so nothing in a card fetches from the page's host", async () => {
-    serve(() => page(`<head><meta property="og:image" content="https://tracker.example/px.png">`));
+  it("returns the page's picture as one of our own addresses, never the site's", async () => {
+    // An <img> pointing at the linked host would tell that host the pointer
+    // passed over a word in somebody's private note.
+    serve(() => page(`<head><meta property="og:image" content="https://cdn.example/cover.png">`));
 
     const { body } = await get("https://example.com/a");
-    expect(JSON.stringify(body)).not.toContain("tracker.example");
+
+    expect(body.image).toBe(
+      `/api/link-image?url=${encodeURIComponent("https://cdn.example/cover.png")}`,
+    );
+    expect(body.image.startsWith("/api/")).toBe(true);
+  });
+
+  it("resolves a picture written as a path against the page it was found on", async () => {
+    serve(() => page(`<head><meta property="og:image" content="/og/cover.png">`));
+
+    expect((await get("https://example.com/deep/page")).body.image).toBe(
+      `/api/link-image?url=${encodeURIComponent("https://example.com/og/cover.png")}`,
+    );
+  });
+
+  it("drops a picture that is not an http address", async () => {
+    serve(() => page(`<head><meta property="og:image" content="data:image/png;base64,AAAA">`));
+
+    expect((await get("https://example.com/a")).body.image).toBeNull();
+  });
+
+  it("has no picture when the page offers none", async () => {
+    serve(() => page("<head><title>Plain</title></head>"));
+
+    expect((await get("https://example.com/plain")).body.image).toBeNull();
   });
 });
 

--- a/apps/web/src/app/api/link-preview/route.ts
+++ b/apps/web/src/app/api/link-preview/route.ts
@@ -14,10 +14,15 @@ import { assertPublicUrl, UnsafeUrlError } from "@/lib/safe-fetch";
  *
  * Deliberately narrower than `/api/capture`, which this is not a second copy
  * of: no archiving, no snapshot lookup, a shorter timeout and a much smaller
- * read, because this fires on hover and has to be cheap. It also returns text
- * only — never an image URL. A remote image in a card would mean the reader's
- * browser fetching from whatever host a note links to, which is a tracking
- * pixel with extra steps, and our own CSP would refuse to load it anyway.
+ * read, because this fires on hover and has to be cheap.
+ *
+ * The picture a page offers of itself comes back as a link to `/api/link-image`
+ * rather than as the address it actually lives at. The CSP would allow the
+ * direct address — notes embed images from anywhere — so this is a deliberate
+ * choice, not a workaround: an `<img>` pointing at the linked site would mean
+ * the reader's browser connecting to it, with a referrer and an IP address,
+ * merely because the pointer crossed a word in a note. Hovering a link should
+ * not tell the other end that you did.
  *
  * Signed in only, and rate limited: it fetches an address the caller chose, so
  * it is exactly the shape of thing that gets pointed at somebody else's server
@@ -146,6 +151,36 @@ export interface LinkPreview {
   description: string | null;
   /** Where it lives, which is the part that is always known. */
   host: string;
+  /**
+   * A same-origin URL for the page's own picture of itself, when it offers one.
+   *
+   * Always one of ours — never the address the image actually lives at. See
+   * the note above: that distinction is the whole point.
+   */
+  image: string | null;
+}
+
+/**
+ * Turns a page's advertised image into a URL of ours, or into nothing.
+ *
+ * Relative addresses are resolved against the page, because plenty of sites
+ * write `og:image` as `/og/cover.png`. Anything that will not parse, or is not
+ * http(s), is dropped here rather than sent to a route that would only refuse
+ * it a moment later.
+ */
+function proxied(candidate: string | null, base: URL): string | null {
+  if (!candidate) return null;
+
+  let absolute: URL;
+  try {
+    absolute = new URL(candidate, base);
+  } catch {
+    return null;
+  }
+
+  if (absolute.protocol !== "http:" && absolute.protocol !== "https:") return null;
+
+  return `/api/link-image?url=${encodeURIComponent(absolute.toString())}`;
 }
 
 export async function GET(request: NextRequest) {
@@ -194,6 +229,7 @@ export async function GET(request: NextRequest) {
           ? metaContent(head, ["description", "og:description", "twitter:description"])
           : null,
         host: url.host,
+        image: head ? proxied(metaContent(head, ["og:image", "twitter:image"]), url) : null,
       };
 
       return preview;

--- a/apps/web/src/app/docs/content/features.tsx
+++ b/apps/web/src/app/docs/content/features.tsx
@@ -183,19 +183,29 @@ hello world
         A note that cites a page has a hole in it waiting to open: the page moves, the site is sold,
         the post is deleted, and the citation becomes a dead link that still looks sourced.
       </P>
+      <P>
+        There are three ways in, and they all open the same dialog: the properties panel →{" "}
+        <strong>Capture a web page as a source</strong>; the <Code>/</Code> menu in the editor →{" "}
+        <strong>Web source</strong>; or <Code>⌘K</Code> → <strong>Capture a web page</strong>.
+      </P>
       <OL>
         <LI>
-          Properties panel → <strong>Capture a web page as a source</strong>.
+          Paste the address — the <strong>Paste</strong> button fills it from your clipboard — and
+          press <strong>Capture</strong>, or just press Enter.
         </LI>
         <LI>
-          Paste the address and press <strong>Capture</strong>.
+          Two things are looked for, and each is reported as it arrives. The page&rsquo;s title
+          comes back in about a second. The archived copy can take up to a minute, because a page
+          the Wayback Machine has never seen has to be archived before it can be linked, and the
+          dialog says so while it waits rather than showing a bare spinner.
         </LI>
         <LI>
-          It shows what it found — the page title, and whether the Wayback Machine has an archived
-          copy and how old it is.
+          The citation is shown exactly as it will be written into the note, before it is written.
         </LI>
         <LI>
-          Press <strong>Add to this note</strong>.
+          Press <strong>Add to this note</strong>. You can press it while the archive lookup is
+          still running — the citation is worth having either way, and it says for itself whether an
+          archived copy exists.
         </LI>
       </OL>
       <P>The citation is written at the end of the note as an ordinary blockquote:</P>
@@ -219,10 +229,15 @@ hello world
         hovering a link never tells that site you did.
       </P>
       <Note>
-        Capturing needs you to be signed in, because the fetch happens on the server. It refuses
-        addresses that resolve inside a private network, which is why it cannot capture a page on
-        your own machine or an intranet.
+        Capturing needs you to be signed in, because the fetch happens on the server — your browser
+        never contacts the page being cited. It refuses addresses that resolve inside a private
+        network, which is why it cannot capture a page on your own machine or an intranet, and it is
+        rate limited at twenty captures every five minutes.
       </Note>
+      <P>
+        Nothing is inserted into a note that is <strong>locked</strong>; the dialog says so rather
+        than appearing to work. See <strong>Reading a note</strong> for what locking does.
+      </P>
     </>
   );
 }

--- a/apps/web/src/app/docs/content/features.tsx
+++ b/apps/web/src/app/docs/content/features.tsx
@@ -81,13 +81,6 @@ hello world
         never on your computer, and never on the server. It does have internet access, because a
         runbook that cannot reach the host it is about is a text file.
       </P>
-      <Note>
-        This needs a sandbox to be configured, in both your local <Code>apps/web/.env.local</Code>{" "}
-        and your hosting project&rsquo;s environment variables: <Code>VERCEL_TOKEN</Code>,{" "}
-        <Code>VERCEL_TEAM_ID</Code> and <Code>VERCEL_PROJECT_ID</Code>. Without them the Run button
-        says so rather than failing quietly.
-      </Note>
-
       <H2 id="review">5. Reviewing a note as a pull request</H2>
       <OL>
         <LI>

--- a/apps/web/src/app/docs/content/index.tsx
+++ b/apps/web/src/app/docs/content/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { GettingStarted, HowItWorks } from "./start";
 import { Editor, Diagrams, Properties, Export, Shortcuts } from "./writing";
+import { Reading } from "./reading";
 import { Features } from "./features";
 import { SigningIn, Repositories, Sync, Conflicts } from "./github";
 import { Plans, PrivacyAndData, Security } from "./account";
@@ -21,6 +22,7 @@ export const DOC_CONTENT: Record<string, () => React.JSX.Element> = {
   diagrams: Diagrams,
   properties: Properties,
   export: Export,
+  reading: Reading,
   shortcuts: Shortcuts,
   features: Features,
   "signing-in": SigningIn,

--- a/apps/web/src/app/docs/content/reading.tsx
+++ b/apps/web/src/app/docs/content/reading.tsx
@@ -1,0 +1,164 @@
+import { Code, H2, H3, Lead, LI, Note, P, Table, UL } from "@/components/prose";
+
+/**
+ * Reading a note, as opposed to writing one.
+ *
+ * The rest of the documentation is about getting text in. This page is about
+ * everything that happens once it is there and you are looking at it: links
+ * that open, a card that says where they go, files read in place, and a lock
+ * that stops your hands changing what you came to read.
+ */
+export function Reading() {
+  return (
+    <>
+      <Lead>
+        A notebook is read far more often than it is written. This page covers what a note does when
+        you are reading it: following links, seeing where they go before you commit to them, opening
+        a linked file, and locking a note so that reading it cannot change it.
+      </Lead>
+
+      <H2 id="links">Opening a link</H2>
+      <P>
+        Click it. Links always open in a new tab, from the preview and from Rich view alike — the
+        alternative is navigating away from a note that may hold writing which has not reached
+        GitHub yet.
+      </P>
+
+      <Table
+        head={["Where you are", "Click", "Alt-click", "⌘ / Ctrl-click"]}
+        rows={[
+          [
+            "Rich view",
+            "Opens the link in a new tab",
+            "Puts the cursor in the link text",
+            "Opens the link in a new tab",
+          ],
+          [
+            "Split & Source (preview side)",
+            "Opens the link in a new tab",
+            "—",
+            "Opens the link in a new tab",
+          ],
+          ["Source (markdown side)", "The address is plain text; edit it as text", "—", "—"],
+        ]}
+      />
+
+      <P>
+        Alt-click is how you edit a link&rsquo;s text in Rich view. It takes the modifier rather
+        than the plain click because a link gets followed a great many times for every time its
+        wording is changed — and in Source view the markdown is plain text you edit like any other.
+      </P>
+
+      <H3 id="wikilinks">Links to your own notes</H3>
+      <P>
+        A <Code>[[wikilink]]</Code> opens the note it names in a tab here, rather than in the
+        browser. If no note of that name exists yet, clicking it writes one — linking ahead of
+        yourself is how an outline gets built.
+      </P>
+
+      <H2 id="hover">The hover card</H2>
+      <P>Rest the pointer on a link for a moment and a small card appears with:</P>
+      <UL>
+        <LI>
+          the host — <Code>github.com</Code>, <Code>builtwith.com</Code>;
+        </LI>
+        <LI>the page&rsquo;s own title;</LI>
+        <LI>its own one-line description of itself, when it publishes one;</LI>
+        <LI>the picture it offers of itself, when it has one;</LI>
+        <LI>the full address, so you can see where you are actually going.</LI>
+      </UL>
+      <P>
+        The card stays while the pointer is on it, so the address can be selected and copied. Escape
+        closes it, and it closes by itself when the note scrolls.
+      </P>
+
+      <Note>
+        <strong>Nothing in the card is loaded from the site you are hovering.</strong> The page is
+        read by ForkLeaf&rsquo;s own server, and even the picture is fetched by the server and
+        served back from this origin. Hovering a link in your private notes does not tell the other
+        end that you did — no request, no referrer, no address. That is also why the card needs you
+        to be signed in: the reading is done server-side. Signed out, the card still names the host
+        and the full address.
+      </Note>
+
+      <P>
+        A page that cannot be read — offline, blocked, an address inside a private network — still
+        gets a card with its host and address. Addresses that resolve inside a private network are
+        refused outright, which is why a link to something on your own machine or an intranet shows
+        no title.
+      </P>
+
+      <H2 id="repo-files">Reading a linked file</H2>
+      <P>
+        A <Code>[[repo:path/to/file]]</Code> link names a file in the repository rather than a note.
+        Clicking one opens the file for reading without leaving the note:
+      </P>
+      <UL>
+        <LI>Markdown renders as markdown; everything else is shown as highlighted source.</LI>
+        <LI>Images are shown as images.</LI>
+        <LI>
+          It opens at the revision the link pinned — <Code>@a1b2c3d</Code> — not at whatever the
+          branch holds now. That is the point: a link that reports itself stale has to be able to
+          show you what the note was actually written about.
+        </LI>
+        <LI>
+          <strong>Open on GitHub</strong> is there for the rest — history, blame, editing.
+        </LI>
+      </UL>
+      <P>
+        The file names listed under <strong>Freshness</strong> in the properties panel open the same
+        viewer.
+      </P>
+
+      <H2 id="locking">Locking a note</H2>
+      <P>
+        A reference note is one you read far more often than you write. Reading it means clicking
+        around in it, which leaves the cursor somewhere in the text — and from there a stray
+        keystroke is an edit that saves itself, commits itself, and is found weeks later as a lone
+        character in the middle of a paragraph.
+      </P>
+      <P>
+        The padlock in the editor header locks the note on screen. <Code>⌘⇧L</Code> does the same,
+        and so does <strong>Lock this note against editing</strong> in the command palette.
+      </P>
+
+      <H3 id="locking-what">What a lock stops</H3>
+      <UL>
+        <LI>Typing, in all three views.</LI>
+        <LI>The formatting bar, which disappears rather than sitting there greyed out.</LI>
+        <LI>
+          The <Code>/</Code> menu, and every toolbar action that would write to the note.
+        </LI>
+        <LI>Pasting or dropping an image.</LI>
+        <LI>Undo and redo.</LI>
+        <LI>The properties panel — title, tags and custom fields are all disabled.</LI>
+        <LI>Adding a linked file or a captured source, which say so rather than doing nothing.</LI>
+        <LI>The automatic repair pass that fixes image links when a note opens.</LI>
+      </UL>
+
+      <H3 id="locking-what-not">What it does not stop</H3>
+      <UL>
+        <LI>
+          Reading, selecting and copying — the whole point. Links still open, diagrams still render.
+        </LI>
+        <LI>
+          Changes arriving from GitHub. A colleague&rsquo;s commit still lands: the lock is about
+          your hands, not about freezing the file.
+        </LI>
+        <LI>
+          Renaming or deleting the note. Both are deliberate acts behind their own confirmation, and
+          a lock carries across a rename rather than falling off.
+        </LI>
+        <LI>Editing the same note somewhere else. The lock is remembered on this device only.</LI>
+      </UL>
+
+      <Note>
+        Locks are per device and per workspace, kept beside your other preferences rather than in
+        the note itself. Writing them into the file would mean a commit every time anybody locked or
+        unlocked anything — history nobody asked for, from a button whose whole job is to prevent
+        changes nobody asked for. They survive a reload, and a locked note that is renamed stays
+        locked.
+      </Note>
+    </>
+  );
+}

--- a/apps/web/src/app/docs/nav.ts
+++ b/apps/web/src/app/docs/nav.ts
@@ -55,6 +55,12 @@ export const DOC_SECTIONS: DocSection[] = [
         summary: "Titles, tags and custom fields, and how they map onto YAML in the file.",
       },
       {
+        slug: "reading",
+        title: "Reading a note",
+        summary:
+          "Following links, the hover card that says where they go, reading a linked file, and locking a note so reading it cannot change it.",
+      },
+      {
         slug: "export",
         title: "Exporting",
         summary: "Markdown, PDF, HTML, Word, plain text and JSON — all produced in your browser.",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -438,6 +438,13 @@ select:focus-visible {
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
+  /*
+   * A link looks like a link and behaves like one, so the pointer has to say
+   * so. In the rich-text editor the surrounding text is editable, which means
+   * the browser draws an I-beam over everything including the links in it —
+   * and a link that gives no sign of being clickable is one nobody clicks.
+   */
+  cursor: pointer;
 }
 
 /*

--- a/apps/web/src/components/CaptureDialog.test.tsx
+++ b/apps/web/src/components/CaptureDialog.test.tsx
@@ -5,21 +5,54 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { CaptureDialog } from "./CaptureDialog";
 
 const capturePage = vi.fn();
-vi.mock("@/lib/gateway", () => ({ capturePage: (...a: unknown[]) => capturePage(...a) }));
+
+/**
+ * Only `capturePage` is faked. The error class is the real one, because the
+ * dialog decides what to say with `instanceof` — a stand-in would make the
+ * tests agree with a version of the code that does not exist.
+ */
+vi.mock("@/lib/gateway", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/gateway")>("@/lib/gateway");
+  return { ...actual, capturePage: (...a: unknown[]) => capturePage(...a) };
+});
+
+const { ApiGatewayError } = await import("@/lib/gateway");
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 
-const RESULT = {
+const PAGE = {
   url: "https://example.com/a",
   title: "The article",
   capturedAt: "2026-08-27T10:04:09.000Z",
-  archiveUrl: "https://web.archive.org/web/20240315120000/https://example.com/a",
-  archivedAt: "2024-03-15T12:00:00.000Z",
+  archiveUrl: null,
+  archivedAt: null,
   titleFromUrl: false,
 };
+
+const ARCHIVE = {
+  ...PAGE,
+  archiveUrl: "https://web.archive.org/web/20240315120000/https://example.com/a",
+  archivedAt: "2024-03-15T12:00:00.000Z",
+};
+
+/** Answers the two halves of a capture separately, as the route does. */
+function serve(
+  page: unknown = PAGE,
+  archive: unknown = ARCHIVE,
+  options: { pageRejects?: unknown; archiveRejects?: unknown } = {},
+) {
+  capturePage.mockImplementation((_url: string, want: string) => {
+    if (want === "page") {
+      return options.pageRejects ? Promise.reject(options.pageRejects) : Promise.resolve(page);
+    }
+    return options.archiveRejects
+      ? Promise.reject(options.archiveRejects)
+      : Promise.resolve(archive);
+  });
+}
 
 function view(onInsert = vi.fn()) {
   render(<CaptureDialog onInsert={onInsert} onClose={vi.fn()} />);
@@ -29,50 +62,115 @@ function view(onInsert = vi.fn()) {
 const type = (value: string) =>
   fireEvent.change(screen.getByLabelText(/address to capture/i), { target: { value } });
 
-describe("CaptureDialog", () => {
+const capture = () => fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+
+describe("CaptureDialog — before anything is typed", () => {
+  it("says what the feature does and what it writes", async () => {
+    // "I do not know how this works or how to use it" is a bug in the dialog,
+    // not in the reader.
+    view();
+
+    expect(screen.getByText(/paste the address of a page you are citing/i)).toBeTruthy();
+    expect(screen.getByText(/> \*\*Source\*\*/)).toBeTruthy();
+  });
+
   it("refuses something that is not a web address, without asking the server", async () => {
     view();
     type("not a url");
-    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    capture();
 
     await waitFor(() => expect(screen.getByText(/not a web address/i)).toBeTruthy());
     expect(capturePage).not.toHaveBeenCalled();
   });
+});
 
-  it("shows what it found before anything is written down", async () => {
-    capturePage.mockResolvedValue(RESULT);
+describe("CaptureDialog — while it works", () => {
+  it("asks for the two halves separately, so the fast one is not held up", async () => {
+    serve();
     view();
     type("https://example.com/a");
-    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    capture();
+
+    await waitFor(() => expect(capturePage).toHaveBeenCalledTimes(2));
+    expect(capturePage).toHaveBeenCalledWith("https://example.com/a", "page");
+    expect(capturePage).toHaveBeenCalledWith("https://example.com/a", "archive");
+  });
+
+  it("names what it is waiting for rather than showing a bare spinner", async () => {
+    // A slow archive with no explanation is why this read as broken.
+    capturePage.mockImplementation((_url: string, want: string) =>
+      want === "page" ? Promise.resolve(PAGE) : new Promise(() => {}),
+    );
+    view();
+    type("https://example.com/a");
+    capture();
 
     await waitFor(() => expect(screen.getByText("The article")).toBeTruthy());
-    expect(screen.getByText(/an archived copy exists/i)).toBeTruthy();
+    expect(screen.getByText(/looking for an archived copy/i)).toBeTruthy();
+    expect(screen.getByText(/up to a minute/i)).toBeTruthy();
+  });
+
+  it("offers to add the citation before the archive lookup has finished", async () => {
+    capturePage.mockImplementation((_url: string, want: string) =>
+      want === "page" ? Promise.resolve(PAGE) : new Promise(() => {}),
+    );
+    const onInsert = view();
+    type("https://example.com/a");
+    capture();
+
+    await waitFor(() => expect(screen.getByText("The article")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /add to this note/i }));
+
+    await waitFor(() => expect(onInsert).toHaveBeenCalled());
+  });
+});
+
+describe("CaptureDialog — what it found", () => {
+  it("shows the exact text that will be written into the note", async () => {
+    serve();
+    view();
+    type("https://example.com/a");
+    capture();
+
+    await waitFor(() => expect(screen.getByText(/what goes into the note/i)).toBeTruthy());
+    expect(screen.getByText(/> \*\*Source\*\* — \[The article\]/)).toBeTruthy();
+  });
+
+  it("puts the archived copy into that text once it arrives", async () => {
+    serve();
+    view();
+    type("https://example.com/a");
+    capture();
+
+    await waitFor(() => expect(screen.getByText(/archived copy from/i)).toBeTruthy());
+    expect(screen.getByText(/web\.archive\.org/)).toBeTruthy();
   });
 
   it("says plainly when there is no archived copy", async () => {
-    // This changes what the citation is worth and used to be invisible.
-    capturePage.mockResolvedValue({ ...RESULT, archiveUrl: null, archivedAt: null });
+    serve(PAGE, { ...PAGE, archiveUrl: null, archivedAt: null });
     view();
     type("https://example.com/a");
-    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    capture();
 
-    await waitFor(() => expect(screen.getByText(/no snapshot of this page/i)).toBeTruthy());
+    // Said twice on purpose: once as the step's own outcome, and once inside
+    // the citation, which carries the caveat into the note.
+    await waitFor(() => expect(screen.getAllByText(/no archived copy/i).length).toBe(2));
   });
 
   it("says when the title is only the address", async () => {
-    capturePage.mockResolvedValue({ ...RESULT, titleFromUrl: true });
+    serve({ ...PAGE, titleFromUrl: true });
     view();
     type("https://example.com/a");
-    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    capture();
 
-    await waitFor(() => expect(screen.getByText(/could not be read/i)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/address stands in for a title/i)).toBeTruthy());
   });
 
   it("writes nothing until the reader says so", async () => {
-    capturePage.mockResolvedValue(RESULT);
+    serve();
     const onInsert = view();
     type("https://example.com/a");
-    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    capture();
 
     await waitFor(() => expect(screen.getByText("The article")).toBeTruthy());
     expect(onInsert).not.toHaveBeenCalled();
@@ -83,20 +181,89 @@ describe("CaptureDialog", () => {
   });
 
   it("captures on Enter, without reaching for the button", async () => {
-    capturePage.mockResolvedValue(RESULT);
+    serve();
     view();
     type("https://example.com/a");
     fireEvent.keyDown(screen.getByLabelText(/address to capture/i), { key: "Enter" });
 
-    await waitFor(() => expect(capturePage).toHaveBeenCalledWith("https://example.com/a"));
+    await waitFor(() => expect(capturePage).toHaveBeenCalledWith("https://example.com/a", "page"));
   });
+});
 
+describe("CaptureDialog — when it fails", () => {
   it("passes on why a capture failed", async () => {
-    capturePage.mockRejectedValue(new Error("That address is inside a private network."));
+    serve(undefined, undefined, {
+      pageRejects: new Error("That address is inside a private network."),
+    });
     view();
     type("https://example.com/a");
-    fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    capture();
 
     await waitFor(() => expect(screen.getByText(/private network/i)).toBeTruthy());
+  });
+
+  it("explains an expired sign-in instead of repeating the status code", async () => {
+    serve(undefined, undefined, {
+      pageRejects: new ApiGatewayError("unauthorized", "Sign in with GitHub to continue.", 401),
+    });
+    view();
+    type("https://example.com/a");
+    capture();
+
+    await waitFor(() => expect(screen.getByText(/sign in with github to capture/i)).toBeTruthy());
+  });
+
+  it("explains being rate limited", async () => {
+    serve(undefined, undefined, {
+      pageRejects: new ApiGatewayError("rate-limited", "Too many requests", 429),
+    });
+    view();
+    type("https://example.com/a");
+    capture();
+
+    await waitFor(() => expect(screen.getByText(/a lot of captures/i)).toBeTruthy());
+  });
+
+  it("does not treat a missing archive as a failure of the capture", async () => {
+    serve(PAGE, undefined, { archiveRejects: new Error("archive.org is down") });
+    view();
+    type("https://example.com/a");
+    capture();
+
+    await waitFor(() => expect(screen.getByText("The article")).toBeTruthy());
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("ignores an answer for an address the reader has moved on from", async () => {
+    // The slow half routinely outlives the reader's patience; its snapshot
+    // must not land in the citation for whatever they typed next.
+    let resolveFirst: (value: unknown) => void = () => {};
+    capturePage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    capturePage.mockImplementation((_url: string, want: string) =>
+      want === "page"
+        ? Promise.resolve({ ...PAGE, title: "The second one" })
+        : Promise.resolve(ARCHIVE),
+    );
+
+    view();
+    type("https://example.com/first");
+    capture();
+
+    // Enter rather than the button, which reads "Reading…" and is disabled
+    // while the first capture is still outstanding — which is the whole
+    // situation being tested.
+    type("https://example.com/second");
+    fireEvent.keyDown(screen.getByLabelText(/address to capture/i), { key: "Enter" });
+    await waitFor(() => expect(screen.getByText("The second one")).toBeTruthy());
+
+    resolveFirst({ ...PAGE, title: "The first one" });
+
+    await waitFor(() => expect(screen.queryByText("The first one")).toBeNull());
+    expect(screen.getByText("The second one")).toBeTruthy();
   });
 });

--- a/apps/web/src/components/CaptureDialog.tsx
+++ b/apps/web/src/components/CaptureDialog.tsx
@@ -1,22 +1,29 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { formatSource, isCapturable, type CapturedSource } from "@forkleaf/markdown-engine";
-import { capturePage, type CaptureResult } from "@/lib/gateway";
+import { capturePage, ApiGatewayError, type CaptureResult } from "@/lib/gateway";
 import { Dialog } from "./Dialog";
 
 /**
- * Capturing a page, with the result shown before it is written down.
+ * Capturing a page, with what is happening said out loud while it happens.
  *
- * This was a bare text prompt: paste a URL, press enter, and a citation
- * appeared at the end of the note with no indication of what had been found —
- * whether the title was read or guessed from the address, whether an archived
- * copy exists, or how old that copy is. All three change what the citation is
- * worth, and all three were invisible until you went looking in the note.
+ * This was a text box and a button, and pressing the button did nothing
+ * visible for up to a minute — because the slow half of a capture is asking
+ * the Wayback Machine to archive a page it has never seen, and that was being
+ * waited for before anything at all was shown. An honest answer that arrives
+ * forty seconds later is indistinguishable, from the outside, from a feature
+ * that does not work.
  *
- * So the capture happens first and is shown, and inserting it is a separate
- * decision. The honest failure — a page with no snapshot — is stated plainly
- * here rather than discovered later.
+ * So the two halves are asked for separately and each is shown as it lands:
+ * the title in about a second, the archived copy whenever it arrives. Both are
+ * named on screen while they are still outstanding, because "what is it doing"
+ * is the question a spinner refuses to answer.
+ *
+ * What actually goes into the note is shown before it goes in, exactly as it
+ * will be written, and inserting stays a separate press. A citation is a claim
+ * about where something came from; nobody should have to go and look in the
+ * note to find out what claim was made on their behalf.
  */
 
 export interface CaptureDialogProps {
@@ -25,11 +32,29 @@ export interface CaptureDialogProps {
   onClose: () => void;
 }
 
+/** What each half of the capture is doing. */
+type Step = "idle" | "working" | "done" | "failed";
+
 export function CaptureDialog({ onInsert, onClose }: CaptureDialogProps) {
   const [url, setUrl] = useState("");
-  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [found, setFound] = useState<CaptureResult | null>(null);
+
+  const [page, setPage] = useState<CaptureResult | null>(null);
+  const [pageStep, setPageStep] = useState<Step>("idle");
+  const [archive, setArchive] = useState<{ archiveUrl: string | null; archivedAt: string | null }>({
+    archiveUrl: null,
+    archivedAt: null,
+  });
+  const [archiveStep, setArchiveStep] = useState<Step>("idle");
+
+  /**
+   * The capture the answers belong to.
+   *
+   * Two requests are in flight at once and the slow one routinely outlives the
+   * reader's patience: without this, a snapshot for the address they gave up
+   * on lands in the citation for the one they typed next.
+   */
+  const attempt = useRef(0);
 
   const capture = useCallback(async () => {
     const trimmed = url.trim();
@@ -39,32 +64,111 @@ export function CaptureDialog({ onInsert, onClose }: CaptureDialogProps) {
       return;
     }
 
-    setBusy(true);
-    setError(null);
-    setFound(null);
+    const mine = attempt.current + 1;
+    attempt.current = mine;
 
-    try {
-      setFound(await capturePage(trimmed));
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "That page could not be captured.");
-    } finally {
-      setBusy(false);
-    }
+    setError(null);
+    setPage(null);
+    setArchive({ archiveUrl: null, archivedAt: null });
+    setPageStep("working");
+    setArchiveStep("working");
+
+    // Not awaited together: the whole point is that the fast half is shown
+    // without waiting for the slow one.
+    void capturePage(trimmed, "page")
+      .then((found) => {
+        if (attempt.current !== mine) return;
+        setPage(found);
+        setPageStep("done");
+      })
+      .catch((caught: unknown) => {
+        if (attempt.current !== mine) return;
+        setPageStep("failed");
+        setError(explain(caught));
+      });
+
+    void capturePage(trimmed, "archive")
+      .then((found) => {
+        if (attempt.current !== mine) return;
+        setArchive({ archiveUrl: found.archiveUrl, archivedAt: found.archivedAt });
+        setArchiveStep(found.archiveUrl ? "done" : "failed");
+      })
+      .catch(() => {
+        if (attempt.current !== mine) return;
+        // Not an error the reader has to act on: the citation is still worth
+        // having, and it will say for itself that nothing was archived.
+        setArchiveStep("failed");
+      });
   }, [url]);
 
+  /** The exact text that will be written into the note. */
+  const citation = page
+    ? formatSource({
+        url: page.url,
+        title: page.title,
+        capturedAt: page.capturedAt,
+        ...archive,
+      } as CapturedSource)
+    : null;
+
   const insert = useCallback(async () => {
-    if (!found) return;
-    await onInsert(formatSource(found as CapturedSource));
+    if (!citation) return;
+    await onInsert(citation);
     onClose();
-  }, [found, onInsert, onClose]);
+  }, [citation, onInsert, onClose]);
+
+  /**
+   * Fills the box from the clipboard, which is where the address always is.
+   *
+   * Offered as a button rather than done on open: reading somebody's clipboard
+   * unasked is not a thing an app should do, and in most browsers it prompts.
+   */
+  // Read once, when the dialog mounts. Not in an effect: that would be a state
+  // write during mount for a value that never changes, and this component only
+  // ever mounts in response to a click, so there is no server render to differ
+  // from.
+  const [canPaste] = useState(
+    () => typeof navigator !== "undefined" && Boolean(navigator.clipboard?.readText),
+  );
+
+  const pasteFromClipboard = useCallback(async () => {
+    try {
+      const text = (await navigator.clipboard.readText()).trim();
+      if (text) setUrl(text);
+    } catch {
+      // Refused, or empty. The box is still there to type into.
+    }
+  }, []);
+
+  const busy = pageStep === "working";
 
   return (
     <Dialog
-      title="Capture a web page"
+      title="Capture a web page as a source"
       subtitle="Its address, when you read it, and a copy that outlives it"
       onClose={onClose}
     >
       <div className="space-y-3">
+        {/* Said before anything is typed, because "what will this do to my
+            note" is the question, and the answer is short. */}
+        {pageStep === "idle" && (
+          <div className="space-y-2 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-3 text-[12px] leading-snug text-[var(--fl-muted)]">
+            <p>
+              Paste the address of a page you are citing. ForkLeaf reads its title, records the
+              moment you read it, and finds — or asks the Wayback Machine to make — an archived
+              copy.
+            </p>
+            <p>
+              You get a plain blockquote at the end of the note, committed with it like any other
+              edit:
+            </p>
+            <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-[var(--fl-surface)] p-2 font-mono text-[11px] text-[var(--fl-text)]">
+              {"> **Source** — [The article](https://example.com/article)\n" +
+                "> Read 2026-08-27 10:04 UTC · [archived copy](https://web.archive.org/…)"}
+            </pre>
+          </div>
+        )}
+
         <div className="flex gap-2">
           <input
             autoFocus
@@ -80,63 +184,131 @@ export function CaptureDialog({ onInsert, onClose }: CaptureDialogProps) {
             aria-label="Address to capture"
             className="min-w-0 flex-1 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-2 text-[13px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
           />
+
+          {canPaste && url.trim() === "" && (
+            <button
+              type="button"
+              onClick={() => void pasteFromClipboard()}
+              className="fl-btn shrink-0"
+            >
+              Paste
+            </button>
+          )}
+
           <button
             type="button"
             onClick={() => void capture()}
             disabled={busy || url.trim() === ""}
-            className="fl-btn shrink-0 disabled:opacity-40"
+            className="fl-btn fl-btn-primary shrink-0 disabled:opacity-40"
           >
             {busy ? "Reading…" : "Capture"}
           </button>
         </div>
 
-        {error && <p className="text-[13px] text-[var(--fl-danger)]">{error}</p>}
+        {error && (
+          <p role="alert" className="text-[13px] text-[var(--fl-danger)]">
+            {error}
+          </p>
+        )}
 
-        {found && (
+        {pageStep !== "idle" && (
           <div className="space-y-2 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-3">
-            <p className="text-[13px] font-medium text-[var(--fl-text)]">{found.title}</p>
-            <p className="truncate font-mono text-[11.5px] text-[var(--fl-muted)]">{found.url}</p>
+            {/* Both halves are named while they are still outstanding. A
+                spinner says "wait"; this says what for. */}
+            <Line
+              step={pageStep}
+              working="Reading the page…"
+              done={page?.title ?? ""}
+              failed="The page itself could not be read."
+            />
 
-            {/* All three of these change what the citation is worth, and all
-                three used to be invisible until you looked in the note. */}
-            {found.titleFromUrl && (
+            {page?.titleFromUrl && pageStep === "done" && (
               <p className="text-[12px] text-[var(--fl-muted)]">
-                The page itself could not be read, so its address stands in for a title.
+                Its address stands in for a title, since the page could not be read from here.
               </p>
             )}
 
-            <p className="text-[12px] text-[var(--fl-muted)]">
-              {found.archiveUrl ? (
-                <>
-                  An archived copy exists
-                  {found.archivedAt
-                    ? ` from ${new Date(found.archivedAt).toLocaleDateString()}`
-                    : ""}
-                  . It will still be readable if this page disappears.
-                </>
-              ) : (
-                <>
-                  The Wayback Machine has no snapshot of this page. The citation will say so — this
-                  link may not outlive the page.
-                </>
-              )}
-            </p>
+            <Line
+              step={archiveStep}
+              working="Looking for an archived copy — this can take up to a minute…"
+              done={
+                archive.archivedAt
+                  ? `Archived copy from ${new Date(archive.archivedAt).toLocaleDateString()}`
+                  : "Archived copy found"
+              }
+              failed="No archived copy — the citation will say so."
+            />
 
-            <div className="flex justify-end pt-1">
-              <button type="button" onClick={() => void insert()} className="fl-btn fl-btn-primary">
-                Add to this note
-              </button>
-            </div>
+            {citation && (
+              <>
+                <p className="pt-1 text-[11.5px] uppercase tracking-wide text-[var(--fl-muted)]">
+                  What goes into the note
+                </p>
+                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-[var(--fl-surface)] p-2 font-mono text-[11px] text-[var(--fl-text)]">
+                  {citation}
+                </pre>
+
+                <div className="flex items-center justify-between gap-3 pt-1">
+                  <span className="text-[11.5px] text-[var(--fl-muted)]">
+                    {archiveStep === "working"
+                      ? "You can add it now — the archived copy is still being looked for."
+                      : "Added at the end of this note."}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => void insert()}
+                    className="fl-btn fl-btn-primary shrink-0"
+                  >
+                    Add to this note
+                  </button>
+                </div>
+              </>
+            )}
           </div>
-        )}
-
-        {!found && !busy && (
-          <p className="text-[11.5px] leading-snug text-[var(--fl-muted)]">
-            The address, the time you read it, and a link to an archived copy are written into the
-            note as an ordinary blockquote, and committed with it like any other edit.
-          </p>
         )}
       </div>
     </Dialog>
   );
+}
+
+/** One step of the capture, in whichever state it is in. */
+function Line({
+  step,
+  working,
+  done,
+  failed,
+}: {
+  step: Step;
+  working: string;
+  done: string;
+  failed: string;
+}) {
+  if (step === "idle") return null;
+
+  const text = step === "working" ? working : step === "done" ? done : failed;
+
+  return (
+    <p className="flex items-start gap-2 text-[12.5px] leading-snug">
+      <span aria-hidden="true" className="mt-[3px] shrink-0 text-[var(--fl-muted)]">
+        {step === "working" ? "…" : step === "done" ? "✓" : "—"}
+      </span>
+      <span className={step === "done" ? "text-[var(--fl-text)]" : "text-[var(--fl-muted)]"}>
+        {text}
+      </span>
+    </p>
+  );
+}
+
+/** The sentence that helps, for the failures that have one. */
+function explain(caught: unknown): string {
+  if (caught instanceof ApiGatewayError) {
+    if (caught.needsAuth)
+      return "Sign in with GitHub to capture pages — the page is read by our server, not by your browser.";
+    if (caught.code === "rate-limited")
+      return "That is a lot of captures in a short time. Try again in a few minutes.";
+    if (caught.status === 0) return "No connection to the server, so the page could not be read.";
+    return caught.message;
+  }
+
+  return caught instanceof Error ? caught.message : "That page could not be captured.";
 }

--- a/apps/web/src/components/EditorRightPanel.tsx
+++ b/apps/web/src/components/EditorRightPanel.tsx
@@ -39,6 +39,16 @@ export interface EditorRightPanelProps {
   onLinkFile?: () => void;
   /** Reads a linked file in place, rather than sending the reader to github.com. */
   onOpenFile?: (target: RepoTarget) => void;
+  /**
+   * True when this note is locked against editing.
+   *
+   * The properties here are text fields like any other, and a title
+   * half-retyped by accident is exactly what locking exists to prevent. The
+   * writes are refused upstream regardless — this is so the panel says so
+   * rather than accepting keystrokes and quietly dropping them, which is the
+   * worst of both.
+   */
+  locked?: boolean;
   /** Opens the capture dialog; absent when signed out. */
   onCapture?: () => void;
   /** Opens the publish dialog. Absent for a workspace with no repository. */
@@ -111,6 +121,7 @@ export function EditorRightPanel({
   onLinkFile,
   onOpenFile,
   onCapture,
+  locked = false,
   onRewrite,
   onPublish,
   published,
@@ -249,120 +260,133 @@ export function EditorRightPanel({
         ) : (
           <>
             {/* ── Document ──────────────────────────────────────────────── */}
-            <Section title="Document">
-              <label className="block">
-                <span className="mb-1.5 block text-[12px] text-[var(--fl-muted)]">Title</span>
-                <input
-                  value={(frontmatter.title as string) ?? ""}
-                  onChange={(event) => update({ title: event.target.value })}
-                  placeholder="Untitled"
-                  className="fl-input"
-                />
-              </label>
+            {/* A `fieldset` rather than `disabled` on each control: it
+                disables everything nested inside it, including controls added
+                later, which is the difference between a lock and a list of
+                places somebody remembered to lock. */}
+            <fieldset disabled={locked} className="contents">
+              <Section title="Document">
+                <label className="block">
+                  <span className="mb-1.5 block text-[12px] text-[var(--fl-muted)]">Title</span>
+                  <input
+                    value={(frontmatter.title as string) ?? ""}
+                    onChange={(event) => update({ title: event.target.value })}
+                    placeholder="Untitled"
+                    className="fl-input"
+                  />
+                </label>
 
-              <div className="mt-3">
-                <span className="mb-1.5 block text-[12px] text-[var(--fl-muted)]">Tags</span>
+                <div className="mt-3">
+                  <span className="mb-1.5 block text-[12px] text-[var(--fl-muted)]">Tags</span>
 
-                <div className="flex min-h-[38px] flex-wrap items-center gap-1.5 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2 py-1.5">
-                  {tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="flex items-center gap-1 rounded-md bg-[var(--fl-accent-soft)] px-1.5 py-0.5 text-[11.5px] text-[var(--fl-accent)]"
-                    >
-                      {tag}
+                  <div className="flex min-h-[38px] flex-wrap items-center gap-1.5 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2 py-1.5">
+                    {tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="flex items-center gap-1 rounded-md bg-[var(--fl-accent-soft)] px-1.5 py-0.5 text-[11.5px] text-[var(--fl-accent)]"
+                      >
+                        {tag}
+                        <button
+                          type="button"
+                          onClick={() => update({ tags: tags.filter((t) => t !== tag) })}
+                          aria-label={`Remove tag ${tag}`}
+                          className="opacity-70 transition-opacity hover:opacity-100"
+                        >
+                          <CrossGlyph />
+                        </button>
+                      </span>
+                    ))}
+
+                    {newTag === null ? (
                       <button
                         type="button"
-                        onClick={() => update({ tags: tags.filter((t) => t !== tag) })}
-                        aria-label={`Remove tag ${tag}`}
-                        className="opacity-70 transition-opacity hover:opacity-100"
+                        onClick={() => setNewTag("")}
+                        aria-label="Add a tag"
+                        className="ml-auto rounded p-0.5 text-[var(--fl-muted)] transition-colors hover:text-[var(--fl-text)]"
+                      >
+                        <PlusGlyph />
+                      </button>
+                    ) : (
+                      <input
+                        autoFocus
+                        value={newTag}
+                        onChange={(event) => setNewTag(event.target.value)}
+                        onBlur={() => setNewTag(null)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Escape") setNewTag(null);
+                          if (event.key !== "Enter") return;
+
+                          event.preventDefault();
+                          const value = newTag.trim();
+                          // Silently ignoring a duplicate is right: the tag the
+                          // user wanted is already there.
+                          if (value && !tags.includes(value)) update({ tags: [...tags, value] });
+                          setNewTag("");
+                        }}
+                        placeholder="Add a tag…"
+                        aria-label="New tag"
+                        className="min-w-[6rem] flex-1 bg-transparent text-[12px] text-[var(--fl-text)] outline-none placeholder:text-[var(--fl-muted)]"
+                      />
+                    )}
+                  </div>
+                </div>
+
+                {custom.map(([key, value]) => (
+                  <div key={key} className="mt-3">
+                    <span className="mb-1.5 block text-[12px] text-[var(--fl-muted)]">{key}</span>
+                    <div className="flex gap-1">
+                      <input
+                        value={String(value ?? "")}
+                        onChange={(event) => update({ [key]: event.target.value })}
+                        className="fl-input min-w-0 flex-1"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => update({ [key]: undefined })}
+                        title={`Remove ${key}`}
+                        aria-label={`Remove ${key}`}
+                        className="shrink-0 rounded-lg px-2 text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-danger)]"
                       >
                         <CrossGlyph />
                       </button>
-                    </span>
-                  ))}
-
-                  {newTag === null ? (
-                    <button
-                      type="button"
-                      onClick={() => setNewTag("")}
-                      aria-label="Add a tag"
-                      className="ml-auto rounded p-0.5 text-[var(--fl-muted)] transition-colors hover:text-[var(--fl-text)]"
-                    >
-                      <PlusGlyph />
-                    </button>
-                  ) : (
-                    <input
-                      autoFocus
-                      value={newTag}
-                      onChange={(event) => setNewTag(event.target.value)}
-                      onBlur={() => setNewTag(null)}
-                      onKeyDown={(event) => {
-                        if (event.key === "Escape") setNewTag(null);
-                        if (event.key !== "Enter") return;
-
-                        event.preventDefault();
-                        const value = newTag.trim();
-                        // Silently ignoring a duplicate is right: the tag the
-                        // user wanted is already there.
-                        if (value && !tags.includes(value)) update({ tags: [...tags, value] });
-                        setNewTag("");
-                      }}
-                      placeholder="Add a tag…"
-                      aria-label="New tag"
-                      className="min-w-[6rem] flex-1 bg-transparent text-[12px] text-[var(--fl-text)] outline-none placeholder:text-[var(--fl-muted)]"
-                    />
-                  )}
-                </div>
-              </div>
-
-              {custom.map(([key, value]) => (
-                <div key={key} className="mt-3">
-                  <span className="mb-1.5 block text-[12px] text-[var(--fl-muted)]">{key}</span>
-                  <div className="flex gap-1">
-                    <input
-                      value={String(value ?? "")}
-                      onChange={(event) => update({ [key]: event.target.value })}
-                      className="fl-input min-w-0 flex-1"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => update({ [key]: undefined })}
-                      title={`Remove ${key}`}
-                      aria-label={`Remove ${key}`}
-                      className="shrink-0 rounded-lg px-2 text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-danger)]"
-                    >
-                      <CrossGlyph />
-                    </button>
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))}
 
-              <form
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  const key = newKey.trim();
-                  if (key && !(key in frontmatter)) update({ [key]: "" });
-                  setNewKey("");
-                }}
-                className="mt-3 flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--fl-border)] px-2.5 py-1.5"
-              >
-                <CheckGlyph muted />
-                <input
-                  value={newKey}
-                  onChange={(event) => setNewKey(event.target.value)}
-                  placeholder="Add property"
-                  aria-label="New property name"
-                  className="min-w-0 flex-1 bg-transparent text-[12.5px] text-[var(--fl-text)] outline-none placeholder:text-[var(--fl-muted)]"
-                />
-                <button
-                  type="submit"
-                  aria-label="Add property"
-                  className="shrink-0 rounded p-0.5 text-[var(--fl-muted)] transition-colors hover:text-[var(--fl-text)]"
+                <form
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    const key = newKey.trim();
+                    if (key && !(key in frontmatter)) update({ [key]: "" });
+                    setNewKey("");
+                  }}
+                  className="mt-3 flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--fl-border)] px-2.5 py-1.5"
                 >
-                  <PlusGlyph />
-                </button>
-              </form>
-            </Section>
+                  <CheckGlyph muted />
+                  <input
+                    value={newKey}
+                    onChange={(event) => setNewKey(event.target.value)}
+                    placeholder="Add property"
+                    aria-label="New property name"
+                    className="min-w-0 flex-1 bg-transparent text-[12.5px] text-[var(--fl-text)] outline-none placeholder:text-[var(--fl-muted)]"
+                  />
+                  <button
+                    type="submit"
+                    aria-label="Add property"
+                    className="shrink-0 rounded p-0.5 text-[var(--fl-muted)] transition-colors hover:text-[var(--fl-text)]"
+                  >
+                    <PlusGlyph />
+                  </button>
+                </form>
+
+                {locked && (
+                  <p className="mt-3 text-[11.5px] leading-snug text-[var(--fl-muted)]">
+                    This note is locked. Unlock it from the padlock in the header, or with ⌘⇧L, to
+                    change its properties.
+                  </p>
+                )}
+              </Section>
+            </fieldset>
 
             {/* ── Stats ─────────────────────────────────────────────────── */}
             {stats && (
@@ -721,7 +745,14 @@ function PanelButton({
       disabled={busy}
       className="flex w-full items-center justify-center gap-2 rounded-lg border border-[var(--fl-border)] px-3 py-2 text-[12.5px] font-medium text-[var(--fl-text)] transition-colors hover:border-[var(--fl-border-strong)] hover:bg-[var(--fl-elevated)] disabled:opacity-50"
     >
-      <span aria-hidden="true" className="shrink-0 text-[var(--fl-muted)]">
+      {/* The size is enforced here as well as in each glyph. An `<svg>` with a
+          viewBox and no width collapses to nothing in a flex row, which is a
+          silent failure — the button still works and simply looks unfinished,
+          which is exactly the kind of thing nobody files a bug about. */}
+      <span
+        aria-hidden="true"
+        className="shrink-0 text-[var(--fl-muted)] [&_svg]:h-3.5 [&_svg]:w-3.5"
+      >
         {icon}
       </span>
       {busy ? "Working…" : children}
@@ -918,11 +949,28 @@ function CaptureGlyph() {
 }
 
 /** Two lines of talk against a document — a review, in miniature. */
+/**
+ * Two lines of talk against a document — a review, in miniature.
+ *
+ * It had no size of its own, and the button it sits in did not give it one, so
+ * an `<svg>` with a viewBox and no width collapsed to nothing: "Review & merge
+ * this note" was the one action in the panel with a blank space where every
+ * other row has an icon.
+ */
 function ReviewGlyph() {
   return (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
-      <path d="M2 3.5h7M2 6h5" strokeLinecap="round" />
-      <path d="M6.5 9.5h7a1 1 0 0 1 1 1v2.5a1 1 0 0 1-1 1H9l-2 1.5V14h-.5a1 1 0 0 1-1-1v-2.5a1 1 0 0 1 1-1Z" />
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2.25 3.25h7.5M2.25 5.75h5" />
+      <path d="M6.75 8.75h6.5a1 1 0 0 1 1 1v2.75a1 1 0 0 1-1 1H9.5l-2.25 1.5v-1.5h-.5a1 1 0 0 1-1-1V9.75a1 1 0 0 1 1-1Z" />
     </svg>
   );
 }

--- a/apps/web/src/components/EditorStatusBar.tsx
+++ b/apps/web/src/components/EditorStatusBar.tsx
@@ -22,6 +22,14 @@ export interface EditorStatusBarProps {
   cursor: CursorPosition | null;
   /** Word count of the open note. */
   words: number;
+  /**
+   * True when the open note is locked against editing.
+   *
+   * Stated here as well as in the header because this is the bar people read
+   * to answer "is my writing safe" — and "why is nothing I type appearing" is
+   * the same kind of question.
+   */
+  locked?: boolean;
   /** How this workspace is configured to push, and how to change it. */
   syncPreference: SyncPreference;
   onSyncModeChange: (mode: SyncMode, intervalMinutes?: number) => void | Promise<void>;
@@ -56,6 +64,7 @@ export function EditorStatusBar({
   localFile,
   cursor,
   words,
+  locked = false,
   syncPreference,
   onSyncModeChange,
   onSyncNow,
@@ -149,6 +158,28 @@ export function EditorStatusBar({
           <span className="hidden truncate font-mono lg:inline" title={notePath}>
             {notePath}
           </span>
+
+          {locked && (
+            <span
+              title="This note is locked against editing. Unlock it from the header, or with ⌘⇧L."
+              className="flex shrink-0 items-center gap-1 rounded-full bg-[var(--fl-accent-soft)] px-2 py-0.5 text-[var(--fl-accent)]"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                className="h-3 w-3"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="3.5" y="7" width="9" height="6.5" rx="1.4" />
+                <path d="M5.75 7V5.2a2.25 2.25 0 0 1 4.5 0V7" />
+              </svg>
+              Locked
+            </span>
+          )}
 
           {localFile && (
             <span

--- a/apps/web/src/components/LinkHoverCard.tsx
+++ b/apps/web/src/components/LinkHoverCard.tsx
@@ -17,11 +17,11 @@ import { previewLink, type LinkPreviewResult } from "@/lib/gateway";
  * rebuilds its DOM whenever the document changes — anything bound per anchor
  * would be lost on the next keystroke.
  *
- * Text only, and that is deliberate. A card showing a remote image would mean
- * the reader's browser fetching from whatever host the note links to, merely
- * because the pointer passed over a word — a tracking pixel with extra steps.
- * The host, the page's own title and its own summary are what the decision
- * actually rests on.
+ * The picture a page offers of itself is shown, because "is this the right
+ * link" is often a question about what the page looks like — but it is served
+ * through `/api/link-image` rather than from the site itself. An `<img>`
+ * pointing at the linked host would tell that host the pointer passed over a
+ * word in somebody's private note, which is not a thing hovering should do.
  */
 
 /** Long enough that crossing a link on the way somewhere else shows nothing. */
@@ -74,6 +74,8 @@ export interface LinkHoverCardProps {
 export function LinkHoverCard({ within, canRead = true }: LinkHoverCardProps) {
   const [anchored, setAnchored] = useState<Anchored | null>(null);
   const [loaded, setLoaded] = useState<Loaded | null>(null);
+  /** Set when the page's picture will not load, so the card drops it. */
+  const [imageFailed, setImageFailed] = useState(false);
 
   // Timers and the pointer's whereabouts are not rendered, so they are refs:
   // re-rendering the card because the mouse moved would defeat the point.
@@ -107,6 +109,7 @@ export function LinkHoverCard({ within, canRead = true }: LinkHoverCardProps) {
     const show = (anchor: HTMLAnchorElement, url: string) => {
       const box = anchor.getBoundingClientRect();
       showing.current = url;
+      setImageFailed(false);
       setAnchored({
         url,
         rect: { left: box.left, right: box.right, top: box.top, bottom: box.bottom },
@@ -122,7 +125,7 @@ export function LinkHoverCard({ within, canRead = true }: LinkHoverCardProps) {
       if (!canRead) {
         setLoaded({
           status: "ready",
-          preview: { url, title: null, description: null, host: hostOf(url) },
+          preview: { url, title: null, description: null, host: hostOf(url), image: null },
         });
         return;
       }
@@ -144,6 +147,7 @@ export function LinkHoverCard({ within, canRead = true }: LinkHoverCardProps) {
             title: null,
             description: null,
             host: hostOf(url),
+            image: null,
           }),
         )
         .then((preview) => {
@@ -209,7 +213,9 @@ export function LinkHoverCard({ within, canRead = true }: LinkHoverCardProps) {
   // past either edge of the window.
   const below = anchored.rect.bottom + 8;
   const above = anchored.rect.top - 8;
-  const openDownwards = below + 140 < window.innerHeight || above < 160;
+  const tall = loaded.status === "ready" && Boolean(loaded.preview.image) && !imageFailed;
+  const height = tall ? 300 : 150;
+  const openDownwards = below + height < window.innerHeight || above < height;
 
   const left = Math.min(
     Math.max(8, anchored.rect.left),
@@ -240,6 +246,20 @@ export function LinkHoverCard({ within, canRead = true }: LinkHoverCardProps) {
         <p className="text-[12px] text-[var(--fl-muted)]">Reading {hostOf(anchored.url)}…</p>
       ) : (
         <div className="space-y-1">
+          {/* Above the text, and allowed to fail silently: plenty of pages
+              offer no picture, and plenty of the ones that do point at
+              something that will not load. `onError` hides it rather than
+              leaving the browser's broken-image glyph in a card whose whole
+              job is to look like the page. */}
+          {loaded.preview.image && !imageFailed && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={loaded.preview.image}
+              alt=""
+              onError={() => setImageFailed(true)}
+              className="mb-2 h-32 w-full rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] object-cover"
+            />
+          )}
           <p className="truncate text-[11px] uppercase tracking-wide text-[var(--fl-muted)]">
             {loaded.preview.host}
           </p>

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -148,6 +148,15 @@ export function EditorWorkspace() {
   const [cursor, setCursor] = useState<CursorPosition | null>(null);
   const [theme, , toggleTheme] = useTheme();
 
+  /**
+   * Whether the note on screen is locked against editing.
+   *
+   * Read here rather than passed down piecemeal because four things depend on
+   * it: the editing surfaces, the formatting bar, the properties panel, and
+   * the button that says so.
+   */
+  const noteLocked = notebook.isLocked(notebook.activePath);
+
   // Signed in with nothing connected: ask where the notes should live rather
   // than creating a repository on the user's account without being asked. The
   // dashboard asks the same question with more room; this is the answer for
@@ -705,6 +714,9 @@ export function EditorWorkspace() {
 
         // Typed since it was read: their version is the one that counts.
         if (notebook.note?.path !== path || notebook.note.content !== opened) return;
+        // Repairing image links rewrites the note, which is exactly the kind
+        // of well-meaning automatic change a locked note is locked against.
+        if (notebook.isLocked(path)) return;
 
         await notebook.saveNote(result.content);
         setNotice(
@@ -932,6 +944,14 @@ export function EditorWorkspace() {
           run: () => setDialog("export"),
         },
         {
+          id: "lock",
+          label: noteLocked ? "Unlock this note" : "Lock this note against editing",
+          group: "Notes",
+          hint: "⌘⇧L",
+          keywords: "lock unlock read only readonly protect freeze",
+          run: () => notebook.toggleLocked(note.path),
+        },
+        {
           id: "rename",
           label: "Rename this note",
           group: "Notes",
@@ -1054,6 +1074,9 @@ export function EditorWorkspace() {
     // Signing in adds the capture command; without this the list would keep
     // its signed-out shape until something else happened to invalidate it.
     user,
+    // The lock command's label is the state, so it has to be rebuilt when the
+    // state changes or the palette offers to lock a note that already is.
+    noteLocked,
     theme,
     sidebarCollapsed,
     panelCollapsed,
@@ -1124,6 +1147,16 @@ export function EditorWorkspace() {
           if (event.shiftKey) {
             event.preventDefault();
             router.push("/dashboard");
+          }
+          break;
+
+        case "l":
+          // ⌘⇧L, not ⌘L: the browser's own ⌘L is the address bar, and taking
+          // that away from somebody who meant it would be worse than the
+          // shortcut not existing.
+          if (event.shiftKey && note) {
+            event.preventDefault();
+            notebook.toggleLocked(note.path);
           }
           break;
 
@@ -1307,6 +1340,28 @@ export function EditorWorkspace() {
                 </kbd>
               </button>
 
+              {/* Beside the note it applies to, not in a menu: the whole
+                  point is to be able to see at a glance whether the thing you
+                  are about to type into will accept it. Absent with no note
+                  open, since there would be nothing to lock. */}
+              {note && (
+                <IconButton
+                  onClick={() => notebook.toggleLocked(note.path)}
+                  label={
+                    noteLocked
+                      ? "Unlock this note so it can be edited (⌘⇧L)"
+                      : "Lock this note against editing (⌘⇧L)"
+                  }
+                  className={
+                    noteLocked
+                      ? "inline-flex bg-[var(--fl-accent-soft)] text-[var(--fl-accent)]"
+                      : ""
+                  }
+                >
+                  {noteLocked ? <LockedGlyph /> : <UnlockedGlyph />}
+                </IconButton>
+              )}
+
               <IconButton onClick={() => setDialog("help")} label="Help (⌘⇧?)">
                 <svg
                   viewBox="0 0 16 16"
@@ -1449,6 +1504,7 @@ export function EditorWorkspace() {
             {note ? (
               <MarkdownEditor
                 key={note.id}
+                readOnly={noteLocked}
                 extraActions={editorExtras}
                 onExtraAction={(id) => setDialog(id === "link-file" ? "link-file" : "capture")}
                 value={note.content}
@@ -1490,6 +1546,7 @@ export function EditorWorkspace() {
               onToggle={() => (drawer === "document" ? setDrawer(null) : setPanelCollapsed(true))}
               note={note}
               workspace={workspace}
+              locked={noteLocked}
               onFrontmatterChange={notebook.updateFrontmatter}
               onRewrite={notebook.saveNote}
               onExport={() => {
@@ -1558,6 +1615,7 @@ export function EditorWorkspace() {
       </div>
 
       <EditorStatusBar
+        locked={noteLocked}
         onSwitchBranch={notebook.switchBranch}
         onPropose={() => setDialog("propose")}
         sync={notebook.sync}
@@ -1655,6 +1713,12 @@ export function EditorWorkspace() {
           onInsert={(link) => {
             const current = notebook.note;
             if (!current) return;
+            // The write would be refused upstream anyway; saying so is the
+            // difference between a lock and a button that does nothing.
+            if (noteLocked) {
+              setNotice("This note is locked. Unlock it — ⌘⇧L — to add to it.");
+              return;
+            }
             // Appended rather than inserted at the caret: the editor owns the
             // selection and this dialog has taken focus away from it.
             const separator = current.content.endsWith("\n") ? "" : "\n";
@@ -1670,6 +1734,10 @@ export function EditorWorkspace() {
           onInsert={async (markdown) => {
             const current = notebook.note;
             if (!current) return;
+            if (noteLocked) {
+              setNotice("This note is locked. Unlock it — ⌘⇧L — to add a source to it.");
+              return;
+            }
             const separator = current.content.endsWith("\n") ? "" : "\n";
             await notebook.saveNote(`${current.content}${separator}\n${markdown}\n`);
             setNotice("Source added to the end of this note.");
@@ -1849,6 +1917,52 @@ function ExtraGlyph({ d }: { d: string }) {
       strokeLinejoin="round"
     >
       <path d={d} />
+    </svg>
+  );
+}
+
+/**
+ * A closed padlock — this note will not take a keystroke.
+ *
+ * Two glyphs rather than one drawn in two colours: colour alone is not a
+ * state, and the shackle sitting up off the body is the part that reads as
+ * "open" at a glance and at any contrast.
+ */
+function LockedGlyph() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3.25" y="7" width="9.5" height="7" rx="1.5" />
+      <path d="M5.5 7V5a2.5 2.5 0 0 1 5 0v2" />
+      <path d="M8 9.75v1.5" />
+    </svg>
+  );
+}
+
+/** The same padlock, open. */
+function UnlockedGlyph() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3.25" y="7" width="9.5" height="7" rx="1.5" />
+      <path d="M5.5 7V5a2.5 2.5 0 0 1 4.9-.6" />
+      <path d="M8 9.75v1.5" />
     </svg>
   );
 }

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -26,6 +26,7 @@ import {
 import { dirname, serializeDocument } from "@forkleaf/markdown-engine";
 import { GitHubGateway, LocalGateway, fetchSession, type SessionResponse } from "@/lib/gateway";
 import { LOCAL_WORKSPACE, collapseBranchDuplicates } from "@/lib/workspaces";
+import { forgetLock, isPathLocked, lockedKey, renameLock, toggleLock } from "@/lib/locks";
 import { assetFrom, assetObjectUrl } from "@/lib/assets";
 
 /**
@@ -83,6 +84,22 @@ export interface NotebookState {
    * they chose, kept alongside the other per-device preferences.
    */
   pinnedPaths: string[];
+  /**
+   * Notes locked against editing on this device.
+   *
+   * A reference note is a note you read far more often than you write, and
+   * reading one means clicking around in it — at which point the caret is
+   * somewhere in the text and any stray keystroke is an edit that saves
+   * itself, commits itself, and is discovered later as a stray character in
+   * the middle of a paragraph.
+   *
+   * Kept per device, beside the other per-device preferences, rather than in
+   * the note's frontmatter. Locking is about protecting your own hands, not a
+   * property of the document — and writing it into the file would mean a
+   * commit every time somebody locked or unlocked a note, which is history
+   * nobody wants and a change the app made without being asked to write one.
+   */
+  lockedPaths: string[];
   /**
    * Folders the reader has open, in the order they were opened.
    *
@@ -200,6 +217,7 @@ export function useNotebook(request: NotebookRequest = {}) {
     busy: null,
     emptyFolders: [],
     pinnedPaths: [],
+    lockedPaths: [],
     expandedFolders: null,
     needsRepoChoice: false,
     remoteChange: null,
@@ -415,6 +433,9 @@ export function useNotebook(request: NotebookRequest = {}) {
 
       const pinned = (await dbRef.current?.getMeta<string[]>(pinnedKey(workspace.id))) ?? [];
       if (!cancelled) patch({ pinnedPaths: pinned });
+
+      const locked = (await dbRef.current?.getMeta<string[]>(lockedKey(workspace.id))) ?? [];
+      if (!cancelled) patch({ lockedPaths: locked });
 
       const expanded = await dbRef.current?.getMeta<string[]>(expandedKey(workspace.id));
       // No record at all is a first visit, not a deliberate "all closed" — the
@@ -640,16 +661,46 @@ export function useNotebook(request: NotebookRequest = {}) {
     }));
   }, []);
 
+  /**
+   * The last line of defence for a locked note.
+   *
+   * The editing surfaces are made read-only when a note is locked, which is
+   * what stops the keystrokes. This is here because "read-only" is a property
+   * of four different surfaces plus a paste handler plus a drop handler plus a
+   * toolbar, and a lock that holds only as long as every one of them remembers
+   * to check is not a lock. Everything that writes a note's content goes
+   * through here.
+   */
+  const isLocked = useCallback(
+    (path: string | null | undefined) => isPathLocked(state.lockedPaths, path),
+    [state.lockedPaths],
+  );
+
+  const putLocked = useCallback(
+    (next: string[]) => {
+      const workspace = state.activeWorkspace;
+      patch({ lockedPaths: next });
+      if (workspace) void dbRef.current?.putMeta(lockedKey(workspace.id), next);
+    },
+    [state.activeWorkspace, patch],
+  );
+
+  const toggleLocked = useCallback(
+    (path: string) => putLocked(toggleLock(state.lockedPaths, path)),
+    [state.lockedPaths, putLocked],
+  );
+
   const saveNote = useCallback(
     async (content: string) => {
       const notes = repoRef.current;
       if (!notes || !activeNote) return;
+      if (isLocked(activeNote.path)) return;
 
       // Optimistic: show the new content immediately, persist in the background.
       patchOpenNote(activeNote.path, { content, dirty: true });
       await notes.saveNote(activeNote, content);
     },
-    [activeNote, patchOpenNote],
+    [activeNote, patchOpenNote, isLocked],
   );
 
   /**
@@ -665,22 +716,26 @@ export function useNotebook(request: NotebookRequest = {}) {
       const notes = repoRef.current;
       const target = state.openNotes.find((note) => note.path === path);
       if (!notes || !target || target.content === content) return;
+      if (isLocked(path)) return;
 
       patchOpenNote(path, { content, dirty: true });
       await notes.saveNote(target, content);
     },
-    [state.openNotes, patchOpenNote],
+    [state.openNotes, patchOpenNote, isLocked],
   );
 
   const updateFrontmatter = useCallback(
     async (frontmatter: Note["frontmatter"]) => {
       const notes = repoRef.current;
       if (!notes || !activeNote) return;
+      // The properties panel is a text field like any other, and a title
+      // half-retyped by accident is exactly what locking exists to prevent.
+      if (isLocked(activeNote.path)) return;
 
       patchOpenNote(activeNote.path, { frontmatter, dirty: true });
       await notes.saveNote(activeNote, activeNote.content, frontmatter);
     },
-    [activeNote, patchOpenNote],
+    [activeNote, patchOpenNote, isLocked],
   );
 
   const createNote = useCallback(
@@ -738,13 +793,27 @@ export function useNotebook(request: NotebookRequest = {}) {
 
       await notes.deletePath(workspace.id, path, shaFor(state.tree, path));
 
+      // A path left in the locked list would lock the next note created at it,
+      // which is a haunting rather than a feature.
+      const remaining = forgetLock(state.lockedPaths, path);
+      if (remaining.length !== state.lockedPaths.length) putLocked(remaining);
+
       const open = state.openNotes.filter((candidate) => candidate.path !== path);
       const activePath = state.activePath === path ? (open[0]?.path ?? null) : state.activePath;
 
       patch({ tree: removeFromTree(state.tree, path), openNotes: open, activePath });
       rememberTabs(workspace.id, open, activePath);
     },
-    [state.tree, state.openNotes, state.activePath, state.activeWorkspace, patch, rememberTabs],
+    [
+      state.tree,
+      state.openNotes,
+      state.activePath,
+      state.activeWorkspace,
+      state.lockedPaths,
+      putLocked,
+      patch,
+      rememberTabs,
+    ],
   );
 
   const deleteNote = useCallback(async (note: Note) => deleteNoteAt(note.path), [deleteNoteAt]);
@@ -755,6 +824,12 @@ export function useNotebook(request: NotebookRequest = {}) {
       if (!notes) return;
 
       const renamed = await notes.renameNote(note, toPath);
+
+      // Renaming a note is not unlocking it. Without this the lock falls off
+      // silently, and the reader finds out by typing into a note they had
+      // every reason to believe was protected.
+      const carried = renameLock(state.lockedPaths, note.path, renamed.path);
+      if (state.lockedPaths.includes(note.path)) putLocked(carried);
 
       const open = state.openNotes.map((candidate) =>
         candidate.path === note.path ? renamed : candidate,
@@ -769,7 +844,16 @@ export function useNotebook(request: NotebookRequest = {}) {
       if (state.activeWorkspace) rememberTabs(state.activeWorkspace.id, open, activePath);
       return renamed;
     },
-    [state.tree, state.openNotes, state.activePath, state.activeWorkspace, patch, rememberTabs],
+    [
+      state.tree,
+      state.openNotes,
+      state.activePath,
+      state.activeWorkspace,
+      state.lockedPaths,
+      putLocked,
+      patch,
+      rememberTabs,
+    ],
   );
 
   /**
@@ -811,6 +895,14 @@ export function useNotebook(request: NotebookRequest = {}) {
     [state.pinnedPaths, putPinned],
   );
 
+  /**
+   * Locks a note against editing, or unlocks one already locked.
+   *
+   * Per note rather than per workspace: the point is a handful of references
+   * you keep open and keep reading, not a mode you have to remember you are
+   * in. A path that is not in the list is editable, which is what every note
+   * is until somebody says otherwise.
+   */
   /**
    * Moves a pinned note up or down the list.
    *
@@ -1371,6 +1463,8 @@ export function useNotebook(request: NotebookRequest = {}) {
       renameNote,
       createFolder,
       togglePinned,
+      toggleLocked,
+      isLocked,
       movePinned,
       renameFolder,
       deleteFolder,
@@ -1423,6 +1517,8 @@ export function useNotebook(request: NotebookRequest = {}) {
       renameNote,
       createFolder,
       togglePinned,
+      toggleLocked,
+      isLocked,
       movePinned,
       renameFolder,
       deleteFolder,

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -485,8 +485,26 @@ export interface CaptureResult {
  * The address is resolved and checked server-side before anything is fetched —
  * see `lib/safe-fetch` for why that cannot be done in the browser.
  */
-export async function capturePage(url: string): Promise<CaptureResult> {
-  return call("/api/capture", { method: "POST", body: JSON.stringify({ url }) });
+export async function capturePage(
+  url: string,
+  /**
+   * Which half of the work to wait for.
+   *
+   * `page` is the fast one — a title, in about a second. `archive` is the slow
+   * one, because a page the Wayback Machine has never seen has to be archived
+   * before it can be linked, and Save Page Now takes as long as it takes. The
+   * capture dialog asks for both at once and shows each as it lands, rather
+   * than making the reader watch a spinner for the length of the slower one.
+   */
+  want: "page" | "archive" | "both" = "both",
+): Promise<CaptureResult> {
+  return call("/api/capture", {
+    method: "POST",
+    body: JSON.stringify({ url, want }),
+    // Longer than the server's own ceiling for the archive step, so a slow
+    // snapshot is reported by the server rather than cut off here.
+    timeoutMs: want === "page" ? 15_000 : 70_000,
+  });
 }
 
 /**
@@ -523,6 +541,8 @@ export interface LinkPreviewResult {
   title: string | null;
   description: string | null;
   host: string;
+  /** A same-origin URL for the page's own picture of itself, or null. */
+  image: string | null;
 }
 
 /**

--- a/apps/web/src/lib/locks.test.ts
+++ b/apps/web/src/lib/locks.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { forgetLock, isPathLocked, lockedKey, renameLock, toggleLock } from "./locks";
+
+describe("isPathLocked", () => {
+  it("is false for a note nobody locked", () => {
+    expect(isPathLocked(["a.md"], "b.md")).toBe(false);
+  });
+
+  it("is true for a note that is locked", () => {
+    expect(isPathLocked(["a.md", "b.md"], "b.md")).toBe(true);
+  });
+
+  it("is false with no note open, rather than throwing", () => {
+    expect(isPathLocked(["a.md"], null)).toBe(false);
+    expect(isPathLocked(["a.md"], undefined)).toBe(false);
+  });
+
+  it("matches the whole path, not a prefix of it", () => {
+    // `notes/a.md` and `notes/a.md.bak` are different files.
+    expect(isPathLocked(["notes/a.md"], "notes/a.md.bak")).toBe(false);
+  });
+});
+
+describe("toggleLock", () => {
+  it("locks a note", () => {
+    expect(toggleLock([], "a.md")).toEqual(["a.md"]);
+  });
+
+  it("unlocks one already locked", () => {
+    expect(toggleLock(["a.md", "b.md"], "a.md")).toEqual(["b.md"]);
+  });
+
+  it("never grows a duplicate", () => {
+    // A path listed twice would unlock on the first press and stay locked,
+    // which is exactly the kind of bug a toggle hides.
+    const once = toggleLock([], "a.md");
+    expect(toggleLock(toggleLock(once, "a.md"), "a.md")).toEqual(["a.md"]);
+  });
+
+  it("leaves the list it was given alone", () => {
+    const before = ["a.md"];
+    toggleLock(before, "b.md");
+    expect(before).toEqual(["a.md"]);
+  });
+});
+
+describe("renameLock", () => {
+  it("carries a lock across a rename", () => {
+    expect(renameLock(["a.md"], "a.md", "b.md")).toEqual(["b.md"]);
+  });
+
+  it("leaves other notes where they are", () => {
+    expect(renameLock(["a.md", "c.md"], "a.md", "b.md")).toEqual(["b.md", "c.md"]);
+  });
+
+  it("does nothing for a note that was not locked", () => {
+    expect(renameLock(["a.md"], "c.md", "d.md")).toEqual(["a.md"]);
+  });
+});
+
+describe("forgetLock", () => {
+  it("drops the lock on a deleted note", () => {
+    expect(forgetLock(["a.md", "b.md"], "a.md")).toEqual(["b.md"]);
+  });
+
+  it("drops the locks inside a deleted folder", () => {
+    expect(forgetLock(["docs/a.md", "docs/deep/b.md", "c.md"], "docs")).toEqual(["c.md"]);
+  });
+
+  it("does not drop a note whose name merely starts the same way", () => {
+    expect(forgetLock(["docs-old/a.md"], "docs")).toEqual(["docs-old/a.md"]);
+  });
+});
+
+describe("lockedKey", () => {
+  it("is per workspace, so a lock on one repo does not lock another", () => {
+    expect(lockedKey("me/notes@main:")).not.toBe(lockedKey("me/notes@draft:"));
+  });
+});

--- a/apps/web/src/lib/locks.ts
+++ b/apps/web/src/lib/locks.ts
@@ -1,0 +1,62 @@
+/**
+ * Which notes are locked against editing, and where that is remembered.
+ *
+ * A reference note is one you read far more often than you write. Reading it
+ * means clicking around in it, which leaves the caret somewhere in the text —
+ * and from there a stray keystroke is an edit that saves itself, commits
+ * itself, and is found weeks later as a lone character in the middle of a
+ * paragraph. Locking is the answer to that, and it is deliberately a small
+ * idea: a list of paths that will not accept writes.
+ *
+ * Per device, beside the other per-device preferences, rather than in the
+ * note's frontmatter. Locking protects your own hands rather than describing
+ * the document, and writing it into the file would mean a commit every time
+ * anybody locked or unlocked anything — history nobody asked for, from a
+ * button that is supposed to prevent unasked-for changes.
+ *
+ * The rules live here, apart from the hook that holds the state, so that "is
+ * this note locked" has one answer that can be tested on its own.
+ */
+
+/** Meta key the locked list is stored under, per workspace. */
+export function lockedKey(workspaceId: string): string {
+  return `locked:${workspaceId}`;
+}
+
+/** True when this path may not be written to. */
+export function isPathLocked(locked: readonly string[], path: string | null | undefined): boolean {
+  return path ? locked.includes(path) : false;
+}
+
+/**
+ * The list with this path locked, or unlocked if it already was.
+ *
+ * Returns a new array rather than mutating, and never grows a duplicate: a
+ * path listed twice would unlock on the first press and stay locked, which is
+ * the kind of bug a toggle can hide for a long time.
+ */
+export function toggleLock(locked: readonly string[], path: string): string[] {
+  return locked.includes(path) ? locked.filter((item) => item !== path) : [...locked, path];
+}
+
+/**
+ * The list with a renamed note's lock carried over.
+ *
+ * Renaming a note is not unlocking it. Without this the lock would silently
+ * fall off — and the reader, who has every reason to believe the note is still
+ * protected, would find out by typing into it.
+ */
+export function renameLock(locked: readonly string[], from: string, to: string): string[] {
+  if (!locked.includes(from)) return [...locked];
+  return locked.map((item) => (item === from ? to : item));
+}
+
+/**
+ * The list with notes that no longer exist dropped.
+ *
+ * A deleted note leaving its path behind would lock the next note created at
+ * that path, which is a haunting rather than a feature.
+ */
+export function forgetLock(locked: readonly string[], path: string): string[] {
+  return locked.filter((item) => item !== path && !item.startsWith(`${path}/`));
+}

--- a/packages/editor/src/MarkdownEditor.tsx
+++ b/packages/editor/src/MarkdownEditor.tsx
@@ -58,6 +58,16 @@ export interface MarkdownEditorProps {
   imageDestination?: string;
   /** How `[[wikilinks]]` resolve, and what clicking one does. */
   links?: LinkBridge;
+  /**
+   * Makes the note readable but not writable, in every mode at once.
+   *
+   * One flag rather than three, because a lock that holds in rich text and not
+   * in the source view is not a lock — and switching mode is one click. It
+   * takes the formatting bar away as well as the caret: a toolbar button is a
+   * programmatic edit, which no amount of read-only state on the surface
+   * itself would stop.
+   */
+  readOnly?: boolean;
 }
 
 const MODES: { value: EditorViewMode; label: string; hint: string }[] = [
@@ -93,6 +103,7 @@ export function MarkdownEditor({
   images,
   imageDestination,
   links,
+  readOnly = false,
 }: MarkdownEditorProps) {
   // Split view: the divider position, as a percentage of the container width.
   const [splitRatio, setSplitRatio] = useState(50);
@@ -375,7 +386,10 @@ export function MarkdownEditor({
         </div>
       )}
 
-      {!hideToolbar && (
+      {/* The whole bar goes, rather than being disabled in place: a row of
+          twenty greyed-out buttons above a note you are reading is noise, and
+          the lock button in the header already says why it is not there. */}
+      {!hideToolbar && !readOnly && (
         <EditorToolbar
           actions={actions}
           onRun={runAction}
@@ -391,6 +405,7 @@ export function MarkdownEditor({
           <WysiwygEditor
             value={value}
             onChange={onChange}
+            editable={!readOnly}
             onReady={handleTiptapReady}
             onImageStatus={setImageStatus}
             slashActions={actionContext}
@@ -409,10 +424,11 @@ export function MarkdownEditor({
           <SourceEditor
             value={value}
             onChange={onChange}
+            readOnly={readOnly}
             handleRef={sourceHandle}
             onCursorChange={handleCursor}
             slashActions={actionContext}
-            {...(canUpload ? { onImageFiles: handleSourceImages } : {})}
+            {...(canUpload && !readOnly ? { onImageFiles: handleSourceImages } : {})}
             {...(placeholder ? { placeholder } : {})}
             showLineNumbers
           />
@@ -429,10 +445,11 @@ export function MarkdownEditor({
             <SourceEditor
               value={value}
               onChange={onChange}
+              readOnly={readOnly}
               handleRef={sourceHandle}
               onCursorChange={handleCursor}
               slashActions={actionContext}
-              {...(canUpload ? { onImageFiles: handleSourceImages } : {})}
+              {...(canUpload && !readOnly ? { onImageFiles: handleSourceImages } : {})}
               {...(placeholder ? { placeholder } : {})}
               showLineNumbers
               className="min-h-0 w-full flex-1 overflow-hidden"

--- a/packages/editor/src/SourceEditor.tsx
+++ b/packages/editor/src/SourceEditor.tsx
@@ -71,6 +71,17 @@ export interface SourceEditorProps {
    * kind of difference that makes one of the two views feel broken.
    */
   slashActions?: ActionContext;
+  /**
+   * Makes the document readable but not writable.
+   *
+   * Both halves are needed and they are not the same thing: `EditorState.
+   * readOnly` stops the commands and the input handlers, and
+   * `EditorView.editable` takes the surface out of the tab order and tells the
+   * browser not to put a caret in it. With only the first, a stray keystroke
+   * does nothing but the editor still looks and behaves like something you are
+   * typing into, which is its own kind of lie.
+   */
+  readOnly?: boolean;
 }
 
 /** Caret location, in the terms a status bar uses. */
@@ -142,6 +153,7 @@ export function SourceEditor({
   onCursorChange,
   onImageFiles,
   slashActions,
+  readOnly = false,
 }: SourceEditorProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -171,6 +183,10 @@ export function SourceEditor({
   // Extensions supplied by the caller can change (the mermaid linter closes
   // over the current error), so they live in a compartment we can reconfigure.
   const dynamicCompartment = useMemo(() => new Compartment(), []);
+  // Read-only gets its own compartment, so locking and unlocking a note is a
+  // reconfigure rather than a rebuild — a rebuild would drop the undo history
+  // and the scroll position every time somebody toggled the lock.
+  const readOnlyCompartment = useMemo(() => new Compartment(), []);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -239,6 +255,11 @@ export function SourceEditor({
         editorTheme(),
         EditorView.domEventHandlers({
           paste: (event, view) => {
+            // Checked here as well as by `EditorState.readOnly`: this handler
+            // does not type anything, it uploads a file and dispatches the
+            // markdown itself, so the read-only state would never see it.
+            if (view.state.readOnly) return false;
+
             const files = imagesFrom(event.clipboardData);
             if (files.length === 0 || !onImageFilesRef.current) return false;
 
@@ -247,6 +268,8 @@ export function SourceEditor({
             return true;
           },
           drop: (event, view) => {
+            if (view.state.readOnly) return false;
+
             const files = imagesFrom(event.dataTransfer);
             if (files.length === 0 || !onImageFilesRef.current) return false;
 
@@ -280,6 +303,10 @@ export function SourceEditor({
           }
         }),
         dynamicCompartment.of(extensions ?? []),
+        readOnlyCompartment.of([
+          EditorState.readOnly.of(readOnly),
+          EditorView.editable.of(!readOnly),
+        ]),
       ],
     });
 
@@ -324,11 +351,26 @@ export function SourceEditor({
     emitted.current = [];
   }, [value]);
 
+  /**
+   * The live view, but only when it may be written to.
+   *
+   * Every method below that changes the document goes through this rather than
+   * through `viewRef` directly. `EditorState.readOnly` stops typing and the
+   * keymap; it does *not* stop a `view.dispatch` — so a toolbar button, which
+   * is exactly that, would edit a locked note happily. The toolbar is hidden
+   * when a note is locked, and this is what makes that a guarantee rather than
+   * a habit.
+   */
+  const writableView = () => {
+    const view = viewRef.current;
+    return view && !view.state.readOnly ? view : null;
+  };
+
   useImperativeHandle(
     handleRef,
     (): SourceEditorHandle => ({
       insertAtCursor: (text, cursorOffset) => {
-        const view = viewRef.current;
+        const view = writableView();
         if (!view) return;
 
         const { from, to } = view.state.selection.main;
@@ -343,7 +385,7 @@ export function SourceEditor({
       focus: () => viewRef.current?.focus(),
 
       wrapSelection: (before, after = before) => {
-        const view = viewRef.current;
+        const view = writableView();
         if (!view) return;
 
         const { from, to } = view.state.selection.main;
@@ -388,7 +430,7 @@ export function SourceEditor({
       },
 
       toggleLinePrefix: (prefix, pattern) => {
-        const view = viewRef.current;
+        const view = writableView();
         if (!view) return;
 
         const { from, to } = view.state.selection.main;
@@ -421,7 +463,7 @@ export function SourceEditor({
       },
 
       indent: (direction) => {
-        const view = viewRef.current;
+        const view = writableView();
         if (!view) return;
 
         const { from, to } = view.state.selection.main;
@@ -444,14 +486,14 @@ export function SourceEditor({
       },
 
       undo: () => {
-        const view = viewRef.current;
+        const view = writableView();
         if (!view) return;
         cmUndo(view);
         view.focus();
       },
 
       redo: () => {
-        const view = viewRef.current;
+        const view = writableView();
         if (!view) return;
         cmRedo(view);
         view.focus();
@@ -489,6 +531,16 @@ export function SourceEditor({
       effects: dynamicCompartment.reconfigure(extensions ?? []),
     });
   }, [extensions, dynamicCompartment]);
+
+  // Lock and unlock in place, for the same reason.
+  useEffect(() => {
+    viewRef.current?.dispatch({
+      effects: readOnlyCompartment.reconfigure([
+        EditorState.readOnly.of(readOnly),
+        EditorView.editable.of(!readOnly),
+      ]),
+    });
+  }, [readOnly, readOnlyCompartment]);
 
   return (
     <div

--- a/packages/editor/src/WysiwygEditor.tsx
+++ b/packages/editor/src/WysiwygEditor.tsx
@@ -105,6 +105,16 @@ export interface WysiwygEditorProps {
   slashActions?: ActionContext;
   /** How `[[wikilinks]]` resolve, and what ⌘-clicking one does. */
   links?: LinkBridge;
+  /**
+   * Makes the note readable but not writable.
+   *
+   * Tiptap's own `editable` flag, which takes `contenteditable` off the
+   * surface: no caret, no input, no drag-and-drop into it, and the browser
+   * itself stops treating it as somewhere text can go. Clicking still selects
+   * text and still follows links, because reading a locked note is the entire
+   * point of locking one.
+   */
+  editable?: boolean;
 }
 
 /**
@@ -124,6 +134,7 @@ export function WysiwygEditor({
   images,
   onImageStatus,
   slashActions,
+  editable = true,
   links,
 }: WysiwygEditorProps) {
   const onChangeRef = useRef(onChange);
@@ -367,6 +378,7 @@ export function WysiwygEditor({
   const editor = useEditor({
     extensions,
     content: value,
+    editable,
     autofocus: autoFocus,
     // Required in Next.js: rendering the editor during SSR causes a hydration
     // mismatch because ProseMirror generates DOM the server cannot produce.
@@ -409,6 +421,11 @@ export function WysiwygEditor({
         return true;
       },
       handlePaste: (view, event) => {
+        // ProseMirror will not apply a paste to a non-editable view, but this
+        // handler does not paste — it uploads a file and inserts markdown of
+        // its own, which would sail straight past that.
+        if (!view.editable) return false;
+
         const files = imagesFrom(event.clipboardData);
         if (files.length === 0 || !imagesRef.current?.upload) return false;
 
@@ -420,6 +437,7 @@ export function WysiwygEditor({
         return true;
       },
       handleDrop: (view, event, _slice, moved) => {
+        if (!view.editable) return false;
         // A node being dragged within the document is not an upload.
         if (moved) return false;
 
@@ -506,6 +524,18 @@ export function WysiwygEditor({
     onReadyRef.current?.(editor ?? null);
     return () => onReadyRef.current?.(null);
   }, [editor]);
+
+  /**
+   * Locking and unlocking an editor that already exists.
+   *
+   * `editable` is read when the editor is built, and the editor is built once
+   * per note — so without this, locking a note you already had open changed
+   * nothing until you closed and reopened it, which is the worst possible
+   * behaviour for a switch whose whole job is to be trusted.
+   */
+  useEffect(() => {
+    if (editor && editor.isEditable !== editable) editor.setEditable(editable);
+  }, [editor, editable]);
 
   // Pull external changes in (switching notes, resolving a conflict) without
   // disturbing the caret during normal typing.

--- a/packages/editor/src/locked.test.tsx
+++ b/packages/editor/src/locked.test.tsx
@@ -1,0 +1,363 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { WysiwygEditor } from "./WysiwygEditor";
+import { SourceEditor, type SourceEditorHandle } from "./SourceEditor";
+import { MarkdownEditor } from "./MarkdownEditor";
+
+/**
+ * A locked note, from every direction somebody could type into one.
+ *
+ * The lock exists to stop an accident, so the interesting cases are all the
+ * ones that are not typing: a toolbar button, a paste, a dropped screenshot, a
+ * programmatic insert from the "/" menu, a mode switch to a surface that
+ * forgot. Each of those is a separate code path, and any one of them left open
+ * makes the padlock a decoration.
+ */
+
+afterEach(cleanup);
+
+const NOTE = "# Reference\n\nSome text that must not change.";
+
+async function richEditor(props: { editable?: boolean } = {}) {
+  const onChange = vi.fn();
+  let editor: Editor | null = null;
+
+  render(
+    <WysiwygEditor
+      value={NOTE}
+      onChange={onChange}
+      onReady={(instance) => (editor = instance)}
+      {...props}
+    />,
+  );
+
+  await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+  return { editor: editor as unknown as Editor, onChange };
+}
+
+describe("rich text, locked", () => {
+  it("takes contenteditable off the surface, so the browser will not type into it", async () => {
+    await richEditor({ editable: false });
+
+    const surface = document.querySelector(".ProseMirror");
+    expect(surface?.getAttribute("contenteditable")).toBe("false");
+  });
+
+  it("is editable by default, so nothing changes for a note nobody locked", async () => {
+    await richEditor();
+
+    expect(document.querySelector(".ProseMirror")?.getAttribute("contenteditable")).toBe("true");
+  });
+
+  it("locks a note that is already open, without waiting for it to be reopened", async () => {
+    const onChange = vi.fn();
+    let editor: Editor | null = null;
+
+    const { rerender } = render(
+      <WysiwygEditor value={NOTE} onChange={onChange} onReady={(i) => (editor = i)} editable />,
+    );
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    rerender(
+      <WysiwygEditor
+        value={NOTE}
+        onChange={onChange}
+        onReady={(i) => (editor = i)}
+        editable={false}
+      />,
+    );
+
+    await waitFor(() => expect((editor as unknown as Editor).isEditable).toBe(false));
+    expect(document.querySelector(".ProseMirror")?.getAttribute("contenteditable")).toBe("false");
+  });
+
+  it("unlocks again, in place", async () => {
+    let editor: Editor | null = null;
+    const { rerender } = render(
+      <WysiwygEditor
+        value={NOTE}
+        onChange={vi.fn()}
+        onReady={(i) => (editor = i)}
+        editable={false}
+      />,
+    );
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    rerender(
+      <WysiwygEditor value={NOTE} onChange={vi.fn()} onReady={(i) => (editor = i)} editable />,
+    );
+
+    await waitFor(() => expect((editor as unknown as Editor).isEditable).toBe(true));
+  });
+
+  it("refuses a pasted screenshot rather than uploading it", async () => {
+    const upload = vi.fn().mockResolvedValue("assets/shot.png");
+    let editor: Editor | null = null;
+
+    render(
+      <WysiwygEditor
+        value={NOTE}
+        onChange={vi.fn()}
+        onReady={(i) => (editor = i)}
+        editable={false}
+        images={{ upload }}
+      />,
+    );
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    const file = new File([new Uint8Array([1])], "shot.png", { type: "image/png" });
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: { files: [file], items: [], types: ["Files"], getData: () => "" },
+    });
+    document.querySelector(".ProseMirror")!.dispatchEvent(event);
+
+    // An upload writes a file into the repository *and* an `![](…)` into the
+    // note, so this is the one paste path a read-only view cannot stop by
+    // itself.
+    await waitFor(() => expect(upload).not.toHaveBeenCalled());
+  });
+
+  it("refuses a dropped screenshot for the same reason", async () => {
+    const upload = vi.fn().mockResolvedValue("assets/shot.png");
+    let editor: Editor | null = null;
+
+    render(
+      <WysiwygEditor
+        value={NOTE}
+        onChange={vi.fn()}
+        onReady={(i) => (editor = i)}
+        editable={false}
+        images={{ upload }}
+      />,
+    );
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    const file = new File([new Uint8Array([1])], "shot.png", { type: "image/png" });
+    const event = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", {
+      value: { files: [file], items: [], types: ["Files"], getData: () => "" },
+    });
+    document.querySelector(".ProseMirror")!.dispatchEvent(event);
+
+    await waitFor(() => expect(upload).not.toHaveBeenCalled());
+  });
+
+  it("still follows a link, because reading a locked note is the point", async () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+
+    let editor: Editor | null = null;
+    render(
+      <WysiwygEditor
+        value="See [the docs](https://example.com/docs)"
+        onChange={vi.fn()}
+        onReady={(i) => (editor = i)}
+        editable={false}
+      />,
+    );
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    const anchor = document.querySelector<HTMLAnchorElement>(".ProseMirror a[href]");
+    expect(anchor).not.toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("markdown source, locked", () => {
+  function source(readOnly: boolean) {
+    const onChange = vi.fn();
+    const handle = React.createRef<SourceEditorHandle>();
+    render(
+      <SourceEditor value={NOTE} onChange={onChange} readOnly={readOnly} handleRef={handle} />,
+    );
+    return { onChange, handle };
+  }
+
+  it("takes the surface out of the tab order and refuses input", () => {
+    source(true);
+
+    const content = document.querySelector(".cm-content");
+    expect(content?.getAttribute("contenteditable")).toBe("false");
+  });
+
+  it("is writable by default", () => {
+    source(false);
+
+    expect(document.querySelector(".cm-content")?.getAttribute("contenteditable")).toBe("true");
+  });
+
+  it("refuses a toolbar insert, which is a dispatch and not a keystroke", () => {
+    // `EditorState.readOnly` stops typing and the keymap. It does not stop a
+    // `view.dispatch`, which is exactly what every toolbar button is.
+    const { onChange, handle } = source(true);
+
+    handle.current?.insertAtCursor("**bold**");
+    handle.current?.wrapSelection("**");
+    handle.current?.toggleLinePrefix("# ");
+    handle.current?.indent(1);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("refuses undo and redo, which would rewrite the document just as well", () => {
+    const { onChange, handle } = source(true);
+
+    handle.current?.undo();
+    handle.current?.redo();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("still reports what is selected, so copying out of it works", () => {
+    const { handle } = source(true);
+
+    expect(typeof handle.current?.selection()).toBe("string");
+    expect(typeof handle.current?.currentLine()).toBe("string");
+  });
+
+  it("accepts the same inserts once it is unlocked", () => {
+    const { onChange, handle } = source(false);
+
+    handle.current?.insertAtCursor("**bold**");
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("locks and unlocks in place, keeping the document", () => {
+    const onChange = vi.fn();
+    const handle = React.createRef<SourceEditorHandle>();
+
+    const { rerender } = render(
+      <SourceEditor value={NOTE} onChange={onChange} readOnly={false} handleRef={handle} />,
+    );
+    expect(document.querySelector(".cm-content")?.getAttribute("contenteditable")).toBe("true");
+
+    rerender(<SourceEditor value={NOTE} onChange={onChange} readOnly handleRef={handle} />);
+    expect(document.querySelector(".cm-content")?.getAttribute("contenteditable")).toBe("false");
+
+    handle.current?.insertAtCursor("x");
+    expect(onChange).not.toHaveBeenCalled();
+
+    rerender(<SourceEditor value={NOTE} onChange={onChange} readOnly={false} handleRef={handle} />);
+    expect(document.querySelector(".cm-content")?.getAttribute("contenteditable")).toBe("true");
+    handle.current?.insertAtCursor("x");
+    expect(onChange).toHaveBeenCalled();
+  });
+});
+
+describe("the editor as a whole, locked", () => {
+  it("takes the formatting bar away in every mode", () => {
+    for (const mode of ["wysiwyg", "source", "split"] as const) {
+      const { unmount } = render(
+        <MarkdownEditor value={NOTE} onChange={vi.fn()} mode={mode} readOnly />,
+      );
+
+      expect(screen.queryByRole("button", { name: /^bold$/i })).toBeNull();
+      unmount();
+    }
+  });
+
+  it("shows the formatting bar again when it is not locked", () => {
+    render(<MarkdownEditor value={NOTE} onChange={vi.fn()} mode="source" />);
+
+    expect(screen.getAllByRole("button").length).toBeGreaterThan(0);
+  });
+
+  it("holds in the split view, where two surfaces are live at once", () => {
+    render(<MarkdownEditor value={NOTE} onChange={vi.fn()} mode="split" readOnly />);
+
+    for (const content of document.querySelectorAll(".cm-content")) {
+      expect(content.getAttribute("contenteditable")).toBe("false");
+    }
+  });
+
+  it("does not offer image dropping into the source surface", () => {
+    const upload = vi.fn().mockResolvedValue("assets/a.png");
+    render(
+      <MarkdownEditor value={NOTE} onChange={vi.fn()} mode="source" readOnly images={{ upload }} />,
+    );
+
+    const file = new File([new Uint8Array([1])], "a.png", { type: "image/png" });
+    const event = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", {
+      value: { files: [file], items: [], types: ["Files"], getData: () => "" },
+    });
+    document.querySelector(".cm-content")!.dispatchEvent(event);
+
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("still renders the note, because a locked note is one you are reading", () => {
+    render(<MarkdownEditor value={NOTE} onChange={vi.fn()} mode="split" readOnly />);
+
+    expect(document.body.textContent).toContain("Some text that must not change.");
+  });
+});
+
+describe("a locked note that changes underneath the reader", () => {
+  it("still takes an update from outside — a pull is not an edit", async () => {
+    let editor: Editor | null = null;
+    const { rerender } = render(
+      <WysiwygEditor
+        value="# One"
+        onChange={vi.fn()}
+        onReady={(i) => (editor = i)}
+        editable={false}
+      />,
+    );
+    await waitFor(() => expect(editor).not.toBeNull(), { timeout: 4000 });
+
+    // A colleague's commit arriving through sync has to land, or a locked note
+    // would quietly stop receiving other people's changes.
+    rerender(
+      <WysiwygEditor
+        value="# Two"
+        onChange={vi.fn()}
+        onReady={(i) => (editor = i)}
+        editable={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector(".ProseMirror")?.textContent).toContain("Two"),
+    );
+  });
+
+  it("does the same in the source view", () => {
+    const { rerender } = render(
+      <SourceEditor value="one" onChange={vi.fn()} readOnly ariaLabel="Markdown source" />,
+    );
+
+    rerender(<SourceEditor value="two" onChange={vi.fn()} readOnly ariaLabel="Markdown source" />);
+
+    expect(document.querySelector(".cm-content")?.textContent).toContain("two");
+  });
+});
+
+describe("keyboard, locked", () => {
+  it("ignores typing into the rich surface", async () => {
+    const { onChange } = await richEditor({ editable: false });
+
+    const surface = document.querySelector(".ProseMirror")!;
+    fireEvent.keyDown(surface, { key: "a" });
+    fireEvent.input(surface);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores typing into the source surface", () => {
+    const onChange = vi.fn();
+    render(<SourceEditor value={NOTE} onChange={onChange} readOnly />);
+
+    const content = document.querySelector(".cm-content")!;
+    fireEvent.keyDown(content, { key: "a" });
+    fireEvent.input(content, { data: "a" });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Follows on from [#48](https://github.com/praneeth132006/ForkLeaf/pull/48), which merged while these were being written. All of it is about the half of a notebook that is *reading* rather than writing.

## A picture of the page in the hover card

Knowing a link's title answers "what is this"; seeing the page answers "is this the one I meant".

The picture comes through a new `/api/link-image` rather than from the site itself. An `<img>` pointing at the linked host would tell that host the pointer crossed a word in somebody's private note — the CSP would permit the direct address, so this is a deliberate choice rather than a workaround. The route reuses the same SSRF checking as the others (address resolved and checked, re-checked at each redirect), refuses anything that is not a raster image — SVG is a document that can carry script, and serving one from our own origin is precisely the hole this otherwise closes — and caps what it will stream, because an image proxy that will fetch anything at any size is a bandwidth amplifier with a URL bar.

It is the page's declared `og:image`, not a live screenshot; a screenshot would mean a headless browser per hover.

## Links look clickable

In rich text the surrounding prose is editable, so the browser drew an I-beam over the links in it — and a link that gives no sign of being clickable is one nobody clicks.

## Locking a note

A reference note is one you read far more often than you write. Reading it means clicking around in it, which leaves the caret in the text — and from there a stray keystroke is an edit that saves itself, commits itself, and is found weeks later as a lone character mid-paragraph.

The padlock in the header, `⌘⇧L`, or the command palette. Deliberately not one flag on one surface:

| Path | Why it needed its own guard |
| --- | --- |
| Rich text | `editable: false`, applied to an already-open editor too — otherwise locking did nothing until the note was reopened |
| Source & split | `EditorState.readOnly` **and** `EditorView.editable`, in a compartment so toggling keeps undo history and scroll position |
| The formatting bar | A toolbar button is a `view.dispatch`, which `readOnly` does not stop — the bar goes, and the source handle's mutating methods refuse as well |
| Paste / drop of an image | Uploads a file and inserts markdown of its own rather than typing, so a read-only view never sees it |
| Properties panel | A `fieldset`, so controls added later are covered too |
| Everything else | One guard in the notebook, since a lock that holds only while four surfaces each remember to check is not a lock |

It carries across a rename, is dropped when the note is deleted, is per device, and survives a reload. It does **not** stop reading, copying, following links, or a colleague's commit arriving — a lock is about your hands, not about freezing the file.

Locks are stored beside the other per-device preferences rather than in the note's frontmatter: writing them into the file would mean a commit every time anybody locked or unlocked anything, from a button whose whole job is to prevent changes nobody asked for.

## The capture dialog now says what it is doing

Pressing **Capture** showed nothing for up to a minute, because the slow half — asking the Wayback Machine to archive a page it has never seen — was awaited before anything appeared. An honest answer that arrives forty seconds later is indistinguishable, from the outside, from a feature that does not work.

The two halves are now separate requests (`want: "page" | "archive"`, defaulting to both, so nothing else changes), each reported as it lands. The dialog also explains what the feature does before anything is typed, shows the citation exactly as it will be written, offers a Paste button, and gives real messages for an expired sign-in and for being rate limited. The citation can be added while the archive lookup is still running.

## The review icon

An `<svg>` with a viewBox and no width collapses to nothing in a flex row, so "Review & merge this note" was the one action in the properties panel with a blank space where every other row has an icon. Fixed in the glyph, and the size is now enforced by the button too, so the next glyph cannot vanish the same way.

## Documentation

- New **Reading a note** page: opening links (including the Alt-click table), the hover card and what it does *not* send, reading a repository file, and exactly what locking does and does not stop.
- The capture section rewritten around the staged flow.
- README: a Reading section, `⌘⇧L` in the shortcut table, and capture listed under History and review.
- The sandbox-configuration callout is removed from the features page — `VERCEL_TOKEN` and friends are a deployment detail, and on a page written for people *using* the app it read as a prerequisite. The self-hosting docs are where they belong; the Run button still explains itself when no sandbox is configured.

## Notes for the reviewer

- `format:check`, `lint`, `typecheck`, `build` and the full suite (1543 tests, 96 new) pass. The lock has 38 of them, covering each path in the table above plus lock/unlock in place and updates arriving from outside.
- Verified live in the dev server: the hover card renders and positions itself; a plain click calls `window.open(href, "_blank", "noopener,noreferrer")` and an Alt-click does not; the pointer is `pointer` over links in both surfaces; and the lock was exercised by hand in all three views — typing, ⌘B, the toolbar, the properties panel, a reload, and unlocking again.
- **Not** exercised against live GitHub or a signed-in session: the hover card's server-side read, the image proxy and the capture dialog all need a session, so those are covered by unit tests only. Worth a manual pass while signed in before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)