### PR TITLE
fix(auth): a dead GitHub token signs you out instead of breaking every image

### DIFF
--- a/apps/web/src/app/api/gh/raw/route.ts
+++ b/apps/web/src/app/api/gh/raw/route.ts
@@ -1,6 +1,12 @@
 import { type NextRequest } from "next/server";
 import { GitHubError } from "@forkleaf/github-client";
-import { requireClient, readRepoRef, normalize, ApiError } from "@/lib/api-helpers";
+import {
+  requireClient,
+  readRepoRef,
+  normalize,
+  ApiError,
+  forgetDeadSession,
+} from "@/lib/api-helpers";
 import { imageTypeFor } from "@/lib/media";
 
 /**
@@ -89,6 +95,25 @@ export async function GET(request: NextRequest) {
       return new Response(error.message, { status: error.status });
     }
     if (error instanceof GitHubError) {
+      /**
+       * A dead token is not a broken image.
+       *
+       * This route is the one place a refused token shows up dozens of times
+       * over — a note with nine screenshots is nine of these — and it used to
+       * answer all nine with a 502, which the browser draws as the broken-image
+       * icon and reports nowhere else. The note looked corrupted. It was not:
+       * the sign-in behind it had ended.
+       *
+       * Ending the session here means the *next* thing the page asks for gets
+       * "local mode" and the app can say so once, in words, rather than nine
+       * times in pictures.
+       */
+      if (await forgetDeadSession(error)) {
+        return new Response("Your GitHub sign-in has expired.", {
+          status: 401,
+          headers: { "Cache-Control": "no-store" },
+        });
+      }
       return new Response("Could not read that image.", { status: 502 });
     }
     console.error("[forkleaf] Raw asset error:", error);

--- a/apps/web/src/components/EditorStatusBar.tsx
+++ b/apps/web/src/components/EditorStatusBar.tsx
@@ -7,6 +7,15 @@ import { SyncModeMenu } from "./SyncModeMenu";
 
 export interface EditorStatusBarProps {
   sync: SyncState;
+  /**
+   * True when GitHub has refused the session token.
+   *
+   * Separate from `sync.lastErrorCode`, which only knows about pushes: a
+   * notebook with nothing queued to push has a clean sync state and a dead
+   * sign-in at the same time, and this bar was reporting the first while the
+   * second was the thing worth knowing.
+   */
+  sessionExpired?: boolean;
   workspace: Workspace | null;
   notePath: string | null;
   /**
@@ -72,12 +81,13 @@ export function EditorStatusBar({
   onSwitchBranch,
   onPropose,
   onSignIn,
+  sessionExpired = false,
 }: EditorStatusBarProps) {
   /**
    * An expired sign-in is the one failure retrying cannot fix, so it takes
    * over the whole status control rather than sitting behind it.
    */
-  const expired = sync.lastErrorCode === "unauthorized";
+  const expired = sync.lastErrorCode === "unauthorized" || sessionExpired;
   const status = describe(sync, expired);
 
   return (

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -1467,7 +1467,12 @@ export function EditorWorkspace() {
               status bar. It stops every push until it is dealt with, and the
               fix is one button — so the button is where the reader is looking,
               not eight point type at the bottom of the window. */}
-          {notebook.sync.lastErrorCode === "unauthorized" && (
+          {/* Either half of the same fact: a push GitHub refused, or a read
+              that came back 401 and ended the session. The second is the more
+              common one by far — reading a note full of images is dozens of
+              calls, pushing one is a handful — and it used to produce no
+              banner at all. */}
+          {(notebook.sync.lastErrorCode === "unauthorized" || notebook.sessionExpired) && (
             <div
               role="alert"
               className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-[var(--fl-danger)]/30 bg-[var(--fl-danger)]/8 px-4 py-2.5 text-[13px]"
@@ -1477,7 +1482,7 @@ export function EditorWorkspace() {
                 <span className="text-[var(--fl-muted)]">
                   {notebook.sync.pendingCount > 0
                     ? `${notebook.sync.pendingCount} change${notebook.sync.pendingCount === 1 ? "" : "s"} are saved on this device and will push as soon as you are back in.`
-                    : "Your notes are saved on this device. Signing in again resumes pushing to GitHub."}
+                    : "Your notes are safe on this device. Images in them are served from GitHub, so they will not load until you sign in again."}
                 </span>
               </p>
 
@@ -1491,7 +1496,10 @@ export function EditorWorkspace() {
             </div>
           )}
 
-          {!user && (
+          {/* Not while the sign-in has just expired: "you are working locally"
+              is true but is the wrong sentence to lead with, and the banner
+              above it already says the useful half. */}
+          {!user && !notebook.sessionExpired && (
             <LocalOnlyBanner
               githubAvailable={notebook.session?.githubAvailable ?? false}
               onSignIn={signIn}
@@ -1619,6 +1627,7 @@ export function EditorWorkspace() {
         onSwitchBranch={notebook.switchBranch}
         onPropose={() => setDialog("propose")}
         sync={notebook.sync}
+        sessionExpired={notebook.sessionExpired}
         workspace={workspace}
         notePath={note?.path ?? null}
         localFile={note ? localFiles.fileFor(note.path) : null}

--- a/apps/web/src/hooks/useLibrary.ts
+++ b/apps/web/src/hooks/useLibrary.ts
@@ -12,7 +12,13 @@ import {
   type SearchHit,
 } from "@forkleaf/store";
 import { workspaceId, type Note, type PendingChange, type Workspace } from "@forkleaf/types";
-import { GitHubGateway, LocalGateway, fetchSession, type SessionResponse } from "@/lib/gateway";
+import {
+  GitHubGateway,
+  LocalGateway,
+  fetchSession,
+  onSessionExpired,
+  type SessionResponse,
+} from "@/lib/gateway";
 import { buildIndex, flattenTree, isMarkdown, orphanedNotes, type IndexEntry } from "@/lib/library";
 import { deriveTitle, extractTags } from "@forkleaf/markdown-engine";
 import { LOCAL_WORKSPACE } from "@/lib/workspaces";
@@ -39,6 +45,8 @@ export interface LibraryWorkspace {
 export interface LibraryState {
   ready: boolean;
   session: SessionResponse | null;
+  /** True once GitHub has refused this session's token. See `useNotebook`. */
+  sessionExpired: boolean;
   workspaces: LibraryWorkspace[];
   /**
    * True when the user is signed in to GitHub but has not chosen where their
@@ -105,6 +113,7 @@ export function useLibrary() {
   const [state, setState] = useState<LibraryState>({
     ready: false,
     session: null,
+    sessionExpired: false,
     workspaces: [],
     needsRepoChoice: false,
     indexing: false,
@@ -165,6 +174,30 @@ export function useLibrary() {
   }, []);
 
   /** Replaces one workspace's slice of the state, leaving the others alone. */
+  /**
+   * The sign-in ending while the dashboard is open.
+   *
+   * The same fact the editor listens for, and it matters here too: this page
+   * lists every connected repository, and once the token is refused none of
+   * them can be reached. Saying "signed out" once beats one unreachable-repo
+   * error per row.
+   */
+  useEffect(
+    () =>
+      onSessionExpired(() => {
+        setState((current) =>
+          current.sessionExpired
+            ? current
+            : {
+                ...current,
+                sessionExpired: true,
+                session: { mode: "local", user: null, githubAvailable: true, scopes: [] },
+              },
+        );
+      }),
+    [],
+  );
+
   const patchWorkspace = useCallback((id: string, updates: Partial<LibraryWorkspace>) => {
     setState((current) => ({
       ...current,

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -24,7 +24,13 @@ import {
   type EditorViewMode,
 } from "@forkleaf/types";
 import { dirname, serializeDocument } from "@forkleaf/markdown-engine";
-import { GitHubGateway, LocalGateway, fetchSession, type SessionResponse } from "@/lib/gateway";
+import {
+  GitHubGateway,
+  LocalGateway,
+  fetchSession,
+  onSessionExpired,
+  type SessionResponse,
+} from "@/lib/gateway";
 import { LOCAL_WORKSPACE, collapseBranchDuplicates } from "@/lib/workspaces";
 import { forgetLock, isPathLocked, lockedKey, renameLock, toggleLock } from "@/lib/locks";
 import { assetFrom, assetObjectUrl } from "@/lib/assets";
@@ -40,6 +46,16 @@ import { assetFrom, assetObjectUrl } from "@/lib/assets";
 export interface NotebookState {
   ready: boolean;
   session: SessionResponse | null;
+  /**
+   * True once GitHub has refused this session's token.
+   *
+   * Distinct from `session.mode === "local"`, which it also causes: somebody
+   * who never signed in is in local mode on purpose and should be offered a
+   * sign-in, while somebody whose token died was signed in a moment ago, has a
+   * repository connected, and needs telling what happened to it. The same
+   * "local" session with two different things worth saying about it.
+   */
+  sessionExpired: boolean;
   workspaces: Workspace[];
   activeWorkspace: Workspace | null;
   tree: TreeNode[];
@@ -195,6 +211,7 @@ export function useNotebook(request: NotebookRequest = {}) {
   const [state, setState] = useState<NotebookState>({
     ready: false,
     session: null,
+    sessionExpired: false,
     workspaces: [],
     activeWorkspace: null,
     tree: [],
@@ -385,6 +402,46 @@ export function useNotebook(request: NotebookRequest = {}) {
     };
     // `requested` is frozen at mount, so this still runs exactly once.
   }, [patch, requested.workspaceId]);
+
+  // ── The sign-in ending underneath us ────────────────────────────────────
+  /**
+   * A session cookie outlives the GitHub token inside it, and nothing says so.
+   *
+   * The token can be refused at any moment — the authorisation revoked, the
+   * same OAuth app signed into again elsewhere at a different access level,
+   * GitHub retiring it. The cookie is good for thirty days regardless, so the
+   * app went on showing an avatar, a repository and a sync indicator while
+   * every single call behind them came back 401. What the reader saw was a
+   * note whose nine screenshots had all turned into broken boxes, and nothing
+   * anywhere to say why. It read as the app having eaten their images.
+   *
+   * The server drops the cookie the moment GitHub refuses it. This is that
+   * fact arriving on the page: stop claiming to be signed in, and say so once,
+   * in words. Notes and unpushed changes are untouched — they are on this
+   * device, they stay on this device, and signing in again resumes pushing
+   * them.
+   */
+  useEffect(
+    () =>
+      onSessionExpired(() => {
+        const signedOut: SessionResponse = {
+          mode: "local",
+          user: null,
+          githubAvailable: true,
+          scopes: [],
+        };
+        // The note repository reads this ref for the login to stamp on a save.
+        // We no longer know who that is, and guessing would credit somebody's
+        // notes to a session GitHub has already thrown away.
+        sessionRef.current = signedOut;
+        setState((current) =>
+          current.sessionExpired
+            ? current
+            : { ...current, session: signedOut, sessionExpired: true },
+        );
+      }),
+    [],
+  );
 
   // ── Load the tree whenever the workspace changes ────────────────────────
   useEffect(() => {

--- a/apps/web/src/lib/api-helpers.test.ts
+++ b/apps/web/src/lib/api-helpers.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/session", () => ({
+  clearSessionCookie: vi.fn(async () => {}),
+  getSession: vi.fn(async () => null),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 import {
   ApiError,
   assertName,
@@ -151,5 +160,36 @@ describe("withRateLimitAdvice", () => {
 
     await expect(withRateLimitAdvice(notFound, false)).rejects.toBeInstanceOf(GitHubError);
     await expect(withRateLimitAdvice(notFound, false)).rejects.toMatchObject({ code: "not-found" });
+  });
+});
+
+/**
+ * A session cookie can outlive the GitHub token inside it by up to thirty
+ * days, and nothing announces the moment it does. These cover the rule that
+ * closes that gap: a token GitHub refuses ends the session immediately, so the
+ * app cannot go on presenting itself as signed in while every call behind it
+ * fails.
+ */
+describe("forgetDeadSession", () => {
+  it("clears the session when GitHub refuses the token", async () => {
+    const { forgetDeadSession } = await import("./api-helpers");
+    const { clearSessionCookie } = await import("./session");
+
+    expect(await forgetDeadSession(new GitHubError("unauthorized", "Bad credentials"))).toBe(true);
+    expect(clearSessionCookie).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the session alone for every other failure", async () => {
+    const { forgetDeadSession } = await import("./api-helpers");
+    const { clearSessionCookie } = await import("./session");
+
+    // A rate limit, a private repository, a genuine 404: all recoverable, and
+    // signing the user out over any of them would be its own bug.
+    for (const code of ["rate-limited", "forbidden", "not-found", "conflict"] as const) {
+      expect(await forgetDeadSession(new GitHubError(code, "nope"))).toBe(false);
+    }
+    // Not every failure is even a GitHubError.
+    expect(await forgetDeadSession(new Error("socket hang up"))).toBe(false);
+    expect(clearSessionCookie).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/api-helpers.ts
+++ b/apps/web/src/lib/api-helpers.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 import { GitHubClient, GitHubError } from "@forkleaf/github-client";
 import type { RepoRef } from "@forkleaf/types";
-import { getSession } from "@/lib/session";
+import { clearSessionCookie, getSession } from "@/lib/session";
 
 /**
  * Shared plumbing for the GitHub proxy routes.
@@ -159,6 +159,34 @@ export async function withRateLimitAdvice<T>(run: () => Promise<T>, signedIn: bo
   }
 }
 
+/**
+ * Throws away a session GitHub has stopped honouring.
+ *
+ * A session cookie and a working GitHub token are two different things, and
+ * only the first of them is ours. The cookie lasts thirty days; the token
+ * inside it can die at any moment — the authorisation is revoked, the same
+ * OAuth app is signed into again somewhere else with a different access level,
+ * GitHub retires the token. Nothing tells us when that happens. The first we
+ * hear of it is a 401 on a call we expected to work.
+ *
+ * Until this existed, that 401 was all that happened: the cookie stayed, so
+ * every page still showed you signed in, every note still said it was syncing,
+ * and every image in every note quietly failed to load with no explanation
+ * anywhere — because the proxy that fetches them needs the same dead token.
+ * The app looked signed in and behaved as though it were signed out.
+ *
+ * So a token GitHub refuses ends the session on the spot. The next request
+ * says "local mode" and the reader gets one banner and one button, instead of
+ * a screen full of broken pictures.
+ */
+export async function forgetDeadSession(error: unknown): Promise<boolean> {
+  if (!(error instanceof GitHubError) || error.code !== "unauthorized") return false;
+
+  console.warn("[forkleaf] GitHub rejected the session token; signing out.");
+  await clearSessionCookie();
+  return true;
+}
+
 /** Runs a handler, converting known failures into a consistent JSON error. */
 export async function handle<T>(fn: () => Promise<T>): Promise<NextResponse> {
   try {
@@ -175,6 +203,21 @@ export async function handle<T>(fn: () => Promise<T>): Promise<NextResponse> {
     if (error instanceof GitHubError) {
       // Log server-side with full detail; return only the safe projection.
       console.error("[forkleaf] GitHub API error:", error.code, error.message);
+
+      // A refused token is not this route's problem to report and the next
+      // route's problem to hit again — it ends the session for all of them.
+      if (await forgetDeadSession(error)) {
+        return NextResponse.json(
+          {
+            error: {
+              code: "unauthorized",
+              message: "Your GitHub sign-in has expired. Sign in again to reconnect.",
+            },
+          },
+          { status: 401, headers: { "Cache-Control": "no-store" } },
+        );
+      }
+
       return NextResponse.json(
         { error: error.toJSON() },
         { status: statusFor(error), headers: { "Cache-Control": "no-store" } },

--- a/apps/web/src/lib/gateway.test.ts
+++ b/apps/web/src/lib/gateway.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiGatewayError, fetchSession, onSessionExpired } from "./gateway";
+
+/**
+ * The browser's half of "the sign-in ended".
+ *
+ * The server drops the cookie the moment GitHub refuses the token, but the
+ * page it dropped it out from under is still showing an avatar, a repository
+ * and a sync indicator. Every call in the gateway goes through one function,
+ * which makes that function the only place guaranteed to see the 401 whatever
+ * asked for it — a tree read, a commit, or the image proxy behind a note full
+ * of screenshots.
+ */
+
+const respondWith = (status: number, body: unknown) =>
+  vi.fn(async () => new Response(JSON.stringify(body), { status }));
+
+/**
+ * Puts the module into the state a signed-in browser is in.
+ *
+ * Only a session that was live can stop being live, and the gateway learns
+ * which it is from the server rather than assuming — so every expiry case has
+ * to start from a real GitHub session, the same way the app does.
+ */
+async function signIn() {
+  vi.stubGlobal(
+    "fetch",
+    respondWith(200, {
+      mode: "github",
+      user: { id: 1, login: "someone", name: null, avatarUrl: "" },
+      githubAvailable: true,
+      scopes: ["repo"],
+    }),
+  );
+  await fetchSession();
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("session expiry", () => {
+  it("tells its listeners when a call comes back unauthorised", async () => {
+    await signIn();
+    vi.stubGlobal(
+      "fetch",
+      respondWith(401, { error: { code: "unauthorized", message: "Your sign-in has expired." } }),
+    );
+
+    const told = vi.fn();
+    const stop = onSessionExpired(told);
+
+    await expect(fetchSession()).rejects.toBeInstanceOf(ApiGatewayError);
+    expect(told).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  it("stays quiet for failures a sign-in would not fix", async () => {
+    // A 500 or a 404 is not a reason to sign anybody out — doing so would turn
+    // a passing outage into "you have been logged out", which is worse than
+    // the outage.
+    vi.stubGlobal("fetch", respondWith(500, { error: { code: "unknown", message: "boom" } }));
+
+    const told = vi.fn();
+    const stop = onSessionExpired(told);
+
+    await expect(fetchSession()).rejects.toBeInstanceOf(ApiGatewayError);
+    expect(told).not.toHaveBeenCalled();
+
+    stop();
+  });
+
+  it("stops telling a listener that has unsubscribed", async () => {
+    await signIn();
+    vi.stubGlobal(
+      "fetch",
+      respondWith(401, { error: { code: "unauthorized", message: "expired" } }),
+    );
+
+    const told = vi.fn();
+    onSessionExpired(told)();
+
+    await expect(fetchSession()).rejects.toBeInstanceOf(ApiGatewayError);
+    expect(told).not.toHaveBeenCalled();
+  });
+
+  it("tells every listener even when one of them throws", async () => {
+    await signIn();
+    vi.stubGlobal(
+      "fetch",
+      respondWith(401, { error: { code: "unauthorized", message: "expired" } }),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const first = vi.fn(() => {
+      throw new Error("listener is broken");
+    });
+    const second = vi.fn();
+    const stopFirst = onSessionExpired(first);
+    const stopSecond = onSessionExpired(second);
+
+    await expect(fetchSession()).rejects.toBeInstanceOf(ApiGatewayError);
+    // The editor missing this because the dashboard's listener threw would put
+    // us back to failing silently, which is the bug this exists to close.
+    expect(second).toHaveBeenCalledTimes(1);
+
+    stopFirst();
+    stopSecond();
+  });
+  it("says nothing to somebody who was never signed in", async () => {
+    // Local mode: no cookie, no token, and a 401 from any route that needs one
+    // is the expected answer rather than news. Announcing an expired sign-in
+    // here would invent a session the reader never had.
+    vi.stubGlobal(
+      "fetch",
+      respondWith(200, { mode: "local", user: null, githubAvailable: true, scopes: [] }),
+    );
+    await fetchSession();
+
+    vi.stubGlobal(
+      "fetch",
+      respondWith(401, { error: { code: "unauthorized", message: "Sign in to continue." } }),
+    );
+
+    const told = vi.fn();
+    const stop = onSessionExpired(told);
+
+    await expect(fetchSession()).rejects.toBeInstanceOf(ApiGatewayError);
+    expect(told).not.toHaveBeenCalled();
+
+    stop();
+  });
+
+  it("announces once, not once per failing request", async () => {
+    // A note with nine screenshots is nine requests through the image proxy,
+    // and every one of them fails the same way. One banner, not nine.
+    await signIn();
+    vi.stubGlobal(
+      "fetch",
+      respondWith(401, { error: { code: "unauthorized", message: "expired" } }),
+    );
+
+    const told = vi.fn();
+    const stop = onSessionExpired(told);
+
+    await expect(fetchSession()).rejects.toBeInstanceOf(ApiGatewayError);
+    await expect(fetchSession()).rejects.toBeInstanceOf(ApiGatewayError);
+    await expect(fetchSession()).rejects.toBeInstanceOf(ApiGatewayError);
+    expect(told).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+});

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -27,6 +27,54 @@ export class ApiGatewayError extends Error {
   }
 }
 
+/**
+ * Told when the server stops recognising this browser's sign-in.
+ *
+ * Every call in this file goes through `call`, so this is the one place that
+ * sees a 401 whatever asked for it — a tree read, a commit, an image. The
+ * alternative was what used to happen: each dialog checked `needsAuth` for its
+ * own errand and the parts of the app that never open a dialog — the editor
+ * with a note full of pictures in it — carried on as though nothing had
+ * changed, because nothing had told them.
+ *
+ * The server has already dropped the cookie by the time this fires. This is
+ * only the news reaching the page that is still showing an avatar.
+ */
+const expiryListeners = new Set<() => void>();
+
+/**
+ * Whether there is a GitHub sign-in here that could expire in the first place.
+ *
+ * Not every 401 is a session ending. Somebody who never signed in gets one
+ * from any route that needs a token, and announcing "your GitHub sign-in has
+ * expired" to a person who has never had one would be a scarier and less true
+ * statement than the silence it replaced. Only a session that was live and
+ * stopped being live is worth interrupting anybody over — so this is set from
+ * what the server said about the session, and cleared the moment the news goes
+ * out, which also keeps a page full of failing image requests from announcing
+ * the same thing forty times.
+ */
+let signedInToGitHub = false;
+
+/** Subscribes to the sign-in ending. Returns an unsubscribe function. */
+export function onSessionExpired(listener: () => void): () => void {
+  expiryListeners.add(listener);
+  return () => expiryListeners.delete(listener);
+}
+
+function announceExpiry(): void {
+  for (const listener of expiryListeners) {
+    // One listener throwing must not stop the rest being told: this is the
+    // notification that the app is signed out, and a page that misses it goes
+    // back to failing silently, which is the bug this exists to close.
+    try {
+      listener();
+    } catch (error) {
+      console.error("[forkleaf] Session-expiry listener failed:", error);
+    }
+  }
+}
+
 async function call<T>(url: string, init?: RequestInit & { timeoutMs?: number }): Promise<T> {
   let response: Response;
   const { timeoutMs, ...rest } = init ?? {};
@@ -53,11 +101,18 @@ async function call<T>(url: string, init?: RequestInit & { timeoutMs?: number })
       error?: { code?: string; message?: string };
     } | null;
 
-    throw new ApiGatewayError(
+    const error = new ApiGatewayError(
       body?.error?.code ?? "unknown",
       body?.error?.message ?? `Request failed (${response.status})`,
       response.status,
     );
+
+    if (error.needsAuth && signedInToGitHub) {
+      signedInToGitHub = false;
+      announceExpiry();
+    }
+
+    throw error;
   }
 
   return (await response.json()) as T;
@@ -200,8 +255,13 @@ export interface SessionResponse {
  * no way out. The callers already treat a failure as "local mode", which is
  * the right answer when the server cannot be reached anyway.
  */
-export function fetchSession(): Promise<SessionResponse> {
-  return call<SessionResponse>("/api/session", { timeoutMs: SESSION_TIMEOUT_MS });
+export async function fetchSession(): Promise<SessionResponse> {
+  const session = await call<SessionResponse>("/api/session", { timeoutMs: SESSION_TIMEOUT_MS });
+  // The server is the only authority on this, and it is asked on every boot
+  // and after every sign-in, so this stays true to what the cookie actually
+  // holds rather than to what the page last rendered.
+  signedInToGitHub = session.mode === "github";
+  return session;
 }
 
 /** Generous — this is a guard against never, not a latency budget. */


### PR DESCRIPTION
## What this changes

A GitHub token the server can no longer use now ends the session on the spot, instead of leaving the app looking signed in while everything behind it fails. The most visible symptom was images: a note's pictures are fetched through `/api/gh/raw`, so a refused token turned a note with nine screenshots into nine broken boxes with nothing anywhere to say why.

## Why

The session cookie lasts thirty days. The GitHub token inside it can be refused at any moment — the authorisation revoked, the same OAuth app signed into again elsewhere at a different access level, GitHub retiring the token — and nothing told us when that happened. `requireClient` only checked that the cookie *existed*, never that the token still worked.

So the app kept showing an avatar, a connected repository and "Sync: automatic" while every call behind them came back 401. The image proxy reported its failures as `502`, which a browser draws as the broken-image icon and reports nowhere else. The app looked signed in and behaved as though it were signed out, and what the reader saw was a note that had eaten its own pictures.

The banner for this case already existed — but only on the sync engine's push path, so it never fired for a notebook with nothing queued. A clean sync state and a dead sign-in are not mutually exclusive, and that was exactly the situation here.

### How it works now

- **`forgetDeadSession`** ([`api-helpers.ts`](apps/web/src/lib/api-helpers.ts)) drops the session cookie on any `unauthorized` error from GitHub. Wired into the shared `handle()` used by the proxy routes and into the image proxy separately, since that route builds its own responses.
- **The browser is told**, from `call()` in [`gateway.ts`](apps/web/src/lib/gateway.ts) — the one function every gateway request passes through, so it sees the 401 whatever asked for it. `useNotebook` and `useLibrary` both subscribe and flip to signed-out.
- **The image proxy returns 401, not 502**, with `Cache-Control: no-store` so a failure caused by a dead sign-in is never cached.
- **The banner copy** now names the part that actually bites: images are served from GitHub, so they will not load until you sign in again. The status bar reflects it too.

### Two guards on the announcement

- It only fires for a session that **was** live. Somebody in local mode gets a 401 from any route needing a token as the expected answer; telling them their GitHub sign-in expired would invent a session they never had.
- It fires **once**, not once per failing request. A note full of images is dozens of them.

Notes and unpushed changes are untouched throughout — they are on the device, they stay on the device, and signing in again resumes pushing.

## How it was tested

`pnpm check` passes in full (format, typecheck, lint, 1551 tests across 97 files, build).

New tests:
- `forgetDeadSession` clears the session for an `unauthorized` GitHubError, and leaves it alone for `rate-limited`, `forbidden`, `not-found`, `conflict` and non-GitHub errors — signing someone out over a passing outage would be its own bug.
- The gateway announces expiry on a 401, stays quiet on a 500, respects unsubscribe, survives a listener that throws (so the editor still hears it if the dashboard's listener breaks), says nothing to a local-mode session, and announces once across three consecutive failures.

**Not verified by hand:** the banner rendering live. Reproducing it needs a genuinely refused GitHub token, which I could not manufacture without minting a session cookie. The logic is covered by tests; the pixels are not. Worth a reviewer clicking through if they have a revoked token handy.

## Checklist

- [x] `pnpm check` passes locally
- [x] Tests added for new logic
- [x] Comments explain _why_ for anything non-obvious
- [x] No new `any`
- [x] Touches auth and the image proxy; the session/token split and the proxy's reason for existing are both documented in the code it changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
