### PR TITLE
feat: notebook order, support, and Find that points at the image

### DIFF
--- a/apps/web/src/app/docs/content/index.tsx
+++ b/apps/web/src/app/docs/content/index.tsx
@@ -5,7 +5,7 @@ import { Reading } from "./reading";
 import { Features } from "./features";
 import { SigningIn, Repositories, Sync, Conflicts } from "./github";
 import { Plans, PrivacyAndData, Security } from "./account";
-import { Troubleshooting, Faq } from "./running";
+import { Troubleshooting, Faq, Support } from "./running";
 
 /**
  * Slug → article body.
@@ -34,4 +34,5 @@ export const DOC_CONTENT: Record<string, () => React.JSX.Element> = {
   security: Security,
   troubleshooting: Troubleshooting,
   faq: Faq,
+  support: Support,
 };

--- a/apps/web/src/app/docs/content/running.tsx
+++ b/apps/web/src/app/docs/content/running.tsx
@@ -1,4 +1,5 @@
-import { A, Code, Def, H2, Lead, P } from "@/components/prose";
+import { A, Code, Def, H2, LI, Lead, P, UL } from "@/components/prose";
+import { ISSUES_URL, SECURITY_URL, SUPPORT_EMAIL, SUPPORT_MAILTO } from "@/lib/constants";
 
 /**
  * What is left of the operations pages: the errors people hit, and the
@@ -182,6 +183,68 @@ export function Faq() {
         Delete the repository on GitHub, clear site data in your browser, and revoke the OAuth app.
         Step-by-step in <A href="/docs/privacy-and-data">Your data</A>.
       </Def>
+    </>
+  );
+}
+
+/**
+ * The last page of the Help section, and the one every "Support" link in the
+ * app can be followed to from inside the documentation.
+ *
+ * Deliberately short. It exists so that somebody reading the docs and not
+ * finding their answer has a next step on the page they are already on, rather
+ * than having to go back to the marketing site to discover there is an inbox.
+ */
+export function Support() {
+  return (
+    <>
+      <Lead>
+        When the documentation does not have your answer, write in. ForkLeaf is built and answered
+        by one person, and the inbox is read.
+      </Lead>
+
+      <H2 id="where">Where to write</H2>
+      <P>
+        Email <A href={SUPPORT_MAILTO}>{SUPPORT_EMAIL}</A> for anything specific to your account,
+        your repository, or something you would rather not post in public. A reply usually takes a
+        day or two. For bugs and feature requests that other people would hit too,{" "}
+        <A href={ISSUES_URL}>GitHub Issues</A> is better: it is searchable, and the fix is visible
+        when it lands.
+      </P>
+      <P>
+        Security findings go through the <A href={SECURITY_URL}>security policy</A> rather than the
+        public tracker, so a flaw is fixed before it is advertised.
+      </P>
+
+      <H2 id="include">What to include</H2>
+      <P>
+        None of this is required, but a report with these in it can usually be answered rather than
+        asked about:
+      </P>
+      <UL>
+        <LI>What you were doing, and what happened instead.</LI>
+        <LI>
+          Whether the repository is connected to GitHub, or the notes are local to that browser.
+        </LI>
+        <LI>
+          The exact text of any error, including whatever is behind its “Details” or “Why” link.
+        </LI>
+        <LI>
+          Your browser and operating system, and the note&rsquo;s path if it is about one note.
+        </LI>
+      </UL>
+      <P>
+        Never send a GitHub token, a password, or a screenshot containing one. Nothing about a
+        support request needs one.
+      </P>
+
+      <H2 id="meanwhile">While you wait</H2>
+      <P>
+        Your notes are Markdown files in a repository you own, in ordinary git history. Whatever is
+        wrong with the app, you can clone that repository and keep working in any editor that reads
+        text — nothing you are waiting on a reply for is holding your writing.{" "}
+        <A href="/support">The support page</A> lists what to try first.
+      </P>
     </>
   );
 }

--- a/apps/web/src/app/docs/nav.ts
+++ b/apps/web/src/app/docs/nav.ts
@@ -139,6 +139,12 @@ export const DOC_SECTIONS: DocSection[] = [
         title: "FAQ",
         summary: "Short answers to the questions that come up most.",
       },
+      {
+        slug: "support",
+        title: "Contact support",
+        summary:
+          "Where to write when the documentation does not have it, what to include, and how long a reply takes.",
+      },
     ],
   },
 ];

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -978,6 +978,41 @@ mark.fl-hl-orange {
   animation: fl-caret 1.2s steps(1, end) infinite;
 }
 
+/* "That one, there." Put on an image by Find, and taken off again a couple of
+   seconds later.
+
+   A ring plus two pulses, rather than a ring alone: a static outline on a
+   screenshot that may already have a border of its own is easy to look past,
+   and the point of this is to be the thing your eye lands on. The ring is
+   drawn with `box-shadow` so it follows the image's own corner radius and
+   takes up no layout — an outline that reflowed the paragraph around it would
+   move the picture as it was being pointed at. */
+@keyframes fl-reveal {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 3px var(--fl-accent),
+      0 0 0 8px color-mix(in srgb, var(--fl-accent) 28%, transparent);
+  }
+
+  50% {
+    box-shadow:
+      0 0 0 3px var(--fl-accent),
+      0 0 0 16px color-mix(in srgb, var(--fl-accent) 0%, transparent);
+  }
+}
+
+.fl-reveal {
+  border-radius: 6px;
+  animation: fl-reveal 900ms ease-out 3;
+  /* The ring is still there when the animation is not — reduced motion, or the
+     third pulse having finished a moment before the class comes off. */
+  box-shadow:
+    0 0 0 3px var(--fl-accent),
+    0 0 0 8px color-mix(in srgb, var(--fl-accent) 28%, transparent);
+  scroll-margin-block: 25vh;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -987,13 +1022,19 @@ mark.fl-hl-orange {
   }
 
   /* An infinite animation reduced to a hundredth of a millisecond is not
-     stillness, it is a strobe. These two are named rather than left to the
-     rule above: one repeats forever, and the other only means anything while
-     it is running. */
+     stillness, it is a strobe. These are named rather than left to the rule
+     above: one repeats forever, and the others only mean anything while they
+     are running. The revealed image keeps its ring — that is the answer to
+     "where is it", and it is the animation that was unwelcome, not the mark. */
   .fl-caret,
-  .fl-tick {
+  .fl-tick,
+  .fl-reveal {
     animation: none !important;
     opacity: 1;
+  }
+
+  .fl-caret,
+  .fl-tick {
     transform: none;
   }
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,6 +10,7 @@ import { Positioning } from "@/components/landing/Positioning";
 import { Comparison } from "@/components/landing/Comparison";
 import { Ownership } from "@/components/landing/Ownership";
 import { Faq } from "@/components/landing/Faq";
+import { Support } from "@/components/landing/Support";
 import { Pricing } from "@/components/landing/Pricing";
 import { CallToAction } from "@/components/landing/CallToAction";
 import { Footer } from "@/components/landing/Footer";
@@ -78,6 +79,7 @@ export default async function Home({
         <Ownership />
         <Pricing />
         <Faq />
+        <Support />
         <CallToAction githubAvailable={githubAvailable} />
       </main>
 

--- a/apps/web/src/app/support/page.tsx
+++ b/apps/web/src/app/support/page.tsx
@@ -1,0 +1,172 @@
+import Link from "next/link";
+import { SiteShell } from "@/components/SiteShell";
+import { A, Code, H2, LI, Lead, Note, OL, P, UL } from "@/components/prose";
+import { ISSUES_URL, SECURITY_URL, SUPPORT_EMAIL, SUPPORT_MAILTO } from "@/lib/constants";
+
+export const metadata = {
+  title: "Support",
+  description:
+    "How to get help with ForkLeaf: what to try first, where to write, what to include, and how long a reply takes.",
+};
+
+/**
+ * The page every "Support" link in the app points at.
+ *
+ * It exists because "email us" on its own is not support. Somebody writing in
+ * is usually stuck, often worried about their writing, and the two things that
+ * actually help are said here rather than in a reply two days later: their
+ * notes are safe and reachable without us, and here is the handful of facts
+ * that make a reply useful instead of a round of questions.
+ */
+export default function SupportPage() {
+  return (
+    <SiteShell>
+      <div className="mx-auto w-full max-w-3xl px-6 py-14">
+        <p className="text-[13px] font-semibold uppercase tracking-[0.16em] text-[var(--fl-accent)]">
+          Support
+        </p>
+        <h1 className="mt-3 text-[2.5rem] font-semibold leading-[1.1] tracking-[-0.03em] text-[var(--fl-text)]">
+          Getting help
+        </h1>
+
+        <div className="mt-10">
+          <Lead>
+            ForkLeaf is built and answered by one person. Write in about anything — a bug, a note
+            that will not sync, a question about your data, or something you wish it did.
+          </Lead>
+
+          <Note>
+            <strong>Before anything else: your notes are not trapped.</strong> They are Markdown
+            files in a GitHub repository you own, in ordinary git history. Whatever is wrong with
+            the app, you can clone that repository and keep working in any editor that reads text.
+            Nothing you are waiting on a reply for is holding your writing hostage.
+          </Note>
+
+          <H2 id="email">Email</H2>
+          <P>
+            <A href={SUPPORT_MAILTO}>{SUPPORT_EMAIL}</A> — the fastest route for anything specific
+            to your account, your repository, or something you would rather not post in public. It
+            is the same address the{" "}
+            <Link href="/privacy" className="fl-link">
+              Privacy Policy
+            </Link>{" "}
+            gives for data requests.
+          </P>
+          <P>
+            One person reads it, so a reply usually takes a day or two rather than an hour. There is
+            no paid tier that gets answered sooner.
+          </P>
+
+          <H2 id="what-to-include">What to include</H2>
+          <P>
+            None of this is required — a one-line description of what went wrong is a perfectly good
+            email. But a report with these in it can usually be answered rather than asked about:
+          </P>
+          <UL>
+            <LI>What you were doing, and what happened instead.</LI>
+            <LI>
+              Whether the repository is connected to GitHub or the notes are local to that browser.
+            </LI>
+            <LI>
+              The exact text of any error the app showed, including anything under a “Details” or
+              “Why” link — those messages carry the reason the plain sentence leaves out.
+            </LI>
+            <LI>Your browser and operating system.</LI>
+            <LI>
+              The note&rsquo;s path if it is about one note — <Code>Fieldwork/soil.md</Code> rather
+              than “the soil one”.
+            </LI>
+          </UL>
+          <P>
+            Please do not send a GitHub token, a password, or a screenshot with one in it. Nothing
+            about a support request needs one, and an address that asks for credentials is one you
+            should be suspicious of.
+          </P>
+
+          <H2 id="first">Things worth trying first</H2>
+          <P>These resolve most of what gets reported, and take less time than an email:</P>
+          <OL>
+            <LI>
+              Read{" "}
+              <Link href="/docs/troubleshooting" className="fl-link">
+                Troubleshooting
+              </Link>{" "}
+              — it lists the errors people actually hit and what each one means.
+            </LI>
+            <LI>
+              If changes are not reaching GitHub, open the sync status in the editor&rsquo;s status
+              bar. A failed push says why it failed and what to do about it, and a push that was
+              refused for being too large names the file.
+            </LI>
+            <LI>
+              If you have been signed out, sign in again from{" "}
+              <Link href="/sign-in" className="fl-link">
+                the sign-in page
+              </Link>
+              . Local notes are untouched by signing out.
+            </LI>
+            <LI>
+              If a note looks wrong, its history is on github.com — every save is a commit, and the
+              previous version is one click away.
+            </LI>
+          </OL>
+
+          <H2 id="public">Bugs and feature requests in public</H2>
+          <P>
+            <A href={ISSUES_URL}>GitHub Issues</A> is the better place for anything other people
+            would hit too. It is searchable, other users can add to it, and the fix is visible when
+            it lands. ForkLeaf is open source under Apache-2.0, so a pull request is welcome as
+            well.
+          </P>
+
+          <H2 id="security">Security</H2>
+          <P>
+            Please do not open a public issue for a vulnerability. The{" "}
+            <A href={SECURITY_URL}>security policy</A> explains how to report one privately so it
+            can be fixed before it is advertised. Email works too — say “security” in the subject
+            and it will be read first.
+          </P>
+
+          <H2 id="cost">What this costs</H2>
+          <P>
+            Nothing. ForkLeaf is free, all of it, with no tiers — see{" "}
+            <Link href="/docs/plans" className="fl-link">
+              what it costs
+            </Link>
+            . Support is not a product being sold here, which is also why it is one person&rsquo;s
+            inbox rather than a helpdesk.
+          </P>
+
+          <div className="mt-16 flex flex-wrap gap-2 border-t border-[var(--fl-border)] pt-8 text-[13.5px]">
+            <a
+              href={SUPPORT_MAILTO}
+              className="rounded-lg border border-[var(--fl-border)] px-3 py-2 text-[var(--fl-text)] transition-colors hover:border-[var(--fl-accent)] hover:text-[var(--fl-accent)]"
+            >
+              Email support
+            </a>
+            <Link
+              href="/docs"
+              className="rounded-lg border border-[var(--fl-border)] px-3 py-2 text-[var(--fl-text)] transition-colors hover:border-[var(--fl-accent)] hover:text-[var(--fl-accent)]"
+            >
+              Documentation
+            </Link>
+            <Link
+              href="/docs/troubleshooting"
+              className="rounded-lg border border-[var(--fl-border)] px-3 py-2 text-[var(--fl-text)] transition-colors hover:border-[var(--fl-accent)] hover:text-[var(--fl-accent)]"
+            >
+              Troubleshooting
+            </Link>
+            <a
+              href={ISSUES_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-lg border border-[var(--fl-border)] px-3 py-2 text-[var(--fl-text)] transition-colors hover:border-[var(--fl-accent)] hover:text-[var(--fl-accent)]"
+            >
+              GitHub Issues
+            </a>
+          </div>
+        </div>
+      </div>
+    </SiteShell>
+  );
+}

--- a/apps/web/src/components/EditorSidebar.test.tsx
+++ b/apps/web/src/components/EditorSidebar.test.tsx
@@ -67,6 +67,12 @@ function renderSidebar(currentFolder: string, overrides: Record<string, unknown>
       activePath={activePath}
       currentFolder={currentFolder}
       onOpenNote={() => {}}
+      sortMode="smart"
+      onSortModeChange={() => {}}
+      onReorder={() => {}}
+      onReorderTo={() => {}}
+      onResetOrder={() => {}}
+      manualFolders={[]}
       onCreateNote={onCreateNote}
       onDeleteNote={() => {}}
       onRenameNote={() => {}}

--- a/apps/web/src/components/EditorSidebar.tsx
+++ b/apps/web/src/components/EditorSidebar.tsx
@@ -7,6 +7,7 @@ import { FileTree } from "./FileTree";
 import { ForkLeafMark } from "./Brand";
 import { useDismissable } from "@/hooks/useDismissable";
 import { collectFilePaths, collectFolders } from "@/lib/tree";
+import { SORT_MODE_LABELS, type TreeSortMode } from "@/lib/tree-order";
 
 export interface EditorSidebarProps {
   collapsed: boolean;
@@ -48,6 +49,22 @@ export interface EditorSidebarProps {
   onMoveNote: (path: string, toFolder: string) => void;
   /** Moves a folder, and everything under it, from a drag within the tree. */
   onMoveFolder: (path: string, toFolder: string) => void;
+  /** How the tree is sorted when nobody has arranged a folder by hand. */
+  sortMode: TreeSortMode;
+  onSortModeChange: (mode: TreeSortMode) => void;
+  /** Moves a row one step up or down inside its own folder. */
+  onReorder: (siblings: readonly TreeNode[], path: string, direction: -1 | 1) => void;
+  /** Drops a row into the gap above or below one of its own siblings. */
+  onReorderTo: (
+    siblings: readonly TreeNode[],
+    path: string,
+    target: string,
+    position: "before" | "after",
+  ) => void;
+  /** Puts one folder's contents back under the automatic sort. */
+  onResetOrder: (parent: string) => void;
+  /** Folders somebody has arranged by hand. */
+  manualFolders: readonly string[];
   /** Notes kept at the top, in the order they were put there. */
   pinnedPaths: readonly string[];
   /** Folders the reader had open last time, in the order they opened them. */
@@ -76,6 +93,8 @@ export function EditorSidebar(props: EditorSidebarProps) {
   const [showWorkspaces, setShowWorkspaces] = useState(false);
   const [showAccount, setShowAccount] = useState(false);
   const [showFolders, setShowFolders] = useState(false);
+  const [showSort, setShowSort] = useState(false);
+  const [showMore, setShowMore] = useState(false);
 
   /**
    * Each menu closes on Escape and on a click anywhere else.
@@ -87,10 +106,14 @@ export function EditorSidebar(props: EditorSidebarProps) {
   const workspacesRef = useRef<HTMLDivElement | null>(null);
   const foldersRef = useRef<HTMLDivElement | null>(null);
   const accountRef = useRef<HTMLDivElement | null>(null);
+  const sortRef = useRef<HTMLDivElement | null>(null);
+  const moreRef = useRef<HTMLDivElement | null>(null);
 
   useDismissable(workspacesRef, showWorkspaces, () => setShowWorkspaces(false));
   useDismissable(foldersRef, showFolders, () => setShowFolders(false));
   useDismissable(accountRef, showAccount, () => setShowAccount(false));
+  useDismissable(sortRef, showSort, () => setShowSort(false));
+  useDismissable(moreRef, showMore, () => setShowMore(false));
   const searchRef = useRef<HTMLInputElement>(null);
 
   /**
@@ -529,9 +552,86 @@ export function EditorSidebar(props: EditorSidebarProps) {
           </>
         )}
 
-        <p className="px-2 pb-1.5 pt-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
-          {props.activeWorkspace?.isLocal ? "Notes" : "Repository"}
-        </p>
+        {/* The heading is also where the order is chosen, because the order is
+            a fact about this list and nowhere else in the app is about it.
+            Buried in a settings screen it would be a preference nobody found;
+            here it is next to the thing it changes. */}
+        <div className="relative flex items-center gap-1 px-2 pb-1.5 pt-1" ref={sortRef}>
+          <p className="min-w-0 flex-1 truncate text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+            {props.activeWorkspace?.isLocal ? "Notes" : "Repository"}
+          </p>
+
+          <button
+            type="button"
+            onClick={() => setShowSort((value) => !value)}
+            aria-expanded={showSort}
+            aria-haspopup="menu"
+            title={`Sort: ${SORT_MODE_LABELS[props.sortMode]}`}
+            aria-label={`Change the order. Currently ${SORT_MODE_LABELS[props.sortMode]}.`}
+            className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
+          >
+            <SortGlyph />
+          </button>
+
+          {showSort && (
+            <div
+              role="menu"
+              className="absolute right-1 top-full z-30 w-64 rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-1 shadow-xl"
+            >
+              <p className="px-2.5 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--fl-muted)]">
+                Sort by
+              </p>
+
+              {(Object.keys(SORT_MODE_LABELS) as TreeSortMode[]).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={props.sortMode === mode}
+                  onClick={() => {
+                    props.onSortModeChange(mode);
+                    setShowSort(false);
+                  }}
+                  className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-[13px] transition-colors hover:bg-[var(--fl-elevated)] ${
+                    props.sortMode === mode ? "text-[var(--fl-text)]" : "text-[var(--fl-muted)]"
+                  }`}
+                >
+                  {/* Hidden from assistive technology: `aria-checked` already
+                      says which one is on, and a tick in the accessible name
+                      makes the row read as "tick, Date created". */}
+                  <span aria-hidden="true" className="w-3 shrink-0 text-[var(--fl-accent)]">
+                    {props.sortMode === mode ? "✓" : ""}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{SORT_MODE_LABELS[mode]}</span>
+                </button>
+              ))}
+
+              <p className="border-t border-[var(--fl-border)] px-2.5 pb-1.5 pt-2 text-[11.5px] leading-relaxed text-[var(--fl-muted)]">
+                Drag a note or folder onto the gap above or below one of its neighbours to arrange a
+                folder by hand, or use Move up and Move down in its right-click menu.
+              </p>
+
+              {/* Only when there is something to undo. An always-present
+                  "reset" on a tree nobody has touched is a button that does
+                  nothing, sitting where a reader has to read past it. */}
+              {props.manualFolders.length > 0 && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    for (const folder of props.manualFolders) props.onResetOrder(folder);
+                    setShowSort(false);
+                  }}
+                  className="mt-0.5 flex w-full items-center rounded-lg px-2.5 py-1.5 text-left text-[13px] text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
+                >
+                  Reset {props.manualFolders.length === 1 ? "the folder" : "all folders"} arranged
+                  by hand
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
         <FileTree
           nodes={props.tree}
           activePath={props.activePath}
@@ -542,6 +642,10 @@ export function EditorSidebar(props: EditorSidebarProps) {
           onCreateFolder={props.onCreateFolder}
           onMoveNote={props.onMoveNote}
           onMoveFolder={props.onMoveFolder}
+          onReorder={props.onReorder}
+          onReorderTo={props.onReorderTo}
+          onResetOrder={props.onResetOrder}
+          manualFolders={props.manualFolders}
           onTogglePin={props.onTogglePin}
           pinnedPaths={props.pinnedPaths}
           onRenameFolder={props.onRenameFolder}
@@ -554,44 +658,81 @@ export function EditorSidebar(props: EditorSidebarProps) {
 
       {/* ── Footer: the ways out, help, account ───────────────────────── */}
       <div className="border-t border-[var(--fl-border)] p-2">
-        {/* The editor used to be a room with no marked exits: once you were in
-            it, the only way back to the rest of the app was the logo, and the
-            dashboard could not be reached at all.
+        {/* Three rows became one.
 
-            It sat between the search row and the tree, which put a link to
-            another page in the middle of the column you use to move around this
-            one — you read past it every time you looked for a note. Down here it
-            is with the other exits, next to help and the account, and the file
-            tree runs uninterrupted from the filter to the bottom. */}
-        <Link
-          href="/dashboard"
-          className="mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-[12.5px] text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
-        >
-          <DashboardGlyph className="h-3.5 w-3.5" />
-          <span className="min-w-0 flex-1 truncate text-left">Dashboard</span>
-          <kbd className="shrink-0 rounded border border-[var(--fl-border)] px-1 py-px font-sans text-[10px]">
-            ⌘⇧D
-          </kbd>
-        </Link>
+            The editor used to be a room with no marked exits, so exits were
+            added — and then each new one took another row off the bottom of the
+            tree. Three of them, stacked, spent a third of the footer on things
+            nobody clicks while they are writing, and the file list is what this
+            column is for.
 
-        <button
-          type="button"
-          onClick={props.onOpenHelp}
-          className="mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-[12.5px] text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
-        >
-          <svg
-            viewBox="0 0 16 16"
-            className="h-3.5 w-3.5"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.6"
-            strokeLinecap="round"
+            One button that says what is behind it, opening upwards over the
+            note rather than over the tree. The ⌘⇧D shortcut still goes straight
+            to the dashboard without passing through here — a menu is the way in
+            for somebody who does not know the shortcut, not a step added for
+            somebody who does. */}
+        <div className="relative" ref={moreRef}>
+          <button
+            type="button"
+            onClick={() => setShowMore((value) => !value)}
+            aria-expanded={showMore}
+            aria-haspopup="menu"
+            className={`mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-[12.5px] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)] ${
+              showMore ? "bg-[var(--fl-elevated)] text-[var(--fl-text)]" : "text-[var(--fl-muted)]"
+            }`}
           >
-            <circle cx="8" cy="8" r="6.25" />
-            <path d="M6.2 6.2a1.9 1.9 0 1 1 2.3 2.2v1.1M8.5 12h.01" />
-          </svg>
-          <span className="min-w-0 flex-1 truncate text-left">Help &amp; shortcuts</span>
-        </button>
+            <MoreGlyph />
+            <span className="min-w-0 flex-1 truncate text-left">More</span>
+            <ChevronGlyph open={showMore} />
+          </button>
+
+          {showMore && (
+            /* Upwards. A menu opening down from a control this close to the
+               bottom would hang off the window. */
+            <div
+              role="menu"
+              className="absolute bottom-full left-0 z-30 mb-1 w-56 rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-1 shadow-xl"
+            >
+              <Link
+                href="/dashboard"
+                role="menuitem"
+                onClick={() => setShowMore(false)}
+                className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-[13px] text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
+              >
+                <DashboardGlyph className="h-3.5 w-3.5 shrink-0" />
+                <span className="min-w-0 flex-1 truncate text-left">Dashboard</span>
+                <kbd className="shrink-0 rounded border border-[var(--fl-border)] px-1 py-px font-sans text-[10px]">
+                  ⌘⇧D
+                </kbd>
+              </Link>
+
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setShowMore(false);
+                  props.onOpenHelp();
+                }}
+                className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-[13px] text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
+              >
+                <HelpGlyph />
+                <span className="min-w-0 flex-1 truncate text-left">Help &amp; shortcuts</span>
+              </button>
+
+              {/* Beneath help, because it is what you reach for when help did
+                  not have it. */}
+              <Link
+                href="/support"
+                role="menuitem"
+                onClick={() => setShowMore(false)}
+                className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-[13px] text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
+              >
+                <SupportGlyph />
+                <span className="min-w-0 flex-1 truncate text-left">Support</span>
+              </Link>
+            </div>
+          )}
+        </div>
 
         {props.user ? (
           <div className="relative" ref={accountRef}>
@@ -692,6 +833,88 @@ function DashboardGlyph({ className = "h-4 w-4" }: { className?: string }) {
 /** `Fieldwork/intro.md` → `intro`, which is what the row is called. */
 function nameOf(path: string): string {
   return (path.split("/").pop() ?? path).replace(/\.mdx?$/i, "");
+}
+
+/** Three dots: the one mark that means "and the rest" without naming them. */
+function MoreGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" className="h-3.5 w-3.5" fill="currentColor">
+      <circle cx="3.5" cy="8" r="1.25" />
+      <circle cx="8" cy="8" r="1.25" />
+      <circle cx="12.5" cy="8" r="1.25" />
+    </svg>
+  );
+}
+
+/** Points the way the menu opens, so the button says where to look. */
+function ChevronGlyph({ open }: { open: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      className={`h-3 w-3 shrink-0 transition-transform duration-150 ${open ? "" : "rotate-180"}`}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2.5 7.5 6 4l3.5 3.5" />
+    </svg>
+  );
+}
+
+function HelpGlyph() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-3.5 w-3.5 shrink-0"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    >
+      <circle cx="8" cy="8" r="6.25" />
+      <path d="M6.2 6.2a1.9 1.9 0 1 1 2.3 2.2v1.1M8.5 12h.01" />
+    </svg>
+  );
+}
+
+/** An envelope: the one glyph nobody has to be taught means "write to us". */
+function SupportGlyph() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-3.5 w-3.5 shrink-0"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="2" y="3.5" width="12" height="9" rx="1.4" />
+      <path d="m2.6 4.6 4.6 3.5a1.3 1.3 0 0 0 1.6 0l4.6-3.5" />
+    </svg>
+  );
+}
+
+/** Three rules, shortest last: the universal "this list has an order" mark. */
+function SortGlyph() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    >
+      <path d="M3 4.5h10M3 8h6.5M3 11.5h3.5" />
+    </svg>
+  );
 }
 
 function PinGlyph() {

--- a/apps/web/src/components/FileTree.test.tsx
+++ b/apps/web/src/components/FileTree.test.tsx
@@ -181,6 +181,71 @@ describe("showing where the selected note lives", () => {
  * that one" — meant creating the destination by hand and moving the notes one
  * at a time.
  */
+describe("rearranging by hand", () => {
+  /** Right-clicks a row and returns the labels its menu offers. */
+  function menuFor(label: string): string[] {
+    fireEvent.contextMenu(screen.getByText(label), { clientX: 0, clientY: 0 });
+    return screen.getAllByRole("menuitem").map((item) => item.textContent ?? "");
+  }
+
+  it("offers to move a row down, and reports the siblings it is moving among", () => {
+    const onReorder = vi.fn();
+    draw({ openFolders: ["OSINT"], onReorder });
+
+    expect(menuFor("Fieldwork")).toContain("Move down");
+    fireEvent.click(screen.getByText("Move down"));
+
+    const [siblings, path, direction] = onReorder.mock.calls[0]!;
+    expect(siblings.map((node: TreeNode) => node.path)).toEqual(["Fieldwork", "OSINT"]);
+    expect([path, direction]).toEqual(["Fieldwork", 1]);
+  });
+
+  it("does not offer to move the first row up or the last row down", () => {
+    draw({ openFolders: [], onReorder: vi.fn() });
+
+    expect(menuFor("Fieldwork")).not.toContain("Move up");
+    cleanup();
+
+    draw({ openFolders: [], onReorder: vi.fn() });
+    expect(menuFor("OSINT")).not.toContain("Move down");
+  });
+
+  it("moves notes as readily as folders", () => {
+    const onReorder = vi.fn();
+    draw({ openFolders: ["OSINT"], onReorder });
+
+    expect(menuFor("osint")).toContain("Move down");
+  });
+
+  it("says nothing about order for an only child", () => {
+    const onReorder = vi.fn();
+    draw({ openFolders: ["Fieldwork"], onReorder });
+
+    expect(menuFor("notes")).not.toContain("Move up");
+    expect(menuFor("notes")).not.toContain("Move down");
+  });
+
+  it("stays quiet while a filter is narrowing the tree, which reorders nothing", () => {
+    draw({ filter: "o", onReorder: vi.fn() });
+
+    expect(menuFor("OSINT")).not.toContain("Move down");
+  });
+
+  it("offers to reset a folder that was arranged, and only that one", () => {
+    const onResetOrder = vi.fn();
+    draw({ openFolders: ["OSINT"], onReorder: vi.fn(), onResetOrder, manualFolders: ["OSINT"] });
+
+    expect(menuFor("Fieldwork")).not.toContain("Reset order");
+    cleanup();
+
+    draw({ openFolders: ["OSINT"], onReorder: vi.fn(), onResetOrder, manualFolders: ["OSINT"] });
+    expect(menuFor("osint")).toContain("Reset order in OSINT");
+
+    fireEvent.click(screen.getByText("Reset order in OSINT"));
+    expect(onResetOrder).toHaveBeenCalledWith("OSINT");
+  });
+});
+
 describe("rearranging by drag", () => {
   it("moves a note into a folder", () => {
     const onMoveNote = vi.fn();

--- a/apps/web/src/components/FileTree.tsx
+++ b/apps/web/src/components/FileTree.tsx
@@ -32,6 +32,25 @@ export interface FileTreeProps {
    * across one at a time.
    */
   onMoveFolder?: (path: string, toFolder: string) => void;
+  /**
+   * Moves a row one step up or down inside its own folder.
+   *
+   * Given the siblings as the tree is currently drawing them, because the order
+   * being recorded is the one the reader can see — not the one the sort mode
+   * would have produced from the same nodes.
+   */
+  onReorder?: (siblings: readonly TreeNode[], path: string, direction: -1 | 1) => void;
+  /** Drops a row into the gap above or below one of its own siblings. */
+  onReorderTo?: (
+    siblings: readonly TreeNode[],
+    path: string,
+    target: string,
+    position: "before" | "after",
+  ) => void;
+  /** Puts one folder's contents back under the automatic sort. */
+  onResetOrder?: (parent: string) => void;
+  /** Folders whose contents somebody has arranged by hand. */
+  manualFolders?: readonly string[];
   /** Pins a note to the top of the sidebar, or unpins one already there. */
   onTogglePin?: (path: string) => void;
   /** Paths currently pinned, so the menu can say which way it will go. */
@@ -74,6 +93,10 @@ export function FileTree({
   onDeleteFolder,
   onMoveNote,
   onMoveFolder,
+  onReorder,
+  onReorderTo,
+  onResetOrder,
+  manualFolders,
   onTogglePin,
   pinnedPaths,
   openFolders,
@@ -156,6 +179,53 @@ export function FileTree({
     },
     [dragging, canDropOn, onMoveNote, onMoveFolder],
   );
+  /**
+   * The gap a reordering drag is currently hovering, if any.
+   *
+   * Separate from `dropTarget`, which means "into this folder". One drag can
+   * mean either — the middle of a row moves the thing inside, the top and
+   * bottom edges move it above or below — and the two need different feedback:
+   * a ring around a folder, or a line between two rows.
+   */
+  const [reorderTarget, setReorderTarget] = useState<{
+    path: string;
+    position: "before" | "after";
+  } | null>(null);
+
+  /**
+   * Reordering is only offered against a row's own siblings.
+   *
+   * Dragging across folders already means something — move it there — and a
+   * gesture that meant "move" or "reorder" depending on which quarter of which
+   * row you released over would be a gesture nobody could aim.
+   *
+   * It is also off while a filter is typed: the rows on screen are then a
+   * subset in filtered order, and recording that as the folder's order would
+   * write down positions for notes the reader cannot currently see.
+   */
+  const canReorderWith = useCallback(
+    (path: string) =>
+      Boolean(onReorderTo) &&
+      !filter &&
+      dragging !== null &&
+      dragging.path !== path &&
+      dirnameOf(dragging.path) === dirnameOf(path),
+    [onReorderTo, filter, dragging],
+  );
+
+  const dropBeside = useCallback(
+    (target: string, position: "before" | "after") => {
+      const payload = dragging;
+      setDragging(null);
+      setDropTarget(null);
+      setReorderTarget(null);
+      if (!payload || !onReorderTo) return;
+
+      onReorderTo(siblingsOf(nodes, target), payload.path, target, position);
+    },
+    [dragging, onReorderTo, nodes],
+  );
+
   const { menu, open: openMenu, close: closeMenu } = useContextMenu<TreeNode>();
 
   const visible = useMemo(
@@ -223,6 +293,46 @@ export function FileTree({
     }
   }
 
+  /**
+   * Move up, move down, and put it back — the same three on a note and on a
+   * folder, because "these two are the wrong way round" is the same complaint
+   * whichever kind of row it is about.
+   *
+   * In the menu rather than only on the drag, so the order is reachable from
+   * the keyboard: a tree that can only be arranged by dragging is a tree some
+   * people cannot arrange at all.
+   */
+  const orderItems = useCallback(
+    (node: TreeNode): MenuItem[] => {
+      if (!onReorder || filter) return [];
+
+      const siblings = siblingsOf(nodes, node.path);
+      const index = siblings.findIndex((sibling) => sibling.path === node.path);
+      if (index === -1 || siblings.length < 2) return [];
+
+      const parent = dirnameOf(node.path);
+      const arranged = manualFolders?.includes(parent) ?? false;
+
+      return [
+        ...(index > 0
+          ? [{ label: "Move up", onSelect: () => onReorder(siblings, node.path, -1) }]
+          : []),
+        ...(index < siblings.length - 1
+          ? [{ label: "Move down", onSelect: () => onReorder(siblings, node.path, 1) }]
+          : []),
+        ...(arranged && onResetOrder
+          ? [
+              {
+                label: parent ? `Reset order in ${nameOf(parent)}` : "Reset order",
+                onSelect: () => onResetOrder(parent),
+              },
+            ]
+          : []),
+      ];
+    },
+    [onReorder, onResetOrder, manualFolders, filter, nodes],
+  );
+
   const menuItems = useMemo((): MenuItem[] => {
     if (!menu) return [];
     const node = menu.target;
@@ -243,6 +353,7 @@ export function FileTree({
             onCreateFolder(node.path);
           },
         },
+        ...orderItems(node),
         { label: "Rename folder…", onSelect: () => onRenameFolder(node.path) },
         {
           label: "Delete folder",
@@ -264,12 +375,14 @@ export function FileTree({
             },
           ]
         : []),
+      ...orderItems(node),
       { label: "Rename…", onSelect: () => onRename(node.path) },
       { label: "Delete note", destructive: true, onSelect: () => onDelete(node.path) },
     ];
   }, [
     menu,
     reveal,
+    orderItems,
     onCreateIn,
     onCreateFolder,
     onRenameFolder,
@@ -340,6 +453,10 @@ export function FileTree({
             onDrop={drop}
             dropTarget={dropTarget}
             onDropTarget={setDropTarget}
+            canReorderWith={canReorderWith}
+            reorderTarget={reorderTarget}
+            onReorderTarget={setReorderTarget}
+            onDropBeside={dropBeside}
             // A search should reveal matches inside collapsed folders.
             forceOpen={filter.length > 0}
           />
@@ -370,6 +487,11 @@ interface TreeItemProps {
   onDrop: (folder: string) => void;
   dropTarget: string | null;
   onDropTarget: (path: string | null) => void;
+  /** Whether a drag hovering this row could be reordered against it. */
+  canReorderWith: (path: string) => boolean;
+  reorderTarget: { path: string; position: "before" | "after" } | null;
+  onReorderTarget: (target: { path: string; position: "before" | "after" } | null) => void;
+  onDropBeside: (target: string, position: "before" | "after") => void;
   forceOpen: boolean;
 }
 
@@ -394,6 +516,10 @@ const TreeItem = memo(function TreeItem({
   onDrop,
   dropTarget,
   onDropTarget,
+  canReorderWith,
+  reorderTarget,
+  onReorderTarget,
+  onDropBeside,
   forceOpen,
 }: TreeItemProps) {
   const open = forceOpen || expanded.has(node.path);
@@ -405,6 +531,40 @@ const TreeItem = memo(function TreeItem({
   const lifted =
     dragging !== null && (dragging.path === node.path || node.path.startsWith(`${dragging.path}/`));
   const dropFolder = isFolder ? node.path : dirnameOf(node.path);
+  const insertion = reorderTarget?.path === node.path ? reorderTarget.position : null;
+
+  /**
+   * Which of the two things a drop on this row means.
+   *
+   * The top and bottom fifth of a row are the gaps between rows, and a release
+   * there puts the dragged thing above or below this one. Everything in
+   * between is the row itself, which for a folder means "inside it".
+   *
+   * A fifth rather than a third: the middle of the row is by far the more
+   * common intent, and edges wide enough to be easy to hit are edges that
+   * swallow the drop somebody meant for the folder.
+   */
+  const intentAt = useCallback(
+    (event: React.DragEvent<HTMLDivElement>): "before" | "after" | "into" => {
+      if (!canReorderWith(node.path)) return "into";
+
+      const box = event.currentTarget.getBoundingClientRect();
+      // jsdom reports every box as zero-sized, and every point in a zero-high
+      // row is on both its edges. Reordering needs real layout to aim, so with
+      // none it is simply not offered.
+      if (box.height === 0) return "into";
+
+      const offset = (event.clientY - box.top) / box.height;
+      if (offset <= 0.2) return "before";
+      if (offset >= 0.8) return "after";
+
+      // A note is not a folder, so the middle of one cannot mean "inside it".
+      // Rather than refuse the drop, it lands beside — which is what dropping
+      // a note onto a note in an arranged folder plainly means.
+      return isFolder ? "into" : offset < 0.5 ? "before" : "after";
+    },
+    [canReorderWith, node.path, isFolder],
+  );
 
   /**
    * Brings the selected row into view.
@@ -460,6 +620,7 @@ const TreeItem = memo(function TreeItem({
         onDragEnd={() => {
           onDragging(null);
           onDropTarget(null);
+          onReorderTarget(null);
         }}
         // Where a drop on this row lands. A folder takes things inside it; a
         // note stands for the folder it is in, which is what dropping "next to
@@ -472,6 +633,17 @@ const TreeItem = memo(function TreeItem({
         // repository instead of doing nothing.
         onDragOver={(event) => {
           event.stopPropagation();
+          const intent = intentAt(event);
+
+          if (intent !== "into") {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "move";
+            onDropTarget(null);
+            onReorderTarget({ path: node.path, position: intent });
+            return;
+          }
+
+          onReorderTarget(null);
           if (!canDropOn(dropFolder)) return;
           event.preventDefault();
           event.dataTransfer.dropEffect = "move";
@@ -480,14 +652,35 @@ const TreeItem = memo(function TreeItem({
         onDragLeave={(event) => {
           event.stopPropagation();
           onDropTarget(null);
+          onReorderTarget(null);
         }}
         onDrop={(event) => {
           event.stopPropagation();
+          const intent = intentAt(event);
+
+          if (intent !== "into") {
+            event.preventDefault();
+            onDropBeside(node.path, intent);
+            return;
+          }
+
           if (!canDropOn(dropFolder)) return;
           event.preventDefault();
           onDrop(dropFolder);
         }}
       >
+        {/* Where a release right now would put it. A line in the gap rather
+            than a highlight on the row, because "between these two" is what
+            the drop means and a highlighted row says "into this one". */}
+        {insertion && (
+          <span
+            aria-hidden="true"
+            className={`pointer-events-none absolute inset-x-1 h-[2px] rounded-full bg-[var(--fl-accent)] ${
+              insertion === "before" ? "top-0" : "bottom-0"
+            }`}
+          />
+        )}
+
         {/* The selected note gets a bar rather than a fill alone: at sidebar
             width, a slightly lighter row is easy to lose track of. */}
         {active && (
@@ -580,6 +773,10 @@ const TreeItem = memo(function TreeItem({
               onDrop={onDrop}
               dropTarget={dropTarget}
               onDropTarget={onDropTarget}
+              canReorderWith={canReorderWith}
+              reorderTarget={reorderTarget}
+              onReorderTarget={onReorderTarget}
+              onDropBeside={onDropBeside}
               forceOpen={forceOpen}
             />
           ))}
@@ -644,6 +841,36 @@ function FileGlyph() {
 function dirnameOf(path: string): string {
   const cut = path.lastIndexOf("/");
   return cut === -1 ? "" : path.slice(0, cut);
+}
+
+/** The last segment of a path, for naming a folder in a menu item. */
+function nameOf(path: string): string {
+  return path.slice(path.lastIndexOf("/") + 1);
+}
+
+/**
+ * The list a path sits in — its parent's children, or the top level.
+ *
+ * Read from the whole tree rather than the filtered one, because the order
+ * being written down is the folder's, not the search result's.
+ */
+function siblingsOf(nodes: readonly TreeNode[], path: string): TreeNode[] {
+  const parent = dirnameOf(path);
+  if (parent === "") return [...nodes];
+
+  const find = (list: readonly TreeNode[]): TreeNode[] | null => {
+    for (const node of list) {
+      if (node.kind !== "folder") continue;
+      if (node.path === parent) return [...(node.children ?? [])];
+      if (parent.startsWith(`${node.path}/`)) {
+        const found = find(node.children ?? []);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+
+  return find(nodes) ?? [];
 }
 
 /** Every folder above a path, outermost first. `[]` for anything at the root. */

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import Link from "next/link";
 import type { SessionUser, Workspace } from "@forkleaf/types";
 import { Dialog } from "./Dialog";
+import { SUPPORT_EMAIL, SUPPORT_MAILTO } from "@/lib/constants";
 
 export interface HelpDialogProps {
   onClose: () => void;
@@ -280,9 +281,16 @@ export function HelpDialog({
         </div>
       )}
 
-      <p className="mt-6 border-t border-[var(--fl-border)] pt-4 text-[13px] text-[var(--fl-muted)]">
+      {/* "Still stuck?" used to end at the documentation, which is only an
+          answer when the documentation has one. Somebody reading this line has
+          usually already looked. */}
+      <p className="mt-6 border-t border-[var(--fl-border)] pt-4 text-[13px] leading-relaxed text-[var(--fl-muted)]">
         Still stuck? The <DocLink href="/docs">full documentation</DocLink> goes into much more
-        depth.
+        depth, and <DocLink href="/support">support</DocLink> is a real inbox — write to{" "}
+        <a href={SUPPORT_MAILTO} className="text-[var(--fl-accent)] underline underline-offset-2">
+          {SUPPORT_EMAIL}
+        </a>{" "}
+        with what happened and what you expected.
       </p>
     </Dialog>
   );

--- a/apps/web/src/components/LegalPage.tsx
+++ b/apps/web/src/components/LegalPage.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 import Link from "next/link";
+import { SUPPORT_EMAIL } from "@/lib/constants";
 
-/** Where privacy and data requests go. */
-export const CONTACT_EMAIL = "praneeth2006.dev@gmail.com";
+/**
+ * Where privacy and data requests go — the support address, because it is the
+ * same inbox and two addresses that reach one person is a way to be told a
+ * problem twice and answer it once.
+ */
+export const CONTACT_EMAIL = SUPPORT_EMAIL;
 
 /**
  * The date shown on the legal pages.

--- a/apps/web/src/components/SyncProblem.tsx
+++ b/apps/web/src/components/SyncProblem.tsx
@@ -312,7 +312,7 @@ export function SyncProblem({
                               onLocate(change.path);
                               setOpen(false);
                             }}
-                            title={`Open the note ${change.path} is in`}
+                            title={`Show ${change.path} in the note that uses it`}
                             aria-label={`Find ${change.path}`}
                             className="rounded border border-[var(--fl-border)] px-1.5 py-0.5 text-[10.5px] font-medium text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)]"
                           >
@@ -347,7 +347,7 @@ export function SyncProblem({
                   reasonably be read as deleting the note it sits in. */}
               <p className="mt-2 text-[11px] leading-relaxed text-[var(--fl-muted)]">
                 <strong className="font-semibold text-[var(--fl-text)]">Find</strong> opens the note
-                the file is in.{" "}
+                the file is in and rings it.{" "}
                 <strong className="font-semibold text-[var(--fl-text)]">Remove</strong> takes it out
                 of the queue so everything behind it can push — your notes and their text are
                 untouched.

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -11,6 +11,7 @@ import {
   documentStats,
   joinPath,
   parseRepoTarget,
+  referencedPaths,
   type RepoTarget,
   serializeDocument,
   slugifyFilename,
@@ -47,6 +48,7 @@ import { LocalOnlyBanner } from "@/components/LocalOnlyBanner";
 import { fetchSession, signOut } from "@/lib/gateway";
 import { postHogReset } from "@/lib/posthog";
 import { assetPathFor, relativeSrc, resolveImageSrc } from "@/lib/assets";
+import { revealAsset } from "@/lib/reveal-asset";
 import { imageTypeFor } from "@/lib/media";
 import { collectFolders } from "@/lib/tree";
 import { hasRelativeImages, repairNoteLinks } from "@/lib/repair-links";
@@ -188,6 +190,15 @@ export function EditorWorkspace() {
    */
   const currentFolder = notePath ? dirname(notePath) : "";
   const takenPaths = useMemo(() => flattenTree(notebook.tree), [notebook.tree]);
+
+  // Which folders the sidebar should offer to put back under the sort mode.
+  const manualFolders = useMemo(
+    () =>
+      Object.entries(notebook.treeOrder.manual)
+        .filter(([, paths]) => paths.length > 0)
+        .map(([folder]) => folder),
+    [notebook.treeOrder],
+  );
 
   /**
    * Where images in this note come from and go.
@@ -443,15 +454,74 @@ export function EditorWorkspace() {
   }, [notebook, workspace, signInAgain]);
 
   /**
-   * Opens whatever a stuck file needs somebody to look at.
+   * The element the note is drawn into, so a picture in it can be found.
+   *
+   * A ref rather than an id lookup: two editors are never on screen at once
+   * today, but a `document.querySelector` that assumes so is a bug waiting for
+   * the day one is.
+   */
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+
+  /**
+   * Rings an image once the note it is in has actually drawn it.
+   *
+   * Opening a note is not the same as the note being on screen: its text is
+   * fetched, the editor mounts, and an image resolves through an asset store
+   * that may still be reading the bytes off this device. Marking the image in
+   * the same tick as the open would reliably mark nothing.
+   *
+   * So it is retried across frames until the image appears or the window
+   * closes. The window exists because "never" is a real answer — raw markdown
+   * view draws no images at all — and something has to say so rather than
+   * polling for the rest of the session.
+   */
+  const revealWhenDrawn = useCallback(
+    (notePath: string, assetPath: string) =>
+      new Promise<"revealed" | "not-rendered">((resolve) => {
+        const deadline = Date.now() + 2500;
+
+        const attempt = () => {
+          const outcome = revealAsset({
+            root: canvasRef.current,
+            notePath,
+            assetPath,
+            // Recomputed each time: the resolver reads an asset store that
+            // fills up while this is running, so its answer for a picture
+            // being read off disk changes between one frame and the next.
+            resolvedSrc: images.resolve?.(relativeSrc(notePath, assetPath)) ?? null,
+          });
+
+          if (outcome === "revealed" || Date.now() > deadline) {
+            resolve(outcome);
+            return;
+          }
+
+          requestAnimationFrame(attempt);
+        };
+
+        requestAnimationFrame(attempt);
+      }),
+    [images],
+  );
+
+  /**
+   * Opens whatever a stuck file needs somebody to look at, and points at it.
    *
    * A note is its own answer — open it. A picture is not: it has no note of
    * its own, it lives inside one, and the one thing the reader needs is to be
-   * standing in front of that note with the image in view. So its filename is
-   * looked for across the notebook and the note carrying it is opened.
+   * standing in front of that note with the image in view.
    *
-   * A picture nothing references any more still gets an honest outcome: there
-   * is nowhere to go, and saying so beats opening an unrelated note.
+   * Which note that is used to be decided by `content.includes(filename)`,
+   * which is a substring search for a bare name. It matched a note that merely
+   * wrote the words `sunset.png` in a sentence, matched `archive/sunset.png`
+   * in a different folder as readily as the picture actually queued, and, when
+   * several notes were candidates, opened whichever came first. Every
+   * reference form is resolved against the note holding it now, so the match
+   * is the file and not its name.
+   *
+   * Opening the note was also only half the errand: in a note of any length,
+   * "it is in here somewhere" is the same complaint the button was added to
+   * answer, moved one step later. The image is scrolled to and ringed.
    */
   const locateUnsynced = useCallback(
     async (path: string) => {
@@ -462,18 +532,34 @@ export function EditorWorkspace() {
 
       const name = path.split("/").pop() ?? path;
       const notes = await notebook.allNotes();
-      const holder = notes.find((note) => note.content.includes(name));
+      const holders = notes.filter((note) =>
+        referencedPaths(note.path, note.content).includes(path),
+      );
+      const holder = holders[0];
 
-      if (holder) {
-        await notebook.openNote(holder.path);
+      if (!holder) {
+        setNotice(
+          `${name} is not referenced by any note any more. Removing it will unblock everything else.`,
+        );
         return;
       }
 
+      await notebook.openNote(holder.path);
+
+      // Also used in more than one note, which changes what removing it means.
+      const alsoIn = holders.length > 1 ? ` It is used in ${holders.length} notes.` : "";
+
+      const outcome = await revealWhenDrawn(holder.path, path);
+
       setNotice(
-        `${name} is not referenced by any note any more. Removing it will unblock everything else.`,
+        outcome === "revealed"
+          ? `${name} is here, in ${holder.path}.${alsoIn}`
+          : // Raw markdown draws no images, so there is nothing on screen to
+            // ring. Saying which note it is in beats a silent no-op.
+            `${name} is in ${holder.path}. Switch to Rich or Split view to see it.${alsoIn}`,
       );
     },
-    [notebook],
+    [notebook, revealWhenDrawn],
   );
 
   // ── Actions ─────────────────────────────────────────────────────────────
@@ -1318,6 +1404,12 @@ export function EditorWorkspace() {
             pinnedPaths={notebook.pinnedPaths}
             {...(notebook.expandedFolders ? { openFolders: notebook.expandedFolders } : {})}
             onOpenFoldersChange={notebook.setExpandedFolders}
+            sortMode={notebook.treeOrder.mode}
+            onSortModeChange={notebook.setTreeSortMode}
+            onReorder={notebook.moveInTree}
+            onReorderTo={notebook.dropInTree}
+            onResetOrder={notebook.resetTreeOrder}
+            manualFolders={manualFolders}
             onTogglePin={notebook.togglePinned}
             onMovePin={notebook.movePinned}
             user={user}
@@ -1583,7 +1675,7 @@ export function EditorWorkspace() {
           )}
 
           {/* ── Canvas ───────────────────────────────────────────────── */}
-          <div className="flex min-h-0 flex-1 flex-col">
+          <div ref={canvasRef} className="flex min-h-0 flex-1 flex-col">
             {note ? (
               <MarkdownEditor
                 key={note.id}

--- a/apps/web/src/components/landing/Footer.tsx
+++ b/apps/web/src/components/landing/Footer.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import Link from "next/link";
 import { ForkLeafLogo } from "@/components/Brand";
-import { CONTRIBUTING_URL, ISSUES_URL, LICENSE_URL, REPO_URL } from "@/lib/constants";
+import {
+  CONTRIBUTING_URL,
+  ISSUES_URL,
+  LICENSE_URL,
+  REPO_URL,
+  SUPPORT_EMAIL,
+  SUPPORT_MAILTO,
+} from "@/lib/constants";
 import { SectionLink } from "./SectionLink";
 
 /**
@@ -60,6 +67,16 @@ const COLUMNS = [
     ],
   },
   {
+    heading: "Support",
+    links: [
+      { label: "Getting help", href: "/support" },
+      { label: "Email support", href: SUPPORT_MAILTO },
+      { label: "Troubleshooting", href: "/docs/troubleshooting" },
+      { label: "Report a bug", href: ISSUES_URL },
+      { label: "FAQ", href: "/docs/faq" },
+    ],
+  },
+  {
     heading: "Legal & data",
     links: [
       { label: "Privacy Policy", href: "/privacy" },
@@ -75,7 +92,7 @@ export function Footer() {
   return (
     <footer className="border-t border-[var(--fl-border)] bg-[var(--fl-bg)]">
       <div className="mx-auto w-full max-w-6xl px-6 py-16">
-        <div className="grid gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-[1.5fr_repeat(5,minmax(0,1fr))]">
+        <div className="grid gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-[1.5fr_repeat(6,minmax(0,1fr))]">
           <div>
             <ForkLeafLogo textClassName="text-[1.0625rem]" />
             <p className="mt-4 max-w-xs text-[14px] leading-relaxed text-[var(--fl-muted)]">
@@ -105,6 +122,7 @@ export function Footer() {
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
             <FooterLink href="/privacy">Privacy</FooterLink>
             <FooterLink href="/terms">Terms</FooterLink>
+            <FooterLink href={SUPPORT_MAILTO}>{SUPPORT_EMAIL}</FooterLink>
             <span>Your notes are in your repository, not ours.</span>
           </div>
         </div>
@@ -128,6 +146,16 @@ function FooterLink({ href, children }: { href: string; children: React.ReactNod
       <SectionLink hash={href} className={className}>
         {children}
       </SectionLink>
+    );
+  }
+
+  // A mail client is not a tab, so `target="_blank"` would open an empty one
+  // beside the compose window and leave it there.
+  if (href.startsWith("mailto:")) {
+    return (
+      <a href={href} className={className}>
+        {children}
+      </a>
     );
   }
 

--- a/apps/web/src/components/landing/Nav.tsx
+++ b/apps/web/src/components/landing/Nav.tsx
@@ -22,6 +22,7 @@ const SECTIONS = [
   { hash: "#features", label: "Features" },
   { hash: "#compare", label: "Compare" },
   { hash: "#pricing", label: "Pricing" },
+  { hash: "#support", label: "Support" },
 ] as const;
 
 export function Nav({

--- a/apps/web/src/components/landing/Support.tsx
+++ b/apps/web/src/components/landing/Support.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import Link from "next/link";
+import { ISSUES_URL, SECURITY_URL, SUPPORT_EMAIL, SUPPORT_MAILTO } from "@/lib/constants";
+import { SectionHeading } from "./SectionHeading";
+
+/**
+ * Where to go when something is wrong.
+ *
+ * The page argued the product for nine sections and never once said how to
+ * reach anybody. That is a strange omission for an app you are being asked to
+ * trust with your notes: the question underneath "is this any good" is "and
+ * what happens when it breaks", and a site with no answer to the second reads
+ * as one that would rather not be asked.
+ *
+ * Four routes, in the order they are usually the right one, each saying what it
+ * is for. A single "contact us" would make somebody with a crashed editor and
+ * somebody with a security finding pick the same door.
+ */
+
+const ROUTES = [
+  {
+    title: "Read the documentation",
+    body: "Most questions are already answered in writing — signing in, syncing, conflicts, exporting, and the errors people actually hit.",
+    action: "Open the docs",
+    href: "/docs",
+    external: false,
+  },
+  {
+    title: "Email support",
+    body: "Anything else: a bug, a note that will not sync, a question about your data, or a feature you wish existed. A real inbox, read by the person who builds this.",
+    action: SUPPORT_EMAIL,
+    href: SUPPORT_MAILTO,
+    external: false,
+  },
+  {
+    title: "Open an issue",
+    body: "Bugs and feature requests, in public, where anyone else hitting the same thing can find the answer and add to it.",
+    action: "Go to GitHub Issues",
+    href: ISSUES_URL,
+    external: true,
+  },
+  {
+    title: "Report a vulnerability",
+    body: "Security findings go through the disclosure policy rather than the public tracker, so a flaw is fixed before it is advertised.",
+    action: "Read the security policy",
+    href: SECURITY_URL,
+    external: true,
+  },
+] as const;
+
+export function Support() {
+  return (
+    <section id="support" className="border-t border-[var(--fl-border)] py-24">
+      <div className="mx-auto w-full max-w-6xl px-6">
+        <SectionHeading
+          eyebrow="Support"
+          title="If something breaks, here is who to tell"
+          body="ForkLeaf is free and open source, and it is also somebody's notes. Every route below reaches a person; the first one that fits is the right one."
+        />
+
+        <div className="mt-12 grid gap-4 sm:grid-cols-2">
+          {ROUTES.map((route) => (
+            <div
+              key={route.title}
+              className="flex flex-col rounded-2xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-6"
+            >
+              <h3 className="text-[17px] font-semibold text-[var(--fl-text)]">{route.title}</h3>
+              <p className="mt-2.5 flex-1 text-[15px] leading-relaxed text-[var(--fl-muted)]">
+                {route.body}
+              </p>
+
+              <p className="mt-5">
+                {route.external ? (
+                  <a
+                    href={route.href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="fl-link break-words text-[15px] font-medium"
+                  >
+                    {route.action} →
+                  </a>
+                ) : (
+                  <Link href={route.href} className="fl-link break-words text-[15px] font-medium">
+                    {route.action} →
+                  </Link>
+                )}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <p className="mt-8 text-[14.5px] leading-relaxed text-[var(--fl-muted)]">
+          One person answers this inbox, so a reply takes as long as it takes — usually a couple of
+          days. Nothing you send is needed to recover your work in the meantime: your notes are
+          Markdown files in your own repository, and{" "}
+          <Link href="/support" className="fl-link">
+            the support page
+          </Link>{" "}
+          lists what to try first and what to include when you write in.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -11,6 +11,7 @@ import {
 } from "@forkleaf/store";
 import {
   workspaceId,
+  compareTreeEntries,
   DEFAULT_SYNC_PREFERENCE,
   type LocalAsset,
   type Note,
@@ -34,6 +35,21 @@ import {
 import { LOCAL_WORKSPACE, collapseBranchDuplicates } from "@/lib/workspaces";
 import { forgetLock, isPathLocked, lockedKey, renameLock, toggleLock } from "@/lib/locks";
 import { assetFrom, assetObjectUrl } from "@/lib/assets";
+import {
+  DEFAULT_TREE_ORDER,
+  orderTree,
+  prunedOrder,
+  withCreated,
+  withCreatedRenamed,
+  withDropped,
+  withMoved,
+  withPathRenamed,
+  withoutCreated,
+  withoutManual,
+  type CreationTimes,
+  type TreeOrder,
+  type TreeSortMode,
+} from "@/lib/tree-order";
 
 /**
  * The application's single source of truth.
@@ -125,6 +141,25 @@ export interface NotebookState {
    */
   expandedFolders: string[] | null;
   /**
+   * The order the sidebar draws the tree in, and any folder somebody has
+   * arranged by hand.
+   *
+   * A per-device preference like the pinned notes above it: git sorts its own
+   * tree and records nothing about what anybody wanted to read first, so an
+   * order kept anywhere else would have to be a manifest committed into the
+   * repository that no other tool would understand.
+   */
+  treeOrder: TreeOrder;
+  /**
+   * When each note and folder was made, for the modes that sort by it.
+   *
+   * Only ever holds what ForkLeaf watched happen. Everything that was already
+   * in a repository when it was connected has no entry here, and sorts by name
+   * instead — GitHub's tree carries no creation date, and a made-up one would
+   * order the notebook confidently and wrongly.
+   */
+  createdAt: CreationTimes;
+  /**
    * True when this is a GitHub session with no repository connected yet. The
    * editor turns it into the connect dialog; the dashboard turns it into the
    * first-run repository chooser.
@@ -165,6 +200,10 @@ const pinnedKey = (workspace: string) => `pinned:${workspace}`;
  * opened are a fair description of what they are working on.
  */
 const expandedKey = (workspace: string) => `expanded:${workspace}`;
+/** The sidebar's sort mode and any folder arranged by hand. See `treeOrder`. */
+const treeOrderKey = (workspace: string) => `treeOrder:${workspace}`;
+/** When each note and folder ForkLeaf made was made. See `createdAt`. */
+const createdKey = (workspace: string) => `created:${workspace}`;
 
 /**
  * Shown when the browser will not give ForkLeaf durable local storage at all.
@@ -239,6 +278,8 @@ export function useNotebook(request: NotebookRequest = {}) {
     pinnedPaths: [],
     lockedPaths: [],
     expandedFolders: null,
+    treeOrder: DEFAULT_TREE_ORDER,
+    createdAt: {},
     needsRepoChoice: false,
     remoteChange: null,
   });
@@ -501,6 +542,19 @@ export function useNotebook(request: NotebookRequest = {}) {
       // No record at all is a first visit, not a deliberate "all closed" — the
       // top level opens, as it always did.
       if (!cancelled) patch({ expandedFolders: expanded ?? null });
+
+      // Per workspace, because how you want to read a course numbered 1 to 10
+      // and how you want to read a colleague's documentation repo are not the
+      // same question.
+      const order = await dbRef.current?.getMeta<TreeOrder>(treeOrderKey(workspace.id));
+      const created =
+        (await dbRef.current?.getMeta<Record<string, string>>(createdKey(workspace.id))) ?? {};
+      if (!cancelled) {
+        patch({
+          treeOrder: order ? { ...DEFAULT_TREE_ORDER, ...order } : DEFAULT_TREE_ORDER,
+          createdAt: created,
+        });
+      }
 
       // Reopen the tabs this workspace had last time, plus whatever the URL
       // asked for. A note that has since been deleted simply fails to load and
@@ -798,6 +852,44 @@ export function useNotebook(request: NotebookRequest = {}) {
     [activeNote, patchOpenNote, isLocked],
   );
 
+  /**
+   * Persists the sidebar's order and reflects it in state in one step.
+   *
+   * Folders that are no longer in the tree are dropped on the way past. They
+   * accumulate whenever a folder is deleted somewhere this device did not
+   * watch — another machine, a commit made on github.com — and while they cost
+   * nothing to draw (`orderTree` ignores an arrangement for a folder that is
+   * not there), a record that only ever grows is one that eventually holds a
+   * repository's worth of folders nobody has had in years.
+   *
+   * Here, rather than in an effect watching the tree: an effect that writes
+   * state on every refresh from GitHub is a cascading render on a hot path, to
+   * tidy something nothing is reading.
+   */
+  const putTreeOrder = useCallback(
+    (next: TreeOrder) => {
+      const workspace = state.activeWorkspace;
+      const pruned =
+        state.tree.length > 0
+          ? prunedOrder(next, withEmptyFolders(state.tree, state.emptyFolders))
+          : next;
+
+      patch({ treeOrder: pruned });
+      if (workspace) void dbRef.current?.putMeta(treeOrderKey(workspace.id), pruned);
+    },
+    [state.activeWorkspace, state.tree, state.emptyFolders, patch],
+  );
+
+  /** Persists the creation stamps and reflects them in state in one step. */
+  const putCreated = useCallback(
+    (next: CreationTimes) => {
+      const workspace = state.activeWorkspace;
+      patch({ createdAt: next });
+      if (workspace) void dbRef.current?.putMeta(createdKey(workspace.id), next);
+    },
+    [state.activeWorkspace, patch],
+  );
+
   const createNote = useCallback(
     async (title: string, folder = "", content?: string) => {
       const workspace = state.activeWorkspace;
@@ -831,10 +923,22 @@ export function useNotebook(request: NotebookRequest = {}) {
       if (stillEmpty.length !== state.emptyFolders.length) {
         void dbRef.current?.putMeta(emptyFoldersKey(workspace.id), stillEmpty);
       }
+      // So the sidebar can put it where it was written rather than where its
+      // name falls in the alphabet.
+      putCreated(withCreated(state.createdAt, note.path, new Date().toISOString()));
       rememberTabs(workspace.id, open, note.path);
       return note;
     },
-    [state.activeWorkspace, state.tree, state.openNotes, state.emptyFolders, patch, rememberTabs],
+    [
+      state.activeWorkspace,
+      state.tree,
+      state.openNotes,
+      state.emptyFolders,
+      state.createdAt,
+      putCreated,
+      patch,
+      rememberTabs,
+    ],
   );
 
   /**
@@ -862,6 +966,9 @@ export function useNotebook(request: NotebookRequest = {}) {
       const activePath = state.activePath === path ? (open[0]?.path ?? null) : state.activePath;
 
       patch({ tree: removeFromTree(state.tree, path), openNotes: open, activePath });
+      // A stamp left behind would date the next note created at this path to
+      // whenever the deleted one was written.
+      putCreated(withoutCreated(state.createdAt, path));
       rememberTabs(workspace.id, open, activePath);
     },
     [
@@ -870,7 +977,9 @@ export function useNotebook(request: NotebookRequest = {}) {
       state.activePath,
       state.activeWorkspace,
       state.lockedPaths,
+      state.createdAt,
       putLocked,
+      putCreated,
       patch,
       rememberTabs,
     ],
@@ -901,6 +1010,13 @@ export function useNotebook(request: NotebookRequest = {}) {
         openNotes: open,
         activePath,
       });
+
+      // A rename is the same note under a new name, and a drag into another
+      // folder is the same note somewhere else. Neither is a new note, so
+      // neither loses when it was written or where somebody put it.
+      putCreated(withCreatedRenamed(state.createdAt, note.path, renamed.path));
+      putTreeOrder(withPathRenamed(state.treeOrder, note.path, renamed.path));
+
       if (state.activeWorkspace) rememberTabs(state.activeWorkspace.id, open, activePath);
       return renamed;
     },
@@ -910,7 +1026,11 @@ export function useNotebook(request: NotebookRequest = {}) {
       state.activePath,
       state.activeWorkspace,
       state.lockedPaths,
+      state.createdAt,
+      state.treeOrder,
       putLocked,
+      putCreated,
+      putTreeOrder,
       patch,
       rememberTabs,
     ],
@@ -944,6 +1064,45 @@ export function useNotebook(request: NotebookRequest = {}) {
       if (workspace) void dbRef.current?.putMeta(pinnedKey(workspace.id), next);
     },
     [state.activeWorkspace, patch],
+  );
+
+  /**
+   * Switches how the tree is sorted.
+   *
+   * Folders somebody arranged by hand are left alone: the mode is what to do
+   * with everything nobody has said anything about, and throwing away a
+   * hand-made order because the mode was changed once would make the mode
+   * menu a destructive control.
+   */
+  const setTreeSortMode = useCallback(
+    (mode: TreeSortMode) => putTreeOrder({ ...state.treeOrder, mode }),
+    [state.treeOrder, putTreeOrder],
+  );
+
+  /**
+   * Moves one row up or down within its own folder.
+   *
+   * `siblings` is what the sidebar is currently drawing, so the recorded order
+   * is the one the reader can see rather than the one the sort mode would have
+   * produced.
+   */
+  const moveInTree = useCallback(
+    (siblings: readonly TreeNode[], path: string, direction: -1 | 1) =>
+      putTreeOrder(withMoved(state.treeOrder, siblings, path, direction)),
+    [state.treeOrder, putTreeOrder],
+  );
+
+  /** Drops one row into the gap above or below another in the same folder. */
+  const dropInTree = useCallback(
+    (siblings: readonly TreeNode[], path: string, target: string, position: "before" | "after") =>
+      putTreeOrder(withDropped(state.treeOrder, siblings, path, target, position)),
+    [state.treeOrder, putTreeOrder],
+  );
+
+  /** Puts one folder's contents back under whichever sort mode is in force. */
+  const resetTreeOrder = useCallback(
+    (parent: string) => putTreeOrder(withoutManual(state.treeOrder, parent)),
+    [state.treeOrder, putTreeOrder],
   );
 
   /** Pins a note, or unpins one already pinned. */
@@ -1014,9 +1173,20 @@ export function useNotebook(request: NotebookRequest = {}) {
       );
 
       putEmptyFolders([...state.emptyFolders, ...ancestors, clean].sort());
+
+      // Every level that had to be invented counts as made now, so a folder
+      // and its new parent do not end up dated differently.
+      const at = new Date().toISOString();
+      putCreated(
+        [...ancestors, clean].reduce(
+          (times, folder) => withCreated(times, folder, at),
+          state.createdAt,
+        ),
+      );
+
       return clean;
     },
-    [state.tree, state.emptyFolders, putEmptyFolders],
+    [state.tree, state.emptyFolders, state.createdAt, putEmptyFolders, putCreated],
   );
 
   /**
@@ -1051,6 +1221,9 @@ export function useNotebook(request: NotebookRequest = {}) {
           ),
         );
 
+        putCreated(withCreatedRenamed(state.createdAt, source, target));
+        putTreeOrder(withPathRenamed(state.treeOrder, source, target));
+
         await refreshTree();
       } finally {
         patch({ busy: null });
@@ -1059,7 +1232,18 @@ export function useNotebook(request: NotebookRequest = {}) {
     // `state.openNotes` was here to find an already-open note to rename;
     // `moveFolderContents` looks that up itself, so keeping it in this list
     // would rebuild the callback on every keystroke in any open note.
-    [state.tree, state.activeWorkspace, state.emptyFolders, putEmptyFolders, refreshTree, patch],
+    [
+      state.tree,
+      state.activeWorkspace,
+      state.emptyFolders,
+      state.createdAt,
+      state.treeOrder,
+      putEmptyFolders,
+      putCreated,
+      putTreeOrder,
+      refreshTree,
+      patch,
+    ],
   );
 
   /** Deletes a folder and every note inside it. */
@@ -1093,6 +1277,8 @@ export function useNotebook(request: NotebookRequest = {}) {
           : (open[0]?.path ?? null);
 
         patch({ openNotes: open, activePath });
+        putCreated(withoutCreated(state.createdAt, folder));
+        putTreeOrder(withoutManual(state.treeOrder, folder));
         rememberTabs(workspace.id, open, activePath);
         await refreshTree();
       } finally {
@@ -1105,7 +1291,11 @@ export function useNotebook(request: NotebookRequest = {}) {
       state.activePath,
       state.activeWorkspace,
       state.emptyFolders,
+      state.createdAt,
+      state.treeOrder,
       putEmptyFolders,
+      putCreated,
+      putTreeOrder,
       refreshTree,
       rememberTabs,
       patch,
@@ -1512,9 +1702,19 @@ export function useNotebook(request: NotebookRequest = {}) {
     [state.activeWorkspace, patch],
   );
 
+  /**
+   * The tree as the sidebar draws it: the repository, plus the folders made
+   * here that are still waiting for their first note, in the order the reader
+   * asked for.
+   *
+   * The ordering happens here rather than in the tree itself because the tree
+   * is replaced wholesale by every refresh from GitHub — an order written into
+   * it would survive exactly until the next pull.
+   */
   const displayTree = useMemo(
-    () => withEmptyFolders(state.tree, state.emptyFolders),
-    [state.tree, state.emptyFolders],
+    () =>
+      orderTree(withEmptyFolders(state.tree, state.emptyFolders), state.treeOrder, state.createdAt),
+    [state.tree, state.emptyFolders, state.treeOrder, state.createdAt],
   );
 
   return useMemo(
@@ -1537,6 +1737,10 @@ export function useNotebook(request: NotebookRequest = {}) {
       toggleLocked,
       isLocked,
       movePinned,
+      setTreeSortMode,
+      moveInTree,
+      dropInTree,
+      resetTreeOrder,
       renameFolder,
       deleteFolder,
       setViewMode,
@@ -1565,10 +1769,7 @@ export function useNotebook(request: NotebookRequest = {}) {
        * somebody closes the tab believing it was committed.
        */
       reportError: (message: string) => patch({ error: message }),
-      /**
-       * The tree as the sidebar should draw it: what is in the repository,
-       * plus the folders made here that are still waiting for their first note.
-       */
+      /** The tree as the sidebar should draw it. See `displayTree`. */
       tree: displayTree,
     }),
     [
@@ -1592,6 +1793,10 @@ export function useNotebook(request: NotebookRequest = {}) {
       toggleLocked,
       isLocked,
       movePinned,
+      setTreeSortMode,
+      moveInTree,
+      dropInTree,
+      resetTreeOrder,
       renameFolder,
       deleteFolder,
       displayTree,
@@ -1742,10 +1947,7 @@ function removeFromTree(tree: TreeNode[], path: string): TreeNode[] {
 }
 
 function sortNodes(nodes: TreeNode[]): TreeNode[] {
-  return [...nodes].sort((a, b) => {
-    if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
-    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
-  });
+  return [...nodes].sort(compareTreeEntries);
 }
 
 /** The blob SHA the tree reported for a path, when it reported one. */

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -6,3 +6,20 @@ export const CONTRIBUTING_URL = `${REPO_URL}/blob/main/CONTRIBUTING.md`;
 export const SECURITY_URL = `${REPO_URL}/blob/main/SECURITY.md`;
 export const ARCHITECTURE_URL = `${REPO_URL}/blob/main/docs/architecture.md`;
 export const SPONSOR_URL = `https://github.com/sponsors/praneeth132006`;
+
+/**
+ * Where to write when something is wrong.
+ *
+ * The same address the legal pages give, on purpose: one inbox that answers
+ * for the whole project is easier to trust than three that each answer for a
+ * corner of it, and a support address nobody watches is worse than none.
+ */
+export const SUPPORT_EMAIL = "praneeth2006.dev@gmail.com";
+
+/**
+ * A pre-addressed message, so writing in is one click rather than a copy, a
+ * paste and a subject line somebody has to invent.
+ */
+export const SUPPORT_MAILTO = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+  "ForkLeaf support",
+)}`;

--- a/apps/web/src/lib/library.ts
+++ b/apps/web/src/lib/library.ts
@@ -1,5 +1,5 @@
 import { deriveTitle, documentStats, extractTags } from "@forkleaf/markdown-engine";
-import type { Note, TreeNode, Workspace } from "@forkleaf/types";
+import { compareTreeNames, type Note, type TreeNode, type Workspace } from "@forkleaf/types";
 
 /**
  * The note index that the dashboard is built on.
@@ -324,9 +324,9 @@ export function queryIndex(entries: IndexEntry[], options: QueryOptions = {}): I
 function compare(a: IndexEntry, b: IndexEntry, sort: SortKey): number {
   switch (sort) {
     case "title":
-      return a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+      return compareTreeNames(a.title, b.title);
     case "path":
-      return a.path.localeCompare(b.path, undefined, { sensitivity: "base" });
+      return compareTreeNames(a.path, b.path);
     case "words":
       return b.words - a.words;
     case "recent":
@@ -334,7 +334,7 @@ function compare(a: IndexEntry, b: IndexEntry, sort: SortKey): number {
       // Never-opened notes have no local timestamp, so they sort last rather
       // than pretending to be from 1970.
       if (!a.updatedAt && !b.updatedAt) {
-        return a.path.localeCompare(b.path, undefined, { sensitivity: "base" });
+        return compareTreeNames(a.path, b.path);
       }
       if (!a.updatedAt) return 1;
       if (!b.updatedAt) return -1;
@@ -358,7 +358,7 @@ export function folderCounts(entries: IndexEntry[]): { path: string; count: numb
 
   return [...counts.entries()]
     .map(([path, count]) => ({ path, count }))
-    .sort((a, b) => a.path.localeCompare(b.path, undefined, { sensitivity: "base" }));
+    .sort((a, b) => compareTreeNames(a.path, b.path));
 }
 
 /**
@@ -395,7 +395,7 @@ export function subfolders(
 
   return [...counts.entries()]
     .map(([path, count]) => ({ path, name: path.slice(prefix.length), count }))
-    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+    .sort((a, b) => compareTreeNames(a.name, b.name));
 }
 
 /** How many notes sit in this exact folder rather than in one below it. */
@@ -500,10 +500,12 @@ export function buildNoteTree(entries: IndexEntry[]): NoteFolder {
   }
 
   // Counts roll up, and both lists sort by name so the tree is stable between
-  // renders and between sessions.
+  // renders and between sessions. By natural name order, the same as the
+  // editor's sidebar — a numbered notebook that read in two different orders
+  // depending on which screen you were looking at was its own small bug.
   const finish = (node: NoteFolder): number => {
-    node.folders.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
-    node.notes.sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: "base" }));
+    node.folders.sort((a, b) => compareTreeNames(a.name, b.name));
+    node.notes.sort((a, b) => compareTreeNames(a.title, b.title));
     node.count =
       node.notes.length + node.folders.reduce((total, child) => total + finish(child), 0);
     return node.count;

--- a/apps/web/src/lib/reveal-asset.test.tsx
+++ b/apps/web/src/lib/reveal-asset.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { REVEAL_CLASS, REVEAL_MS, revealAsset } from "./reveal-asset";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.useRealTimers();
+});
+
+/** A note canvas holding the given images, as one of the two surfaces draws them. */
+function canvas(images: { src: string; dataSrc?: string }[]): HTMLElement {
+  const root = document.createElement("div");
+  for (const image of images) {
+    const element = document.createElement("img");
+    element.setAttribute("src", image.src);
+    if (image.dataSrc) element.setAttribute("data-src", image.dataSrc);
+    root.append(element);
+  }
+  document.body.append(root);
+  return root;
+}
+
+const reveal = (root: HTMLElement | null, assetPath: string, resolvedSrc?: string | null) =>
+  revealAsset({
+    root,
+    notePath: "Fieldwork/soil.md",
+    assetPath,
+    ...(resolvedSrc !== undefined ? { resolvedSrc } : {}),
+  });
+
+describe("revealAsset", () => {
+  it("finds the image the rich editor drew, by what the markdown says", () => {
+    const root = canvas([{ src: "/api/gh/raw?path=x", dataSrc: "assets/chart.png" }]);
+
+    expect(reveal(root, "Fieldwork/assets/chart.png")).toBe("revealed");
+    expect(root.querySelector("img")!.classList.contains(REVEAL_CLASS)).toBe(true);
+  });
+
+  it("finds the image the preview drew, which keeps no copy of the original", () => {
+    const root = canvas([{ src: "blob:one" }]);
+
+    expect(reveal(root, "Fieldwork/assets/chart.png", "blob:one")).toBe("revealed");
+  });
+
+  it("resolves a path that climbs out of the note's folder", () => {
+    const root = canvas([{ src: "blob:one", dataSrc: "../shared/chart.png" }]);
+
+    expect(reveal(root, "shared/chart.png")).toBe("revealed");
+  });
+
+  it("does not mistake a same-named picture in another folder for this one", () => {
+    const root = canvas([{ src: "blob:one", dataSrc: "assets/chart.png" }]);
+
+    expect(reveal(root, "Archive/assets/chart.png")).toBe("not-rendered");
+    expect(root.querySelector("img")!.classList.contains(REVEAL_CLASS)).toBe(false);
+  });
+
+  it("marks only the image asked for, out of several in one note", () => {
+    const root = canvas([
+      { src: "blob:one", dataSrc: "assets/first.png" },
+      { src: "blob:two", dataSrc: "assets/second.png" },
+      { src: "blob:three", dataSrc: "assets/third.png" },
+    ]);
+
+    reveal(root, "Fieldwork/assets/second.png");
+
+    const marked = [...root.querySelectorAll("img")].filter((image) =>
+      image.classList.contains(REVEAL_CLASS),
+    );
+    expect(marked).toHaveLength(1);
+    expect(marked[0]!.getAttribute("data-src")).toBe("assets/second.png");
+  });
+
+  it("ignores an absolute image, which is not ours to point at", () => {
+    const root = canvas([{ src: "https://example.com/assets/chart.png" }]);
+
+    expect(reveal(root, "assets/chart.png")).toBe("not-rendered");
+  });
+
+  it("reports a note with no images drawn rather than throwing", () => {
+    expect(reveal(canvas([]), "assets/chart.png")).toBe("not-rendered");
+    expect(reveal(null, "assets/chart.png")).toBe("not-rendered");
+  });
+
+  it("takes the mark off again, so it does not sit on the image for the session", () => {
+    vi.useFakeTimers();
+    const root = canvas([{ src: "blob:one", dataSrc: "assets/chart.png" }]);
+
+    reveal(root, "Fieldwork/assets/chart.png");
+    expect(root.querySelector("img")!.classList.contains(REVEAL_CLASS)).toBe(true);
+
+    vi.advanceTimersByTime(REVEAL_MS + 1);
+    expect(root.querySelector("img")!.classList.contains(REVEAL_CLASS)).toBe(false);
+  });
+
+  it("scrolls it into view, since being marked off screen is not being found", () => {
+    const root = canvas([{ src: "blob:one", dataSrc: "assets/chart.png" }]);
+    const image = root.querySelector("img")!;
+    image.scrollIntoView = vi.fn();
+
+    reveal(root, "Fieldwork/assets/chart.png");
+
+    expect(image.scrollIntoView).toHaveBeenCalledWith({ block: "center", behavior: "smooth" });
+  });
+});

--- a/apps/web/src/lib/reveal-asset.ts
+++ b/apps/web/src/lib/reveal-asset.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { isRepoRelative, resolveAgainstNote } from "@/lib/assets";
+
+/**
+ * Finding one picture inside the note that uses it, and saying so on screen.
+ *
+ * "Find" used to open the note and stop there. In a note of any length that
+ * leaves somebody scrolling for a screenshot they have been told is too big to
+ * push, which is the same "I cannot find those images" the button was added to
+ * answer — moved one step later.
+ *
+ * The image itself is what has to be pointed at, so this looks for it in the
+ * rendered note and marks it.
+ */
+
+/** How long the marker stays on. Long enough to find, short enough to leave. */
+export const REVEAL_MS = 2600;
+
+/** The class the flash is drawn with. Defined in `globals.css`. */
+export const REVEAL_CLASS = "fl-reveal";
+
+export type RevealOutcome = "revealed" | "not-rendered";
+
+/**
+ * Marks the image at `assetPath` inside `root`, and scrolls it into view.
+ *
+ * Two ways of recognising it, because the two surfaces that draw a note write
+ * the `<img>` differently:
+ *
+ *   - The rich editor keeps the document's own `src` in `data-src` and puts
+ *     the loadable URL in `src`, so the path as the markdown writes it is
+ *     still there to be resolved against the note.
+ *   - The preview renders through the markdown pipeline, which rewrites `src`
+ *     and keeps no copy of the original — so there it is matched on the
+ *     resolved URL instead, which the caller already knows how to compute.
+ *
+ * Matching on both rather than picking one means neither surface has to grow a
+ * new attribute to be searchable, and an image that resolves to itself — a
+ * note with an absolute URL in it — still matches by the first route.
+ *
+ * Returns `not-rendered` when there is no such `<img>` on screen. That is not
+ * a failure to find the note: raw markdown view draws no images at all, and
+ * saying so beats silently doing nothing.
+ */
+export function revealAsset(options: {
+  root: HTMLElement | null;
+  notePath: string;
+  assetPath: string;
+  /** The URL the app's own resolver produces for `assetPath`, when it has one. */
+  resolvedSrc?: string | null;
+}): RevealOutcome {
+  const { root, notePath, assetPath, resolvedSrc } = options;
+  if (!root) return "not-rendered";
+
+  const image = [...root.querySelectorAll("img")].find((candidate) =>
+    matches(candidate, notePath, assetPath, resolvedSrc),
+  );
+  if (!image) return "not-rendered";
+
+  // `center` rather than `nearest`: an image that is technically on screen but
+  // half under the toolbar has not been found for you.
+  image.scrollIntoView?.({ block: "center", behavior: "smooth" });
+  flash(image);
+
+  return "revealed";
+}
+
+function matches(
+  image: HTMLImageElement,
+  notePath: string,
+  assetPath: string,
+  resolvedSrc?: string | null,
+): boolean {
+  // What the markdown says, where it survived rendering.
+  const written = image.getAttribute("data-src");
+  if (written && isRepoRelative(written) && resolveAgainstNote(notePath, written) === assetPath) {
+    return true;
+  }
+
+  // `getAttribute`, not `image.src`: the property resolves against the page's
+  // own origin, so a note-relative `assets/chart.png` comes back as
+  // `http://localhost/assets/chart.png` and matches nothing.
+  const src = image.getAttribute("src");
+  if (!src) return false;
+
+  if (resolvedSrc && src === resolvedSrc) return true;
+  return !written && isRepoRelative(src) && resolveAgainstNote(notePath, src) === assetPath;
+}
+
+/**
+ * Adds the marker, and takes it off again.
+ *
+ * Removed on a timer rather than left for the next render to clear: the rich
+ * editor reuses an image's DOM node for as long as the node itself does not
+ * change, so a class put on it stays until something takes it off.
+ */
+function flash(image: HTMLImageElement): void {
+  image.classList.remove(REVEAL_CLASS);
+  // Reading a layout property between the two forces the removal to take
+  // effect, so a second Find on the same image restarts the animation rather
+  // than doing nothing visible.
+  void image.offsetWidth;
+  image.classList.add(REVEAL_CLASS);
+
+  window.setTimeout(() => image.classList.remove(REVEAL_CLASS), REVEAL_MS);
+}

--- a/apps/web/src/lib/tree-order.test.ts
+++ b/apps/web/src/lib/tree-order.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { compareTreeNames, serialNumberOf, type TreeNode } from "@forkleaf/types";
+import {
+  DEFAULT_TREE_ORDER,
+  orderTree,
+  prunedOrder,
+  withCreated,
+  withCreatedRenamed,
+  withDropped,
+  withMoved,
+  withPathRenamed,
+  withoutCreated,
+  withoutManual,
+  type TreeOrder,
+} from "./tree-order";
+
+function folder(name: string, children: TreeNode[] = [], parent = ""): TreeNode {
+  const path = parent ? `${parent}/${name}` : name;
+  return { path, name, kind: "folder", children };
+}
+
+function file(name: string, parent = ""): TreeNode {
+  const path = parent ? `${parent}/${name}` : name;
+  return { path, name, kind: "file" };
+}
+
+const names = (nodes: TreeNode[]) => nodes.map((node) => node.name);
+
+describe("compareTreeNames", () => {
+  it("puts a numbered folder where its number says, not where its first digit does", () => {
+    const sorted = ["10. Attacking AD", "1. Introduction", "2. Networking"].sort(compareTreeNames);
+    expect(sorted).toEqual(["1. Introduction", "2. Networking", "10. Attacking AD"]);
+  });
+
+  it("compares runs of digits too long for a double by value", () => {
+    expect(compareTreeNames("n9007199254740993", "n9007199254740992")).toBeGreaterThan(0);
+  });
+
+  it("ignores case the way a file listing does", () => {
+    expect(compareTreeNames("apple.md", "Banana.md")).toBeLessThan(0);
+  });
+
+  it("orders two spellings of the same name the same way every time", () => {
+    expect(compareTreeNames("Notes.md", "notes.md")).not.toBe(0);
+  });
+});
+
+describe("serialNumberOf", () => {
+  it("reads a leading serial number", () => {
+    expect(serialNumberOf("7. Capstone Projects")).toBe(7);
+    expect(serialNumberOf("03 - Recon")).toBe(3);
+    expect(serialNumberOf("12) Notes")).toBe(12);
+  });
+
+  it("does not treat a word that starts with a digit as numbering", () => {
+    expect(serialNumberOf("2fa-notes")).toBeNull();
+    expect(serialNumberOf("Reconnaissance")).toBeNull();
+  });
+});
+
+describe("orderTree", () => {
+  const tree = [
+    folder("10. Attacking AD"),
+    folder("1. Introduction"),
+    folder("2. Networking"),
+    folder("Python 101"),
+    folder("OSINT"),
+    file("readme.md"),
+  ];
+
+  it("reads a numbered notebook in its own order", () => {
+    expect(names(orderTree(tree, DEFAULT_TREE_ORDER, {}))).toEqual([
+      "1. Introduction",
+      "2. Networking",
+      "10. Attacking AD",
+      "OSINT",
+      "Python 101",
+      "readme.md",
+    ]);
+  });
+
+  it("falls back to creation order for anything unnumbered", () => {
+    const created = {
+      "Python 101": "2026-01-01T00:00:00.000Z",
+      OSINT: "2026-03-01T00:00:00.000Z",
+    };
+
+    expect(names(orderTree(tree, DEFAULT_TREE_ORDER, created))).toEqual([
+      "1. Introduction",
+      "2. Networking",
+      "10. Attacking AD",
+      "Python 101",
+      "OSINT",
+      "readme.md",
+    ]);
+  });
+
+  it("keeps folders above files", () => {
+    const ordered = orderTree(tree, DEFAULT_TREE_ORDER, {});
+    expect(ordered[ordered.length - 1]!.kind).toBe("file");
+  });
+
+  it("sorts by name alone when asked to", () => {
+    const order: TreeOrder = { mode: "name", manual: {} };
+    expect(names(orderTree(tree, order, {})).slice(0, 3)).toEqual([
+      "1. Introduction",
+      "2. Networking",
+      "10. Attacking AD",
+    ]);
+  });
+
+  it("puts anything with no known creation date after everything that has one", () => {
+    const order: TreeOrder = { mode: "created", manual: {} };
+    const created = { OSINT: "2026-05-01T00:00:00.000Z" };
+    expect(names(orderTree(tree, order, created))[0]).toBe("OSINT");
+  });
+
+  it("orders the inside of a folder as well as the top level", () => {
+    const nested = [
+      folder("Course", [
+        folder("10. Ten", [], "Course"),
+        folder("2. Two", [], "Course"),
+        file("9. nine.md", "Course"),
+      ]),
+    ];
+
+    expect(names(orderTree(nested, DEFAULT_TREE_ORDER, {})[0]!.children!)).toEqual([
+      "2. Two",
+      "10. Ten",
+      "9. nine.md",
+    ]);
+  });
+});
+
+describe("rearranging by hand", () => {
+  const siblings = [folder("A"), folder("B"), file("c.md")];
+
+  it("moves one row down and writes the whole run down with it", () => {
+    const order = withMoved(DEFAULT_TREE_ORDER, siblings, "A", 1);
+    expect(order.manual[""]).toEqual(["B", "A", "c.md"]);
+    expect(names(orderTree(siblings, order, {}))).toEqual(["B", "A", "c.md"]);
+  });
+
+  it("refuses to move the first row up or the last row down", () => {
+    expect(withMoved(DEFAULT_TREE_ORDER, siblings, "A", -1)).toBe(DEFAULT_TREE_ORDER);
+    expect(withMoved(DEFAULT_TREE_ORDER, siblings, "c.md", 1)).toBe(DEFAULT_TREE_ORDER);
+  });
+
+  it("drops a row above another one", () => {
+    const order = withDropped(DEFAULT_TREE_ORDER, siblings, "c.md", "A", "before");
+    expect(order.manual[""]).toEqual(["c.md", "A", "B"]);
+  });
+
+  it("lets a note sit above a folder once somebody put it there", () => {
+    const order = withDropped(DEFAULT_TREE_ORDER, siblings, "c.md", "A", "before");
+    expect(names(orderTree(siblings, order, {}))[0]).toBe("c.md");
+  });
+
+  it("shows a newly added row after the ones that were arranged", () => {
+    const order = withMoved(DEFAULT_TREE_ORDER, siblings, "A", 1);
+    const withNew = [...siblings, folder("New")];
+    expect(names(orderTree(withNew, order, {}))).toEqual(["B", "A", "c.md", "New"]);
+  });
+
+  it("puts a folder back under the sort mode when the order is cleared", () => {
+    const order = withoutManual(withMoved(DEFAULT_TREE_ORDER, siblings, "A", 1), "");
+    expect(names(orderTree(siblings, order, {}))).toEqual(["A", "B", "c.md"]);
+  });
+
+  it("carries a hand-made position across a rename", () => {
+    const order = withMoved(DEFAULT_TREE_ORDER, siblings, "A", 1);
+    expect(withPathRenamed(order, "A", "Z").manual[""]).toEqual(["B", "Z", "c.md"]);
+  });
+
+  it("forgets the arrangement of a folder that no longer exists", () => {
+    const order: TreeOrder = { mode: "smart", manual: { gone: ["gone/a.md"], "": ["A"] } };
+    expect(Object.keys(prunedOrder(order, siblings).manual)).toEqual([""]);
+  });
+});
+
+describe("creation stamps", () => {
+  it("keeps the first date it was told, not the latest", () => {
+    const once = withCreated({}, "a.md", "2026-01-01T00:00:00.000Z");
+    expect(withCreated(once, "a.md", "2026-06-01T00:00:00.000Z")).toBe(once);
+  });
+
+  it("moves the stamps under a renamed folder", () => {
+    const created = withCreated(withCreated({}, "old", "1"), "old/a.md", "2");
+    expect(withCreatedRenamed(created, "old", "new")).toEqual({ new: "1", "new/a.md": "2" });
+  });
+
+  it("drops the stamps for a deleted folder and its contents", () => {
+    const created = withCreated(withCreated({}, "gone", "1"), "gone/a.md", "2");
+    expect(withoutCreated(created, "gone")).toEqual({});
+  });
+});

--- a/apps/web/src/lib/tree-order.ts
+++ b/apps/web/src/lib/tree-order.ts
@@ -1,0 +1,317 @@
+import {
+  compareTreeNames,
+  serialNumberOf,
+  type TreeNode,
+  type TreeNodeKind,
+} from "@forkleaf/types";
+
+/**
+ * The order the sidebar draws a folder's contents in.
+ *
+ * A git repository has no file order of its own — the tree is sorted, and
+ * nothing in it records what somebody wanted to read first. So the order is a
+ * per-device preference, alongside the pinned notes and the open folders,
+ * rather than a manifest written into the repository that no other tool would
+ * understand.
+ *
+ * `smart` is the default and does what a numbered notebook is asking for:
+ *
+ *   - Anything whose name starts with a serial number is in that number's
+ *     order — `1. Introduction`, `2. Networking`, … `10. Attacking AD`, which
+ *     is exactly the order a plain alphabetical sort was refusing to show.
+ *   - Everything else falls back to the order it was created in, oldest first,
+ *     because that is the order it was written in.
+ *   - Anything ForkLeaf never watched being created — every file that was
+ *     already in the repository when it was connected — has no creation date
+ *     to sort by, so those keep natural name order at the end of the
+ *     unnumbered run. Inventing a date for them would be a worse answer than
+ *     admitting we do not know one.
+ */
+export type TreeSortMode = "smart" | "name" | "created";
+
+export interface TreeOrder {
+  mode: TreeSortMode;
+  /**
+   * Folders whose contents were arranged by hand: parent path (`""` for the
+   * repository root) to the paths inside it, in the order somebody put them.
+   *
+   * Per folder rather than one flat list, so dragging one note in one folder
+   * does not freeze the ordering of the entire repository.
+   */
+  manual: Record<string, string[]>;
+}
+
+export const DEFAULT_TREE_ORDER: TreeOrder = { mode: "smart", manual: {} };
+
+/** When each path was made, ISO 8601, for the folders ForkLeaf made itself. */
+export type CreationTimes = Readonly<Record<string, string>>;
+
+export const SORT_MODE_LABELS: Record<TreeSortMode, string> = {
+  smart: "Numbered, then oldest first",
+  name: "Name (A–Z)",
+  created: "Date created",
+};
+
+/** The folder a path sits in. `""` for anything at the repository root. */
+export function parentOf(path: string): string {
+  const cut = path.lastIndexOf("/");
+  return cut === -1 ? "" : path.slice(0, cut);
+}
+
+/**
+ * The tree in the order it should be drawn.
+ *
+ * Folders still come before files in every automatic mode — that is what makes
+ * a deep tree scannable, and it is what every file manager does. A folder
+ * arranged by hand is the one exception: somebody who dragged a note above a
+ * folder meant it, and quietly putting it back would make the drag look broken.
+ */
+export function orderTree(
+  nodes: readonly TreeNode[],
+  order: TreeOrder,
+  created: CreationTimes,
+): TreeNode[] {
+  const arrange = (list: readonly TreeNode[], parent: string): TreeNode[] => {
+    const withChildren = list.map((node) =>
+      node.children ? { ...node, children: arrange(node.children, node.path) } : node,
+    );
+
+    const automatic = [...withChildren].sort((a, b) =>
+      compareAutomatically(a, b, order.mode, created),
+    );
+    return applyManual(automatic, order.manual[parent]);
+  };
+
+  return arrange(nodes, "");
+}
+
+/**
+ * The hand-made order first, then anything it does not mention.
+ *
+ * A folder arranged by hand and then added to would otherwise have to be
+ * re-arranged before the new note could be seen: the list is a record of what
+ * somebody moved, not a claim to be exhaustive. New arrivals land after it, in
+ * whichever automatic order is in force, which is where "and this one too"
+ * belongs.
+ */
+function applyManual(nodes: TreeNode[], manual: readonly string[] | undefined): TreeNode[] {
+  if (!manual || manual.length === 0) return nodes;
+
+  const byPath = new Map(nodes.map((node) => [node.path, node]));
+  const placed: TreeNode[] = [];
+  const seen = new Set<string>();
+
+  for (const path of manual) {
+    const node = byPath.get(path);
+    if (!node || seen.has(path)) continue;
+    placed.push(node);
+    seen.add(path);
+  }
+
+  return [...placed, ...nodes.filter((node) => !seen.has(node.path))];
+}
+
+function compareAutomatically(
+  a: TreeNode,
+  b: TreeNode,
+  mode: TreeSortMode,
+  created: CreationTimes,
+): number {
+  if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
+
+  if (mode === "name") return compareTreeNames(a.name, b.name);
+  if (mode === "created") return compareByCreation(a, b, created);
+
+  const left = serialNumberOf(displayName(a));
+  const right = serialNumberOf(displayName(b));
+
+  // A numbered run sits above an unnumbered one. Mixing them by name would
+  // scatter `1.`…`10.` through the alphabet, which is the whole complaint.
+  if (left !== null && right !== null) {
+    return left === right ? compareTreeNames(a.name, b.name) : left - right;
+  }
+  if (left !== null) return -1;
+  if (right !== null) return 1;
+
+  return compareByCreation(a, b, created);
+}
+
+/** Oldest first, with anything we have no date for kept in name order at the end. */
+function compareByCreation(a: TreeNode, b: TreeNode, created: CreationTimes): number {
+  const left = created[a.path];
+  const right = created[b.path];
+
+  if (left && right)
+    return left === right ? compareTreeNames(a.name, b.name) : left < right ? -1 : 1;
+  if (left) return -1;
+  if (right) return 1;
+  return compareTreeNames(a.name, b.name);
+}
+
+/** The name as the sidebar shows it — notes are drawn without their extension. */
+function displayName(node: TreeNode): string {
+  return node.kind === "folder" ? node.name : node.name.replace(/\.mdx?$/i, "");
+}
+
+// ─── Rearranging by hand ────────────────────────────────────────────────────
+
+/**
+ * One step up or down within its own folder.
+ *
+ * The whole run of siblings is written down, not just the two that swapped:
+ * a list recording only "these two are out of order" would be undone by the
+ * next automatic sort, and the reader would watch their move come apart.
+ */
+export function withMoved(
+  order: TreeOrder,
+  siblings: readonly TreeNode[],
+  path: string,
+  direction: -1 | 1,
+): TreeOrder {
+  const paths = siblings.map((node) => node.path);
+  const index = paths.indexOf(path);
+  const target = index + direction;
+  if (index === -1 || target < 0 || target >= paths.length) return order;
+
+  const next = [...paths];
+  [next[index], next[target]] = [next[target]!, next[index]!];
+  return withManual(order, parentOf(path), next);
+}
+
+/** Dropped onto the gap above or below another row in the same folder. */
+export function withDropped(
+  order: TreeOrder,
+  siblings: readonly TreeNode[],
+  path: string,
+  target: string,
+  position: "before" | "after",
+): TreeOrder {
+  if (path === target) return order;
+
+  const paths = siblings.map((node) => node.path);
+  if (!paths.includes(path) || !paths.includes(target)) return order;
+
+  const without = paths.filter((candidate) => candidate !== path);
+  const at = without.indexOf(target);
+  if (at === -1) return order;
+
+  without.splice(position === "before" ? at : at + 1, 0, path);
+  return withManual(order, parentOf(path), without);
+}
+
+/** Forgets one folder's hand-made order, putting it back under the sort mode. */
+export function withoutManual(order: TreeOrder, parent: string): TreeOrder {
+  if (!order.manual[parent]) return order;
+
+  const manual = { ...order.manual };
+  delete manual[parent];
+  return { ...order, manual };
+}
+
+/** True when this folder's contents were arranged by hand. */
+export function isManual(order: TreeOrder, parent: string): boolean {
+  return (order.manual[parent]?.length ?? 0) > 0;
+}
+
+/**
+ * Carries a hand-made position across a rename or a move.
+ *
+ * Without it, renaming a note drops it out of its folder's order and it
+ * reappears at the bottom — which reads as the app having thrown the
+ * arrangement away because the file was given a better name.
+ */
+export function withPathRenamed(order: TreeOrder, from: string, to: string): TreeOrder {
+  const rename = (path: string) =>
+    path === from ? to : path.startsWith(`${from}/`) ? `${to}${path.slice(from.length)}` : path;
+
+  const manual: Record<string, string[]> = {};
+  for (const [parent, paths] of Object.entries(order.manual)) {
+    manual[rename(parent)] = paths.map(rename);
+  }
+
+  return { ...order, manual };
+}
+
+/**
+ * Drops folders that no longer exist, so the record does not grow forever as
+ * notes are deleted and folders emptied.
+ */
+export function prunedOrder(order: TreeOrder, tree: readonly TreeNode[]): TreeOrder {
+  const folders = new Set<string>([""]);
+  const walk = (nodes: readonly TreeNode[]) => {
+    for (const node of nodes) {
+      if (node.kind !== "folder") continue;
+      folders.add(node.path);
+      walk(node.children ?? []);
+    }
+  };
+  walk(tree);
+
+  const manual: Record<string, string[]> = {};
+  for (const [parent, paths] of Object.entries(order.manual)) {
+    if (folders.has(parent)) manual[parent] = paths;
+  }
+
+  return Object.keys(manual).length === Object.keys(order.manual).length
+    ? order
+    : { ...order, manual };
+}
+
+function withManual(order: TreeOrder, parent: string, paths: string[]): TreeOrder {
+  return { ...order, manual: { ...order.manual, [parent]: paths } };
+}
+
+// ─── Creation stamps ────────────────────────────────────────────────────────
+
+/**
+ * Records when a path was made, so `smart` and `created` have something to sort
+ * unnumbered notes by.
+ *
+ * Kept here rather than read from each note's `created` front matter, because
+ * folders have no front matter of their own and the sidebar has to order them
+ * too — and because reading every note in a repository to draw a tree of names
+ * would make opening the sidebar as expensive as opening the notebook.
+ */
+export function withCreated(created: CreationTimes, path: string, at: string): CreationTimes {
+  if (created[path]) return created;
+  return { ...created, [path]: at };
+}
+
+/** Moves the stamps for a path and everything under it, on a rename or move. */
+export function withCreatedRenamed(
+  created: CreationTimes,
+  from: string,
+  to: string,
+): CreationTimes {
+  const next: Record<string, string> = {};
+  let changed = false;
+
+  for (const [path, at] of Object.entries(created)) {
+    if (path === from || path.startsWith(`${from}/`)) {
+      next[`${to}${path.slice(from.length)}`] = at;
+      changed = true;
+    } else {
+      next[path] = at;
+    }
+  }
+
+  return changed ? next : created;
+}
+
+/** Drops the stamps for a deleted path and anything that was inside it. */
+export function withoutCreated(created: CreationTimes, path: string): CreationTimes {
+  const next: Record<string, string> = {};
+  let changed = false;
+
+  for (const [candidate, at] of Object.entries(created)) {
+    if (candidate === path || candidate.startsWith(`${path}/`)) changed = true;
+    else next[candidate] = at;
+  }
+
+  return changed ? next : created;
+}
+
+/** The kinds a row can be, spelled out for the menus that talk about them. */
+export function nounFor(kind: TreeNodeKind): string {
+  return kind === "folder" ? "folder" : "note";
+}

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -1,4 +1,4 @@
-import type { RepoRef, TreeNode } from "@forkleaf/types";
+import { compareTreeEntries, type RepoRef, type TreeNode } from "@forkleaf/types";
 import { Transport, type RateLimit, type TransportConfig } from "./http";
 import { GitHubError } from "./errors";
 import { encodeBase64, decodeBase64 } from "./base64";
@@ -1526,12 +1526,15 @@ export function buildTree(entries: { path: string; sha: string; size?: number }[
   return root;
 }
 
-/** Folders first, then files, each alphabetical and case-insensitive. */
+/**
+ * Folders first, then files, each in natural name order.
+ *
+ * Natural rather than plain alphabetical: a notebook whose folders are
+ * numbered `1.`…`10.` is numbered so it reads in that order, and a straight
+ * string compare puts the tenth second.
+ */
 function sortTree(nodes: TreeNode[]): void {
-  nodes.sort((a, b) => {
-    if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
-    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
-  });
+  nodes.sort(compareTreeEntries);
   for (const node of nodes) {
     if (node.children) sortTree(node.children);
   }

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -1,4 +1,11 @@
-import type { Note, NoteFrontmatter, RepoRef, TreeNode, Workspace } from "@forkleaf/types";
+import {
+  compareTreeEntries,
+  type Note,
+  type NoteFrontmatter,
+  type RepoRef,
+  type TreeNode,
+  type Workspace,
+} from "@forkleaf/types";
 import {
   parseDocument,
   serializeDocument,
@@ -626,8 +633,5 @@ function withPath(tree: TreeNode[], path: string): TreeNode[] {
 
 /** Folders first, then by name — the order the tree already arrives in. */
 function sortNodes(nodes: TreeNode[]): TreeNode[] {
-  return [...nodes].sort((a, b) => {
-    if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
-    return a.name.localeCompare(b.name);
-  });
+  return [...nodes].sort(compareTreeEntries);
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -404,3 +404,7 @@ export interface SerializedError {
   /** Unix seconds at which a rate limit resets, when the API told us. */
   retryAt?: number;
 }
+
+// ─── Ordering ───────────────────────────────────────────────────────────────
+
+export * from "./order";

--- a/packages/types/src/order.ts
+++ b/packages/types/src/order.ts
@@ -1,0 +1,94 @@
+/**
+ * How names are compared wherever ForkLeaf lists files and folders.
+ *
+ * `localeCompare` gets a numbered notebook wrong. Given `1. Introduction`,
+ * `2. Networking` and `10. Attacking AD`, it compares the `1`, then the `0`
+ * against the `.`, and files the tenth folder second — so a repository whose
+ * folders are numbered precisely so they read in order was shown out of order,
+ * and the numbering the author added was the thing being ignored.
+ *
+ * Digits are compared as numbers here, and everything between them as text.
+ *
+ * It lives in the types package because four separate places build or re-sort
+ * the same tree — the GitHub client that first assembles it, the note
+ * repository that patches it on create and rename, the editor's notebook hook
+ * that grafts locally made folders on, and the dashboard's library index — and
+ * a fifth private copy of "compare two names" is a fifth chance for two
+ * listings of one folder to disagree with each other.
+ */
+
+/** Runs of digits and runs of everything else, in the order they appear. */
+const CHUNKS = /\d+|\D+/g;
+const ALL_DIGITS = /^\d+$/;
+
+/**
+ * A leading serial number, when a name starts with one — `7` for
+ * `7. Capstone Projects`, `null` for `Reconnaissance`.
+ *
+ * The number has to be followed by punctuation, a space, or the end of the
+ * name, so `2024 review` counts and `2fa-notes` does not: the first is somebody
+ * numbering their material, the second is a word that happens to start with a
+ * digit.
+ */
+const SERIAL = /^\s*(\d{1,9})(?=\s*(?:[.)\]:_-]|\s|$))/;
+
+export function serialNumberOf(name: string): number | null {
+  const match = SERIAL.exec(name);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Natural comparison: `2. Networking` before `10. Attacking AD`, and `img2`
+ * before `img10`.
+ */
+export function compareTreeNames(a: string, b: string): number {
+  const left = a.match(CHUNKS) ?? [];
+  const right = b.match(CHUNKS) ?? [];
+  const shared = Math.min(left.length, right.length);
+
+  for (let index = 0; index < shared; index += 1) {
+    const one = left[index]!;
+    const two = right[index]!;
+
+    const difference =
+      ALL_DIGITS.test(one) && ALL_DIGITS.test(two)
+        ? compareNumeric(one, two)
+        : one.localeCompare(two, undefined, { sensitivity: "base" });
+
+    if (difference !== 0) return difference;
+  }
+
+  if (left.length !== right.length) return left.length - right.length;
+
+  // Same shape, same letters to a case-insensitive eye. A strict compare last
+  // keeps the order total, so `Notes.md` and `notes.md` cannot swap places
+  // between two renders of the same folder.
+  return a.localeCompare(b);
+}
+
+/** Folders before files, then by name — the shape every listing shares. */
+export function compareTreeEntries(
+  a: { kind: "file" | "folder"; name: string },
+  b: { kind: "file" | "folder"; name: string },
+): number {
+  if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
+  return compareTreeNames(a.name, b.name);
+}
+
+/**
+ * Two runs of digits by value, without going through `Number`.
+ *
+ * A path can hold a run of digits longer than a double can represent exactly —
+ * a timestamp, a hash fragment — and two such runs both parse to the same
+ * float and compare equal, which is a sort that quietly loses entries' order.
+ */
+function compareNumeric(a: string, b: string): number {
+  const one = a.replace(/^0+(?=\d)/, "");
+  const two = b.replace(/^0+(?=\d)/, "");
+
+  if (one.length !== two.length) return one.length - two.length;
+  if (one !== two) return one < two ? -1 : 1;
+
+  // Equal in value: `01` and `1` still need a fixed order between them.
+  return a.length - b.length;
+}


### PR DESCRIPTION
Four changes, each with its own commit.

## The sidebar read a numbered notebook in the wrong order

A repository whose folders are numbered `1.` to `10.` showed the tenth second, between the first and the second — `localeCompare` compares the `1`, then the `0` against the `.`. Numbering folders is somebody saying what order they want them read in, and that was the one thing the tree threw away.

Four places built or re-sorted the same tree with their own copy of that comparison (the GitHub client, the note repository, the notebook hook, the dashboard index). There is now one comparator in `@forkleaf/types` and they all use it.

Numbering is half of it. Notes with no number have an order too — the one they were written in. So the default sort is **numbered things by their number, everything else oldest first**, from a creation date recorded as notes and folders are made and carried across renames and moves.

> Files already in a repository when it was connected have **no** creation date and keep natural name order. GitHub's tree carries no creation time, and inventing one would order a notebook confidently and wrongly.

Two other modes — Name (A–Z) and Date created — are in a menu on the tree's heading, and any row, note or folder, can be **arranged by hand**: drag it onto the gap above or below a neighbour, or use Move up / Move down in its right-click menu. In the menu as well as on the drag, because a tree that can only be arranged by dragging is one some people cannot arrange at all. Kept per device beside the pinned notes; the alternative is a manifest committed into the repository that no other tool understands.

## There was no support anywhere

The landing page argued the product for nine sections and never said how to reach anybody. The editor — where people are standing when something breaks — had no way to say so. The only address in the app was buried in the privacy policy under "data requests".

Now: a Support section on the landing page, a `/support` page every in-app link points at, an entry in the editor sidebar, a line in the help dialog where "still stuck?" used to dead-end at the docs, a footer column, and a docs page. Four routes rather than one "contact us", so somebody with a crashed editor and somebody with a vulnerability are not picking the same door.

## Find opened the wrong note, then left you looking

It matched by bare filename with `content.includes(name)` — which matched a note that merely wrote the words `sunset.png` in a sentence, matched `archive/sunset.png` as readily as the file actually queued, and opened whichever candidate came back first. Every reference form is now resolved against the note holding it, the same resolution the unused-image scan uses to decide what is safe to delete.

Opening the note was also only half the errand. **The image is now scrolled to and ringed.** Two match routes, because the rich editor keeps the document's path in `data-src` and the preview rewrites `src` and keeps no copy of the original. Raw markdown view draws no images at all, so there it names the note instead of silently doing nothing.

## Three footer rows became one

Dashboard, Help & shortcuts and Support were three stacked rows spending a third of the footer on things nobody clicks while writing. One **More** button now opens them upward over the note. ⌘⇧D still goes straight to the dashboard.

---

## Verification

`pnpm check` passes — format, typecheck, lint, **1627 tests**, build. 32 of those tests are new (`tree-order`, `reveal-asset`, and the FileTree reordering menu).

Driven in a real browser as well: four notes created as `10. Ten, 2. Two, Alpha, Zebra` draw as `2. Two → 10. Ten → Alpha → Zebra`; each sort mode and the reset were switched through; Move down and a drag-reorder were both performed and persisted; dropping into a folder still moves the note into it; and the reveal ring was checked on a rendered image in both themes' accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)