### PR TITLE
feat(landing): the hero window shows the whole editor, in the reader's theme

### DIFF
--- a/apps/web/src/app/docs/content/account.tsx
+++ b/apps/web/src/app/docs/content/account.tsx
@@ -106,9 +106,12 @@ export function PrivacyAndData() {
 
       <H2 id="session">Your session</H2>
       <Def term="The session cookie">
-        Contains your GitHub access token and your public profile — id, login, name, avatar URL —
-        encrypted with JWE (A256GCM). <Code>httpOnly</Code>, <Code>SameSite=Lax</Code>,{" "}
-        <Code>Secure</Code> in production, 30-day expiry. Only the server can decrypt it.
+        Contains your GitHub access token, the refresh token that renews it, and your public profile
+        — id, login, name, avatar URL — encrypted with JWE (A256GCM). <Code>httpOnly</Code>,{" "}
+        <Code>SameSite=Lax</Code>, <Code>Secure</Code> in production, 30-day expiry. Only the server
+        can decrypt it. The refresh token is there because a GitHub App&rsquo;s access token expires
+        after eight hours; it is spent server-side to get a new one, and never reaches the browser
+        either.
       </Def>
       <Def term="The OAuth state cookie">
         A random value that lives for ten minutes during sign-in and is deleted the moment it is
@@ -186,7 +189,8 @@ export function PrivacyAndData() {
         </li>
         <li>
           <strong>Your session:</strong> sign out, then revoke the app at{" "}
-          <A href="https://github.com/settings/applications">GitHub → Authorized OAuth Apps</A>.
+          <A href="https://github.com/settings/applications">GitHub → Applications</A> (the hosted
+          ForkLeaf is registered as a GitHub App, so it is under <em>Authorized GitHub Apps</em>).
         </li>
         <li>
           <strong>Your Firebase record:</strong> email the address in the{" "}

--- a/apps/web/src/app/docs/content/github.tsx
+++ b/apps/web/src/app/docs/content/github.tsx
@@ -141,7 +141,13 @@ export function SigningIn() {
         <LI>
           <Code>SameSite=Lax</Code>, and <Code>Secure</Code> in production.
         </LI>
-        <LI>It expires after 30 days, at which point you sign in again.</LI>
+        <LI>
+          The cookie lasts 30 days. The GitHub token inside it lasts eight hours — ForkLeaf is a
+          GitHub App, and that is how long a GitHub App&rsquo;s user token is valid for — so it is
+          renewed for you in the background, using the refresh token GitHub issues alongside it. You
+          sign in again when the cookie ends, when you have been away for six months, or when you
+          revoke access.
+        </LI>
       </UL>
       <P>
         The usual shortcut — a token in <Code>localStorage</Code> — would be readable by any script
@@ -161,9 +167,11 @@ export function SigningIn() {
         not revoke the token on GitHub&rsquo;s side and it does not touch your repository. To revoke
         access entirely, go to{" "}
         <A href="https://github.com/settings/applications">
-          GitHub → Settings → Applications → Authorized OAuth Apps
+          GitHub → Settings → Applications → Authorized GitHub Apps
         </A>{" "}
-        and remove ForkLeaf.
+        and remove ForkLeaf. Revoking takes effect at once rather than at the end of the current
+        eight-hour token: the next renewal is refused, and ForkLeaf ends the session where it finds
+        out.
       </P>
       <P>
         Notes in the <strong>On this device</strong> workspace stay in your browser after signing

--- a/apps/web/src/app/docs/content/running.tsx
+++ b/apps/web/src/app/docs/content/running.tsx
@@ -58,6 +58,17 @@ pnpm dev`}</Pre>
         Development and production need <strong>separate OAuth apps</strong>, because each app has
         one callback URL. Trying to share one between localhost and a deployed domain does not work.
       </Note>
+      <P>
+        A <strong>GitHub App</strong> works here too, and is the better choice if you want
+        per-repository access rather than the account-wide <Code>repo</Code> scope — its client ID
+        and secret go in the same two variables. Its user tokens expire after eight hours; ForkLeaf
+        keeps the refresh token GitHub issues alongside them and renews in the background, so there
+        is nothing extra to configure. The hosted deployment runs this way. See{" "}
+        <A href="https://github.com/praneeth132006/ForkLeaf/blob/main/docs/self-hosting.md">
+          the self-hosting guide
+        </A>{" "}
+        for the details.
+      </P>
 
       <H2 id="env">Environment variables</H2>
       <P>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -887,12 +887,114 @@ mark.fl-hl-orange {
   animation: fl-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
+/* A strip of controls that scrolls rather than wraps — six tab labels wrapping
+   to a second row turn a segmented control into a paragraph. The bar itself is
+   noise on a control this small, so it is hidden while the overflow stays. */
+.fl-scrollbar-none {
+  scrollbar-width: none;
+}
+
+.fl-scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
+/* ── The hero's product showcase ───────────────────────────────────────────
+   The frame cycles through what the editor can do. Three separate motions,
+   each with a job: the scene arrives (so a change reads as a change rather
+   than as a flicker), its rows arrive just behind it (so the eye is led down
+   the pane instead of meeting all of it at once), and the tick under the
+   active tab shows how long is left, which is what stops an auto-advancing
+   thing from feeling like it is interrupting you.
+
+   All three are switched off wholesale by the reduced-motion rule below, and
+   the timer that drives the cycle is switched off with them, in JavaScript —
+   an animation somebody asked not to see should not carry on invisibly. */
+@keyframes fl-scene-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.fl-scene-in {
+  animation: fl-scene-in 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes fl-row-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.fl-row-in {
+  animation: fl-row-in 380ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes fl-tick {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.fl-tick {
+  transform-origin: left;
+  animation: fl-tick linear both;
+}
+
+/* The insertion point. A still of a text editor with no caret in it reads as a
+   screenshot of a closed file. */
+@keyframes fl-caret {
+  0%,
+  45% {
+    opacity: 1;
+  }
+
+  50%,
+  95% {
+    opacity: 0.15;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.fl-caret {
+  animation: fl-caret 1.2s steps(1, end) infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
   *::after {
     animation-duration: 0.01ms !important;
     transition-duration: 0.01ms !important;
+  }
+
+  /* An infinite animation reduced to a hundredth of a millisecond is not
+     stillness, it is a strobe. These two are named rather than left to the
+     rule above: one repeats forever, and the other only means anything while
+     it is running. */
+  .fl-caret,
+  .fl-tick {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
   }
 }
 

--- a/apps/web/src/components/landing/AppPreview.tsx
+++ b/apps/web/src/components/landing/AppPreview.tsx
@@ -1,167 +1,336 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 /**
- * The hero's product demo: a segmented control above a framed screenshot.
+ * The hero's product demo: one window, cycling through what the editor does.
  *
- * A single still frame can only make one claim. Three tabs let the hero answer
- * the three questions a visitor actually has — what is the writing like, can it
- * really do diagrams, and where do my notes end up — without scrolling, and
- * gives them something to touch on a page that is otherwise all prose.
+ * A landing page gets a few seconds of attention pointed at one rectangle, and
+ * a single still frame spends them making a single claim — here, "it edits
+ * Markdown", which is the least surprising thing ForkLeaf does. The interesting
+ * half is everything a visitor would otherwise have to take on faith: that the
+ * links really resolve, that the search really runs offline, that the diagrams
+ * really are Mermaid, that the history really is git. So the frame shows them,
+ * one after another, and moves on by itself.
  *
- * Everything is drawn in markup rather than shipped as an image: it re-themes,
- * stays sharp at any zoom, and costs nothing to download.
+ * It advances on its own but never traps anybody: hovering or focusing it stops
+ * the clock, the tabs jump straight to a scene, and a visitor who has asked for
+ * reduced motion gets no cycling at all — the tabs still work, the window still
+ * fills, nothing moves unless they ask it to.
+ *
+ * Everything is drawn in markup rather than shipped as a screenshot: it
+ * re-themes with the page, stays sharp at any zoom, costs nothing to download,
+ * and cannot go stale in the way an exported PNG of a UI always does.
  */
-const TABS = [
-  { id: "write", label: "Write", caption: "Rich text, split, or raw Markdown — the same file." },
-  { id: "diagram", label: "Diagram", caption: "Mermaid diagrams without memorising Mermaid." },
-  { id: "sync", label: "Sync", caption: "Every save lands as a commit in your own repository." },
+
+const SCENES = [
+  {
+    id: "write",
+    label: "Write",
+    caption: "Rich text, split, or raw Markdown — the same file either way.",
+    /** What the status bar says while this scene is up. */
+    status: "All changes saved · 412 words",
+  },
+  {
+    id: "link",
+    label: "Link",
+    caption: "[[Wikilinks]] and backlinks that quote the line they were written on.",
+    status: "4 backlinks · 2 outgoing links",
+  },
+  {
+    id: "search",
+    label: "Search",
+    caption: "Every word of every note, ranked and answered in your browser.",
+    status: "Searched 128 notes offline · 9 ms",
+  },
+  {
+    id: "diagram",
+    label: "Diagram",
+    caption: "Mermaid diagrams — drawn on a canvas, or typed with autocomplete.",
+    status: "Saved as a ```mermaid block · renders on github.com too",
+  },
+  {
+    id: "history",
+    label: "History",
+    caption: "Every version, read from your repository's own commit log.",
+    status: "Reading history from GitHub · main",
+  },
+  {
+    id: "share",
+    label: "Share",
+    caption: "Publish a page, or export to PDF, Word and HTML — all in the browser.",
+    status: "Published to your repo · nothing on our servers",
+  },
 ] as const;
 
-type TabId = (typeof TABS)[number]["id"];
+type SceneId = (typeof SCENES)[number]["id"];
+
+/** How long each scene holds. Long enough to read the pane, not to wait on it. */
+const HOLD_MS = 6000;
 
 export function AppPreview() {
-  const [tab, setTab] = useState<TabId>("write");
-  const active = TABS.find((item) => item.id === tab)!;
+  const [index, setIndex] = useState(0);
+  /**
+   * Whether the cycle is currently running.
+   *
+   * Off while a pointer is over the frame or the keyboard is inside it — an
+   * animation that changes what you are reading, while you are reading it, is
+   * the reason auto-advancing carousels have the reputation they have.
+   */
+  const [running, setRunning] = useState(true);
+  const [motion, setMotion] = useState(true);
+  /**
+   * Bumped on every change so the scene and its progress tick remount.
+   *
+   * The tick has to restart from zero when a tab is clicked, and CSS
+   * animations do not restart on their own for an element that stayed put.
+   */
+  const [turn, setTurn] = useState(0);
+
+  const scene = SCENES[index]!;
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Somebody who has asked their system for less motion is asking for this
+  // too: no cycling, no ticking bar, no caret. The tabs still work, so nothing
+  // is out of reach — it just waits to be asked.
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setMotion(!query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+
+  const go = useCallback((next: number) => {
+    setIndex(((next % SCENES.length) + SCENES.length) % SCENES.length);
+    setTurn((value) => value + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!running || !motion) return;
+    timer.current = setTimeout(() => go(index + 1), HOLD_MS);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [index, running, motion, go]);
 
   return (
-    <div>
-      <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+    <div
+      onMouseEnter={() => setRunning(false)}
+      onMouseLeave={() => setRunning(true)}
+      onFocusCapture={() => setRunning(false)}
+      onBlurCapture={() => setRunning(true)}
+    >
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
+        {/* Scrolls rather than wraps on a narrow screen: six labels wrapping to
+            two rows turns the control into a paragraph. */}
         <div
           role="tablist"
-          aria-label="Product preview"
-          className="flex rounded-full border border-[var(--fl-border)] bg-[var(--fl-surface)] p-1"
+          aria-label="What ForkLeaf does"
+          className="fl-scrollbar-none -mx-1 flex max-w-full overflow-x-auto rounded-full border border-[var(--fl-border)] bg-[var(--fl-surface)] p-1"
         >
-          {TABS.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              role="tab"
-              aria-selected={tab === item.id}
-              onClick={() => setTab(item.id)}
-              className={`rounded-full px-4 py-1.5 text-[13.5px] font-medium transition-colors ${
-                tab === item.id
-                  ? "bg-[var(--fl-accent)] text-[var(--fl-accent-contrast)]"
-                  : "text-[var(--fl-muted)] hover:text-[var(--fl-text)]"
-              }`}
-            >
-              {item.label}
-            </button>
-          ))}
+          {SCENES.map((item, position) => {
+            const selected = position === index;
+
+            return (
+              <button
+                key={item.id}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                onClick={() => go(position)}
+                className={`relative shrink-0 overflow-hidden rounded-full px-4 py-1.5 text-[13.5px] font-medium transition-colors ${
+                  selected
+                    ? "bg-[var(--fl-accent)] text-[var(--fl-accent-contrast)]"
+                    : "text-[var(--fl-muted)] hover:text-[var(--fl-text)]"
+                }`}
+              >
+                {item.label}
+
+                {/* How long this scene has left, under the label it belongs to.
+                    Without it an auto-advancing frame changes for no visible
+                    reason, which reads as a glitch rather than as a demo. */}
+                {selected && motion && running && (
+                  <span
+                    key={turn}
+                    aria-hidden="true"
+                    className="fl-tick absolute inset-x-0 bottom-0 h-[2px] bg-[var(--fl-accent-contrast)]/45"
+                    style={{ animationDuration: `${HOLD_MS}ms` }}
+                  />
+                )}
+              </button>
+            );
+          })}
         </div>
 
-        <p className="text-[13.5px] text-[var(--fl-muted)]">{active.caption}</p>
+        {/* Keyed so the caption crossfades with the pane rather than swapping
+            under it a frame early. */}
+        <p
+          key={`caption-${turn}`}
+          className="fl-scene-in min-w-0 text-[13.5px] text-[var(--fl-muted)]"
+        >
+          {scene.caption}
+        </p>
       </div>
 
-      <Frame>
-        {tab === "write" && <WritePane />}
-        {tab === "diagram" && <DiagramPane />}
-        {tab === "sync" && <SyncPane />}
-      </Frame>
+      <Frame status={scene.status} scene={scene.id} turn={turn} motion={motion} />
     </div>
   );
 }
 
 /**
- * The window chrome. Always dark, in both themes, so it reads as a screenshot
- * of an application rather than as part of the page.
+ * The window chrome.
  *
- * Which is why the colours below are literal hex rather than `--fl-*`: these
- * have to stay dark on a light page, so they cannot follow the theme. They are
- * a copy of the dark palette and have to be kept in step with it by hand —
- * a screenshot showing an accent the product no longer uses is worse than no
- * screenshot.
+ * This used to be drawn in literal hex — a hand-kept copy of the dark palette —
+ * so that it stayed dark on a light page and "read as a screenshot". What it
+ * actually read as, next to the theme-aware window further down the page, was a
+ * bug: one product shot in each colour scheme, on the same screen, in a product
+ * whose own light mode this page is otherwise showing off. It follows the theme
+ * now, like everything else here.
+ *
+ * The border is `--fl-border-strong` rather than `--fl-border` for the same
+ * reason a picture gets a frame: this is the one element on the page that has
+ * to hold its own edge against a full-bleed background, and the hairline used
+ * for cards inside the page disappeared against it.
  */
-function Frame({ children }: { children: React.ReactNode }) {
+function Frame({
+  status,
+  scene,
+  turn,
+  motion,
+}: {
+  status: string;
+  scene: SceneId;
+  turn: number;
+  motion: boolean;
+}) {
   return (
     <div
       role="img"
-      aria-label="The ForkLeaf editor"
-      className="overflow-hidden rounded-2xl border border-[#1f1f1f] bg-[#000000] text-[#f0f0f0] shadow-[0_50px_140px_-50px_rgba(0,0,0,0.9)]"
+      aria-label={`The ForkLeaf editor: ${scene}`}
+      className="overflow-hidden rounded-2xl border border-[var(--fl-border-strong)] bg-[var(--fl-surface)] text-[var(--fl-text)] shadow-[var(--fl-shadow-lg)] ring-1 ring-[var(--fl-border)]"
     >
-      <div className="flex items-center gap-3 border-b border-[#1f1f1f] px-4 py-3">
+      {/* Title bar */}
+      <div className="flex items-center gap-3 border-b border-[var(--fl-border)] bg-[var(--fl-elevated)] px-4 py-3">
         <span className="flex gap-1.5" aria-hidden="true">
-          <span className="h-2.5 w-2.5 rounded-full bg-[#2a2a2a]" />
-          <span className="h-2.5 w-2.5 rounded-full bg-[#2a2a2a]" />
-          <span className="h-2.5 w-2.5 rounded-full bg-[#2a2a2a]" />
+          <span className="h-2.5 w-2.5 rounded-full bg-[var(--fl-border-strong)]" />
+          <span className="h-2.5 w-2.5 rounded-full bg-[var(--fl-border-strong)]" />
+          <span className="h-2.5 w-2.5 rounded-full bg-[var(--fl-border-strong)]" />
         </span>
-        <span className="mx-auto rounded-md bg-[#0a0a0a] px-3 py-1 font-mono text-[11px] text-[#8a8a8a]">
+
+        <span className="mx-auto rounded-md border border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-1 font-mono text-[11px] text-[var(--fl-muted)]">
           notes · main
         </span>
-        <span className="hidden items-center gap-1.5 text-[11px] text-[#8a8a8a] sm:flex">
-          <span className="h-1.5 w-1.5 rounded-full bg-[#8a9bb8]" />
+
+        <span className="hidden items-center gap-1.5 text-[11px] text-[var(--fl-muted)] sm:flex">
+          <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-[var(--fl-accent)]" />
           Synced
         </span>
       </div>
 
+      {/* One fixed height for every scene: a frame that resized as it cycled
+          would push the rest of the page up and down on a timer. */}
       <div className="flex h-[380px] sm:h-[420px]">
-        <aside className="hidden w-52 shrink-0 flex-col gap-0.5 border-r border-[#1f1f1f] p-3 sm:flex">
-          <div className="mb-2 rounded-md bg-[#0a0a0a] px-2.5 py-1.5 text-[11px] text-[#8a8a8a]">
-            Search notes…
+        <aside
+          aria-hidden="true"
+          className="hidden w-52 shrink-0 flex-col gap-0.5 border-r border-[var(--fl-border)] p-3 sm:flex"
+        >
+          <div className="mb-2 truncate rounded-md border border-[var(--fl-border)] bg-[var(--fl-elevated)] px-2.5 py-1.5 text-[11px] text-[var(--fl-muted)]">
+            {scene === "search" ? "atomic commit" : "Search notes…"}
           </div>
           <TreeRow depth={0} label="architecture" folder />
-          <TreeRow depth={1} label="sync-engine.md" active />
+          <TreeRow depth={1} label="sync-engine.md" active={scene !== "link"} />
           <TreeRow depth={1} label="storage.md" />
           <TreeRow depth={0} label="meetings" folder />
-          <TreeRow depth={1} label="2026-08-14.md" />
+          <TreeRow depth={1} label="2026-08-14.md" active={scene === "link"} />
           <TreeRow depth={0} label="reading-list.md" />
           <TreeRow depth={0} label="README.md" />
         </aside>
 
-        <div className="min-w-0 flex-1 overflow-hidden">{children}</div>
+        {/* `overflow-hidden` is load-bearing, not tidiness: the frame's height is
+            fixed so the page does not jump as scenes change, and a pane that
+            wraps taller than that on a narrow screen was painting straight over
+            the status bar underneath it. */}
+        <div key={turn} className={`min-w-0 flex-1 overflow-hidden ${motion ? "fl-scene-in" : ""}`}>
+          {scene === "write" && <WritePane motion={motion} />}
+          {scene === "link" && <LinkPane />}
+          {scene === "search" && <SearchPane />}
+          {scene === "diagram" && <DiagramPane />}
+          {scene === "history" && <HistoryPane />}
+          {scene === "share" && <SharePane />}
+        </div>
       </div>
 
-      <div className="flex items-center gap-3 border-t border-[#1f1f1f] px-4 py-2 text-[11px] text-[#8a8a8a]">
-        <span className="flex items-center gap-1.5">
-          <span className="h-1.5 w-1.5 rounded-full bg-[#8a9bb8]" />
-          All changes saved just now
+      {/* Status bar. It says something different per scene, because in the real
+          app it does too — this is the strip that answers "where is my work". */}
+      <div className="flex items-center gap-3 border-t border-[var(--fl-border)] bg-[var(--fl-elevated)] px-4 py-2 text-[11px] text-[var(--fl-muted)]">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span
+            aria-hidden="true"
+            className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--fl-accent)]"
+          />
+          <span key={turn} className={`truncate ${motion ? "fl-scene-in" : ""}`}>
+            {status}
+          </span>
         </span>
-        <span className="ml-auto hidden font-mono md:inline">architecture/sync-engine.md</span>
+        <span className="ml-auto hidden shrink-0 font-mono md:inline">
+          architecture/sync-engine.md
+        </span>
       </div>
     </div>
   );
 }
 
-/* ── Panes ────────────────────────────────────────────────────────────────── */
+/* ── Scenes ───────────────────────────────────────────────────────────────── */
 
-function WritePane() {
+function WritePane({ motion }: { motion: boolean }) {
   return (
-    <div className="flex h-full">
-      <div className="hidden min-w-0 flex-1 flex-col border-r border-[#1f1f1f] p-5 font-mono text-[12.5px] leading-relaxed md:flex">
+    <div className="flex h-full overflow-hidden">
+      <div className="hidden min-w-0 flex-1 flex-col border-r border-[var(--fl-border)] p-5 font-mono text-[12.5px] leading-relaxed md:flex">
         <PaneLabel>Source</PaneLabel>
-        <pre className="whitespace-pre-wrap text-[#c4c4c4]">
-          <span className="text-[#8a9bb8]"># Sync engine</span>
+        <pre className="whitespace-pre-wrap text-[var(--fl-muted)]">
+          <span className="font-semibold text-[var(--fl-accent)]"># Sync engine</span>
           {"\n\n"}
           Writes land in IndexedDB first, then{"\n"}
-          drain to GitHub as one <span className="text-[#f0f0f0]">**atomic commit**</span>.{"\n\n"}
-          <span className="text-[#8a9bb8]">## Guarantees</span>
+          drain to GitHub as one{" "}
+          <span className="font-semibold text-[var(--fl-text)]">**atomic commit**</span>.{"\n\n"}
+          <span className="font-semibold text-[var(--fl-accent)]">## Guarantees</span>
           {"\n\n"}- Nothing is lost when the tab closes{"\n"}- Offline edits queue and replay{"\n"}-
           Conflicts are shown, never merged
+          {motion && (
+            <span
+              aria-hidden="true"
+              className="fl-caret ml-0.5 inline-block h-[1.05em] w-[2px] translate-y-[3px] bg-[var(--fl-accent)]"
+            />
+          )}
         </pre>
       </div>
 
-      <div className="min-w-0 flex-1 p-6">
+      <div className="min-w-0 flex-1 p-5 sm:p-6">
         <PaneLabel>Preview</PaneLabel>
-        <h3 className="mb-3 text-2xl font-semibold tracking-tight">Sync engine</h3>
-        <p className="mb-5 text-[15px] leading-relaxed text-[#c4c4c4]">
+        <h3 className="mb-3 text-2xl font-semibold tracking-tight text-[var(--fl-text)]">
+          Sync engine
+        </h3>
+        <p className="mb-5 text-[15px] leading-relaxed text-[var(--fl-muted)]">
           Writes land in IndexedDB first, then drain to GitHub as one{" "}
-          <strong className="font-semibold text-[#f0f0f0]">atomic commit</strong>.
+          <strong className="font-semibold text-[var(--fl-text)]">atomic commit</strong>.
         </p>
-        <h4 className="mb-2 text-[15px] font-semibold tracking-tight">Guarantees</h4>
-        <ul className="space-y-1.5 text-[14px] text-[#c4c4c4]">
+        <h4 className="mb-2 text-[15px] font-semibold tracking-tight text-[var(--fl-text)]">
+          Guarantees
+        </h4>
+        <ul className="space-y-1.5 text-[14px] text-[var(--fl-muted)]">
           {[
             "Nothing is lost when the tab closes",
             "Offline edits queue and replay",
             "Conflicts are shown, never merged",
-          ].map((item) => (
-            <li key={item} className="flex gap-2.5">
+          ].map((item, row) => (
+            <Row key={item} row={row} className="flex gap-2.5">
               <span
                 aria-hidden="true"
-                className="mt-[9px] h-1 w-1 shrink-0 rounded-full bg-[#8a9bb8]"
+                className="mt-[9px] h-1 w-1 shrink-0 rounded-full bg-[var(--fl-accent)]"
               />
               {item}
-            </li>
+            </Row>
           ))}
         </ul>
       </div>
@@ -169,13 +338,120 @@ function WritePane() {
   );
 }
 
+/** Links and backlinks: the thing that makes a folder of files a notebook. */
+function LinkPane() {
+  const backlinks = [
+    { note: "architecture/sync-engine.md", line: "Blocked on [[Storage layout]] landing first." },
+    { note: "reading-list.md", line: "Re-read [[Storage layout]] before the review." },
+    { note: "meetings/2026-08-07.md", line: "Agreed to fold [[Storage layout]] into v1." },
+  ];
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      <div className="hidden min-w-0 flex-1 flex-col border-r border-[var(--fl-border)] p-5 sm:p-6 md:flex">
+        <PaneLabel>2026-08-14.md</PaneLabel>
+        <p className="text-[14.5px] leading-[1.75] text-[var(--fl-muted)]">
+          Storage is settled — see <WikiLink>Storage layout</WikiLink> for the shape we agreed. The
+          queue work depends on it, so <WikiLink>Sync engine</WikiLink> moves after it, and{" "}
+          <WikiLink pending>Offline queue v2</WikiLink> is not written yet.
+        </p>
+
+        <p className="mt-4 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] px-3 py-2 text-[11.5px] leading-relaxed text-[var(--fl-muted)]">
+          A dotted link is a note that does not exist. Clicking it writes the file.
+        </p>
+      </div>
+
+      <div className="min-w-0 flex-1 p-5 sm:p-6">
+        <PaneLabel>Backlinks · Storage layout</PaneLabel>
+        <ul className="space-y-2">
+          {backlinks.map((item, row) => (
+            <Row
+              key={item.note}
+              row={row}
+              className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] px-3.5 py-2.5"
+            >
+              <p className="truncate font-mono text-[11px] text-[var(--fl-muted)]">{item.note}</p>
+              <p className="mt-1 text-[13px] leading-relaxed text-[var(--fl-text)]">{item.line}</p>
+            </Row>
+          ))}
+        </ul>
+        <p className="mt-4 hidden text-[12.5px] leading-relaxed text-[var(--fl-muted)] sm:block">
+          Every mention, quoted at the line it was written on — so you can see why a note was
+          linked, not just that it was.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/** Search: BM25 over every note, in the browser, with no server involved. */
+function SearchPane() {
+  const results = [
+    {
+      note: "architecture/sync-engine.md",
+      line: "drain to GitHub as one atomic commit.",
+      score: "BM25 8.4",
+    },
+    {
+      note: "meetings/2026-08-14.md",
+      line: "One atomic commit per burst, not per keystroke.",
+      score: "BM25 6.1",
+    },
+    {
+      note: "architecture/storage.md",
+      line: "The queue replays until the commit lands.",
+      score: "BM25 3.7",
+    },
+  ];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden p-5 sm:p-6">
+      <PaneLabel>Search · 128 notes</PaneLabel>
+
+      <div className="flex items-center gap-2 rounded-lg border border-[var(--fl-border-strong)] bg-[var(--fl-elevated)] px-3.5 py-2.5">
+        <span aria-hidden="true" className="text-[13px] text-[var(--fl-muted)]">
+          ⌘K
+        </span>
+        <span className="font-mono text-[13px] text-[var(--fl-text)]">atomic commit</span>
+        <span className="fl-caret inline-block h-[1.05em] w-[2px] bg-[var(--fl-accent)]" />
+        <span className="ml-auto text-[11.5px] text-[var(--fl-muted)]">3 results · 9 ms</span>
+      </div>
+
+      <ul className="mt-3 space-y-2">
+        {results.map((result, row) => (
+          <Row
+            key={result.note}
+            row={row}
+            className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] px-3.5 py-2.5"
+          >
+            <div className="flex items-baseline gap-3">
+              <p className="min-w-0 flex-1 truncate font-mono text-[11px] text-[var(--fl-muted)]">
+                {result.note}
+              </p>
+              <p className="shrink-0 font-mono text-[10.5px] text-[var(--fl-muted)]">
+                {result.score}
+              </p>
+            </div>
+            <p className="mt-1 text-[13px] leading-relaxed text-[var(--fl-text)]">{result.line}</p>
+          </Row>
+        ))}
+      </ul>
+
+      <p className="mt-auto hidden pt-5 text-[12.5px] leading-relaxed text-[var(--fl-muted)] sm:block">
+        The index lives in your browser, so search keeps working on a plane — and no query ever
+        leaves the machine you typed it on.
+      </p>
+    </div>
+  );
+}
+
 function DiagramPane() {
   return (
-    <div className="flex h-full">
-      <div className="hidden min-w-0 flex-1 flex-col border-r border-[#1f1f1f] p-5 font-mono text-[12.5px] leading-relaxed md:flex">
+    <div className="flex h-full overflow-hidden">
+      <div className="hidden min-w-0 flex-1 flex-col border-r border-[var(--fl-border)] p-5 font-mono text-[12.5px] leading-relaxed md:flex">
         <PaneLabel>Source</PaneLabel>
-        <pre className="whitespace-pre-wrap text-[#c4c4c4]">
-          <span className="text-[#6a6a6a]">```mermaid</span>
+        <pre className="whitespace-pre-wrap text-[var(--fl-muted)]">
+          <span className="text-[var(--fl-border-strong)]">```mermaid</span>
           {"\n"}
           flowchart LR{"\n"}
           {"  "}A[Keystroke] --&gt; B[(IndexedDB)]{"\n"}
@@ -183,14 +459,15 @@ function DiagramPane() {
           {"\n"}
           {"  "}C --&gt;|yes| D[Commit]{"\n"}
           {"  "}C --&gt;|no| B{"\n"}
-          <span className="text-[#6a6a6a]">```</span>
+          <span className="text-[var(--fl-border-strong)]">```</span>
         </pre>
-        <p className="mt-4 rounded-lg border border-[#1f1f1f] bg-[#0a0a0a] px-3 py-2 text-[11px] leading-relaxed text-[#8a8a8a]">
-          Or drag it on a canvas — the source is written for you.
+        <p className="mt-4 rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] px-3 py-2 text-[11px] leading-relaxed text-[var(--fl-muted)]">
+          Or drag it on a canvas — the source is written for you, and node positions survive the
+          round trip.
         </p>
       </div>
 
-      <div className="flex min-w-0 flex-1 flex-col p-6">
+      <div className="flex min-w-0 flex-1 flex-col p-5 sm:p-6">
         <PaneLabel>Rendered</PaneLabel>
         <div className="flex flex-1 items-center justify-center">
           <Flowchart />
@@ -200,7 +477,7 @@ function DiagramPane() {
   );
 }
 
-function SyncPane() {
+function HistoryPane() {
   const commits = [
     { msg: "Add conflict resolution notes", sha: "a3f9c21", when: "2 minutes ago", now: true },
     { msg: "Update 3 notes", sha: "7b21e08", when: "1 hour ago", now: false },
@@ -209,37 +486,84 @@ function SyncPane() {
   ];
 
   return (
-    <div className="flex h-full flex-col p-6">
+    <div className="flex h-full flex-col overflow-hidden p-5 sm:p-6">
       <PaneLabel>Version history</PaneLabel>
 
       <ol className="space-y-1.5">
-        {commits.map((commit) => (
-          <li
+        {commits.map((commit, row) => (
+          <Row
             key={commit.sha}
+            row={row}
             className={`flex items-center gap-3 rounded-lg border px-3.5 py-2.5 ${
-              commit.now ? "border-[#8a9bb8]/40 bg-[#8a9bb8]/8" : "border-[#1f1f1f] bg-[#0a0a0a]"
+              commit.now
+                ? "border-[var(--fl-accent)]/40 bg-[var(--fl-accent-soft)]"
+                : "border-[var(--fl-border)] bg-[var(--fl-elevated)]"
             }`}
           >
             <span
               aria-hidden="true"
               className={`h-1.5 w-1.5 shrink-0 rounded-full ${
-                commit.now ? "bg-[#8a9bb8]" : "bg-[#333333]"
+                commit.now ? "bg-[var(--fl-accent)]" : "bg-[var(--fl-border-strong)]"
               }`}
             />
-            <span className="min-w-0 flex-1 truncate text-[13.5px] text-[#f0f0f0]">
+            <span className="min-w-0 flex-1 truncate text-[13.5px] text-[var(--fl-text)]">
               {commit.msg}
             </span>
-            <span className="shrink-0 font-mono text-[11px] text-[#8a8a8a]">{commit.sha}</span>
-            <span className="hidden shrink-0 text-[11.5px] text-[#8a8a8a] sm:inline">
+            <span className="shrink-0 font-mono text-[11px] text-[var(--fl-muted)]">
+              {commit.sha}
+            </span>
+            <span className="hidden shrink-0 text-[11.5px] text-[var(--fl-muted)] sm:inline">
               {commit.when}
             </span>
-          </li>
+          </Row>
         ))}
       </ol>
 
-      <p className="mt-auto pt-5 text-[12.5px] leading-relaxed text-[#8a8a8a]">
-        Real commits in a repository you own. Clone it, revert it, or walk away with all of it —
-        there is no export step, because there was never an import step.
+      <p className="mt-auto hidden pt-5 text-[12.5px] leading-relaxed text-[var(--fl-muted)] sm:block">
+        Read straight from the repository&rsquo;s own log — open any version, compare two, or
+        restore one. Clone it, revert it, or walk away with all of it: there is no export step,
+        because there was never an import step.
+      </p>
+    </div>
+  );
+}
+
+function SharePane() {
+  const exports = ["PDF", "Word", "HTML", "Markdown", "Plain text", "JSON"];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden p-5 sm:p-6">
+      <PaneLabel>Share this note</PaneLabel>
+
+      <div className="rounded-lg border border-[var(--fl-border-strong)] bg-[var(--fl-elevated)] p-4">
+        <p className="text-[13.5px] font-semibold text-[var(--fl-text)]">Published page</p>
+        <p className="mt-1 font-mono text-[12px] text-[var(--fl-accent)]">
+          yourname.github.io/notes/sync-engine
+        </p>
+        <p className="mt-2 text-[12.5px] leading-relaxed text-[var(--fl-muted)]">
+          One self-contained file, committed to <span className="font-mono">docs/</span> in your own
+          repository and served by GitHub Pages. Unpublishing is a deleted file.
+        </p>
+      </div>
+
+      <p className="mb-2 mt-5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+        Or export it
+      </p>
+      <ul className="grid grid-cols-3 gap-2">
+        {exports.map((format, row) => (
+          <Row
+            key={format}
+            row={row}
+            className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] px-3 py-2.5 text-center text-[12.5px] text-[var(--fl-text)]"
+          >
+            {format}
+          </Row>
+        ))}
+      </ul>
+
+      <p className="mt-auto hidden pt-5 text-[12.5px] leading-relaxed text-[var(--fl-muted)] sm:block">
+        Rendered in the browser, diagrams included — the note never leaves your machine in order to
+        become a file.
       </p>
     </div>
   );
@@ -247,9 +571,43 @@ function SyncPane() {
 
 /* ── Pieces ───────────────────────────────────────────────────────────────── */
 
+/**
+ * A row that arrives just after the pane it is in.
+ *
+ * The stagger is small on purpose: enough to lead the eye down the list, not
+ * enough that the last row is still arriving when somebody has read it.
+ */
+function Row({
+  row,
+  className = "",
+  children,
+}: {
+  row: number;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <li className={`fl-row-in ${className}`} style={{ animationDelay: `${120 + row * 70}ms` }}>
+      {children}
+    </li>
+  );
+}
+
+function WikiLink({ children, pending = false }: { children: React.ReactNode; pending?: boolean }) {
+  return pending ? (
+    <span className="rounded border-b border-dashed border-[var(--fl-muted)] px-0.5 text-[var(--fl-muted)]">
+      [[{children}]]
+    </span>
+  ) : (
+    <span className="rounded bg-[var(--fl-accent-soft)] px-1 text-[var(--fl-accent)]">
+      [[{children}]]
+    </span>
+  );
+}
+
 function PaneLabel({ children }: { children: React.ReactNode }) {
   return (
-    <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-[#6a6a6a]">
+    <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
       {children}
     </p>
   );
@@ -269,8 +627,8 @@ function TreeRow({
   return (
     <div
       style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
-      className={`flex items-center gap-1.5 rounded-md py-1 pr-2 text-[12.5px] ${
-        active ? "bg-[#8a9bb8]/12 text-[#8a9bb8]" : folder ? "text-[#8a8a8a]" : "text-[#8a8a8a]"
+      className={`flex items-center gap-1.5 rounded-md py-1 pr-2 text-[12.5px] transition-colors ${
+        active ? "bg-[var(--fl-accent-soft)] text-[var(--fl-accent)]" : "text-[var(--fl-muted)]"
       }`}
     >
       <span aria-hidden="true" className="text-[9px] opacity-70">
@@ -302,11 +660,11 @@ function Flowchart() {
           markerHeight="6"
           orient="auto"
         >
-          <path d="M0 0 8 4 0 8Z" fill="#333333" />
+          <path d="M0 0 8 4 0 8Z" fill="var(--fl-border-strong)" />
         </marker>
       </defs>
 
-      <g stroke="#333333" strokeWidth="1">
+      <g stroke="var(--fl-border-strong)" strokeWidth="1">
         <path d="M92 34h26" markerEnd="url(#fl-hero-arrow)" />
         <path d="M196 34h26" markerEnd="url(#fl-hero-arrow)" />
         <path d="M300 34h26" markerEnd="url(#fl-hero-arrow)" />
@@ -318,10 +676,10 @@ function Flowchart() {
       <Node x={222} y={20} w={78} label="Online?" />
       <Node x={326} y={20} w={84} label="Commit" accent />
 
-      <text x="203" y="74" fill="#6a6a6a">
+      <text x="203" y="74" fill="var(--fl-muted)">
         no
       </text>
-      <text x="306" y="28" fill="#6a6a6a">
+      <text x="306" y="28" fill="var(--fl-muted)">
         yes
       </text>
     </svg>
@@ -349,10 +707,15 @@ function Node({
         width={w}
         height={28}
         rx={7}
-        fill={accent ? "rgba(62,207,142,0.10)" : "#0a0a0a"}
-        stroke={accent ? "#8a9bb8" : "#333333"}
+        fill={accent ? "var(--fl-accent-soft)" : "var(--fl-elevated)"}
+        stroke={accent ? "var(--fl-accent)" : "var(--fl-border-strong)"}
       />
-      <text x={x + w / 2} y={y + 18} textAnchor="middle" fill={accent ? "#8a9bb8" : "#c4c4c4"}>
+      <text
+        x={x + w / 2}
+        y={y + 18}
+        textAnchor="middle"
+        fill={accent ? "var(--fl-accent)" : "var(--fl-muted)"}
+      >
         {label}
       </text>
     </g>

--- a/apps/web/src/components/landing/Features.tsx
+++ b/apps/web/src/components/landing/Features.tsx
@@ -63,6 +63,30 @@ const FEATURES = [
     span: "",
     art: <ExportArt />,
   },
+  {
+    title: "The code in your notes actually runs",
+    body: "Give a fenced block a language and it gets a Run button. bash, Python and JavaScript execute in a throwaway VM, and the output is written into the note underneath — committed with it, replaced on the next run, and kept in the history like anything else.",
+    span: "md:col-span-2",
+    art: <RunArt />,
+  },
+  {
+    title: "Sources that survive link rot",
+    body: "Paste an address and ForkLeaf writes the citation: the page's real title, plus a Wayback archive of it. The link still means something after the site is sold.",
+    span: "",
+    art: <CaptureArt />,
+  },
+  {
+    title: "Notes that say when they have gone off",
+    body: "Version numbers, dates, CVEs and linked files that have moved on since you last touched the note. It never claims a note is wrong — only that it is worth re-reading, and always why.",
+    span: "",
+    art: <FreshnessArt />,
+  },
+  {
+    title: "Review a note like code",
+    body: "Propose changes to a repository you cannot push to and ForkLeaf opens a real pull request. Read a PR as rendered notes rather than a diff, see who wrote each line, and watch the diagrams change shape between two commits.",
+    span: "md:col-span-2",
+    art: <ReviewArt />,
+  },
 ] as const;
 
 export function Features() {
@@ -71,7 +95,7 @@ export function Features() {
       <SectionHeading
         eyebrow="Features"
         title="Built like a text editor, not like a database with a text box"
-        body="Plain files, plain git, plain exports — and the linking, search and diagramming a real notebook needs. Everything below is in the repository today."
+        body="Plain files, plain git, plain exports — and the linking, search, diagramming, reviewing and running that a real notebook needs. Everything below is in the repository today, not on a roadmap."
       />
 
       <div className="mt-12 grid gap-4 md:grid-cols-3">
@@ -129,6 +153,101 @@ function LinksArt() {
               Blocked until [[Q3 roadmap]] lands…
             </p>
           </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RunArt() {
+  return (
+    <div className="overflow-hidden rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)]">
+      <div className="flex items-center gap-2 border-b border-[var(--fl-border)] px-3 py-1.5">
+        <span className="font-mono text-[11px] text-[var(--fl-muted)]">python</span>
+        <span className="ml-auto rounded border border-[var(--fl-accent)] px-1.5 py-0.5 text-[10.5px] font-semibold text-[var(--fl-accent)]">
+          Run
+        </span>
+      </div>
+      <p className="px-3 py-2 font-mono text-[12px] text-[var(--fl-text)]">
+        print(&quot;hello world&quot;)
+      </p>
+      <div className="border-t border-[var(--fl-border)] px-3 py-2">
+        <p className="font-mono text-[10.5px] text-[var(--fl-muted)]">
+          — ran 2026-08-27 11:09 UTC · ok · 34ms
+        </p>
+        <p className="font-mono text-[12px] text-[var(--fl-text)]">hello world</p>
+      </div>
+    </div>
+  );
+}
+
+function CaptureArt() {
+  return (
+    <div className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-3">
+      <p className="truncate font-mono text-[11.5px] text-[var(--fl-muted)]">
+        https://example.com/post
+      </p>
+      <p className="mt-2 text-[12.5px] leading-relaxed text-[var(--fl-text)]">
+        [The post&rsquo;s real title]
+        <span className="text-[var(--fl-muted)]">(https://example.com/post)</span>
+      </p>
+      <p className="mt-1.5 flex items-center gap-1.5 text-[11.5px] text-[var(--fl-accent)]">
+        <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-[var(--fl-accent)]" />
+        archived copy · web.archive.org
+      </p>
+    </div>
+  );
+}
+
+function FreshnessArt() {
+  return (
+    <div className="space-y-2">
+      {[
+        { note: "Deploy runbook", why: "mentions v14 · 8 months untouched", stale: true },
+        { note: "How I think about scope", why: "nothing datable in it", stale: false },
+      ].map((item) => (
+        <div
+          key={item.note}
+          className={`rounded-lg border px-3 py-2 ${
+            item.stale
+              ? "border-[var(--fl-accent)] bg-[var(--fl-accent-soft)]"
+              : "border-[var(--fl-border)] bg-[var(--fl-elevated)]"
+          }`}
+        >
+          <p className="text-[12.5px] text-[var(--fl-text)]">{item.note}</p>
+          <p className="truncate text-[11.5px] text-[var(--fl-muted)]">
+            {item.stale ? "Worth re-reading — " : "Never stale — "}
+            {item.why}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ReviewArt() {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <div className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-3">
+        <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--fl-muted)]">
+          Pull request #42
+        </p>
+        <p className="text-[12.5px] text-[var(--fl-text)]">Update the deploy runbook</p>
+        <p className="mt-1 font-mono text-[11.5px] text-[var(--fl-muted)]">
+          notes:you/patch-1 → main
+        </p>
+      </div>
+      <div className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-3">
+        <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--fl-muted)]">
+          Who wrote this line
+        </p>
+        {[
+          { who: "you", when: "2 days ago" },
+          { who: "priya", when: "last month" },
+        ].map((row) => (
+          <p key={row.who} className="truncate text-[11.5px] text-[var(--fl-muted)]">
+            <span className="text-[var(--fl-accent)]">{row.who}</span> · {row.when}
+          </p>
         ))}
       </div>
     </div>

--- a/apps/web/src/components/landing/Hero.tsx
+++ b/apps/web/src/components/landing/Hero.tsx
@@ -20,16 +20,35 @@ import { SectionLink } from "./SectionLink";
  *    common reason a developer closes the tab.
  */
 
-/** Named capabilities, in the order a writer would meet them. */
+/**
+ * Named capabilities, in the order a writer would meet them.
+ *
+ * The list is long on purpose. "Notes in your own repo" is a storage decision,
+ * and a reader who has only been told that is entitled to assume they are
+ * being offered a text box over an API — so the chips say, before anybody
+ * scrolls, that this is a full notebook: it links, it searches, it draws, it
+ * remembers, it publishes, and it opens the files already on your disk.
+ *
+ * Every one of these is in the repository today. Nothing aspirational goes in
+ * this list; the moment one entry turns out to be a plan, the reader is right
+ * to stop believing the other eleven.
+ */
 const CAPABILITIES = [
   "Rich, split & source editing",
   "[[Wikilinks]] & backlinks",
-  "Full-text search",
+  "Offline full-text search",
   "Visual Mermaid studio",
-  "Offline-first",
   "Real commit history",
+  "Version compare & restore",
+  "Conflicts shown, never merged",
+  "Pull requests from the editor",
+  "Publish to GitHub Pages",
   "PDF, Word & HTML export",
-  "Publish to a public link",
+  "Opens the .md files on your disk",
+  "Runs the code in your notes",
+  "Web sources, archived",
+  "Line-by-line blame",
+  "Works offline",
 ] as const;
 
 export function Hero({ githubAvailable }: { githubAvailable: boolean }) {
@@ -68,15 +87,17 @@ export function Hero({ githubAvailable }: { githubAvailable: boolean }) {
           </h1>
 
           <p className="mx-auto mt-6 max-w-2xl text-[16px] leading-[1.6] text-[var(--fl-muted)] sm:mt-7 sm:text-[17.5px] sm:leading-[1.62]">
-            ForkLeaf is a full Markdown workspace — linked notes, search, diagrams, exports — that
-            keeps every note as a plain{" "}
-            <code className="font-mono text-[15px] text-[var(--fl-text)]">.md</code> file in a
-            GitHub repository <em className="not-italic text-[var(--fl-text)]">you</em> own. It
-            saves to your device as you type, and turns those edits into real commits in your own
-            history. There is no ForkLeaf database to be locked out of.
+            ForkLeaf is a full Markdown workspace — linked notes, offline search, a visual diagram
+            studio, real version history, exports and publishing — and its database is a{" "}
+            <em className="not-italic text-[var(--fl-text)]">GitHub repository you already own</em>.
+            Every note is a plain{" "}
+            <code className="font-mono text-[15px] text-[var(--fl-text)]">.md</code> file. It saves
+            to your device as you type, then turns those edits into real commits under your own
+            name. Nothing is stored on our servers, and there is no ForkLeaf database to be locked
+            out of.
           </p>
 
-          <ul className="mx-auto mt-7 flex max-w-2xl flex-wrap items-center justify-center gap-x-2 gap-y-2 text-[12.5px] text-[var(--fl-muted)]">
+          <ul className="mx-auto mt-7 flex max-w-3xl flex-wrap items-center justify-center gap-x-2 gap-y-2 text-[12.5px] text-[var(--fl-muted)]">
             {CAPABILITIES.map((item) => (
               <li
                 key={item}


### PR DESCRIPTION
Stacked on [#51](https://github.com/praneeth132006/ForkLeaf/pull/51) — base retargets to `main` when that merges. Review only the second commit here.

## The bug you reported

The hero's window was hardcoded to the dark palette so it would "read as a screenshot". A screen below it, the **How it works** window is theme-aware. So in light mode the page showed two product shots in two different colour schemes — in a product whose own light mode that page is otherwise demonstrating.

Every colour in the frame is a token now. Its border also moves from `--fl-border` to `--fl-border-strong` with a ring beneath it: this is the one element on the page that has to hold its own edge against a full-bleed background, and the hairline used for cards *inside* the page disappeared against it.

## The frame now shows the whole editor

Six scenes, ~6s each, cycling on their own:

| Scene | What it proves |
| --- | --- |
| **Write** | source + preview of the same file |
| **Link** | `[[wikilinks]]`, a pending link drawn dotted, and backlinks quoting the line each was written on |
| **Search** | a `⌘K` query with BM25 scores and "3 results · 9 ms", answered in the browser |
| **Diagram** | Mermaid source beside its rendered flowchart |
| **History** | four real commits with SHAs, read from the repository's own log |
| **Share** | a GitHub Pages URL, and the six export formats |

The status bar changes per scene, because in the app it does too.

**It never traps anybody.** Hover or keyboard focus stops the clock. The tabs jump straight to a scene. A ticking bar under the active tab shows how long is left, so a change never reads as a glitch. And `prefers-reduced-motion` turns the whole thing off — no cycling, no tick, no caret, tabs still fully working (the two infinite/duration-dependent animations are named explicitly in the reduced-motion block, because an infinite animation squashed to 0.01ms is a strobe, not stillness).

**Nothing can break the layout.** The frame's height is fixed so the page cannot jump on a timer, and the panes clip rather than paint over the status bar — which they did, at 375px, on the Share scene. Fixed, and the trailing explanatory line in each pane is hidden below `sm` so short panes are not crowded.

## The page was underselling the product

Nine feature cards and eight chips, for an app that also runs the code in your notes, archives the pages you cite, flags notes that have gone off, opens pull requests and shows who wrote each line.

Added — four cards (**The code in your notes actually runs**, **Sources that survive link rot**, **Notes that say when they have gone off**, **Review a note like code**) and seven chips. Every entry maps to code in this repository today; that is the only rule the list has. The hero paragraph now leads with the positioning — a full Markdown workspace *whose database is a GitHub repository you already own* — rather than with the storage decision alone.

## Docs

Following the token work in #51: the session docs say the access token lasts eight hours and is renewed with a refresh token that never reaches the browser; the cookie-contents list includes it; revoke instructions point at **Authorized GitHub Apps** rather than OAuth Apps (ForkLeaf is a GitHub App — the old link was simply wrong); and the self-hosting page notes a GitHub App needs no extra configuration.

## Verified

Driven in a real browser at desktop and 375px, in both themes: all six scenes, the tab strip scrolling rather than wrapping, the light/dark match against the How it works window, and the mobile overflow that is now clipped. 1568 tests, lint, typecheck, prettier and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
