### PR TITLE
fix(auth): keep the sign-in alive across a GitHub App's eight-hour token

### DIFF
--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { GitHubClient } from "@forkleaf/github-client";
 import { appUrl, safeReturnPath } from "@/lib/app-url";
+import { exchangeCodeForToken } from "@/lib/github-oauth";
 import {
   consumeOAuthState,
   consumeReturnPath,
@@ -44,18 +45,31 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const { token, scopes } = await exchangeCodeForToken(
+    const grant = await exchangeCodeForToken(
       code,
       appUrl(request, "/api/auth/callback").toString(),
     );
 
     // Confirm the token works and capture the profile in one call.
-    const client = new GitHubClient({ token });
+    const client = new GitHubClient({ token: grant.token });
     const user = await client.getAuthenticatedUser();
 
+    /**
+     * The refresh token is kept, not discarded.
+     *
+     * ForkLeaf is a GitHub App, and a GitHub App's user token expires eight
+     * hours after this moment. Storing only the access token — which is what
+     * this did — meant every session was over by the same afternoon it began,
+     * with a thirty-day cookie still insisting otherwise. The refresh token
+     * GitHub hands over alongside it is good for six months, and is the entire
+     * reason nobody should have to sign in twice in a day.
+     */
     await setSessionCookie({
-      token,
-      scopes,
+      token: grant.token,
+      scopes: grant.scopes,
+      ...(grant.expiresAt !== undefined ? { expiresAt: grant.expiresAt } : {}),
+      ...(grant.refreshToken !== undefined ? { refreshToken: grant.refreshToken } : {}),
+      ...(grant.refreshExpiresAt !== undefined ? { refreshExpiresAt: grant.refreshExpiresAt } : {}),
       user: {
         id: user.id,
         login: user.login,
@@ -80,45 +94,6 @@ export async function GET(request: NextRequest) {
     console.error("[forkleaf] OAuth callback failed:", error);
     return NextResponse.redirect(withError(home, "exchange_failed"));
   }
-}
-
-async function exchangeCodeForToken(
-  code: string,
-  redirectUri: string,
-): Promise<{ token: string; scopes: string[] }> {
-  const response = await fetch("https://github.com/login/oauth/access_token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      client_id: process.env.GITHUB_OAUTH_CLIENT_ID,
-      client_secret: process.env.GITHUB_OAUTH_CLIENT_SECRET,
-      code,
-      redirect_uri: redirectUri,
-    }),
-  });
-
-  const data = (await response.json()) as {
-    access_token?: string;
-    scope?: string;
-    error?: string;
-    error_description?: string;
-  };
-
-  if (!data.access_token) {
-    throw new Error(data.error_description ?? data.error ?? "No access token returned");
-  }
-
-  // What was granted, which is not always what was asked for: somebody can
-  // approve a narrower set on GitHub's own screen.
-  const scopes = (data.scope ?? "")
-    .split(",")
-    .map((scope) => scope.trim())
-    .filter(Boolean);
-
-  return { token: data.access_token, scopes };
 }
 
 function withError(url: URL, code: string): URL {

--- a/apps/web/src/app/api/capture/route.test.ts
+++ b/apps/web/src/app/api/capture/route.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/session", () => ({
   getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+  // What `requireClient` actually calls: the session with a token that has
+  // been renewed if it needed renewing.
+  getLiveSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
 }));
 
 vi.mock("@forkleaf/github-client", async () => {

--- a/apps/web/src/app/api/gh/file-head/route.test.ts
+++ b/apps/web/src/app/api/gh/file-head/route.test.ts
@@ -4,6 +4,9 @@ const listFileCommits = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+  // What `requireClient` actually calls: the session with a token that has
+  // been renewed if it needed renewing.
+  getLiveSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
 }));
 
 vi.mock("@forkleaf/github-client", async () => {

--- a/apps/web/src/app/api/gh/history/route.test.ts
+++ b/apps/web/src/app/api/gh/history/route.test.ts
@@ -6,6 +6,9 @@ const getCommitFiles = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+  // What `requireClient` actually calls: the session with a token that has
+  // been renewed if it needed renewing.
+  getLiveSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
 }));
 
 vi.mock("@forkleaf/github-client", async () => {

--- a/apps/web/src/app/api/gh/pr-diagrams/route.ts
+++ b/apps/web/src/app/api/gh/pr-diagrams/route.ts
@@ -4,7 +4,7 @@ import { extractMermaidBlocks } from "@forkleaf/markdown-engine";
 import { pairDiagrams, diffDiagrams, summarizeDiff } from "@forkleaf/diagrams";
 import type { RepoRef } from "@forkleaf/types";
 import { ApiError, assertName, handle, withRateLimitAdvice } from "@/lib/api-helpers";
-import { getSession } from "@/lib/session";
+import { getLiveSession } from "@/lib/session";
 
 /**
  * The diagrams a pull request changes.
@@ -40,7 +40,7 @@ export async function GET(request: NextRequest) {
       throw new ApiError(400, "validation", "That is not a pull request number.");
     }
 
-    const session = await getSession();
+    const session = await getLiveSession();
 
     // No retry budget for a rate limit on this route.
     //

--- a/apps/web/src/app/api/gh/review/route.test.ts
+++ b/apps/web/src/app/api/gh/review/route.test.ts
@@ -11,6 +11,9 @@ const mergePullRequest = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+  // What `requireClient` actually calls: the session with a token that has
+  // been renewed if it needed renewing.
+  getLiveSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
 }));
 
 vi.mock("@forkleaf/github-client", async () => {

--- a/apps/web/src/app/api/link-image/route.test.ts
+++ b/apps/web/src/app/api/link-image/route.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const session = vi.fn().mockResolvedValue({ token: "t", user: { login: "me" } });
-vi.mock("@/lib/session", () => ({ getSession: () => session() }));
+vi.mock("@/lib/session", () => ({
+  getSession: () => session(),
+  getLiveSession: () => session(),
+}));
 
 // Every hostname resolves to one public address unless a test says otherwise.
 const lookup = vi.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);

--- a/apps/web/src/app/api/link-preview/route.test.ts
+++ b/apps/web/src/app/api/link-preview/route.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const session = vi.fn().mockResolvedValue({ token: "t", user: { login: "me" } });
-vi.mock("@/lib/session", () => ({ getSession: () => session() }));
+vi.mock("@/lib/session", () => ({
+  getSession: () => session(),
+  getLiveSession: () => session(),
+}));
 
 // Every hostname resolves to one public address unless a test says otherwise.
 const lookup = vi.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);

--- a/apps/web/src/app/api/run/route.test.ts
+++ b/apps/web/src/app/api/run/route.test.ts
@@ -7,6 +7,9 @@ const stop = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+  // What `requireClient` actually calls: the session with a token that has
+  // been renewed if it needed renewing.
+  getLiveSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
 }));
 
 vi.mock("@forkleaf/github-client", async () => {

--- a/apps/web/src/app/api/session/route.ts
+++ b/apps/web/src/app/api/session/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getSession, githubOAuthConfigured } from "@/lib/session";
+import { getLiveSession, githubOAuthConfigured } from "@/lib/session";
 
 /**
  * Reports who is signed in, and whether GitHub sign-in is even available on
@@ -9,7 +9,11 @@ import { getSession, githubOAuthConfigured } from "@/lib/session";
  * Never returns the access token.
  */
 export async function GET() {
-  const session = await getSession();
+  // The live session, not just the cookie: this is what the browser asks on
+  // every boot, so it is the natural moment to renew an eight-hour token that
+  // ran out while the tab was closed — and the answer here is what decides
+  // whether the app draws itself as signed in.
+  const session = await getLiveSession();
 
   return NextResponse.json(
     {

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -44,7 +44,7 @@ import { CommandPalette, type Command } from "@/components/CommandPalette";
 import { StorageBlocked } from "@/components/StorageBlocked";
 import { BootScreen } from "@/components/BootScreen";
 import { LocalOnlyBanner } from "@/components/LocalOnlyBanner";
-import { signOut } from "@/lib/gateway";
+import { fetchSession, signOut } from "@/lib/gateway";
 import { postHogReset } from "@/lib/posthog";
 import { assetPathFor, relativeSrc, resolveImageSrc } from "@/lib/assets";
 import { collectFolders } from "@/lib/tree";
@@ -400,6 +400,41 @@ export function EditorWorkspace() {
     const here = `${window.location.pathname}${window.location.search}`;
     router.push(`/sign-in?expired=1&next=${encodeURIComponent(here)}`);
   }, [router]);
+
+  /**
+   * The click on a failed push, doing whichever of the two things is needed.
+   *
+   * "Click to retry" is only the right offer while the sign-in still works.
+   * When it does not, retrying pushes into the same refusal and the bar
+   * reprints the same red sentence with nothing having moved — and the app
+   * does not always know which case it is in. A push can fail for a reason
+   * that never names the sign-in: a 500 from our own route, a proxy in the
+   * way, a request that died before GitHub answered. All of those print the
+   * general "could not push" sentence, whose retry is a dead end whenever the
+   * real reason underneath was the session.
+   *
+   * So a failing push asks the server where it stands before offering
+   * anything. If the sign-in has gone, the click is the sign-in — one press,
+   * from the control the reader already went for, instead of a retry that
+   * fails and a button that appears afterwards. Only on a failure, so an
+   * ordinary "sync now" still goes straight to pushing.
+   */
+  const retrySync = useCallback(async () => {
+    const failing = notebook.sync.status === "error" || notebook.sync.status === "blocked";
+
+    if (failing && workspace && !workspace.isLocal) {
+      // A server we cannot reach tells us nothing about the sign-in, so it
+      // falls through to the retry rather than throwing somebody who is merely
+      // offline at a sign-in page.
+      const session = await fetchSession().catch(() => null);
+      if (session && session.mode !== "github" && session.githubAvailable) {
+        signInAgain();
+        return;
+      }
+    }
+
+    await saveEverything();
+  }, [notebook.sync.status, workspace, signInAgain, saveEverything]);
 
   // ── Actions ─────────────────────────────────────────────────────────────
 
@@ -1635,7 +1670,7 @@ export function EditorWorkspace() {
         words={words}
         syncPreference={notebook.syncPreference}
         onSyncModeChange={notebook.setSyncMode}
-        onSyncNow={() => void saveEverything()}
+        onSyncNow={() => void retrySync()}
         onShowConflicts={() => setConflictsDismissed(false)}
         onSignIn={signInAgain}
       />

--- a/apps/web/src/lib/api-helpers.test.ts
+++ b/apps/web/src/lib/api-helpers.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/lib/session", () => ({
   clearSessionCookie: vi.fn(async () => {}),
   getSession: vi.fn(async () => null),
+  getLiveSession: vi.fn(async () => null),
 }));
 
 beforeEach(() => {

--- a/apps/web/src/lib/api-helpers.ts
+++ b/apps/web/src/lib/api-helpers.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 import { GitHubClient, GitHubError } from "@forkleaf/github-client";
 import type { RepoRef } from "@forkleaf/types";
-import { clearSessionCookie, getSession } from "@/lib/session";
+import { clearSessionCookie, getLiveSession } from "@/lib/session";
 
 /**
  * Shared plumbing for the GitHub proxy routes.
@@ -23,9 +23,16 @@ export class ApiError extends Error {
   }
 }
 
-/** Builds an authenticated client, or throws a 401. */
+/**
+ * Builds an authenticated client, or throws a 401.
+ *
+ * `getLiveSession` rather than `getSession`, because this is the function every
+ * GitHub call in the app passes through and a GitHub App's user token lasts
+ * eight hours. Renewing it here means one place knows about expiry, and every
+ * route gets a token that works.
+ */
 export async function requireClient(): Promise<{ client: GitHubClient; login: string }> {
-  const session = await getSession();
+  const session = await getLiveSession();
   if (!session) {
     throw new ApiError(401, "unauthorized", "Sign in with GitHub to continue.");
   }

--- a/apps/web/src/lib/gateway.test.ts
+++ b/apps/web/src/lib/gateway.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ApiGatewayError, fetchSession, onSessionExpired } from "./gateway";
+import { ApiGatewayError, fetchSession, onSessionExpired, signOut } from "./gateway";
 
 /**
  * The browser's half of "the sign-in ended".
@@ -127,6 +127,52 @@ describe("session expiry", () => {
     const stop = onSessionExpired(told);
 
     await expect(fetchSession()).rejects.toBeInstanceOf(ApiGatewayError);
+    expect(told).not.toHaveBeenCalled();
+
+    stop();
+  });
+
+  it("notices a session that ended without anything failing", async () => {
+    // The quiet ending: the cookie reaches its thirty days, or another tab
+    // signs out, and the very next answer is a successful 200 saying "local
+    // mode". Nothing throws, so nothing used to be told, and the page went on
+    // showing an avatar until some later request happened to fail.
+    await signIn();
+    vi.stubGlobal(
+      "fetch",
+      respondWith(200, { mode: "local", user: null, githubAvailable: true, scopes: [] }),
+    );
+
+    const told = vi.fn();
+    const stop = onSessionExpired(told);
+
+    await fetchSession();
+    expect(told).toHaveBeenCalledTimes(1);
+
+    // And not again on every subsequent check, which is what a status bar
+    // asking before each retry would otherwise produce.
+    await fetchSession();
+    expect(told).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  it("says nothing when the sign-out was deliberate", async () => {
+    // "Your GitHub sign-in has expired" is the wrong thing to say to somebody
+    // who has just pressed Sign out.
+    await signIn();
+    vi.stubGlobal("fetch", respondWith(200, { ok: true }));
+    await signOut();
+
+    vi.stubGlobal(
+      "fetch",
+      respondWith(200, { mode: "local", user: null, githubAvailable: true, scopes: [] }),
+    );
+
+    const told = vi.fn();
+    const stop = onSessionExpired(told);
+
+    await fetchSession();
     expect(told).not.toHaveBeenCalled();
 
     stop();

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -260,7 +260,25 @@ export async function fetchSession(): Promise<SessionResponse> {
   // The server is the only authority on this, and it is asked on every boot
   // and after every sign-in, so this stays true to what the cookie actually
   // holds rather than to what the page last rendered.
-  signedInToGitHub = session.mode === "github";
+  const stillSignedIn = session.mode === "github";
+
+  /**
+   * A session can also end quietly, without a 401 for anyone to catch.
+   *
+   * The cookie reaches its thirty days; another tab signs out; a call on some
+   * other route finds the token dead and drops the cookie there. In all of
+   * those the next answer here is a perfectly successful 200 that says "local
+   * mode" — no error, nothing thrown, nothing told. The page carries on
+   * showing an avatar until something happens to fail.
+   *
+   * So the disappearance is the news, not only the refusal. Asking the server
+   * is then a way for any part of the app to find out where it stands, which
+   * is what the failed-push control does before offering to try again.
+   */
+  const ended = signedInToGitHub && !stillSignedIn;
+  signedInToGitHub = stillSignedIn;
+  if (ended) announceExpiry();
+
   return session;
 }
 
@@ -268,6 +286,10 @@ export async function fetchSession(): Promise<SessionResponse> {
 const SESSION_TIMEOUT_MS = 10_000;
 
 export function signOut(): Promise<{ ok: boolean }> {
+  // Leaving on purpose is not a session expiring, and the difference matters:
+  // without this, the next `fetchSession` would find the cookie gone and tell
+  // somebody who has just pressed "Sign out" that their sign-in has expired.
+  signedInToGitHub = false;
   return call<{ ok: boolean }>("/api/auth/logout", { method: "POST" });
 }
 

--- a/apps/web/src/lib/github-oauth.test.ts
+++ b/apps/web/src/lib/github-oauth.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { exchangeCodeForToken, refreshUserToken, TokenRefused } from "./github-oauth";
+
+/**
+ * GitHub's token endpoint, and the two things worth being exact about: the
+ * lifetimes it reports, and the difference between "no" and "not right now".
+ */
+
+const respondWith = (body: unknown) =>
+  vi.fn(async () => new Response(JSON.stringify(body), { status: 200 }));
+
+beforeEach(() => {
+  process.env.GITHUB_OAUTH_CLIENT_ID = "Ov23liTEST";
+  process.env.GITHUB_OAUTH_CLIENT_SECRET = "secret";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("exchangeCodeForToken", () => {
+  it("turns GitHub's relative lifetimes into absolute times", async () => {
+    // `expires_in` is only meaningful at the moment of the answer. Stored as a
+    // duration it would be re-read hours later as though it still had eight
+    // hours left on it, which is the same bug in a new place.
+    vi.stubGlobal(
+      "fetch",
+      respondWith({
+        access_token: "gho_new",
+        expires_in: 28_800,
+        refresh_token: "ghr_new",
+        refresh_token_expires_in: 15_811_200,
+        scope: "repo",
+      }),
+    );
+
+    const before = Math.floor(Date.now() / 1000);
+    const grant = await exchangeCodeForToken("code", "https://example.test/api/auth/callback");
+
+    expect(grant.token).toBe("gho_new");
+    expect(grant.refreshToken).toBe("ghr_new");
+    expect(grant.scopes).toEqual(["repo"]);
+    expect(grant.expiresAt).toBeGreaterThanOrEqual(before + 28_800);
+    expect(grant.refreshExpiresAt).toBeGreaterThanOrEqual(before + 15_811_200);
+  });
+
+  it("reports no expiry for a token that has none", async () => {
+    // An OAuth App, or a GitHub App with token expiration switched off. An
+    // invented expiry here would renew a token that never needed renewing —
+    // with no refresh token to do it with.
+    vi.stubGlobal("fetch", respondWith({ access_token: "gho_forever", scope: "repo" }));
+
+    const grant = await exchangeCodeForToken("code", "https://example.test/cb");
+
+    expect(grant.expiresAt).toBeUndefined();
+    expect(grant.refreshToken).toBeUndefined();
+  });
+});
+
+describe("refreshUserToken", () => {
+  it("asks for a renewal with the refresh grant", async () => {
+    const fetchMock = respondWith({
+      access_token: "gho_renewed",
+      expires_in: 28_800,
+      refresh_token: "ghr_rotated",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const grant = await refreshUserToken("ghr_old");
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body.grant_type).toBe("refresh_token");
+    expect(body.refresh_token).toBe("ghr_old");
+    // Rotated on every use, which is why the caller has to store what comes
+    // back before using it.
+    expect(grant.refreshToken).toBe("ghr_rotated");
+  });
+
+  it("treats a refusal as a refusal, however cheerfully it is delivered", async () => {
+    // GitHub answers a spent or revoked refresh token with a 200 and an
+    // `error` field, so the status line is no help: the body is the signal.
+    vi.stubGlobal(
+      "fetch",
+      respondWith({
+        error: "bad_refresh_token",
+        error_description: "The refresh token is incorrect or expired.",
+      }),
+    );
+
+    await expect(refreshUserToken("ghr_dead")).rejects.toBeInstanceOf(TokenRefused);
+  });
+
+  it("does not call a network failure a refusal", async () => {
+    // The difference decides whether somebody is signed out. A refused token
+    // is the end of a session; an unreachable GitHub is not.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("fetch failed");
+      }),
+    );
+
+    const failure = await refreshUserToken("ghr_fine").catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure).not.toBeInstanceOf(TokenRefused);
+  });
+});

--- a/apps/web/src/lib/github-oauth.ts
+++ b/apps/web/src/lib/github-oauth.ts
@@ -1,0 +1,129 @@
+import "server-only";
+
+/**
+ * Talking to GitHub's token endpoint: getting a token, and keeping it alive.
+ *
+ * ForkLeaf is registered as a **GitHub App**, and a GitHub App's user access
+ * token expires eight hours after it is issued. That is the whole story behind
+ * "why does it keep signing me out": nothing was timing out on our side — the
+ * session cookie is good for thirty days and was still perfectly valid — the
+ * token sealed inside it had simply stopped working, several times a day,
+ * every day. The app went on showing an avatar and a connected repository
+ * while every call behind them came back 401.
+ *
+ * GitHub issues a refresh token alongside it, valid for six months, for
+ * exactly this. Using it is the difference between a sign-in that lasts a
+ * working month and one that lasts a working morning.
+ *
+ * An OAuth App — or a GitHub App with token expiration turned off — returns no
+ * refresh token and no expiry, and everything here degrades to what it was:
+ * one token, held until GitHub refuses it.
+ */
+
+const TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+export interface TokenGrant {
+  token: string;
+  scopes: string[];
+  /** Unix seconds when this token stops working, if GitHub gave it a lifetime. */
+  expiresAt?: number;
+  refreshToken?: string;
+  /** Unix seconds when the refresh token itself expires. */
+  refreshExpiresAt?: number;
+}
+
+interface TokenResponse {
+  access_token?: string;
+  expires_in?: number;
+  refresh_token?: string;
+  refresh_token_expires_in?: number;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+/**
+ * A refusal GitHub will keep repeating.
+ *
+ * Distinguished from a network failure on purpose. A refresh token GitHub says
+ * is bad will be just as bad in thirty seconds, so the session is over and the
+ * honest thing is to say so. A refresh that could not reach GitHub says nothing
+ * about the session at all, and treating it as an ending would sign people out
+ * every time the network hiccuped.
+ */
+export class TokenRefused extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TokenRefused";
+  }
+}
+
+async function post(body: Record<string, string | undefined>): Promise<TokenGrant> {
+  let response: Response;
+
+  try {
+    response = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+      // GitHub's token endpoint answering slowly must not hold a page open
+      // indefinitely — this runs inside a request somebody is waiting on.
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (error) {
+    throw new Error(`Could not reach GitHub to exchange a token: ${String(error)}`);
+  }
+
+  const data = (await response.json().catch(() => ({}))) as TokenResponse;
+
+  if (!data.access_token) {
+    // GitHub answers a bad or spent refresh token with 200 and an `error`
+    // field, so the status is no help here; the body is the only signal.
+    throw new TokenRefused(data.error_description ?? data.error ?? "No access token returned");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  return {
+    token: data.access_token,
+    // What was granted, which is not always what was asked for: somebody can
+    // approve a narrower set on GitHub's own screen. (A GitHub App sends this
+    // back empty — its permissions live on the app, not on the token.)
+    scopes: (data.scope ?? "")
+      .split(",")
+      .map((scope) => scope.trim())
+      .filter(Boolean),
+    ...(data.expires_in ? { expiresAt: now + data.expires_in } : {}),
+    ...(data.refresh_token ? { refreshToken: data.refresh_token } : {}),
+    ...(data.refresh_token_expires_in
+      ? { refreshExpiresAt: now + data.refresh_token_expires_in }
+      : {}),
+  };
+}
+
+/** Completes a sign-in: the one-time code becomes a usable token. */
+export function exchangeCodeForToken(code: string, redirectUri: string): Promise<TokenGrant> {
+  return post({
+    client_id: process.env.GITHUB_OAUTH_CLIENT_ID,
+    client_secret: process.env.GITHUB_OAUTH_CLIENT_SECRET,
+    code,
+    redirect_uri: redirectUri,
+  });
+}
+
+/**
+ * Renews an eight-hour token without anybody being asked to sign in again.
+ *
+ * The refresh token is single use: GitHub returns a new one with every renewal
+ * and retires the one just spent. That is why the result has to be written back
+ * to the cookie before it is used — a renewal whose new refresh token is lost
+ * has spent the session's last one.
+ */
+export function refreshUserToken(refreshToken: string): Promise<TokenGrant> {
+  return post({
+    client_id: process.env.GITHUB_OAUTH_CLIENT_ID,
+    client_secret: process.env.GITHUB_OAUTH_CLIENT_SECRET,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  });
+}

--- a/apps/web/src/lib/session.test.ts
+++ b/apps/web/src/lib/session.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Keeping a sign-in alive across an eight-hour token.
+ *
+ * ForkLeaf is registered as a GitHub App, whose user tokens expire eight hours
+ * after they are issued. The session cookie lasts thirty days, so for most of
+ * its life it carried a token that no longer worked — which is what "it keeps
+ * signing me out" actually was. These are the cases that decide whether a
+ * session survives that: the ordinary renewal, the refusal that really is the
+ * end, the network blip that is not, and the burst of parallel requests that
+ * must not each spend the same single-use refresh token.
+ */
+
+const store = new Map<string, string>();
+
+const cookieJar = {
+  get: (name: string) => {
+    const value = store.get(name);
+    return value === undefined ? undefined : { name, value };
+  },
+  set: (name: string, value: string) => void store.set(name, value),
+  delete: (name: string) => void store.delete(name),
+};
+
+vi.mock("next/headers", () => ({ cookies: async () => cookieJar }));
+
+const refreshUserToken = vi.fn();
+vi.mock("@/lib/github-oauth", async () => {
+  class TokenRefused extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "TokenRefused";
+    }
+  }
+  return {
+    TokenRefused,
+    refreshUserToken: (...args: unknown[]) => refreshUserToken(...args),
+    exchangeCodeForToken: vi.fn(),
+  };
+});
+
+process.env.SESSION_SECRET = "a-test-secret-that-is-certainly-long-enough";
+
+import { TokenRefused } from "@/lib/github-oauth";
+import { decryptSession, encryptSession, getLiveSession, getSession } from "./session";
+
+const user = { id: 1, login: "someone", name: null, avatarUrl: "" };
+const inSeconds = (seconds: number) => Math.floor(Date.now() / 1000) + seconds;
+
+/** Puts a session in the cookie jar, the way a completed sign-in would. */
+async function signedInWith(overrides: Record<string, unknown> = {}) {
+  store.set("forkleaf_session", await encryptSession({ token: "old-token", user, ...overrides }));
+}
+
+beforeEach(() => {
+  store.clear();
+  refreshUserToken.mockReset();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("what the cookie carries", () => {
+  it("brings back every field it was given, not a hand-picked two", async () => {
+    // `scopes` is written at sign-in so a genuine "no such repository" can be
+    // told apart from "you did not grant access to private ones". It used to
+    // be dropped on the way out, which made that distinction unreachable — and
+    // would have taken the renewal fields with it.
+    const value = await encryptSession({
+      token: "t",
+      user,
+      scopes: ["repo"],
+      expiresAt: 1_800_000_000,
+      refreshToken: "r",
+      refreshExpiresAt: 1_820_000_000,
+    });
+
+    expect(await decryptSession(value)).toEqual({
+      token: "t",
+      user,
+      scopes: ["repo"],
+      expiresAt: 1_800_000_000,
+      refreshToken: "r",
+      refreshExpiresAt: 1_820_000_000,
+    });
+  });
+});
+
+describe("getLiveSession", () => {
+  it("leaves a token that has not expired alone", async () => {
+    await signedInWith({ expiresAt: inSeconds(3600), refreshToken: "r" });
+
+    const session = await getLiveSession();
+
+    expect(session?.token).toBe("old-token");
+    expect(refreshUserToken).not.toHaveBeenCalled();
+  });
+
+  it("leaves a token with no expiry alone", async () => {
+    // An OAuth App, or a GitHub App with token expiration switched off: there
+    // is nothing to renew and nothing to renew it with.
+    await signedInWith();
+
+    expect((await getLiveSession())?.token).toBe("old-token");
+    expect(refreshUserToken).not.toHaveBeenCalled();
+  });
+
+  it("renews a token that is about to expire, before it does", async () => {
+    // Two minutes left is not enough: it would expire during the request it
+    // was about to be used for.
+    await signedInWith({ expiresAt: inSeconds(120), refreshToken: "old-refresh" });
+    refreshUserToken.mockResolvedValue({
+      token: "new-token",
+      scopes: [],
+      expiresAt: inSeconds(28_800),
+      refreshToken: "new-refresh",
+    });
+
+    const session = await getLiveSession();
+
+    expect(refreshUserToken).toHaveBeenCalledWith("old-refresh");
+    expect(session?.token).toBe("new-token");
+    // Written back before it was used: the spent refresh token is dead, and a
+    // renewal whose replacement never reached the cookie has thrown away the
+    // session's only way back.
+    expect((await getSession())?.refreshToken).toBe("new-refresh");
+  });
+
+  it("keeps what the sign-in recorded when a renewal reports no scopes", async () => {
+    // A GitHub App renewal comes back with an empty scope list; replacing the
+    // real one with it would lose the only record of what was granted.
+    await signedInWith({
+      expiresAt: inSeconds(0),
+      refreshToken: "r",
+      scopes: ["repo"],
+    });
+    refreshUserToken.mockResolvedValue({
+      token: "new-token",
+      scopes: [],
+      expiresAt: inSeconds(28_800),
+      refreshToken: "r2",
+    });
+
+    expect((await getLiveSession())?.scopes).toEqual(["repo"]);
+  });
+
+  it("spends the refresh token once, however many requests arrive together", async () => {
+    // Opening a note is a burst: the tree, the file, one call per image. Each
+    // would notice the same expired token, and the refresh token is single
+    // use — so the first would win and the rest would end the session that was
+    // in the middle of being saved.
+    await signedInWith({ expiresAt: inSeconds(0), refreshToken: "r" });
+    refreshUserToken.mockResolvedValue({
+      token: "new-token",
+      scopes: [],
+      expiresAt: inSeconds(28_800),
+      refreshToken: "r2",
+    });
+
+    const sessions = await Promise.all([getLiveSession(), getLiveSession(), getLiveSession()]);
+
+    expect(refreshUserToken).toHaveBeenCalledTimes(1);
+    for (const session of sessions) expect(session?.token).toBe("new-token");
+  });
+
+  it("ends the session when GitHub refuses to renew it", async () => {
+    // The authorisation was revoked, or the refresh token is past its six
+    // months. GitHub will say the same thing next time, so this really is over.
+    await signedInWith({ expiresAt: inSeconds(0), refreshToken: "r" });
+    refreshUserToken.mockRejectedValue(new TokenRefused("bad_refresh_token"));
+
+    expect(await getLiveSession()).toBeNull();
+    expect(store.has("forkleaf_session")).toBe(false);
+  });
+
+  it("keeps the session when GitHub could not be reached", async () => {
+    // A network blip says nothing about whether this sign-in is still good,
+    // and signing somebody out over one is worse than the failed call.
+    await signedInWith({ expiresAt: inSeconds(0), refreshToken: "r" });
+    refreshUserToken.mockRejectedValue(new Error("fetch failed"));
+
+    expect((await getLiveSession())?.token).toBe("old-token");
+    expect(store.has("forkleaf_session")).toBe(true);
+  });
+
+  it("ends an expired session that has nothing to renew it with", async () => {
+    await signedInWith({ expiresAt: inSeconds(-10) });
+
+    expect(await getLiveSession()).toBeNull();
+    expect(store.has("forkleaf_session")).toBe(false);
+  });
+
+  it("says nothing is signed in when there is no cookie", async () => {
+    expect(await getLiveSession()).toBeNull();
+  });
+});

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { EncryptJWT, jwtDecrypt } from "jose";
 import { cookies } from "next/headers";
 import type { SessionUser } from "@forkleaf/types";
+import { refreshUserToken, TokenRefused } from "@/lib/github-oauth";
 
 /**
  * Server-side session handling.
@@ -33,6 +34,22 @@ export interface SessionPayload {
    * telling somebody their repository does not exist.
    */
   scopes?: string[];
+  /**
+   * Unix seconds when the GitHub token stops working.
+   *
+   * A GitHub App's user token lasts eight hours, which is shorter than one
+   * working day and far shorter than this cookie. Knowing when it runs out is
+   * what makes it possible to renew it a minute early instead of finding out
+   * from a 401 in the middle of somebody's writing.
+   *
+   * Absent for a token with no lifetime — an OAuth App, or a GitHub App with
+   * token expiration switched off.
+   */
+  expiresAt?: number;
+  /** GitHub's six-month refresh token, if this deployment gets one. */
+  refreshToken?: string;
+  /** Unix seconds when the refresh token itself expires. */
+  refreshExpiresAt?: number;
 }
 
 let cachedKey: Uint8Array | null = null;
@@ -81,9 +98,27 @@ export async function encryptSession(payload: SessionPayload): Promise<string> {
 export async function decryptSession(value: string): Promise<SessionPayload | null> {
   try {
     const { payload } = await jwtDecrypt(value, await encryptionKey());
-    const { token, user } = payload as unknown as SessionPayload;
+    // Everything the cookie carries, not a hand-picked two.
+    //
+    // This used to rebuild the session as `{ token, user }`, which quietly
+    // dropped every other field on the way out: `scopes` — written at sign-in
+    // precisely so a "not found" could be told apart from "you did not grant
+    // access to private repositories" — arrived as undefined at both of its
+    // readers, and the renewal fields below would have gone the same way.
+    const session = payload as unknown as SessionPayload;
+    const { token, user } = session;
     if (typeof token !== "string" || !user) return null;
-    return { token, user };
+
+    return {
+      token,
+      user,
+      ...(Array.isArray(session.scopes) ? { scopes: session.scopes } : {}),
+      ...(typeof session.expiresAt === "number" ? { expiresAt: session.expiresAt } : {}),
+      ...(typeof session.refreshToken === "string" ? { refreshToken: session.refreshToken } : {}),
+      ...(typeof session.refreshExpiresAt === "number"
+        ? { refreshExpiresAt: session.refreshExpiresAt }
+        : {}),
+    };
   } catch {
     // Tampered, expired, or encrypted under a rotated secret.
     return null;
@@ -112,6 +147,111 @@ export async function getSession(): Promise<SessionPayload | null> {
   const value = store.get(COOKIE_NAME)?.value;
   if (!value) return null;
   return decryptSession(value);
+}
+
+/**
+ * How early a token is renewed, in seconds.
+ *
+ * A token that expires "in twenty seconds" is a token that will expire during
+ * the request it was about to be used for. The margin also covers clock skew
+ * between this server and GitHub's, which is not guaranteed to be zero.
+ */
+const RENEW_BEFORE_SECONDS = 300;
+
+/**
+ * One renewal at a time, per refresh token.
+ *
+ * Opening a note is a burst of parallel requests — the tree, the file, one call
+ * per image — and every one of them passes through here. Without this they
+ * would all notice the same expired token at the same moment and each spend
+ * the same single-use refresh token; the first would win, and the rest would
+ * come back refused, ending the session that was in the middle of being saved.
+ *
+ * Per instance, which is all that can be promised on serverless, and all that
+ * is needed: the burst that causes the problem is one browser's requests
+ * landing together, and those land on one instance.
+ */
+const renewing = new Map<string, Promise<SessionPayload | null>>();
+
+/** True when the token has expired, or is about to. */
+function needsRenewal(session: SessionPayload): boolean {
+  if (session.expiresAt === undefined) return false;
+  return session.expiresAt - RENEW_BEFORE_SECONDS <= Math.floor(Date.now() / 1000);
+}
+
+/**
+ * The session, with a working token in it.
+ *
+ * `getSession` reads the cookie and nothing more, which is right for a page
+ * that only wants a name and an avatar. Anything that is about to *call*
+ * GitHub wants this instead: a GitHub App's user token lasts eight hours, so
+ * the token in a perfectly valid thirty-day cookie is, most of the time, an
+ * expired one. Renewing it here is the difference between a sign-in that lasts
+ * as long as the cookie says it does and one that ends every working morning.
+ *
+ * Only safe from a route handler, because it writes the cookie back — and it
+ * must write it back, since GitHub retires each refresh token as it is spent.
+ */
+export async function getLiveSession(): Promise<SessionPayload | null> {
+  const session = await getSession();
+  if (!session || !needsRenewal(session)) return session;
+
+  // Expired, and nothing to renew it with: an OAuth App token that has been
+  // revoked, or a refresh token past its six months. Either way this session
+  // is over, and saying so here saves every route behind it a round trip to
+  // GitHub to be told the same thing.
+  if (!session.refreshToken) {
+    await clearSessionCookie();
+    return null;
+  }
+
+  const inFlight = renewing.get(session.refreshToken);
+  if (inFlight) return inFlight;
+
+  const attempt = renew(session).finally(() => {
+    renewing.delete(session.refreshToken!);
+  });
+  renewing.set(session.refreshToken, attempt);
+
+  return attempt;
+}
+
+async function renew(session: SessionPayload): Promise<SessionPayload | null> {
+  try {
+    const grant = await refreshUserToken(session.refreshToken!);
+
+    const renewed: SessionPayload = {
+      ...session,
+      token: grant.token,
+      // A GitHub App returns no scopes on a renewal; keeping what the sign-in
+      // recorded is more honest than replacing it with an empty list.
+      ...(grant.scopes.length > 0 ? { scopes: grant.scopes } : {}),
+      ...(grant.expiresAt !== undefined ? { expiresAt: grant.expiresAt } : {}),
+      ...(grant.refreshToken !== undefined ? { refreshToken: grant.refreshToken } : {}),
+      ...(grant.refreshExpiresAt !== undefined ? { refreshExpiresAt: grant.refreshExpiresAt } : {}),
+    };
+
+    // Before it is used, not after: the refresh token just spent is now dead,
+    // and a renewal whose replacement never reached the cookie has thrown away
+    // the session's only way back.
+    await setSessionCookie(renewed);
+    return renewed;
+  } catch (error) {
+    if (error instanceof TokenRefused) {
+      // GitHub will say the same thing next time — the authorisation was
+      // revoked, or the refresh token is past its six months. The session is
+      // genuinely over.
+      console.warn("[forkleaf] GitHub refused to renew the session token:", error.message);
+      await clearSessionCookie();
+      return null;
+    }
+
+    // Could not reach GitHub. That says nothing about whether this session is
+    // still good, and signing somebody out over a network blip would be a much
+    // worse answer than letting the call they were making fail on its own.
+    console.error("[forkleaf] Could not renew the session token:", error);
+    return session;
+  }
 }
 
 export async function clearSessionCookie(): Promise<void> {

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -85,12 +85,29 @@ If you want per-repository access instead, register a **GitHub App**:
 4. Enable **Request user authorization (OAuth) during installation**
 
 The user-to-server token a GitHub App issues works with the same endpoints
-ForkLeaf already uses, so `apps/web/src/app/api/auth/` needs only small changes:
-the authorize URL becomes the app's install URL, and tokens expire after 8 hours
-unless you enable and handle refresh tokens.
+ForkLeaf already uses, and the same `GITHUB_OAUTH_CLIENT_ID` /
+`GITHUB_OAUTH_CLIENT_SECRET` variables hold its credentials.
 
-This is a genuinely better security posture and a welcome contribution — see
-[CONTRIBUTING.md](../CONTRIBUTING.md).
+**Its user tokens expire after 8 hours.** ForkLeaf handles that: the refresh
+token GitHub issues alongside the access token is kept in the session cookie and
+spent to renew the access token before it runs out, so a sign-in lasts as long
+as the cookie says it does rather than ending every working morning. Nothing to
+configure — if GitHub sends a refresh token, it is used; if it does not (an
+OAuth App, or a GitHub App with user-to-server token expiration switched off),
+the token is simply held until GitHub refuses it.
+
+Two consequences worth knowing when self-hosting a GitHub App:
+
+- **The refresh token is good for 6 months, and only from this deployment.**
+  Changing `SESSION_SECRET` makes every existing cookie undecryptable, which
+  signs every user out at once and discards their refresh tokens with it. Treat
+  it as a value you set once per deployment.
+- **Revoking the authorization ends the session immediately**, rather than at
+  the next 8-hour boundary: GitHub refuses the renewal, and the app says so
+  instead of retrying into a wall.
+
+Per-repository access is a genuinely better security posture than the `repo`
+scope, and this is the setup ForkLeaf itself runs on.
 
 ## Reverse proxies
 


### PR DESCRIPTION
## The bug

ForkLeaf is registered as a **GitHub App** (client id `Ov23li…`), and a GitHub App's user access token **expires eight hours after it is issued**. Nothing in the codebase knew that.

The sign-in kept the access token and threw the refresh token away. So every session was over by the same afternoon it began — while the session cookie, good for thirty days, went on insisting otherwise. The app showed an avatar, a connected repository and "Sync: automatic" while every call behind them came back 401.

That is what "the sessions keep timing out" actually was. Nothing was timing out on our side. `docs/self-hosting.md` described this exact gap and left it as an exercise for a contributor.

## The fix

GitHub issues a refresh token alongside the access token, valid for six months, for precisely this. It is now kept in the session cookie and spent to renew the access token five minutes before it runs out, inside `getLiveSession()` — reached from `requireClient`, which every GitHub call in the app already passes through.

A sign-in now lasts as long as the cookie says it does.

Details worth reviewing closely:

- **The refresh token is single use.** GitHub retires each one as it is spent and returns a replacement, so the renewed session is written back to the cookie *before* it is used — a renewal whose replacement never got stored has spent the session's last one.
- **Single-flight per refresh token.** Opening a note is a burst of parallel requests (tree, file, one per image). Without this they would each notice the same expired token and each spend the same single-use refresh token: the first wins, the rest end the session mid-save.
- **A refusal and a network failure are different news.** `TokenRefused` (GitHub answers a bad refresh token with a *200* and an `error` field, so the status line is no help) ends the session and drops the cookie. An unreachable GitHub keeps the session — signing people out over a network blip is worse than the one call that failed.
- **Renewal only happens where a cookie can be written**, i.e. a route handler. `getSession` still reads and nothing more, for pages that want a name and an avatar.
- **`decryptSession` stopped discarding most of the cookie.** It rebuilt the session as `{ token, user }`, silently dropping `scopes` — written at sign-in so a genuine "no such repository" could be told apart from "you did not grant access to private ones", and undefined at both of its readers ever since. The renewal fields would have gone the same way.

An OAuth App, or a GitHub App with token expiration switched off, sends no refresh token and no expiry; everything degrades to the previous behaviour — one token, held until GitHub refuses it.

## The other half: the dead-end retry

Separately, the red status-bar line in the reported screenshot said *"Could not push to GitHub just now… Click to retry"* — the generic message, whose retry pushed into the same wall. The sign-in path only ever fired on an explicit 401, and a push can fail for reasons that never name the sign-in.

- A failing push now checks the session before offering anything: gone → straight to the sign-in, returning to the open note; fine → the retry it always was; unreachable server → falls through to the retry, so somebody merely offline is not sent to a sign-in page. Normal Sync Now is untouched.
- A session that ends **quietly** — cookie expired, another tab signed out, another route dropped it — now announces itself. Previously expiry was only announced on a 401, but the quiet ending answers `/api/session` with a successful 200 saying "local mode": nothing thrown, nothing told, avatar still on screen. A deliberate sign-out is excluded.

## Testing

- `apps/web/src/lib/session.test.ts` — 10 new tests: the ordinary renewal, the refusal that is really the end, the network blip that is not, parallel requests spending one refresh token, tokens with no expiry left alone, scopes surviving the round trip.
- `apps/web/src/lib/github-oauth.test.ts` — 5 new tests: relative lifetimes becoming absolute times, a refusal delivered as a 200, a network failure that must not be read as one.
- `apps/web/src/lib/gateway.test.ts` — 2 new tests for the quiet expiry and the deliberate sign-out.
- Full suite: 1568 tests, 99 files, all passing. Typecheck, lint, prettier and `next build` all clean.

## Deploying this

No new environment variables. One thing to keep stable: **`SESSION_SECRET`**. Every cookie is encrypted with a key derived from it, so changing it — or having it differ between preview and production — makes every existing cookie undecryptable and signs everyone out at once, discarding their refresh tokens with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
