### PR TITLE
fix(sync): a push too big to send is named, findable, and removable

### DIFF
--- a/apps/web/src/app/api/gh/commit/route.ts
+++ b/apps/web/src/app/api/gh/commit/route.ts
@@ -4,8 +4,13 @@ import { handle, requireClient, readRepoRefFromBody, normalize, ApiError } from 
 import { enforceRateLimit } from "@/lib/rate-limit";
 import { imageTypeFor, MAX_IMAGE_BYTES } from "@/lib/media";
 
-/** Largest single note we will accept, to keep one bad paste from wedging a repo. */
-const MAX_FILE_BYTES = 5 * 1024 * 1024;
+/**
+ * Largest single note we will accept, to keep one bad paste from wedging a
+ * repo — and to stay under what the host will carry in one request body, which
+ * is the lower of the two limits and the one that used to be discovered only
+ * as an unexplained 413 at push time.
+ */
+const MAX_FILE_BYTES = 3 * 1024 * 1024;
 const MAX_CHANGES_PER_COMMIT = 100;
 
 interface CommitBody {
@@ -131,13 +136,13 @@ function assertImage(content: string, path: string): void {
   // Base64 carries three bytes in every four characters; no need to decode to
   // know whether it is over the limit.
   if (Math.floor((packed.length * 3) / 4) > MAX_IMAGE_BYTES) {
-    throw new ApiError(413, "validation", `${path} is larger than 10 MB.`);
+    throw new ApiError(413, "too-large", `${path} is larger than 3 MB.`);
   }
 }
 
 function assertSize(content: string, path: string): void {
   // Byte length, not character count — a note full of emoji is larger than it looks.
   if (new TextEncoder().encode(content).length > MAX_FILE_BYTES) {
-    throw new ApiError(413, "validation", `${path} is too large to save (limit 5 MB).`);
+    throw new ApiError(413, "too-large", `${path} is too large to save (limit 3 MB).`);
   }
 }

--- a/apps/web/src/app/docs/content/writing.tsx
+++ b/apps/web/src/app/docs/content/writing.tsx
@@ -103,7 +103,7 @@ export function Editor() {
       <P>
         Paste a screenshot straight into a note, drag a file onto it, or use the{" "}
         <strong>Image</strong> button — all three work in Rich, Split and Source. PNG, JPEG, GIF,
-        WebP, AVIF, BMP and ICO are accepted, up to 10 MB each. SVG is not: it is a document format
+        WebP, AVIF, BMP and ICO are accepted, up to 3 MB each. SVG is not: it is a document format
         that can carry script, and serving one back would be a hole in every note that embeds it.
       </P>
       <P>

--- a/apps/web/src/components/EditorStatusBar.tsx
+++ b/apps/web/src/components/EditorStatusBar.tsx
@@ -58,6 +58,8 @@ export interface EditorStatusBarProps {
    * is the sign-in, the button has to be the sign-in.
    */
   onSignIn: () => void;
+  /** Removes one change that can never be pushed, and the file behind it. */
+  onDiscardChange: (id: string) => void;
 }
 
 /**
@@ -82,6 +84,7 @@ export function EditorStatusBar({
   onSwitchBranch,
   onPropose,
   onSignIn,
+  onDiscardChange,
   sessionExpired = false,
 }: EditorStatusBarProps) {
   /**
@@ -119,6 +122,7 @@ export function EditorStatusBar({
           onSignIn={onSignIn}
           onShowConflicts={onShowConflicts}
           onPropose={onPropose}
+          onDiscard={onDiscardChange}
         />
       ) : (
         <button

--- a/apps/web/src/components/EditorStatusBar.tsx
+++ b/apps/web/src/components/EditorStatusBar.tsx
@@ -60,6 +60,8 @@ export interface EditorStatusBarProps {
   onSignIn: () => void;
   /** Removes one change that can never be pushed, and the file behind it. */
   onDiscardChange: (id: string) => void;
+  /** Opens the note an unsynced file lives in, so it can be dealt with. */
+  onLocateChange: (path: string) => void;
 }
 
 /**
@@ -85,6 +87,7 @@ export function EditorStatusBar({
   onPropose,
   onSignIn,
   onDiscardChange,
+  onLocateChange,
   sessionExpired = false,
 }: EditorStatusBarProps) {
   /**
@@ -123,6 +126,7 @@ export function EditorStatusBar({
           onShowConflicts={onShowConflicts}
           onPropose={onPropose}
           onDiscard={onDiscardChange}
+          onLocate={onLocateChange}
         />
       ) : (
         <button

--- a/apps/web/src/components/SyncProblem.test.tsx
+++ b/apps/web/src/components/SyncProblem.test.tsx
@@ -47,6 +47,7 @@ function view(sync: SyncState, over: Partial<React.ComponentProps<typeof SyncPro
     onSignIn: vi.fn(),
     onShowConflicts: vi.fn(),
     onPropose: vi.fn(),
+    onDiscard: vi.fn(),
     ...over,
   };
   render(<SyncProblem {...props} />);
@@ -108,14 +109,41 @@ describe("SyncProblem — the reason, not just the failure", () => {
         lastErrorDetail: "assets/screenshot.png is 6.2 MB, which is too big",
         blockedCount: 1,
         blockedChanges: [
-          { path: "assets/screenshot.png", error: "assets/screenshot.png is 6.2 MB" },
+          {
+            id: "w::assets/screenshot.png",
+            path: "assets/screenshot.png",
+            error: "assets/screenshot.png is 6.2 MB",
+          },
         ],
       }),
     );
     open();
     expect(screen.getByText("assets/screenshot.png")).toBeTruthy();
     expect(screen.getByText(/pasted image/)).toBeTruthy();
-    expect(screen.getByText(/delete it from the note/)).toBeTruthy();
+  });
+
+  /**
+   * The step nobody can actually perform on their own: the file is called
+   * something like `Pasted image 20260828.png` and lives in one of hundreds of
+   * notes. The app is holding the change, so the app removes it.
+   */
+  it("removes the stuck file itself rather than describing where to look", () => {
+    const props = view(
+      state({
+        status: "blocked",
+        lastErrorCode: "too-large",
+        blockedCount: 1,
+        blockedChanges: [
+          { id: "w::assets/screenshot.png", path: "assets/screenshot.png", error: "6.2 MB" },
+        ],
+      }),
+    );
+    open();
+    fireEvent.click(screen.getByRole("button", { name: /Remove assets\/screenshot\.png/ }));
+    expect(props.onDiscard).toHaveBeenCalledWith("w::assets/screenshot.png");
+    // And says what it did and did not touch, since "remove" beside a filename
+    // could be read as deleting the note.
+    expect(screen.getByText(/notes and their text are untouched/)).toBeTruthy();
   });
 });
 

--- a/apps/web/src/components/SyncProblem.test.tsx
+++ b/apps/web/src/components/SyncProblem.test.tsx
@@ -29,7 +29,7 @@ function state(over: Partial<SyncState> = {}): SyncState {
     lastErrorCode: "unknown",
     lastErrorAt: new Date().toISOString(),
     failedAttempts: 4,
-    blockedChanges: [],
+    unpushed: [],
     conflicts: [],
     ...over,
   };
@@ -48,6 +48,7 @@ function view(sync: SyncState, over: Partial<React.ComponentProps<typeof SyncPro
     onShowConflicts: vi.fn(),
     onPropose: vi.fn(),
     onDiscard: vi.fn(),
+    onLocate: vi.fn(),
     ...over,
   };
   render(<SyncProblem {...props} />);
@@ -108,10 +109,13 @@ describe("SyncProblem — the reason, not just the failure", () => {
         lastErrorCode: "too-large",
         lastErrorDetail: "assets/screenshot.png is 6.2 MB, which is too big",
         blockedCount: 1,
-        blockedChanges: [
+        unpushed: [
           {
             id: "w::assets/screenshot.png",
             path: "assets/screenshot.png",
+            bytes: 6.2 * 1024 * 1024,
+            tooLarge: true,
+            blocked: true,
             error: "assets/screenshot.png is 6.2 MB",
           },
         ],
@@ -133,8 +137,15 @@ describe("SyncProblem — the reason, not just the failure", () => {
         status: "blocked",
         lastErrorCode: "too-large",
         blockedCount: 1,
-        blockedChanges: [
-          { id: "w::assets/screenshot.png", path: "assets/screenshot.png", error: "6.2 MB" },
+        unpushed: [
+          {
+            id: "w::assets/screenshot.png",
+            path: "assets/screenshot.png",
+            bytes: 6.2 * 1024 * 1024,
+            tooLarge: true,
+            blocked: true,
+            error: "6.2 MB",
+          },
         ],
       }),
     );
@@ -144,6 +155,66 @@ describe("SyncProblem — the reason, not just the failure", () => {
     // And says what it did and did not touch, since "remove" beside a filename
     // could be read as deleting the note.
     expect(screen.getByText(/notes and their text are untouched/)).toBeTruthy();
+  });
+});
+
+describe("SyncProblem — what did not get synced", () => {
+  const queue = [
+    {
+      id: "w::assets/Pasted image 20260828.png",
+      path: "assets/Pasted image 20260828.png",
+      bytes: 6.2 * 1024 * 1024,
+      tooLarge: true,
+      blocked: false,
+      error: null,
+    },
+    {
+      id: "w::notes/tcm.md",
+      path: "notes/tcm.md",
+      bytes: 4096,
+      tooLarge: false,
+      blocked: false,
+      error: null,
+    },
+  ];
+
+  /**
+   * The state the bar is most often read in — still failing, still retrying,
+   * nothing parked yet. It used to list nothing at all here, which is how "2
+   * changes waiting" ended up meaning "waiting for what, exactly".
+   */
+  it("lists the files while the push is still retrying, not only once it gives up", () => {
+    view(state({ status: "error", blockedCount: 0, unpushed: queue }));
+    open();
+    expect(screen.getByText("Not synced (2)")).toBeTruthy();
+    expect(screen.getByText("assets/Pasted image 20260828.png")).toBeTruthy();
+    expect(screen.getByText("notes/tcm.md")).toBeTruthy();
+  });
+
+  it("says which one is too big, and how big it is", () => {
+    view(state({ unpushed: queue }));
+    open();
+    expect(screen.getByText(/6\.2 MB/)).toBeTruthy();
+    expect(screen.getByText(/Too big to send/)).toBeTruthy();
+  });
+
+  /**
+   * The queue is better evidence than the last error: a batch carrying an
+   * oversized file can die as a timeout or a 500 depending on where it fails,
+   * and each of those would otherwise send the reader somewhere useless.
+   */
+  it("blames the large file even when the last attempt reported something else", () => {
+    view(state({ lastErrorCode: "network", unpushed: queue }));
+    open();
+    expect(screen.getByText(/A file is too big to send to GitHub/)).toBeTruthy();
+    expect(screen.getByText(/pasted image/)).toBeTruthy();
+  });
+
+  it("finds the note a stuck picture lives in, rather than describing the search", () => {
+    const props = view(state({ unpushed: queue }));
+    open();
+    fireEvent.click(screen.getByRole("button", { name: /Find assets\/Pasted image/ }));
+    expect(props.onLocate).toHaveBeenCalledWith("assets/Pasted image 20260828.png");
   });
 });
 

--- a/apps/web/src/components/SyncProblem.test.tsx
+++ b/apps/web/src/components/SyncProblem.test.tsx
@@ -29,6 +29,7 @@ function state(over: Partial<SyncState> = {}): SyncState {
     lastErrorCode: "unknown",
     lastErrorAt: new Date().toISOString(),
     failedAttempts: 4,
+    blockedChanges: [],
     conflicts: [],
     ...over,
   };
@@ -92,6 +93,29 @@ describe("SyncProblem — the reason, not just the failure", () => {
     view(state({ lastErrorCode: "network" }));
     open();
     expect(screen.getByText(/api\.github\.com is not blocked/)).toBeTruthy();
+  });
+
+  /**
+   * The failure that made the old status bar a dead end. Retrying sends the
+   * same oversized request and signing in again changes nothing about it, so
+   * the file has to be named or there is nothing anybody can do.
+   */
+  it("names the file that is too big to send, and says so as the reason", () => {
+    view(
+      state({
+        status: "blocked",
+        lastErrorCode: "too-large",
+        lastErrorDetail: "assets/screenshot.png is 6.2 MB, which is too big",
+        blockedCount: 1,
+        blockedChanges: [
+          { path: "assets/screenshot.png", error: "assets/screenshot.png is 6.2 MB" },
+        ],
+      }),
+    );
+    open();
+    expect(screen.getByText("assets/screenshot.png")).toBeTruthy();
+    expect(screen.getByText(/pasted image/)).toBeTruthy();
+    expect(screen.getByText(/delete it from the note/)).toBeTruthy();
   });
 });
 

--- a/apps/web/src/components/SyncProblem.tsx
+++ b/apps/web/src/components/SyncProblem.tsx
@@ -104,6 +104,9 @@ export function SyncProblem({
     sync.lastErrorAt ? `Last attempt: ${sync.lastErrorAt}` : null,
     `Failed attempts since last success: ${sync.failedAttempts}`,
     `Unpushed changes: ${sync.pendingCount} (${sync.blockedCount} stopped retrying)`,
+    ...sync.blockedChanges.map(
+      (change) => `  stuck: ${change.path}${change.error ? ` — ${change.error}` : ""}`,
+    ),
     workspace && !workspace.isLocal
       ? `Repository: ${workspace.repo.owner}/${workspace.repo.repo}@${workspace.repo.branch}`
       : null,
@@ -231,6 +234,34 @@ export function SyncProblem({
 
             <Secondary onClick={copyDetails}>{copied ? "Copied" : "Copy details"}</Secondary>
           </div>
+
+          {/* Which files. A count names nothing to go and fix, and the failure
+              that most needs fixing — a file too big to send — is always about
+              one specific file. */}
+          {sync.blockedChanges.length > 0 && (
+            <div className="border-b border-[var(--fl-border)] px-3 py-2.5">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+                Stuck {sync.blockedChanges.length === 1 ? "file" : "files"}
+              </p>
+              <ul className="mt-1.5 space-y-1.5">
+                {sync.blockedChanges.slice(0, 5).map((change) => (
+                  <li key={change.path} className="text-[11.5px] leading-relaxed">
+                    <span className="break-all font-mono text-[10.5px] text-[var(--fl-text)]">
+                      {change.path}
+                    </span>
+                    {change.error && (
+                      <span className="mt-0.5 block text-[var(--fl-muted)]">{change.error}</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+              {sync.blockedChanges.length > 5 && (
+                <p className="mt-1.5 text-[11px] text-[var(--fl-muted)]">
+                  …and {sync.blockedChanges.length - 5} more.
+                </p>
+              )}
+            </div>
+          )}
 
           {/* The machine's own words, kept but demoted. `GitRPC::BadObjectState`
               is no use to somebody writing notes and every use to whoever ends

--- a/apps/web/src/components/SyncProblem.tsx
+++ b/apps/web/src/components/SyncProblem.tsx
@@ -19,6 +19,15 @@ export interface SyncProblemProps {
   onShowConflicts: () => void;
   /** Opens the pull-request flow — the way out of a protected branch. */
   onPropose: () => void;
+  /**
+   * Removes one stuck change from the queue, and the file behind it.
+   *
+   * The alternative was telling somebody to go and find a file called
+   * `Pasted image 20260828.png` inside one of several hundred notes, which is
+   * not a thing anybody can do. If the app knows which change is stuck — and
+   * it does, it is holding it — it can be the one to remove it.
+   */
+  onDiscard: (id: string) => void;
 }
 
 /**
@@ -49,6 +58,7 @@ export function SyncProblem({
   onSignIn,
   onShowConflicts,
   onPropose,
+  onDiscard,
 }: SyncProblemProps) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -245,10 +255,24 @@ export function SyncProblem({
               </p>
               <ul className="mt-1.5 space-y-1.5">
                 {sync.blockedChanges.slice(0, 5).map((change) => (
-                  <li key={change.path} className="text-[11.5px] leading-relaxed">
-                    <span className="break-all font-mono text-[10.5px] text-[var(--fl-text)]">
-                      {change.path}
-                    </span>
+                  <li key={change.id} className="text-[11.5px] leading-relaxed">
+                    <div className="flex items-start gap-2">
+                      <span className="min-w-0 flex-1 break-all font-mono text-[10.5px] text-[var(--fl-text)]">
+                        {change.path}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => onDiscard(change.id)}
+                        title={`Remove ${change.path} from the queue`}
+                        // Several stuck files mean several buttons reading
+                        // "Remove", which tells a screen reader nothing about
+                        // which file it is about to remove.
+                        aria-label={`Remove ${change.path} from the queue`}
+                        className="shrink-0 rounded border border-[var(--fl-border)] px-1.5 py-0.5 text-[10.5px] font-medium text-[var(--fl-danger)] transition-colors hover:bg-[var(--fl-elevated)]"
+                      >
+                        Remove
+                      </button>
+                    </div>
                     {change.error && (
                       <span className="mt-0.5 block text-[var(--fl-muted)]">{change.error}</span>
                     )}
@@ -260,6 +284,12 @@ export function SyncProblem({
                   …and {sync.blockedChanges.length - 5} more.
                 </p>
               )}
+              {/* Said plainly, because "remove" beside a filename could
+                  reasonably be read as deleting the note it sits in. */}
+              <p className="mt-2 text-[11px] leading-relaxed text-[var(--fl-muted)]">
+                Removing takes the file out of the queue so everything behind it can push. Your
+                notes and their text are untouched.
+              </p>
             </div>
           )}
 

--- a/apps/web/src/components/SyncProblem.tsx
+++ b/apps/web/src/components/SyncProblem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { remedyFor } from "@forkleaf/store";
+import { remedyFor, MAX_REQUEST_BYTES } from "@forkleaf/store";
 import type { SyncState, Workspace } from "@forkleaf/types";
 
 export interface SyncProblemProps {
@@ -28,6 +28,15 @@ export interface SyncProblemProps {
    * it does, it is holding it — it can be the one to remove it.
    */
   onDiscard: (id: string) => void;
+  /**
+   * Opens the note a stuck file lives in.
+   *
+   * "Delete the image from the note" assumes the reader can find the note. For
+   * a picture called `Pasted image 20260828.png` in a notebook of several
+   * hundred, they cannot — so the app takes them there instead of describing
+   * where to look.
+   */
+  onLocate: (path: string) => void;
 }
 
 /**
@@ -59,6 +68,7 @@ export function SyncProblem({
   onShowConflicts,
   onPropose,
   onDiscard,
+  onLocate,
 }: SyncProblemProps) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -89,7 +99,19 @@ export function SyncProblem({
     return () => clearTimeout(handle);
   }, [copied]);
 
-  const code = expired ? "unauthorized" : sync.lastErrorCode;
+  const oversized = sync.unpushed.filter((change) => change.tooLarge);
+  /**
+   * A file too big to send outranks whatever the last attempt happened to
+   * report.
+   *
+   * The queue is the evidence, and it is better evidence than the error: a
+   * batch containing an oversized file can fail with a timeout, a 500, or the
+   * platform's own unexplained 413 depending on where it dies, and every one
+   * of those sends the reader somewhere useless. If something in the queue
+   * cannot be sent, that is the reason, and it stays the reason until it is
+   * out of the queue.
+   */
+  const code = oversized.length > 0 ? "too-large" : expired ? "unauthorized" : sync.lastErrorCode;
   const remedy = remedyFor(code, sync.lastErrorDetail);
   const conflicted = sync.conflicts.length > 0;
   /**
@@ -105,7 +127,9 @@ export function SyncProblem({
 
   const headline = conflicted
     ? `${sync.conflicts.length} note${sync.conflicts.length === 1 ? "" : "s"} changed here and on GitHub`
-    : (sync.lastError ?? "Could not push to GitHub.");
+    : oversized.length > 0
+      ? `${oversized.length === 1 ? "A file is" : `${oversized.length} files are`} too big to send to GitHub`
+      : (sync.lastError ?? "Could not push to GitHub.");
 
   const details = [
     `ForkLeaf sync failure`,
@@ -114,8 +138,9 @@ export function SyncProblem({
     sync.lastErrorAt ? `Last attempt: ${sync.lastErrorAt}` : null,
     `Failed attempts since last success: ${sync.failedAttempts}`,
     `Unpushed changes: ${sync.pendingCount} (${sync.blockedCount} stopped retrying)`,
-    ...sync.blockedChanges.map(
-      (change) => `  stuck: ${change.path}${change.error ? ` — ${change.error}` : ""}`,
+    ...sync.unpushed.map(
+      (change) =>
+        `  ${change.tooLarge ? "too large" : change.blocked ? "stopped" : "waiting"}: ${change.path} (${size(change.bytes)})${change.error ? ` — ${change.error}` : ""}`,
     ),
     workspace && !workspace.isLocal
       ? `Repository: ${workspace.repo.owner}/${workspace.repo.repo}@${workspace.repo.branch}`
@@ -245,50 +270,87 @@ export function SyncProblem({
             <Secondary onClick={copyDetails}>{copied ? "Copied" : "Copy details"}</Secondary>
           </div>
 
-          {/* Which files. A count names nothing to go and fix, and the failure
-              that most needs fixing — a file too big to send — is always about
-              one specific file. */}
-          {sync.blockedChanges.length > 0 && (
+          {/* What has not synced. Everything queued, not only what has given
+              up — a push that is still failing and retrying is the state
+              somebody is most likely to be reading this in, and it used to
+              show no files at all. Oversized first: it is the one that has to
+              go before anything else moves. */}
+          {sync.unpushed.length > 0 && (
             <div className="border-b border-[var(--fl-border)] px-3 py-2.5">
               <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
-                Stuck {sync.blockedChanges.length === 1 ? "file" : "files"}
+                Not synced ({sync.unpushed.length})
               </p>
-              <ul className="mt-1.5 space-y-1.5">
-                {sync.blockedChanges.slice(0, 5).map((change) => (
-                  <li key={change.id} className="text-[11.5px] leading-relaxed">
-                    <div className="flex items-start gap-2">
-                      <span className="min-w-0 flex-1 break-all font-mono text-[10.5px] text-[var(--fl-text)]">
-                        {change.path}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => onDiscard(change.id)}
-                        title={`Remove ${change.path} from the queue`}
-                        // Several stuck files mean several buttons reading
-                        // "Remove", which tells a screen reader nothing about
-                        // which file it is about to remove.
-                        aria-label={`Remove ${change.path} from the queue`}
-                        className="shrink-0 rounded border border-[var(--fl-border)] px-1.5 py-0.5 text-[10.5px] font-medium text-[var(--fl-danger)] transition-colors hover:bg-[var(--fl-elevated)]"
-                      >
-                        Remove
-                      </button>
-                    </div>
-                    {change.error && (
-                      <span className="mt-0.5 block text-[var(--fl-muted)]">{change.error}</span>
-                    )}
-                  </li>
-                ))}
+              <ul className="mt-1.5 space-y-2">
+                {[...sync.unpushed]
+                  .sort((a, b) => Number(b.tooLarge) - Number(a.tooLarge) || b.bytes - a.bytes)
+                  .slice(0, 6)
+                  .map((change) => (
+                    <li key={change.id} className="text-[11.5px] leading-relaxed">
+                      <div className="flex items-start gap-2">
+                        <span className="min-w-0 flex-1">
+                          <span className="block break-all font-mono text-[10.5px] text-[var(--fl-text)]">
+                            {change.path}
+                          </span>
+                          <span className="mt-0.5 block text-[10.5px] text-[var(--fl-muted)]">
+                            {size(change.bytes)}
+                            {change.tooLarge && (
+                              <span className="ml-1.5 rounded bg-[var(--fl-danger-soft,var(--fl-elevated))] px-1 py-px font-semibold uppercase tracking-wide text-[9.5px] text-[var(--fl-danger)]">
+                                Too big to send — over {size(MAX_REQUEST_BYTES)}
+                              </span>
+                            )}
+                            {!change.tooLarge && change.blocked && (
+                              <span className="ml-1.5 text-[var(--fl-danger)]">stopped trying</span>
+                            )}
+                          </span>
+                        </span>
+
+                        <span className="flex shrink-0 gap-1">
+                          {/* The answer to "I cannot find those images". */}
+                          <button
+                            type="button"
+                            onClick={() => {
+                              onLocate(change.path);
+                              setOpen(false);
+                            }}
+                            title={`Open the note ${change.path} is in`}
+                            aria-label={`Find ${change.path}`}
+                            className="rounded border border-[var(--fl-border)] px-1.5 py-0.5 text-[10.5px] font-medium text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)]"
+                          >
+                            Find
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onDiscard(change.id)}
+                            title={`Remove ${change.path} from the queue`}
+                            // Several files mean several buttons reading
+                            // "Remove", which tells a screen reader nothing
+                            // about which file it is about to remove.
+                            aria-label={`Remove ${change.path} from the queue`}
+                            className="rounded border border-[var(--fl-border)] px-1.5 py-0.5 text-[10.5px] font-medium text-[var(--fl-danger)] transition-colors hover:bg-[var(--fl-elevated)]"
+                          >
+                            Remove
+                          </button>
+                        </span>
+                      </div>
+                      {change.error && (
+                        <span className="mt-0.5 block text-[var(--fl-muted)]">{change.error}</span>
+                      )}
+                    </li>
+                  ))}
               </ul>
-              {sync.blockedChanges.length > 5 && (
+              {sync.unpushed.length > 6 && (
                 <p className="mt-1.5 text-[11px] text-[var(--fl-muted)]">
-                  …and {sync.blockedChanges.length - 5} more.
+                  …and {sync.unpushed.length - 6} more.
                 </p>
               )}
               {/* Said plainly, because "remove" beside a filename could
                   reasonably be read as deleting the note it sits in. */}
               <p className="mt-2 text-[11px] leading-relaxed text-[var(--fl-muted)]">
-                Removing takes the file out of the queue so everything behind it can push. Your
-                notes and their text are untouched.
+                <strong className="font-semibold text-[var(--fl-text)]">Find</strong> opens the note
+                the file is in.{" "}
+                <strong className="font-semibold text-[var(--fl-text)]">Remove</strong> takes it out
+                of the queue so everything behind it can push — your notes and their text are
+                untouched.
               </p>
             </div>
           )}
@@ -382,6 +444,13 @@ function Detail({ term, children }: { term: string; children: React.ReactNode })
       <dd className="min-w-0 flex-1 text-[var(--fl-text)]">{children}</dd>
     </div>
   );
+}
+
+/** A byte count as somebody would say it. */
+function size(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${bytes} bytes`;
 }
 
 function when(iso: string): string {

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -1678,6 +1678,7 @@ export function EditorWorkspace() {
         onSyncNow={() => void retrySync()}
         onShowConflicts={() => setConflictsDismissed(false)}
         onSignIn={signInAgain}
+        onDiscardChange={(id) => void notebook.discardChange(id)}
       />
 
       {/* ── Dialogs ────────────────────────────────────────────────────── */}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -47,6 +47,7 @@ import { LocalOnlyBanner } from "@/components/LocalOnlyBanner";
 import { fetchSession, signOut } from "@/lib/gateway";
 import { postHogReset } from "@/lib/posthog";
 import { assetPathFor, relativeSrc, resolveImageSrc } from "@/lib/assets";
+import { imageTypeFor } from "@/lib/media";
 import { collectFolders } from "@/lib/tree";
 import { hasRelativeImages, repairNoteLinks } from "@/lib/repair-links";
 import { flattenTree, isMarkdown } from "@/lib/library";
@@ -440,6 +441,40 @@ export function EditorWorkspace() {
     // went near the queue. From this control the push is the whole point.
     await notebook.syncNow();
   }, [notebook, workspace, signInAgain]);
+
+  /**
+   * Opens whatever a stuck file needs somebody to look at.
+   *
+   * A note is its own answer — open it. A picture is not: it has no note of
+   * its own, it lives inside one, and the one thing the reader needs is to be
+   * standing in front of that note with the image in view. So its filename is
+   * looked for across the notebook and the note carrying it is opened.
+   *
+   * A picture nothing references any more still gets an honest outcome: there
+   * is nowhere to go, and saying so beats opening an unrelated note.
+   */
+  const locateUnsynced = useCallback(
+    async (path: string) => {
+      if (!imageTypeFor(path)) {
+        await notebook.openNote(path);
+        return;
+      }
+
+      const name = path.split("/").pop() ?? path;
+      const notes = await notebook.allNotes();
+      const holder = notes.find((note) => note.content.includes(name));
+
+      if (holder) {
+        await notebook.openNote(holder.path);
+        return;
+      }
+
+      setNotice(
+        `${name} is not referenced by any note any more. Removing it will unblock everything else.`,
+      );
+    },
+    [notebook],
+  );
 
   // ── Actions ─────────────────────────────────────────────────────────────
 
@@ -1679,6 +1714,7 @@ export function EditorWorkspace() {
         onShowConflicts={() => setConflictsDismissed(false)}
         onSignIn={signInAgain}
         onDiscardChange={(id) => void notebook.discardChange(id)}
+        onLocateChange={(path) => void locateUnsynced(path)}
       />
 
       {/* ── Dialogs ────────────────────────────────────────────────────── */}

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -1349,6 +1349,17 @@ export function useNotebook(request: NotebookRequest = {}) {
   }, [state.activeWorkspace]);
 
   /**
+   * Drops one stuck change, so the queue behind it can move.
+   *
+   * The way out of a change that can never be pushed. Needs a refresh of the
+   * sync state afterwards because the queue is the thing that changed, and
+   * nothing about a removal arrives through a push.
+   */
+  const discardChange = useCallback(async (id: string) => {
+    await syncRef.current?.discardChange(id);
+  }, []);
+
+  /**
    * Changes how eagerly this workspace pushes.
    *
    * Auto is the default and stays the default; this only exists for the people
@@ -1538,6 +1549,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       pullRemote,
       pendingChanges,
       discardPending,
+      discardChange,
       setSyncMode,
       resolveConflict,
       allNotes,
@@ -1593,6 +1605,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       pullRemote,
       pendingChanges,
       discardPending,
+      discardChange,
       setSyncMode,
       resolveConflict,
       allNotes,

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -228,7 +228,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       lastErrorCode: null,
       lastErrorAt: null,
       failedAttempts: 0,
-      blockedChanges: [],
+      unpushed: [],
       conflicts: [],
     },
     syncPreference: DEFAULT_SYNC_PREFERENCE,

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -228,6 +228,7 @@ export function useNotebook(request: NotebookRequest = {}) {
       lastErrorCode: null,
       lastErrorAt: null,
       failedAttempts: 0,
+      blockedChanges: [],
       conflicts: [],
     },
     syncPreference: DEFAULT_SYNC_PREFERENCE,

--- a/apps/web/src/lib/assets.ts
+++ b/apps/web/src/lib/assets.ts
@@ -233,7 +233,9 @@ export async function assetFrom(options: {
   const { workspace, repoPath, file, pushed } = options;
 
   if (file.size > MAX_IMAGE_BYTES) {
-    throw new Error("That image is larger than 10 MB.");
+    throw new Error(
+      `That image is ${(file.size / (1024 * 1024)).toFixed(1)} MB. Images have to be under 3 MB to be committed to GitHub — save a smaller copy and paste that instead.`,
+    );
   }
 
   return {

--- a/apps/web/src/lib/media.ts
+++ b/apps/web/src/lib/media.ts
@@ -18,8 +18,19 @@ export const IMAGE_TYPES: Record<string, string> = {
   ico: "image/x-icon",
 };
 
-/** Largest image we will commit. Repositories are not an asset CDN. */
-export const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+/**
+ * Largest image we will commit.
+ *
+ * Repositories are not an asset CDN, and the ceiling is lower than it looks:
+ * an image travels to the commit route as base64 inside a JSON body, which is
+ * a third bigger again than the file, and the host in front of that route
+ * refuses a body over 4.5 MB before any of our code runs. The old 10 MB limit
+ * was therefore a promise the app could not keep — the paste was accepted, the
+ * note saved, and the push then failed 413 forever with nothing said about
+ * which file was at fault. Refusing the picture at the moment it is pasted is
+ * the honest version of the same limit.
+ */
+export const MAX_IMAGE_BYTES = 3 * 1024 * 1024;
 
 /** Extension of a path, lowercased and without the dot. */
 export function extensionOf(path: string): string {

--- a/packages/editor/src/ui/ImageDialog.tsx
+++ b/packages/editor/src/ui/ImageDialog.tsx
@@ -121,7 +121,7 @@ export function ImageDialog({
               Drop an image here, or choose a file
             </p>
             <p className="mt-1 text-[12.5px] text-[var(--fl-muted)]">
-              PNG, JPEG, GIF, WebP, AVIF, BMP or ICO, up to 10 MB. You can also paste one straight
+              PNG, JPEG, GIF, WebP, AVIF, BMP or ICO, up to 3 MB. You can also paste one straight
               into the note.
             </p>
 

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -6,6 +6,8 @@ export {
   plainly,
   codeOf,
   remedyFor,
+  batchBySize,
+  MAX_REQUEST_BYTES,
   type SyncEngineOptions,
   type SyncRemedy,
 } from "./sync-engine";

--- a/packages/store/src/sync-engine.test.ts
+++ b/packages/store/src/sync-engine.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Note, SyncMode, TreeNode } from "@forkleaf/types";
+import type { Note, PendingChange, SyncMode, TreeNode } from "@forkleaf/types";
 import { SyncEngine } from "./sync-engine";
 import { MemoryDatabase } from "./memory-db";
 import { coalesce, describeChanges } from "./queue";
-import { plainly, codeOf, remedyFor } from "./sync-engine";
+import { plainly, codeOf, remedyFor, batchBySize } from "./sync-engine";
 import type { RemoteCommitInput, RemoteGateway } from "./ports";
 
 // ─── Test doubles ───────────────────────────────────────────────────────────
@@ -399,6 +399,53 @@ describe("a failure reported to the reader", () => {
     // An unrecognised failure has nothing to explain it but GitHub's own words,
     // so those become the reason rather than being hidden.
     expect(remedyFor("unknown", "GitRPC::BadObjectState").reason).toContain("BadObjectState");
+  });
+
+  /**
+   * The failure that made all of this necessary. A pasted screenshot made a
+   * request bigger than the host in front of the API will carry, so the push
+   * came back 413 before any of our code ran — unclassified, unexplained, and
+   * identical on every retry. Nothing had checked the size before sending.
+   */
+  it("stops a change too big to send instead of failing on it forever", async () => {
+    const ctx = setup();
+    const huge = "x".repeat(4 * 1024 * 1024);
+
+    await ctx.engine.recordUpsert(makeNote({ path: "big.md", baseSha: null }), huge);
+    await ctx.engine.recordUpsert(makeNote({ path: "small.md", baseSha: null }), "ordinary");
+    await ctx.timers.tick();
+
+    // The one that cannot be sent is parked at once, named, and told why.
+    expect(ctx.engine.state.lastErrorCode).toBe("too-large");
+    const stuck = ctx.engine.state.blockedChanges;
+    expect(stuck.map((change) => change.path)).toEqual(["big.md"]);
+    expect(stuck[0]?.error).toContain("too big to send");
+
+    // And it no longer takes everything else down with it.
+    expect(ctx.gateway.commits.length).toBeGreaterThan(0);
+    expect(ctx.engine.pendingFor().map((change) => change.path)).toEqual(["big.md"]);
+  });
+
+  it("packs the queue into requests that fit rather than one that does not", () => {
+    const change = (path: string, bytes: number): PendingChange => ({
+      id: path,
+      workspaceId: "w",
+      path,
+      op: "upsert",
+      content: "x".repeat(bytes),
+      baseSha: null,
+      queuedAt: new Date().toISOString(),
+      attempts: 0,
+    });
+
+    const { batches, oversized } = batchBySize([
+      change("a.md", 2 * 1024 * 1024),
+      change("b.md", 2 * 1024 * 1024),
+      change("c.md", 4 * 1024 * 1024),
+    ]);
+
+    expect(batches.map((batch) => batch.map((c) => c.path))).toEqual([["a.md"], ["b.md"]]);
+    expect(oversized.map((c) => c.path)).toEqual(["c.md"]);
   });
 
   it("forgets the failure once a push succeeds", async () => {

--- a/packages/store/src/sync-engine.test.ts
+++ b/packages/store/src/sync-engine.test.ts
@@ -417,9 +417,10 @@ describe("a failure reported to the reader", () => {
 
     // The one that cannot be sent is parked at once, named, and told why.
     expect(ctx.engine.state.lastErrorCode).toBe("too-large");
-    const stuck = ctx.engine.state.blockedChanges;
+    const stuck = ctx.engine.state.unpushed.filter((change) => change.tooLarge);
     expect(stuck.map((change) => change.path)).toEqual(["big.md"]);
     expect(stuck[0]?.error).toContain("too big to send");
+    expect(stuck[0]?.blocked).toBe(true);
 
     // And it no longer takes everything else down with it.
     expect(ctx.gateway.commits.length).toBeGreaterThan(0);
@@ -460,12 +461,12 @@ describe("a failure reported to the reader", () => {
     await ctx.engine.recordUpsert(makeNote({ path: "big.md", baseSha: null }), huge);
     await ctx.timers.tick();
 
-    const [stuck] = ctx.engine.state.blockedChanges;
+    const [stuck] = ctx.engine.state.unpushed;
     expect(stuck).toBeDefined();
 
     await ctx.engine.discardChange(stuck!.id);
 
-    expect(ctx.engine.state.blockedChanges).toEqual([]);
+    expect(ctx.engine.state.unpushed).toEqual([]);
     expect(ctx.engine.pendingFor()).toEqual([]);
     // The queue is clear, so the bar stops reporting a failure that is over.
     expect(ctx.engine.state.lastErrorCode).toBeNull();

--- a/packages/store/src/sync-engine.test.ts
+++ b/packages/store/src/sync-engine.test.ts
@@ -448,6 +448,29 @@ describe("a failure reported to the reader", () => {
     expect(oversized.map((c) => c.path)).toEqual(["c.md"]);
   });
 
+  /**
+   * "Go and find the image and delete it" is not an instruction anybody can
+   * follow when the file is called `Pasted image 20260828.png` and the note is
+   * one of hundreds. The queue knows exactly which change is stuck.
+   */
+  it("removes a stuck change, and the unpushed file behind it", async () => {
+    const ctx = setup();
+    const huge = "x".repeat(4 * 1024 * 1024);
+
+    await ctx.engine.recordUpsert(makeNote({ path: "big.md", baseSha: null }), huge);
+    await ctx.timers.tick();
+
+    const [stuck] = ctx.engine.state.blockedChanges;
+    expect(stuck).toBeDefined();
+
+    await ctx.engine.discardChange(stuck!.id);
+
+    expect(ctx.engine.state.blockedChanges).toEqual([]);
+    expect(ctx.engine.pendingFor()).toEqual([]);
+    // The queue is clear, so the bar stops reporting a failure that is over.
+    expect(ctx.engine.state.lastErrorCode).toBeNull();
+  });
+
   it("forgets the failure once a push succeeds", async () => {
     const ctx = setup();
     ctx.gateway.failNext = 1;

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -41,6 +41,22 @@ const RETRY_BASE_MS = 5_000;
 const RETRY_MAX_MS = 5 * 60_000;
 
 /**
+ * The most we will put in one commit request.
+ *
+ * Not a rule of ours — the host in front of the API refuses a request body
+ * over its own limit before any of our code sees it, and answers 413 with no
+ * message of its own. That is what a pasted screenshot used to turn into: a
+ * push that could never succeed, retried forever, explaining nothing, because
+ * nothing on this side had checked the size before sending.
+ *
+ * So the size is checked here, where the queue can do something about it —
+ * split the batch, and isolate a single change too big to ever send. Set well
+ * under the 4.5 MB the platform allows, because base64 inflates by a third and
+ * the JSON around it is not free.
+ */
+const MAX_REQUEST_BYTES = 3 * 1024 * 1024;
+
+/**
  * Local-first sync.
  *
  * Every edit is written to IndexedDB immediately and acknowledged instantly, so
@@ -246,6 +262,13 @@ export class SyncEngine {
       lastErrorCode: this.lastErrorCode,
       lastErrorAt: this.lastErrorAt,
       failedAttempts: this.failedAttempts,
+      blockedChanges: this.blocked().map((change) => ({
+        path:
+          change.op === "rename" || change.op === "move"
+            ? (change.toPath ?? change.path)
+            : change.path,
+        error: change.lastError ?? null,
+      })),
       conflicts: this.conflicts,
     };
   }
@@ -571,7 +594,42 @@ export class SyncEngine {
     const safe = await this.filterConflicts(workspaceId, changes);
     if (safe.length === 0) return;
 
-    await this.push(workspaceId, safe);
+    // Sized before it is sent. A batch over the limit is split; a single
+    // change over it on its own is stopped here, because there is no batch
+    // left to split and the request would come back 413 however many times it
+    // was tried.
+    const { batches, oversized } = batchBySize(safe);
+
+    let failure: unknown = null;
+
+    for (const change of oversized) {
+      await this.stop(change, tooLarge(change));
+      failure ??= tooLarge(change);
+    }
+
+    for (const batch of batches) {
+      try {
+        await this.push(workspaceId, batch);
+      } catch (err) {
+        failure ??= err;
+      }
+    }
+
+    if (failure) throw failure;
+  }
+
+  /**
+   * Parks one change immediately, with the reason on it.
+   *
+   * Distinct from running out of attempts. A change that cannot be sent at all
+   * has nothing to gain from four more tries, and spending them only delays
+   * the moment somebody is told which file is stuck.
+   */
+  private async stop(change: PendingChange, err: Error): Promise<void> {
+    change.attempts += 1;
+    change.lastError = err.message;
+    change.blocked = true;
+    await this.db.putQueueItem(change);
   }
 
   /**
@@ -932,6 +990,69 @@ function forkPath(path: string): string {
 }
 
 /**
+ * Roughly what one change costs on the wire.
+ *
+ * The content dominates and base64 is already text, so the encoded length is
+ * the answer; the path and the JSON scaffolding around it are a rounding error
+ * that the generous headroom below the platform's limit covers.
+ */
+function weigh(change: PendingChange): number {
+  return (change.content?.length ?? 0) + change.path.length + (change.toPath?.length ?? 0) + 64;
+}
+
+/** A change that will not fit in a request however it is batched. */
+function tooLarge(change: PendingChange): Error {
+  const path =
+    change.op === "rename" || change.op === "move" ? (change.toPath ?? change.path) : change.path;
+  const mb = (weigh(change) / (1024 * 1024)).toFixed(1);
+  const err = new Error(
+    `${path} is ${mb} MB, which is too big to send to GitHub in one request (the limit is 3 MB).`,
+  ) as Error & { code: string; status: number };
+  err.code = "too-large";
+  err.status = 413;
+  return err;
+}
+
+/**
+ * Packs the queue into requests that fit, and names what never will.
+ *
+ * Greedy and order-preserving: changes go into the current batch until the
+ * next one would push it over, then a new batch starts. Anything that exceeds
+ * the budget by itself comes back separately, because no amount of batching
+ * makes it sendable and the reader needs to be told which file it is.
+ */
+export function batchBySize(changes: PendingChange[]): {
+  batches: PendingChange[][];
+  oversized: PendingChange[];
+} {
+  const batches: PendingChange[][] = [];
+  const oversized: PendingChange[] = [];
+  let current: PendingChange[] = [];
+  let weight = 0;
+
+  for (const change of changes) {
+    const size = weigh(change);
+
+    if (size > MAX_REQUEST_BYTES) {
+      oversized.push(change);
+      continue;
+    }
+
+    if (current.length > 0 && weight + size > MAX_REQUEST_BYTES) {
+      batches.push(current);
+      current = [];
+      weight = 0;
+    }
+
+    current.push(change);
+    weight += size;
+  }
+
+  if (current.length > 0) batches.push(current);
+  return { batches, oversized };
+}
+
+/**
  * True when the server rejected *what* was sent rather than the fact that we
  * sent it.
  *
@@ -943,7 +1064,10 @@ function forkPath(path: string): string {
 function isContentRejection(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const { code, status } = err as { code?: unknown; status?: unknown };
-  return code === "validation" || status === 422;
+  // 413 belongs here too: a body refused for its size is a statement about
+  // what was sent, and splitting it is both the way to find the file at fault
+  // and, for everything standing behind that file, the way to get pushed.
+  return code === "validation" || code === "too-large" || status === 422 || status === 413;
 }
 
 /**
@@ -975,6 +1099,7 @@ export function codeOf(err: unknown): SyncErrorCode {
     case "rate-limited":
     case "conflict":
     case "validation":
+    case "too-large":
     case "network":
       return code;
   }
@@ -984,6 +1109,7 @@ export function codeOf(err: unknown): SyncErrorCode {
     if (status === 403) return "forbidden";
     if (status === 404) return "not-found";
     if (status === 409) return "conflict";
+    if (status === 413) return "too-large";
     if (status === 422) return "validation";
     if (status === 429) return "rate-limited";
     if (status >= 500) return "server";
@@ -1008,6 +1134,8 @@ export function plainly(err: unknown): string {
       return "This note also changed on GitHub. Open it to choose which version to keep.";
     case "validation":
       return "GitHub refused one of these changes. Everything else has been pushed, and this note is safe on this device.";
+    case "too-large":
+      return "This change is too big to send to GitHub. It is safe on this device, but it will not push until the large file in it is made smaller or removed.";
     case "network":
       return "Could not reach GitHub. Your work is saved on this device and will push when the connection returns.";
   }
@@ -1098,6 +1226,18 @@ export function remedyFor(code: SyncErrorCode | null, detail?: string | null): S
         steps: [
           "Check the note's path for characters GitHub will not take, and its size — the API refuses files over 100 MB.",
           "Renaming the note is usually enough to get it moving.",
+        ],
+        retryable: false,
+      };
+
+    case "too-large":
+      return {
+        reason:
+          "The request was refused for its size before it reached GitHub. Almost always this is one pasted image: a picture is carried as text, which makes it about a third bigger again, and a few megabytes of screenshot is past what a single request may carry.",
+        steps: [
+          "Find the file named below in the note it was pasted into, and delete it from the note.",
+          "If you need the picture, save a smaller copy — an export at a lower resolution, or a JPEG instead of a PNG — and paste that instead.",
+          "Everything else you have written pushes on its own once the large file is out of the queue.",
         ],
         retryable: false,
       };

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -54,7 +54,7 @@ const RETRY_MAX_MS = 5 * 60_000;
  * under the 4.5 MB the platform allows, because base64 inflates by a third and
  * the JSON around it is not free.
  */
-const MAX_REQUEST_BYTES = 3 * 1024 * 1024;
+export const MAX_REQUEST_BYTES = 3 * 1024 * 1024;
 
 /**
  * Local-first sync.
@@ -262,12 +262,15 @@ export class SyncEngine {
       lastErrorCode: this.lastErrorCode,
       lastErrorAt: this.lastErrorAt,
       failedAttempts: this.failedAttempts,
-      blockedChanges: this.blocked().map((change) => ({
+      unpushed: this.queue.map((change) => ({
         id: change.id,
         path:
           change.op === "rename" || change.op === "move"
             ? (change.toPath ?? change.path)
             : change.path,
+        bytes: weigh(change),
+        tooLarge: weigh(change) > MAX_REQUEST_BYTES,
+        blocked: change.blocked === true,
         error: change.lastError ?? null,
       })),
       conflicts: this.conflicts,

--- a/packages/store/src/sync-engine.ts
+++ b/packages/store/src/sync-engine.ts
@@ -263,6 +263,7 @@ export class SyncEngine {
       lastErrorAt: this.lastErrorAt,
       failedAttempts: this.failedAttempts,
       blockedChanges: this.blocked().map((change) => ({
+        id: change.id,
         path:
           change.op === "rename" || change.op === "move"
             ? (change.toPath ?? change.path)
@@ -310,6 +311,44 @@ export class SyncEngine {
 
     this.setStatus(this.restingStatus());
     this.emit();
+  }
+
+  /**
+   * Drops one stuck change, and the file behind it.
+   *
+   * The escape hatch for a change that can never be sent — a picture too big
+   * for one request being the case that made this necessary. Everything else
+   * the app could offer about such a change was advice: find the note it was
+   * pasted into, find the image inside it, delete it by hand. That is not a
+   * thing somebody can reasonably do when the note is one of hundreds and the
+   * file is called `Pasted image 20260828.png`.
+   *
+   * Only removes what was queued to be pushed. A note keeps its text and stays
+   * dirty, so nothing is claimed to be in sync that is not; an image that never
+   * reached GitHub is deleted from this device too, because a local copy of a
+   * file with nothing left to push it is exactly the orphan this app already
+   * goes to some trouble to avoid.
+   */
+  async discardChange(id: string): Promise<void> {
+    const change = this.queue.find((item) => item.id === id);
+    if (!change) return;
+
+    this.queue = this.queue.filter((item) => item.id !== id);
+    await this.db.deleteQueueItem(id);
+
+    const asset = await this.db.getAsset(`${change.workspaceId}::${change.path}`);
+    if (asset && !asset.pushed) await this.db.deleteAsset(asset.id);
+
+    // The failure it was reported under may have been about this change alone.
+    if (this.blocked().length === 0 && this.pushable().length === 0) {
+      this.lastError = null;
+      this.lastErrorDetail = null;
+      this.lastErrorCode = null;
+    }
+
+    this.setStatus(this.restingStatus());
+    this.emit();
+    if (this.pushable().length > 0) this.scheduleFlush();
   }
 
   // ─── Recording changes ────────────────────────────────────────────────────

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -251,14 +251,26 @@ export interface SyncState {
    */
   failedAttempts: number;
   /**
-   * The changes that have stopped trying, and what stopped them.
+   * Everything waiting to reach GitHub, named and sized.
    *
-   * A count alone ("2 changes not on GitHub") names no file, so there is
-   * nothing for the reader to go and fix — and the one failure they most need
-   * to fix, a file too big to send, is always about a specific file. The paths
-   * are the whole point.
+   * A count names no file, so there is nothing for the reader to go and look
+   * at — and the failure they most need to act on, a file too big to send, is
+   * always about one specific file they cannot otherwise find. It was not
+   * enough to list only the changes that had already stopped trying: a push
+   * that is still failing and retrying showed no files at all, which is the
+   * state somebody is most likely to be looking at.
    */
-  blockedChanges: { id: string; path: string; error: string | null }[];
+  unpushed: {
+    id: string;
+    path: string;
+    /** Roughly what it weighs on the wire. */
+    bytes: number;
+    /** True when it is too big to ever be sent, however often it is retried. */
+    tooLarge: boolean;
+    /** True once it has stopped retrying. */
+    blocked: boolean;
+    error: string | null;
+  }[];
   conflicts: Conflict[];
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -258,7 +258,7 @@ export interface SyncState {
    * to fix, a file too big to send, is always about a specific file. The paths
    * are the whole point.
    */
-  blockedChanges: { path: string; error: string | null }[];
+  blockedChanges: { id: string; path: string; error: string | null }[];
   conflicts: Conflict[];
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -184,6 +184,15 @@ export type SyncErrorCode =
   | "rate-limited"
   | "conflict"
   | "validation"
+  /**
+   * The push was too big to send, whoever refused it.
+   *
+   * Its own kind because it is the one failure where every offer the app used
+   * to make is wrong. Retrying sends the same oversized request; signing in
+   * again changes nothing about how many bytes it is. It needs the file named
+   * and taken out, and nothing else will do.
+   */
+  | "too-large"
   | "network"
   | "server"
   | "unknown";
@@ -241,6 +250,15 @@ export interface SyncState {
    * is dead.
    */
   failedAttempts: number;
+  /**
+   * The changes that have stopped trying, and what stopped them.
+   *
+   * A count alone ("2 changes not on GitHub") names no file, so there is
+   * nothing for the reader to go and fix — and the one failure they most need
+   * to fix, a file too big to send, is always about a specific file. The paths
+   * are the whole point.
+   */
+  blockedChanges: { path: string; error: string | null }[];
   conflicts: Conflict[];
 }
 


### PR DESCRIPTION
Follow-up to #55, which made a failed push explain itself. This is what that explanation turned out to be hiding.

## The failure

```
Kind: unknown
GitHub said: Request failed (413)
Failed attempts since last success: 1
Unpushed changes: 2 (2 stopped retrying)
```

413 is "request body too large". The host in front of the commit route refuses an oversized body before any of our code runs, and answers with no message of its own — which is why this arrived unclassified, with two changes parked and nothing anywhere naming the file or the cause. Retrying sent the identical oversized request. Signing in again changed nothing about how many bytes it was. There was no move left.

## The bug underneath

The app was promising something it could not keep. Images were accepted up to **10 MB**, and an image travels to the commit route as base64 inside JSON — a third bigger again — so a picture well under that limit made a request the platform would never carry. The paste succeeded, the note saved locally, and the push then failed identically forever.

## What this does

**Sizes the request before sending it.** A batch over the budget is split into requests that fit. A single change over it on its own is parked immediately with its path and size on it, because no number of attempts makes it sendable and spending five of them only delays telling somebody which file is stuck. Everything queued behind it now pushes instead of being held up.

**Makes 413 a failure kind of its own** (`too-large`), with a reason naming the usual cause — a pasted screenshot — and steps about the file rather than about trying again. `isContentRejection` counts it too, so a 413 that still comes back from the server splits the batch and isolates the offender.

**Lists everything that has not synced**, with path, size, and whether it can be sent at all. Previously only *parked* changes were listed, so a push that was still failing and retrying — the state the bar is most often read in — showed no files at all.

**Takes the reason from the queue, not the last attempt.** A batch carrying an oversized file can die as a timeout, a 500, or the platform's unexplained 413 depending on where it fails, and each of those sent the reader somewhere useless. If something queued cannot be sent, that is the reason until it is out of the queue.

**Find** opens the note a stuck file lives in. "Delete the image from the note" assumes the reader can find the note; for a picture called `Pasted image 20260828.png` in a notebook of several hundred, they cannot. A picture nothing references any more says so rather than opening something unrelated.

**Remove** drops one stuck change and the unpushed file behind it, with a line saying what that does — "remove" beside a filename could reasonably be read as deleting the note, and it does not.

**Refuses the paste at 3 MB**, at the moment it happens, while the person still has the picture in front of them and can save a smaller copy. The honest version of a limit the app was previously discovering only at push time.

## Checks

`pnpm typecheck`, `pnpm lint` and `pnpm test` (1589 passing) are green.

`pnpm build` was not run: it fails with `ENOSPC` on this machine, which is a full disk rather than anything in this diff. Worth running once there is space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)