### PR TITLE
fix(sync): a failed push says why it failed, and retry actually retries

### DIFF
--- a/apps/web/src/components/EditorStatusBar.tsx
+++ b/apps/web/src/components/EditorStatusBar.tsx
@@ -4,6 +4,7 @@ import type { CursorPosition } from "@forkleaf/editor";
 import type { SyncMode, SyncPreference, SyncState, Workspace } from "@forkleaf/types";
 import { BranchMenu } from "./BranchMenu";
 import { SyncModeMenu } from "./SyncModeMenu";
+import { SyncProblem } from "./SyncProblem";
 
 export interface EditorStatusBarProps {
   sync: SyncState;
@@ -88,25 +89,48 @@ export function EditorStatusBar({
    * over the whole status control rather than sitting behind it.
    */
   const expired = sync.lastErrorCode === "unauthorized" || sessionExpired;
-  const status = describe(sync, expired);
+  /**
+   * A failure gets the panel, not the one-liner.
+   *
+   * The old control retried on click and said so, which is fine exactly once.
+   * Every time after that it was a button that reprinted its own sentence with
+   * nothing having changed, and no way anywhere in the app to find out why —
+   * so the reader's only remaining move was to press it again. The reason and
+   * the fix live behind this now, and the retry is one of the things inside.
+   */
+  const failing =
+    sync.conflicts.length > 0 ||
+    sync.status === "error" ||
+    sync.status === "blocked" ||
+    (expired && sync.pendingCount > 0);
+  const status = describe(sync, expired, failing);
 
   return (
     <footer className="flex h-8 shrink-0 items-center gap-3 px-4 text-[0.7rem] text-[var(--fl-muted)]">
-      <button
-        type="button"
-        onClick={sync.conflicts.length > 0 ? onShowConflicts : expired ? onSignIn : onSyncNow}
-        title={
-          sync.conflicts.length > 0
-            ? "Resolve conflicts"
-            : expired
-              ? "Sign in to GitHub again"
-              : "Sync now"
-        }
-        className="flex items-center gap-1.5 rounded px-1.5 py-0.5 hover:bg-[var(--fl-elevated)]"
-      >
-        <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${status.dot}`} />
-        <span className={status.className}>{status.label}</span>
-      </button>
+      {failing ? (
+        <SyncProblem
+          sync={sync}
+          expired={expired}
+          workspace={workspace}
+          label={status.label}
+          labelClassName={status.className}
+          dot={status.dot}
+          onRetry={onSyncNow}
+          onSignIn={onSignIn}
+          onShowConflicts={onShowConflicts}
+          onPropose={onPropose}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={onSyncNow}
+          title="Sync now"
+          className="flex items-center gap-1.5 rounded px-1.5 py-0.5 hover:bg-[var(--fl-elevated)]"
+        >
+          <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${status.dot}`} />
+          <span className={status.className}>{status.label}</span>
+        </button>
+      )}
 
       {/* The way out, drawn as a button rather than left as advice inside a
           sentence. Somebody reading "sign in again" in red text has no reason
@@ -154,7 +178,7 @@ export function EditorStatusBar({
 
       {/* Only when the status control is not already saying it: the same
           sentence printed twice across one bar reads as two problems. */}
-      {sync.lastError && sync.status !== "error" && sync.status !== "blocked" && (
+      {sync.lastError && !failing && (
         <span
           className="ml-auto truncate text-[var(--fl-danger)]"
           title={sync.lastErrorDetail ?? sync.lastError}
@@ -163,7 +187,7 @@ export function EditorStatusBar({
         </span>
       )}
 
-      {notePath && !sync.lastError && (
+      {notePath && (!sync.lastError || failing) && (
         <div className="ml-auto flex shrink-0 items-center gap-3">
           <span className="hidden truncate font-mono lg:inline" title={notePath}>
             {notePath}
@@ -226,6 +250,7 @@ export function EditorStatusBar({
 function describe(
   sync: SyncState,
   expired: boolean,
+  failing: boolean,
 ): { label: string; className: string; dot: string } {
   if (sync.conflicts.length > 0) {
     return {
@@ -265,14 +290,15 @@ function describe(
 
     case "error":
       return {
-        // The message already says what happened and that the work is safe;
-        // what to press is the only thing left to add — and for an expired
-        // token that is not "retry", which is what made the old label a dead
-        // end for the one failure people actually hit.
+        // The sentence is a summary of something that has to be read in full
+        // to be acted on, and this line is too short to hold the full thing —
+        // it was arriving on narrow windows cut off mid-word. So the label
+        // stops trying: it names the failure and points at where the reason,
+        // the fix and the retry all are.
         label: expired
-          ? `${sync.lastError ?? "Your GitHub sign-in has expired."} Click to sign in.`
-          : `${sync.lastError ?? "Could not push to GitHub."} Click to retry.`,
-        className: "text-[var(--fl-danger)] truncate max-w-[500px]",
+          ? "Not pushed to GitHub — your sign-in expired. Click to fix."
+          : `Not pushed to GitHub — ${sync.pendingCount} change${sync.pendingCount === 1 ? "" : "s"} waiting. Click to see why.`,
+        className: "text-[var(--fl-danger)] truncate max-w-[420px]",
         dot: "bg-[var(--fl-danger)]",
       };
 
@@ -283,7 +309,7 @@ function describe(
       return {
         label: expired
           ? `${sync.blockedCount} change${sync.blockedCount === 1 ? "" : "s"} not on GitHub — click to sign in again`
-          : `${sync.blockedCount} change${sync.blockedCount === 1 ? "" : "s"} not on GitHub — click to retry`,
+          : `${sync.blockedCount} change${sync.blockedCount === 1 ? "" : "s"} stopped trying — click to see why`,
         className: "text-[var(--fl-danger)] font-medium",
         dot: "bg-[var(--fl-danger)]",
       };
@@ -300,6 +326,13 @@ function describe(
 
     case "idle":
     default:
+      if (failing && expired) {
+        return {
+          label: "Your GitHub sign-in expired. Click to fix.",
+          className: "text-[var(--fl-danger)] truncate max-w-[420px]",
+          dot: "bg-[var(--fl-danger)]",
+        };
+      }
       return {
         label: sync.lastSyncedAt
           ? `All changes saved ${relative(sync.lastSyncedAt)}`

--- a/apps/web/src/components/SyncProblem.test.tsx
+++ b/apps/web/src/components/SyncProblem.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { SyncState, Workspace } from "@forkleaf/types";
+import { SyncProblem } from "./SyncProblem";
+
+afterEach(cleanup);
+
+const WORKSPACE: Workspace = {
+  id: "me/notes@main:",
+  name: "notes",
+  repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
+  isDefault: false,
+  isLocal: false,
+  createdAt: new Date().toISOString(),
+  lastOpenedAt: new Date().toISOString(),
+};
+
+function state(over: Partial<SyncState> = {}): SyncState {
+  return {
+    status: "error",
+    mode: "auto",
+    pendingCount: 3,
+    blockedCount: 0,
+    lastSyncedAt: null,
+    lastError: "Could not push to GitHub just now.",
+    lastErrorDetail: "GitRPC::BadObjectState",
+    lastErrorCode: "unknown",
+    lastErrorAt: new Date().toISOString(),
+    failedAttempts: 4,
+    conflicts: [],
+    ...over,
+  };
+}
+
+function view(sync: SyncState, over: Partial<React.ComponentProps<typeof SyncProblem>> = {}) {
+  const props = {
+    sync,
+    expired: false,
+    workspace: WORKSPACE,
+    label: "Not pushed to GitHub",
+    labelClassName: "",
+    dot: "",
+    onRetry: vi.fn(),
+    onSignIn: vi.fn(),
+    onShowConflicts: vi.fn(),
+    onPropose: vi.fn(),
+    ...over,
+  };
+  render(<SyncProblem {...props} />);
+  return props;
+}
+
+/** Opens the panel the way a reader does. */
+function open() {
+  fireEvent.click(screen.getByRole("button", { name: /Not pushed to GitHub/ }));
+}
+
+describe("SyncProblem — the reason, not just the failure", () => {
+  it("stays out of the way until asked", () => {
+    view(state());
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("names what GitHub actually said, rather than hiding it in a tooltip", () => {
+    view(state());
+    open();
+    expect(screen.getByText(/GitRPC::BadObjectState/)).toBeTruthy();
+  });
+
+  it("says how many attempts have already gone the same way", () => {
+    view(state());
+    open();
+    expect(screen.getByText(/4 failed in a row/)).toBeTruthy();
+  });
+
+  it("answers the question the reader actually has first", () => {
+    view(state());
+    open();
+    expect(screen.getByText(/3 changes are saved on this device/)).toBeTruthy();
+  });
+
+  it("gives steps for a permission failure that only the reader can take", () => {
+    view(state({ lastErrorCode: "forbidden" }));
+    open();
+    expect(screen.getByText(/write access to this repository/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /pull request instead/ })).toBeTruthy();
+  });
+
+  it("names the proxy case for a network failure, which is the one nobody guesses", () => {
+    view(state({ lastErrorCode: "network" }));
+    open();
+    expect(screen.getByText(/api\.github\.com is not blocked/)).toBeTruthy();
+  });
+});
+
+describe("SyncProblem — offering the thing that would work", () => {
+  it("retries from inside the panel", () => {
+    const props = view(state());
+    open();
+    fireEvent.click(screen.getByRole("button", { name: "Try again now" }));
+    expect(props.onRetry).toHaveBeenCalled();
+  });
+
+  it("shows a push in flight rather than looking inert", () => {
+    view(state({ status: "syncing" }));
+    open();
+    expect(screen.getByRole("button", { name: "Trying…" })).toBeTruthy();
+  });
+
+  it("offers the sign-in, not a retry, when the sign-in is what is wrong", () => {
+    const props = view(state({ lastErrorCode: "unauthorized" }), { expired: true });
+    open();
+    // Still available for anybody who disagrees, just no longer the answer.
+    expect(screen.getByRole("button", { name: /Try again anyway/ })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Sign in to GitHub again/ }));
+    expect(props.onSignIn).toHaveBeenCalled();
+  });
+
+  it("sends a conflict to the resolver instead of a retry", () => {
+    const props = view(
+      state({
+        status: "conflict",
+        conflicts: [
+          {
+            workspaceId: WORKSPACE.id,
+            path: "a.md",
+            localContent: "mine",
+            remoteContent: "theirs",
+            remoteSha: "abc123",
+            detectedAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    );
+    open();
+    fireEvent.click(screen.getByRole("button", { name: /Resolve conflicts/ }));
+    expect(props.onShowConflicts).toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /Try again now/ })).toBeNull();
+  });
+});

--- a/apps/web/src/components/SyncProblem.tsx
+++ b/apps/web/src/components/SyncProblem.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { remedyFor } from "@forkleaf/store";
+import type { SyncState, Workspace } from "@forkleaf/types";
+
+export interface SyncProblemProps {
+  sync: SyncState;
+  /** True when the sign-in is the thing that is wrong, whatever else is. */
+  expired: boolean;
+  workspace: Workspace | null;
+  /** The label and dot the status bar would have drawn for this state. */
+  label: string;
+  labelClassName: string;
+  dot: string;
+  /** Pushes the queue again, right now. */
+  onRetry: () => void;
+  onSignIn: () => void;
+  onShowConflicts: () => void;
+  /** Opens the pull-request flow — the way out of a protected branch. */
+  onPropose: () => void;
+}
+
+/**
+ * A failed push, explained rather than announced.
+ *
+ * The status bar has one line, and one line can only ever say that something
+ * went wrong and offer to try again. When the retry then fails for the same
+ * reason — a revoked token, a protected branch, a proxy eating requests to
+ * api.github.com — that line reprints itself unchanged, and the reader is left
+ * pressing a button that visibly does nothing. Nothing in the bar ever names
+ * the cause, so there is no other move available to them.
+ *
+ * This is where the rest of it goes: what GitHub actually said, what that
+ * means, the steps that would fix it, and how many times we have now tried.
+ * Most of those steps are things only the reader can do — granting access,
+ * unarchiving a repository, getting off the network that is blocking GitHub —
+ * which is precisely why hiding the reason made the app unusable at the moment
+ * it mattered.
+ */
+export function SyncProblem({
+  sync,
+  expired,
+  workspace,
+  label,
+  labelClassName,
+  dot,
+  onRetry,
+  onSignIn,
+  onShowConflicts,
+  onPropose,
+}: SyncProblemProps) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const root = useRef<HTMLDivElement>(null);
+
+  // Click-away and Escape, matching the menus beside it in this bar.
+  useEffect(() => {
+    if (!open) return;
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!root.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!copied) return;
+    const handle = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(handle);
+  }, [copied]);
+
+  const code = expired ? "unauthorized" : sync.lastErrorCode;
+  const remedy = remedyFor(code, sync.lastErrorDetail);
+  const conflicted = sync.conflicts.length > 0;
+  /**
+   * True when the reason above is already GitHub's own words.
+   *
+   * A failure we cannot classify has nothing to explain it *but* the raw
+   * message, so that goes at the top where the reason belongs — and printing
+   * it again under "Details" would read as two separate things having gone
+   * wrong.
+   */
+  const quoted = Boolean(sync.lastErrorDetail && remedy.reason.includes(sync.lastErrorDetail));
+  const syncing = sync.status === "syncing";
+
+  const headline = conflicted
+    ? `${sync.conflicts.length} note${sync.conflicts.length === 1 ? "" : "s"} changed here and on GitHub`
+    : (sync.lastError ?? "Could not push to GitHub.");
+
+  const details = [
+    `ForkLeaf sync failure`,
+    `Kind: ${code ?? "unknown"}`,
+    sync.lastErrorDetail ? `GitHub said: ${sync.lastErrorDetail}` : null,
+    sync.lastErrorAt ? `Last attempt: ${sync.lastErrorAt}` : null,
+    `Failed attempts since last success: ${sync.failedAttempts}`,
+    `Unpushed changes: ${sync.pendingCount} (${sync.blockedCount} stopped retrying)`,
+    workspace && !workspace.isLocal
+      ? `Repository: ${workspace.repo.owner}/${workspace.repo.repo}@${workspace.repo.branch}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const copyDetails = () => {
+    void navigator.clipboard?.writeText(details).then(
+      () => setCopied(true),
+      () => setCopied(false),
+    );
+  };
+
+  return (
+    <div ref={root} className="relative min-w-0">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        title="What went wrong, and what to do about it"
+        className="flex min-w-0 items-center gap-1.5 rounded px-1.5 py-0.5 hover:bg-[var(--fl-elevated)]"
+      >
+        <span aria-hidden="true" className={`h-1.5 w-1.5 shrink-0 rounded-full ${dot}`} />
+        <span className={labelClassName}>{label}</span>
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Sync problem"
+          className="absolute bottom-full left-0 z-40 mb-1.5 w-[24rem] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] shadow-[var(--fl-shadow-lg)]"
+        >
+          <div className="border-b border-[var(--fl-border)] px-3 py-2.5">
+            <p className="text-[12.5px] font-semibold leading-snug text-[var(--fl-text)]">
+              {headline}
+            </p>
+            {/* Said before anything else, because it is the only question that
+                matters while the rest is being read. */}
+            <p className="mt-1 text-[11.5px] leading-relaxed text-[var(--fl-muted)]">
+              {sync.pendingCount === 0
+                ? "Everything you have written is saved on this device."
+                : `${sync.pendingCount} change${sync.pendingCount === 1 ? " is" : "s are"} saved on this device and not yet on GitHub. Nothing has been lost.`}
+            </p>
+          </div>
+
+          {!conflicted && (
+            <div className="border-b border-[var(--fl-border)] px-3 py-2.5">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+                Why
+              </p>
+              <p className="mt-1 text-[11.5px] leading-relaxed text-[var(--fl-text)]">
+                {remedy.reason}
+              </p>
+            </div>
+          )}
+
+          <div className="border-b border-[var(--fl-border)] px-3 py-2.5">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+              What to do
+            </p>
+            <ol className="mt-1.5 list-decimal space-y-1.5 pl-4 text-[11.5px] leading-relaxed text-[var(--fl-text)] marker:text-[var(--fl-muted)]">
+              {(conflicted ? remedyFor("conflict").steps : remedy.steps).map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="flex flex-wrap gap-1.5 border-b border-[var(--fl-border)] px-3 py-2.5">
+            {conflicted ? (
+              <Primary
+                onClick={() => {
+                  onShowConflicts();
+                  setOpen(false);
+                }}
+              >
+                Resolve conflicts
+              </Primary>
+            ) : expired ? (
+              <Primary
+                onClick={() => {
+                  onSignIn();
+                  setOpen(false);
+                }}
+              >
+                Sign in to GitHub again
+              </Primary>
+            ) : (
+              <Primary onClick={onRetry} disabled={syncing}>
+                {syncing ? "Trying…" : "Try again now"}
+              </Primary>
+            )}
+
+            {/* Retrying an expired token pushes into the same refusal, so it
+                stops being the offer — but a reader who disagrees can still
+                make it, from a button that no longer pretends to be the fix. */}
+            {!conflicted && expired && (
+              <Secondary onClick={onRetry} disabled={syncing}>
+                {syncing ? "Trying…" : "Try again anyway"}
+              </Secondary>
+            )}
+
+            {/* The way past a protected branch, offered where the branch is
+                named as the cause rather than left to be found. */}
+            {code === "forbidden" && workspace && !workspace.isLocal && (
+              <Secondary
+                onClick={() => {
+                  onPropose();
+                  setOpen(false);
+                }}
+              >
+                Open a pull request instead
+              </Secondary>
+            )}
+
+            {workspace && !workspace.isLocal && (
+              <Secondary
+                as="a"
+                href={`https://github.com/${workspace.repo.owner}/${workspace.repo.repo}`}
+              >
+                Open repository
+              </Secondary>
+            )}
+
+            <Secondary onClick={copyDetails}>{copied ? "Copied" : "Copy details"}</Secondary>
+          </div>
+
+          {/* The machine's own words, kept but demoted. `GitRPC::BadObjectState`
+              is no use to somebody writing notes and every use to whoever ends
+              up reading the bug report. */}
+          <div className="px-3 py-2.5">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+              Details
+            </p>
+            <dl className="mt-1.5 space-y-1 text-[11px] leading-relaxed">
+              <Detail term="Kind">{code ?? "unknown"}</Detail>
+              {sync.lastErrorDetail && !quoted && (
+                <Detail term="GitHub said">
+                  <span className="break-words font-mono text-[10.5px]">
+                    {sync.lastErrorDetail}
+                  </span>
+                </Detail>
+              )}
+              {sync.failedAttempts > 0 && (
+                <Detail term="Attempts">
+                  {sync.failedAttempts} failed in a row
+                  {sync.lastErrorAt ? `, last ${when(sync.lastErrorAt)}` : ""}
+                </Detail>
+              )}
+            </dl>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Primary({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-md bg-[var(--fl-accent)] px-2.5 py-1 text-[11.5px] font-semibold text-[var(--fl-accent-contrast)] transition-colors hover:bg-[var(--fl-accent-hover)] disabled:opacity-40"
+    >
+      {children}
+    </button>
+  );
+}
+
+function Secondary({
+  children,
+  onClick,
+  disabled,
+  as,
+  href,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  as?: "a";
+  href?: string;
+}) {
+  const className =
+    "rounded-md border border-[var(--fl-border)] px-2.5 py-1 text-[11.5px] font-medium text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)] disabled:opacity-40";
+
+  if (as === "a") {
+    return (
+      <a href={href} target="_blank" rel="noreferrer" className={className}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" onClick={onClick} disabled={disabled} className={className}>
+      {children}
+    </button>
+  );
+}
+
+function Detail({ term, children }: { term: string; children: React.ReactNode }) {
+  return (
+    <div className="flex gap-2">
+      <dt className="shrink-0 text-[var(--fl-muted)]">{term}</dt>
+      <dd className="min-w-0 flex-1 text-[var(--fl-text)]">{children}</dd>
+    </div>
+  );
+}
+
+function when(iso: string): string {
+  const seconds = Math.round((Date.now() - new Date(iso).getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86400)}d ago`;
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -433,8 +433,13 @@ export function EditorWorkspace() {
       }
     }
 
-    await saveEverything();
-  }, [notebook.sync.status, workspace, signInAgain, saveEverything]);
+    // Straight to the push, not through `saveEverything`. That helper writes
+    // the open note back to its linked file on this computer and stops there
+    // when it does — which is right for ⌘S and wrong here, because it meant a
+    // press of "retry" on a failed *GitHub* push wrote a local file and never
+    // went near the queue. From this control the push is the whole point.
+    await notebook.syncNow();
+  }, [notebook, workspace, signInAgain]);
 
   // ── Actions ─────────────────────────────────────────────────────────────
 

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -226,6 +226,8 @@ export function useNotebook(request: NotebookRequest = {}) {
       lastError: null,
       lastErrorDetail: null,
       lastErrorCode: null,
+      lastErrorAt: null,
+      failedAttempts: 0,
       conflicts: [],
     },
     syncPreference: DEFAULT_SYNC_PREFERENCE,

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,7 +1,14 @@
 export type { LocalDatabase, RemoteGateway, RemoteCommitInput, RemoteCommitResult } from "./ports";
 
 export { coalesce, describeChanges, changeId, type CoalesceInput } from "./queue";
-export { SyncEngine, plainly, codeOf, type SyncEngineOptions } from "./sync-engine";
+export {
+  SyncEngine,
+  plainly,
+  codeOf,
+  remedyFor,
+  type SyncEngineOptions,
+  type SyncRemedy,
+} from "./sync-engine";
 export { MemoryDatabase } from "./memory-db";
 export {
   IndexedDbDatabase,

--- a/packages/store/src/sync-engine.test.ts
+++ b/packages/store/src/sync-engine.test.ts
@@ -3,7 +3,7 @@ import type { Note, SyncMode, TreeNode } from "@forkleaf/types";
 import { SyncEngine } from "./sync-engine";
 import { MemoryDatabase } from "./memory-db";
 import { coalesce, describeChanges } from "./queue";
-import { plainly, codeOf } from "./sync-engine";
+import { plainly, codeOf, remedyFor } from "./sync-engine";
 import type { RemoteCommitInput, RemoteGateway } from "./ports";
 
 // ─── Test doubles ───────────────────────────────────────────────────────────
@@ -367,6 +367,38 @@ describe("a failure reported to the reader", () => {
     expect(codeOf({ status: 401 })).toBe("unauthorized");
     expect(codeOf({ status: 503 })).toBe("server");
     expect(codeOf(new Error("who knows"))).toBe("unknown");
+  });
+
+  /**
+   * The number behind "I keep clicking retry and nothing happens". Without it
+   * the fifth failure is indistinguishable from the first, and the only thing
+   * a reader can conclude is that the button is broken.
+   */
+  it("counts the attempts that have failed in a row", async () => {
+    const ctx = setup();
+    ctx.gateway.rejects.add("a.md");
+
+    await ctx.engine.recordUpsert(makeNote({ path: "a.md", baseSha: null }), "a");
+    await ctx.timers.tick();
+    expect(ctx.engine.state.failedAttempts).toBe(1);
+    expect(ctx.engine.state.lastErrorAt).not.toBeNull();
+
+    ctx.engine.retryNow();
+    await ctx.timers.tick();
+    expect(ctx.engine.state.failedAttempts).toBeGreaterThan(1);
+  });
+
+  /**
+   * Most of what fixes a failed push is something only the person at the
+   * keyboard can do, so the app has to be able to say what that is.
+   */
+  it("offers steps for the failures it cannot fix by itself", () => {
+    expect(remedyFor("forbidden").steps.join(" ")).toContain("write access");
+    expect(remedyFor("forbidden").retryable).toBe(false);
+    expect(remedyFor("network").retryable).toBe(true);
+    // An unrecognised failure has nothing to explain it but GitHub's own words,
+    // so those become the reason rather than being hidden.
+    expect(remedyFor("unknown", "GitRPC::BadObjectState").reason).toContain("BadObjectState");
   });
 
   it("forgets the failure once a push succeeds", async () => {

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -76,6 +76,8 @@ export class SyncEngine {
   private lastError: string | null = null;
   private lastErrorDetail: string | null = null;
   private lastErrorCode: SyncErrorCode | null = null;
+  private lastErrorAt: string | null = null;
+  private failedAttempts = 0;
   private readonly listeners = new Set<Listener>();
 
   constructor(options: SyncEngineOptions) {
@@ -242,6 +244,8 @@ export class SyncEngine {
       lastError: this.lastError,
       lastErrorDetail: this.lastErrorDetail,
       lastErrorCode: this.lastErrorCode,
+      lastErrorAt: this.lastErrorAt,
+      failedAttempts: this.failedAttempts,
       conflicts: this.conflicts,
     };
   }
@@ -490,12 +494,16 @@ export class SyncEngine {
       this.lastError = null;
       this.lastErrorDetail = null;
       this.lastErrorCode = null;
+      this.lastErrorAt = null;
+      this.failedAttempts = 0;
       this.retryDelay = 0;
       this.setStatus(this.restingStatus());
     } catch (err) {
       this.lastError = plainly(err);
       this.lastErrorDetail = err instanceof Error ? err.message : String(err);
       this.lastErrorCode = codeOf(err);
+      this.lastErrorAt = this.now().toISOString();
+      this.failedAttempts += 1;
       // "error" means a push failed and will be tried again by itself. Once
       // nothing is left that *will* be tried again, that reading is wrong and
       // the honest word is "blocked" — it has stopped, and it needs asking.
@@ -1009,6 +1017,135 @@ export function plainly(err: unknown): string {
   }
 
   return "Could not push to GitHub just now. Your work is saved on this device and will be retried.";
+}
+
+/**
+ * What is actually wrong, and what a person can do about it.
+ *
+ * `plainly` is one sentence, because the status bar is one line — and one line
+ * is all somebody gets before they have to decide whether to worry. It is not
+ * enough to act on. "Could not push, will be retried" beside a retry that
+ * keeps failing tells a reader nothing about *why* it keeps failing, so the
+ * only move left is to press the button again, which is exactly the loop this
+ * exists to end.
+ *
+ * So every failure also carries the reason underneath it and the steps worth
+ * taking, in the order worth taking them — including the ones the app cannot
+ * do on the reader's behalf, like giving itself write access to a repository.
+ * `retryable` says whether pressing retry unchanged could plausibly work, so
+ * the UI can stop offering it as the answer when it is not one.
+ */
+export interface SyncRemedy {
+  /** The cause, said as a fact about the world rather than about the app. */
+  reason: string;
+  /** What to do, most likely fix first. */
+  steps: string[];
+  /** True when the same push, unchanged, might succeed on another attempt. */
+  retryable: boolean;
+}
+
+export function remedyFor(code: SyncErrorCode | null, detail?: string | null): SyncRemedy {
+  switch (code) {
+    case "unauthorized":
+      return {
+        reason:
+          "GitHub is refusing this app's sign-in. The token it holds has expired, been revoked, or lost the permission it needs.",
+        steps: [
+          "Sign in to GitHub again — this is the only thing that fixes it.",
+          "If signing in does not help, check that ForkLeaf is still authorised at github.com/settings/applications and has not been revoked.",
+        ],
+        retryable: false,
+      };
+
+    case "forbidden":
+      return {
+        reason:
+          "GitHub knows who you are and will not accept this commit. That is a permission on the repository or the branch, not a problem with your notes.",
+        steps: [
+          "Check you still have write access to this repository on GitHub.",
+          "If the branch is protected, switch to another branch from the status bar, or use “Propose changes…” to open a pull request instead.",
+          "If the repository has been archived, unarchive it — archived repositories accept nothing.",
+        ],
+        retryable: false,
+      };
+
+    case "not-found":
+      return {
+        reason:
+          "The repository or branch this workspace points at is not there any more. It may have been renamed, deleted, or made private to an account you are no longer signed in as.",
+        steps: [
+          "Open the repository on GitHub and confirm it still exists under that name.",
+          "If the branch was deleted, pick another one from the branch menu in the status bar.",
+          "Otherwise connect the workspace again — your notes stay on this device throughout.",
+        ],
+        retryable: false,
+      };
+
+    case "conflict":
+      return {
+        reason: "This note changed on GitHub as well, so there are two versions of it.",
+        steps: [
+          "Open the conflict and choose which version to keep.",
+          "Nothing is overwritten until you choose; both versions are intact.",
+        ],
+        retryable: false,
+      };
+
+    case "validation":
+      return {
+        reason:
+          "GitHub rejected one particular file in this commit. Everything else in it went through.",
+        steps: [
+          "Check the note's path for characters GitHub will not take, and its size — the API refuses files over 100 MB.",
+          "Renaming the note is usually enough to get it moving.",
+        ],
+        retryable: false,
+      };
+
+    case "rate-limited":
+      return {
+        reason: "GitHub is throttling this app for making too many requests too quickly.",
+        steps: [
+          "Wait a few minutes — this clears by itself and the queue keeps retrying.",
+          "If it keeps happening, switch syncing to a timer so a burst of writing becomes one push instead of many.",
+        ],
+        retryable: true,
+      };
+
+    case "network":
+      return {
+        reason: "The request never reached GitHub.",
+        steps: [
+          "Check this device is online.",
+          "If you are on a VPN, a corporate network, or behind a proxy, check that api.github.com is not blocked — that is the usual cause when everything else works.",
+          "The queue retries by itself as soon as the connection is back.",
+        ],
+        retryable: true,
+      };
+
+    case "server":
+      return {
+        reason: "GitHub answered with an error of its own. Nothing is wrong on this device.",
+        steps: [
+          "Check githubstatus.com for an ongoing incident.",
+          "This retries by itself; there is nothing to do but wait it out.",
+        ],
+        retryable: true,
+      };
+
+    default:
+      return {
+        reason: detail
+          ? `The push failed without GitHub giving a reason we recognise. What came back was: ${detail}`
+          : "The push failed without saying why, and no error came back that we recognise.",
+        steps: [
+          "Try again — an attempt that fails this way sometimes succeeds on the next one.",
+          "Check githubstatus.com, and whether a VPN or proxy is intercepting requests to api.github.com.",
+          "If it keeps failing, copy the details below and report it. Your notes stay on this device, and you can export them at any time.",
+        ],
+        retryable: true,
+      };
+  }
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -224,6 +224,23 @@ export interface SyncState {
    * out.
    */
   lastErrorCode: SyncErrorCode | null;
+  /**
+   * When the last push failed, so the UI can say how long this has been true.
+   *
+   * "Could not push" with no time on it reads as a thing that just happened,
+   * every time it is read. It is worth knowing that the last attempt was four
+   * seconds ago and the first one was an hour ago.
+   */
+  lastErrorAt: string | null;
+  /**
+   * Pushes that have failed in a row since the last success.
+   *
+   * The number behind "click to retry" not working: somebody pressing it a
+   * fifth time deserves to be told that the previous four went the same way,
+   * rather than watching the same sentence reappear and concluding the button
+   * is dead.
+   */
+  failedAttempts: number;
   conflicts: Conflict[];
 }
 


### PR DESCRIPTION
## What was wrong

The status bar had one line for a failed push, and one line can only say that something went wrong and offer to try again. When the retry then failed for the same reason, that line reprinted itself unchanged — the cause was named nowhere in the app, so the only move left was to press the button again.

Two separate problems underneath it:

**The reasons already existed; nothing showed them.** `plainly` has had specific sentences for an expired sign-in, missing write access, a deleted repository, rate limits and conflicts. What people were hitting was the last-resort fallback — which means the error arrived unclassified — and GitHub's own message was kept only for a tooltip that the error state never attached.

**Retry did nothing at all in one case.** It went through `saveEverything`, which writes the open note back to its linked file on this computer and returns early when it does. Right for ⌘S, wrong for a retry on a failed *GitHub* push: with a linked note open, every click wrote a local file and never touched the push queue.

## What this does

- **`SyncProblem`** — the red status opens a panel instead of silently retrying: what happened, that the work is safe on this device, **why**, the **steps** that would fix it, the action buttons, and GitHub's raw message under Details with a Copy details button.
- **`remedyFor(code, detail)`** — cause and steps per failure kind, beside `plainly` so the two cannot drift. A protected branch offers "open a pull request instead"; a network failure names the VPN/proxy blocking `api.github.com`, which is the cause nobody guesses; an unclassified failure promotes GitHub's own words to the reason, since that is the only reason available.
- **Retry pushes.** `retrySync` goes straight to `syncNow()`.
- **Attempts are counted.** `failedAttempts` and `lastErrorAt` on `SyncState`, so a fifth attempt says four have already failed rather than reprinting the same sentence.
- **The label stops promising a fix it does not have** — "Not pushed to GitHub — 3 changes waiting. Click to see why." It also stops being truncated mid-word on narrow windows, because the sentence that needed reading in full now lives in the panel.
- **Retry stops being the offer when it cannot work.** An expired sign-in gets the sign-in as the primary action; "Try again anyway" stays for anybody who disagrees. The button reads "Trying…" and disables while a push is in flight, so it no longer looks inert.

## Testing

`pnpm typecheck`, `pnpm lint`, `pnpm build` all pass. 1580 tests pass, including 12 new ones: 10 covering the panel (reason shown, attempt count, per-kind steps, retry, the sign-in substitution, conflicts routed to the resolver) and 2 covering the engine (consecutive-failure counting, `remedyFor`).

Not verified in a browser — reproducing a live push failure needs a signed-in session and a repository that actually rejects the commit, so the panel is covered by rendering tests rather than a screenshot.

## Follow-up worth knowing about

`GitHubError.toJSON` sends `code` and `message` but not `status`, and `errorCodeForStatus` maps everything unrecognised (including 5xx) to `unknown`. That is part of why failures were reaching the fallback in the first place. This PR makes an unclassified failure legible rather than silent; narrowing what lands there is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)