### PR TITLE
feat(pdf): read a paper beside the note you are writing from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 Notable changes to ForkLeaf. Dates are the release date; the git history is the
 full record.
 
+## Unreleased
+
+### Reading PDFs
+
+ForkLeaf opens PDFs, beside the note you are writing from them.
+
+- A reader in its own pane: page rendering, the document's own table of
+  contents, and find-across-the-document that matches through line breaks,
+  hyphenation and ligatures — so searching for "find" matches a page that
+  really contains "ﬁnd"
+- Open one by dragging it onto the window, from the command palette, from a
+  `.pdf` in the repository file tree, from an ordinary markdown link in a note,
+  or from the operating system's "Open with" list
+- **Quote into note** turns a selected passage into a blockquote and a link.
+  Nothing bespoke lands in the file: `[On Attention, p. 12](paper.pdf#page=12…)`
+  renders on github.com and opens the right page in every other PDF reader
+- Citations record the sentence, not the page. Clicking one finds those words
+  in the document as it is now — so a citation still points at the right
+  paragraph after the author adds a figure to page 4, and says so plainly when
+  the passage has genuinely gone
+- Nothing is ever written back to the PDF. The file in your repository stays
+  exactly as it was committed
+
 ## 1.0.0 — 2026-08-26
 
 The first release.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ your notes at all:
   command, without leaving the keyboard.
 - Document outline, word count, reading time and task progress.
 
+### Reading PDFs
+
+- **A PDF opens beside the note you're writing from it** — its own pane, its own
+  table of contents, and find-across-the-document that matches through line
+  breaks, hyphenation and ligatures. Drag one onto the window, pick one from the
+  palette, or click a `.pdf` in your repository's file tree.
+- **Select a passage and quote it into the note.** What lands in the file is a
+  blockquote and an ordinary markdown link — it renders on github.com and opens
+  the right page in Acrobat, Preview and your browser's own viewer.
+- **Citations record the sentence, not the page number.** Add a figure to page 4
+  of a paper and every "page 12" reference in every other tool now quietly
+  points at page 13. ForkLeaf searches the document for the words you quoted,
+  uses the text either side to tell repeated phrases apart, and tells you
+  plainly when a passage has genuinely gone.
+- **Nothing is written back to the PDF.** The file in your repository stays
+  exactly as it was committed; your annotations live in markdown next to it.
+
 ### Links between notes
 
 - **`[[Wikilinks]]`**, in the Obsidian dialect — `[[target]]`,
@@ -358,6 +375,7 @@ page can read your token.
 | `@forkleaf/store`           | IndexedDB storage, change queue, sync engine, conflicts, search index  |
 | `@forkleaf/diagrams`        | Mermaid rendering, templates, autocomplete, visual-builder graph model |
 | `@forkleaf/exporter`        | Client-side PDF / HTML / DOCX / Markdown / ZIP export                  |
+| `@forkleaf/pdf`             | PDF reading: text extraction, in-document search, durable citations    |
 | `@forkleaf/editor`          | React editing surfaces (rich text, source, split, diagram studio)      |
 | `@forkleaf/web`             | Next.js app: auth, API routes, publishing, application shell           |
 

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Copied from pdfjs-dist at build time by scripts/copy-pdf-assets.mjs
+/public/pdfjs

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -22,6 +22,7 @@ const nextConfig: NextConfig = {
     "@forkleaf/diagrams",
     "@forkleaf/exporter",
     "@forkleaf/editor",
+    "@forkleaf/pdf",
   ],
 
   /**

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "node scripts/copy-pdf-assets.mjs && next dev",
+    "build": "node scripts/copy-pdf-assets.mjs && next build",
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
@@ -15,12 +15,14 @@
     "@forkleaf/exporter": "workspace:*",
     "@forkleaf/github-client": "workspace:*",
     "@forkleaf/markdown-engine": "workspace:*",
+    "@forkleaf/pdf": "workspace:*",
     "@forkleaf/store": "workspace:*",
     "@forkleaf/types": "workspace:*",
     "@vercel/sandbox": "^3.1.0",
     "firebase": "^12.17.1",
     "jose": "^6.1.0",
     "next": "16.3.1",
+    "pdfjs-dist": "^6.3.289",
     "posthog-js": "^1.421.1",
     "react": "19.2.8",
     "react-dom": "19.2.8"

--- a/apps/web/scripts/copy-pdf-assets.mjs
+++ b/apps/web/scripts/copy-pdf-assets.mjs
@@ -1,0 +1,51 @@
+/**
+ * Copies pdf.js's font and character-map data into `public/pdfjs`.
+ *
+ * pdf.js does not embed two things it frequently needs: the fourteen standard
+ * PDF fonts, and the character maps that make CJK text readable. It fetches
+ * them at runtime from wherever it is told, and the default is a CDN.
+ *
+ * ForkLeaf serves them itself, for the reason the rest of this app exists:
+ * a notes application that quietly reports every document you open to a third
+ * party's server — which is what a CDN fetch for a document's own character
+ * map amounts to — has no business claiming your notes are yours. The Content
+ * Security Policy would refuse the request in any case.
+ *
+ * Copied at build time rather than committed, so the data can never drift out
+ * of step with the installed version of pdf.js. Run before `dev` and `build`
+ * alike: the reader needs them in development too, and a Japanese PDF that
+ * extracts no text only on one developer's machine is a bad afternoon.
+ */
+import { cp, mkdir, readFile, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+
+const source = dirname(require.resolve("pdfjs-dist/package.json"));
+const target = join(here, "..", "public", "pdfjs");
+
+const version = JSON.parse(await readFile(join(source, "package.json"), "utf8")).version;
+const stamp = join(target, ".version");
+
+// Skipping the copy when the version already matches keeps `next dev` starting
+// promptly; without it this is two thousand small file copies on every start.
+try {
+  if ((await readFile(stamp, "utf8")).trim() === version) process.exit(0);
+} catch {
+  // No stamp, or an unreadable one. Copy.
+}
+
+await rm(target, { recursive: true, force: true });
+await mkdir(target, { recursive: true });
+
+for (const folder of ["standard_fonts", "cmaps"]) {
+  await cp(join(source, folder), join(target, folder), { recursive: true });
+}
+
+const { writeFile } = await import("node:fs/promises");
+await writeFile(stamp, `${version}\n`);
+
+console.log(`[forkleaf] pdf.js ${version} assets copied to public/pdfjs`);

--- a/apps/web/src/app/api/gh/raw/route.ts
+++ b/apps/web/src/app/api/gh/raw/route.ts
@@ -7,10 +7,10 @@ import {
   ApiError,
   forgetDeadSession,
 } from "@/lib/api-helpers";
-import { imageTypeFor } from "@/lib/media";
+import { imageTypeFor, servableTypeFor } from "@/lib/media";
 
 /**
- * Serves an image out of the repository.
+ * Serves a file out of the repository — an image in a note, or a PDF.
  *
  * Notes reference their images by repo-relative path, which is what makes them
  * render on github.com and in any other markdown tool. The browser cannot
@@ -18,9 +18,17 @@ import { imageTypeFor } from "@/lib/media";
  * fetch the file even if it could — the OAuth token lives on the server. So
  * this route is the bridge: same-origin URL in, image bytes out.
  *
- * Only image types are served. This proxy reads with the user's token, so
- * letting it return arbitrary file types would turn it into a way to render
- * repository content as HTML on our own origin.
+ * Only an explicit allowlist of types is served — images, and the documents
+ * ForkLeaf can read. This proxy reads with the user's token, so letting it
+ * return arbitrary file types would turn it into a way to render repository
+ * content as HTML on our own origin.
+ *
+ * Anything that is not an image is additionally sent as an attachment. The
+ * reader fetches a PDF as bytes and parses it in a worker, so it never needs
+ * the browser to render the response — and marking it as a download means that
+ * someone who pastes the URL into the address bar gets a file rather than a
+ * document rendered on this origin. Belt to the `nosniff` and `sandbox`
+ * braces already below.
  */
 /**
  * Headers that must match on a 200 and a 304 alike, or the browser will not
@@ -44,6 +52,18 @@ function cacheHeaders(etag: string): Record<string, string> {
   };
 }
 
+/**
+ * A filename safe to put in a header.
+ *
+ * Quotes and control characters in a `Content-Disposition` value are a header
+ * injection, and a repository path is not something this app chose — it can
+ * contain anything a filesystem allows.
+ */
+function downloadName(path: string): string {
+  const name = path.split("/").pop() ?? "file";
+  return name.replace(/[^\w.\-]+/g, "_").slice(0, 100) || "file";
+}
+
 export async function GET(request: NextRequest) {
   try {
     const { client } = await requireClient();
@@ -53,8 +73,11 @@ export async function GET(request: NextRequest) {
     const path = normalize(params.get("path") ?? "");
     if (!path) throw new ApiError(400, "validation", "A file path is required.");
 
-    const type = imageTypeFor(path);
-    if (!type) throw new ApiError(400, "validation", "That file is not a supported image.");
+    const type = servableTypeFor(path);
+    if (!type) {
+      throw new ApiError(400, "validation", "ForkLeaf does not serve that kind of file.");
+    }
+    const inline = imageTypeFor(path) !== null;
 
     /**
      * The browser's own copy, offered back to GitHub before any bytes move.
@@ -86,6 +109,9 @@ export async function GET(request: NextRequest) {
         ...cacheHeaders(`"${file.sha}"`),
         "Content-Type": type,
         "Content-Length": String(bytes.length),
+        ...(inline
+          ? {}
+          : { "Content-Disposition": `attachment; filename="${downloadName(path)}"` }),
         "Content-Security-Policy": "default-src 'none'; sandbox",
         "X-Content-Type-Options": "nosniff",
       },
@@ -114,9 +140,9 @@ export async function GET(request: NextRequest) {
           headers: { "Cache-Control": "no-store" },
         });
       }
-      return new Response("Could not read that image.", { status: 502 });
+      return new Response("Could not read that file.", { status: 502 });
     }
     console.error("[forkleaf] Raw asset error:", error);
-    return new Response("Could not read that image.", { status: 500 });
+    return new Response("Could not read that file.", { status: 500 });
   }
 }

--- a/apps/web/src/app/api/gh/tree/route.ts
+++ b/apps/web/src/app/api/gh/tree/route.ts
@@ -4,8 +4,8 @@ import { handle, requireClient, readRepoRef } from "@/lib/api-helpers";
 /**
  * Returns the file tree for a workspace.
  *
- * Markdown only by default — that is the notebook, and a repository can hold a
- * great deal that is not one. `all=1` asks for every file, which is what the
+ * The notebook by default — markdown and PDF — since a repository can hold a
+ * great deal that is neither. `all=1` asks for every file, which is what the
  * link repair needs: it can only find the image a broken note meant if it can
  * see the images.
  */
@@ -15,8 +15,8 @@ export async function GET(request: NextRequest) {
     const params = new URL(request.url).searchParams;
     const repo = readRepoRef(params);
 
-    const markdownOnly = params.get("all") !== "1";
+    const include = params.get("all") === "1" ? "all" : "notes";
 
-    return { tree: await client.listTree(repo, { markdownOnly }) };
+    return { tree: await client.listTree(repo, { include }) };
   });
 }

--- a/apps/web/src/app/docs/content/reading.tsx
+++ b/apps/web/src/app/docs/content/reading.tsx
@@ -14,7 +14,8 @@ export function Reading() {
       <Lead>
         A notebook is read far more often than it is written. This page covers what a note does when
         you are reading it: following links, seeing where they go before you commit to them, opening
-        a linked file, and locking a note so that reading it cannot change it.
+        a linked file, reading a PDF beside the note you are writing from it, and locking a note so
+        that reading it cannot change it.
       </Lead>
 
       <H2 id="links">Opening a link</H2>
@@ -109,6 +110,107 @@ export function Reading() {
         The file names listed under <strong>Freshness</strong> in the properties panel open the same
         viewer.
       </P>
+
+      <H2 id="pdf">Reading a PDF</H2>
+      <P>
+        ForkLeaf opens PDFs. Not as an attachment or a download — as a document beside the note you
+        are writing from it, with the passages you quote linked back to the exact words on the page.
+      </P>
+
+      <H3 id="pdf-open">Four ways in</H3>
+      <UL>
+        <LI>
+          <strong>Drag one onto the window.</strong> Works in every browser.
+        </LI>
+        <LI>
+          <strong>Open a PDF…</strong> from the command palette (<Code>⌘K</Code>). Chromium browsers
+          only — Firefox and Safari have no file picker ForkLeaf can use, which is why the drag
+          target exists.
+        </LI>
+        <LI>
+          <strong>Click one in the sidebar.</strong> A PDF committed to your repository sits in the
+          file tree beside your notes, and clicking it opens the reader rather than trying to edit
+          it as text.
+        </LI>
+        <LI>
+          <strong>Click a link to one in a note.</strong> An ordinary markdown link —{" "}
+          <Code>[the paper](papers/attention.pdf)</Code> — opens the reader instead of navigating
+          away from what you were writing.
+        </LI>
+      </UL>
+      <P>
+        Install ForkLeaf and <Code>.pdf</Code> joins <Code>.md</Code> in your operating
+        system&rsquo;s <strong>Open with</strong> list. ForkLeaf does not make itself your default
+        PDF viewer and should not; that is your setting to make.
+      </P>
+
+      <H3 id="pdf-reader">In the reader</H3>
+      <Table
+        head={["", "What it does"]}
+        rows={[
+          [
+            "Contents",
+            "The document's own bookmarks, with page numbers. The heading you are currently under is shown beside the page count.",
+          ],
+          [
+            "Find",
+            "Searches the whole document, not the page. Matches across line breaks, through hyphenation, and through the ligatures a typesetter left in — so “find” matches a page that really contains “ﬁnd”.",
+          ],
+          ["Fit", "Fits the page to the panel. Zooming by hand turns it off and leaves it off."],
+          [
+            "Page box",
+            "Type a number and press Enter. Page Up, Page Down and the arrow keys turn pages.",
+          ],
+        ]}
+      />
+
+      <H3 id="pdf-cite">Quoting into a note</H3>
+      <P>
+        Select a passage and the reader offers <strong>Quote into note</strong>. What lands in the
+        note is a blockquote and a link, and nothing else:
+      </P>
+      <P>
+        <Code>
+          &gt; The key result is that latency fell by half.
+          <br />
+          &gt;
+          <br />
+          &gt; — [On Attention, p. 12](papers/attention.pdf#page=12&amp;q=…)
+        </Code>
+      </P>
+      <P>
+        That is a plain markdown link. It renders on github.com, it opens page 12 in Acrobat, in
+        Preview and in your browser&rsquo;s own viewer — <Code>#page=</Code> is the parameter every
+        PDF reader has understood since 2003 — and in ForkLeaf it does something more.
+      </P>
+
+      <H3 id="pdf-anchors">Why the link carries the sentence</H3>
+      <P>
+        A citation that records only a page number is wrong the moment the document changes. Add a
+        figure to page 4 of a paper and every reference to page 12 now points at page 13 — silently,
+        because the link still opens.
+      </P>
+      <P>
+        So a ForkLeaf citation records the <em>words</em>, with the page number kept only as a hint
+        about where to start looking. Clicking one searches the document for that passage, uses the
+        text either side of it to tell two occurrences apart, and opens the page it is actually on
+        with the sentence highlighted. If the passage has genuinely gone, you are told — rather than
+        being shown whatever happens to be on page 12 now.
+      </P>
+      <P>
+        The <Code>q=</Code>, <Code>pre=</Code> and <Code>suf=</Code> parameters are how that is
+        carried, and any tool that does not understand them ignores them and still lands on the
+        right page.
+      </P>
+
+      <Note>
+        ForkLeaf reads PDFs and does not write them. It will not annotate, sign or fill one in: the
+        file in your repository stays exactly as it was committed, and everything you add lives in
+        markdown next to it — which is the only form in which your annotations are still readable in
+        ten years, by something other than ForkLeaf. A PDF opened from your own disk rather than
+        from the repository is quoted with a plain attribution instead of a link, because a link to
+        a path on one computer is a broken link everywhere else.
+      </Note>
 
       <H2 id="locking">Locking a note</H2>
       <P>

--- a/apps/web/src/app/docs/nav.ts
+++ b/apps/web/src/app/docs/nav.ts
@@ -58,7 +58,7 @@ export const DOC_SECTIONS: DocSection[] = [
         slug: "reading",
         title: "Reading a note",
         summary:
-          "Following links, the hover card that says where they go, reading a linked file, and locking a note so reading it cannot change it.",
+          "Following links, the hover card that says where they go, reading a linked file, reading and citing a PDF, and locking a note so reading it cannot change it.",
       },
       {
         slug: "export",

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -54,6 +54,24 @@ export default function manifest(): MetadataRoute.Manifest {
           "text/mdx": [".mdx"],
         },
       },
+      /**
+       * PDFs, declared separately from the markdown handler.
+       *
+       * A separate entry rather than another line in the one above, because
+       * the operating system shows the handler's *action* in the "Open with"
+       * list and these are two different things ForkLeaf does — opening a note
+       * to edit, and opening a document to read and cite. Both land on
+       * `/editor`, which routes by the file's own name.
+       *
+       * ForkLeaf does not claim to be the default PDF viewer and should not
+       * be; it claims to be *a* choice, which is what a "Open with" list is
+       * for. Nothing here makes it the default — that is the user's setting to
+       * make, in their own operating system.
+       */
+      {
+        action: "/editor",
+        accept: { "application/pdf": [".pdf"] },
+      },
     ],
 
     /**

--- a/apps/web/src/components/FileTree.tsx
+++ b/apps/web/src/components/FileTree.tsx
@@ -730,7 +730,13 @@ const TreeItem = memo(function TreeItem({
           <span
             className={`shrink-0 ${active ? "text-[var(--fl-accent)]" : "text-[var(--fl-muted)]"}`}
           >
-            {isFolder ? <FolderGlyph open={open} /> : <FileGlyph />}
+            {isFolder ? (
+              <FolderGlyph open={open} />
+            ) : isPdf(node.path) ? (
+              <PdfGlyph />
+            ) : (
+              <FileGlyph />
+            )}
           </span>
           <span
             className={`truncate text-[14px] leading-[1.35] ${
@@ -807,6 +813,40 @@ function FolderGlyph({ open }: { open: boolean }) {
           it is in; the icon only has to say "folder". */}
       <path d="M2 12.4V4.4a.9.9 0 0 1 .9-.9h2.7l1.4 1.6h6.1a.9.9 0 0 1 .9.9v6.4a.9.9 0 0 1-.9.9H2.9a.9.9 0 0 1-.9-.9Z" />
       {open && <path d="M2.3 6.9h11.4" />}
+    </svg>
+  );
+}
+
+/** True for a row that opens in the reader rather than the editor. */
+function isPdf(path: string): boolean {
+  return /\.pdf$/i.test(path);
+}
+
+/**
+ * A page with a corner turned down, for a document ForkLeaf reads but does not
+ * write.
+ *
+ * Deliberately close to the note glyph rather than a red "PDF" badge. The
+ * distinction the sidebar needs to draw is "this one opens somewhere else",
+ * which a different silhouette carries at 17 pixels; a brand colour would make
+ * the one row in the tree that is not a note the loudest thing in it.
+ */
+function PdfGlyph() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-[17px] w-[17px]"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3.6 2.6h5.3l3.5 3.5v7.3a.9.9 0 0 1-.9.9H3.6a.9.9 0 0 1-.9-.9V3.5a.9.9 0 0 1 .9-.9Z" />
+      <path d="M8.9 2.6v3.5h3.5" />
+      {/* Dense ruling: a typeset page, rather than a note's two written lines. */}
+      <path d="M5.2 8.4h5.6M5.2 10.3h5.6M5.2 12.2h3.6" />
     </svg>
   );
 }

--- a/apps/web/src/components/PdfPage.tsx
+++ b/apps/web/src/components/PdfPage.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { rectsForRange, type PdfPageText, type PdfSession } from "@forkleaf/pdf";
+
+/**
+ * One page of a PDF: the pixels, the words, and anything highlighted on it.
+ *
+ * Three layers, stacked, and each one is there for a reason the others cannot
+ * cover:
+ *
+ *   1. **A canvas**, because that is the only way to draw a PDF faithfully.
+ *   2. **A transparent text layer** of positioned spans, because a canvas
+ *      cannot be selected, searched with the browser's own find, or read by a
+ *      screen reader. This is how every serious web PDF viewer works, and it
+ *      is what makes "select a sentence and cite it" possible at all.
+ *   3. **A highlight layer**, drawn from character ranges rather than from
+ *      coordinates — so a highlight is a *fact about the text* and survives
+ *      zooming, re-rendering and the page being re-laid out.
+ *
+ * The page only draws when it is near the viewport. A three-hundred-page
+ * document is three hundred canvases, and rendering them all costs more memory
+ * than the tab has; keeping them within a screen or two of the reader is the
+ * difference between a viewer that opens a thesis and one that crashes on it.
+ */
+
+export interface PdfHighlight {
+  /** Character range in this page's text. */
+  range: [number, number];
+  /** `citation` is the passage a link points at; `search` is a find result. */
+  kind: "citation" | "search";
+  /** The one the reader is currently on, drawn more strongly. */
+  current?: boolean;
+}
+
+export interface PdfPageProps {
+  session: PdfSession;
+  page: number;
+  /** Page size in PDF points, before zoom. */
+  size: { width: number; height: number };
+  scale: number;
+  text: PdfPageText | null;
+  highlights: readonly PdfHighlight[];
+  /** True when this page is close enough to the viewport to be worth drawing. */
+  visible: boolean;
+  onSelect?: (page: number, start: number, end: number) => void;
+}
+
+export function PdfPage({
+  session,
+  page,
+  size,
+  scale,
+  text,
+  highlights,
+  visible,
+  onSelect,
+}: PdfPageProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  /**
+   * Draws the page, at the device's real pixel density.
+   *
+   * Without the device-pixel-ratio factor the canvas is drawn at CSS pixels
+   * and then scaled up by the browser, which on any modern display makes the
+   * text visibly soft — the single most common way a canvas-based PDF viewer
+   * looks worse than the operating system's.
+   *
+   * Nothing waits for the draw to finish. An earlier version faded the canvas
+   * in when `renderPage` resolved, which looked better and was wrong: pdf.js
+   * renders incrementally through `requestAnimationFrame`, and a tab that is
+   * not visible does not get animation frames — so in a background tab the
+   * promise never settles, and a page that had painted perfectly stayed hidden
+   * behind an opacity of zero until the tab was looked at. The page frame is
+   * already white paper with a shadow, so an undrawn page reads as a page not
+   * yet reached, which is exactly what it is.
+   */
+  useEffect(() => {
+    if (!visible) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const density = Math.min(window.devicePixelRatio || 1, 2);
+
+    void session.renderPage(page, canvas, scale * density).catch((problem: unknown) => {
+      // A page that will not render is one page; the rest of the document is
+      // still readable. Said out loud in development, because the failure is
+      // otherwise completely silent.
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`[forkleaf] PDF page ${page} did not render:`, problem);
+      }
+    });
+  }, [session, page, scale, visible]);
+
+  const width = size.width * scale;
+  const height = size.height * scale;
+
+  return (
+    <div
+      data-pdf-page={page}
+      className="relative mx-auto bg-white shadow-[var(--fl-shadow)]"
+      style={{ width, height }}
+    >
+      <canvas ref={canvasRef} aria-hidden="true" className="absolute inset-0 h-full w-full" />
+
+      {/* Highlights sit under the text layer so selection still works over them. */}
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        {highlights.flatMap((highlight, index) =>
+          text
+            ? rectsForRange(text, highlight.range[0], highlight.range[1]).map((rect, part) => (
+                <div
+                  key={`${index}-${part}`}
+                  className="absolute rounded-[2px]"
+                  style={{
+                    left: rect.x * scale,
+                    // PDF measures from the bottom of the page; the DOM does not.
+                    top: height - (rect.y + rect.height) * scale,
+                    width: rect.width * scale,
+                    height: rect.height * scale,
+                    background:
+                      highlight.kind === "citation"
+                        ? "var(--fl-hl-yellow)"
+                        : highlight.current
+                          ? "var(--fl-hl-pink)"
+                          : "var(--fl-hl-blue)",
+                  }}
+                />
+              ))
+            : [],
+        )}
+      </div>
+
+      {text ? (
+        <TextLayer page={page} text={text} scale={scale} height={height} onSelect={onSelect} />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The invisible words over the page.
+ *
+ * Each run of text becomes a span positioned where the PDF drew it, with the
+ * glyphs made transparent. The reader sees the canvas; the browser sees text.
+ *
+ * The width is matched with `transform: scaleX`, not by choosing a font size
+ * that happens to fit. The page was set in a typeface the browser does not
+ * have, so no available font will ever have the same advance widths — and if
+ * the span is wider or narrower than the glyphs beneath it, the selection
+ * highlight drifts away from the words being selected, a little more with
+ * every line. Stretching a span of known width onto the run's known width is
+ * exact regardless of which font actually renders.
+ */
+function TextLayer({
+  page,
+  text,
+  scale,
+  height,
+  onSelect,
+}: {
+  page: number;
+  text: PdfPageText;
+  scale: number;
+  height: number;
+  onSelect?: (page: number, start: number, end: number) => void;
+}) {
+  const layerRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Turns a DOM selection back into a character range in the page's text.
+   *
+   * Every span carries the offset it starts at, so the sum of that and the
+   * offset within the span is the offset in the page — which is the whole
+   * reason the spans are built from `runs` rather than from pdf.js's own text
+   * layer. A citation has to name characters in the same string the resolver
+   * searches, and two independently-assembled strings will not agree.
+   */
+  useEffect(() => {
+    const layer = layerRef.current;
+    if (!layer || !onSelect) return;
+
+    const handle = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed || selection.rangeCount === 0) return;
+
+      const range = selection.getRangeAt(0);
+      if (!layer.contains(range.commonAncestorContainer)) return;
+
+      const start = offsetOf(layer, range.startContainer, range.startOffset);
+      const end = offsetOf(layer, range.endContainer, range.endOffset);
+      if (start == null || end == null || start === end) return;
+
+      onSelect(page, Math.min(start, end), Math.max(start, end));
+    };
+
+    document.addEventListener("selectionchange", handle);
+    return () => document.removeEventListener("selectionchange", handle);
+  }, [page, onSelect]);
+
+  return (
+    <div
+      ref={layerRef}
+      className="absolute inset-0 select-text"
+      style={{ color: "transparent", lineHeight: 1 }}
+    >
+      {text.runs.map((run, index) => {
+        const content = text.text.slice(run.start, run.end);
+        if (!content.trim()) return null;
+
+        return (
+          <span
+            key={index}
+            data-run-start={run.start}
+            className="absolute origin-top-left whitespace-pre"
+            style={{
+              left: run.x * scale,
+              top: height - (run.y + run.height) * scale,
+              fontSize: Math.max(run.height * scale, 1),
+              fontFamily: "serif",
+              // Measured after layout by the effect below would be more exact
+              // still; this is within a pixel and costs no reflow.
+              transform: `scaleX(${run.width > 0 ? (run.width * scale) / Math.max(measure(content, run.height * scale), 0.01) : 1})`,
+            }}
+          >
+            {content}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * A rough advance width for a string at a font size.
+ *
+ * Deliberately an estimate. Measuring each run properly means a canvas
+ * `measureText` per run per zoom level, which on a dense page is thousands of
+ * calls on every scroll — and the only thing the number affects is how closely
+ * an invisible box hugs the glyphs under it. Half an em per character is
+ * within a few per cent for prose, which is close enough that a selection
+ * lands on the words the reader dragged across.
+ */
+function measure(content: string, fontSize: number): number {
+  return content.length * fontSize * 0.5;
+}
+
+/** The page-text offset a DOM position corresponds to, or null if outside. */
+function offsetOf(layer: HTMLElement, node: Node, offset: number): number | null {
+  const element = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as HTMLElement);
+  const span = element?.closest<HTMLElement>("[data-run-start]");
+  if (!span || !layer.contains(span)) return null;
+
+  const base = Number(span.dataset.runStart);
+  return Number.isFinite(base) ? base + offset : null;
+}

--- a/apps/web/src/components/PdfReader.tsx
+++ b/apps/web/src/components/PdfReader.tsx
@@ -1,0 +1,694 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createCitation,
+  displayTitle,
+  serializeCitation,
+  flattenOutline,
+  outlineEntryForPage,
+  type PdfCitation,
+  type PdfSearchHit,
+} from "@forkleaf/pdf";
+import type { PdfReaderState } from "@/hooks/usePdfReader";
+import { PdfPage, type PdfHighlight } from "@/components/PdfPage";
+
+/**
+ * The reader.
+ *
+ * A PDF in ForkLeaf is not an attachment and not a preview — it is a *source*,
+ * sitting beside the note being written from it. Everything about this
+ * component follows from that. The most prominent action on a selection is
+ * "Cite into note", not "copy"; the search results say which page and show the
+ * sentence; and a document opened from a citation arrives with that passage
+ * already highlighted, because the reason it was opened was to look at that
+ * passage.
+ *
+ * What it is not: an editor. ForkLeaf will not annotate, sign, fill in or
+ * re-save a PDF. The repository holds the file exactly as it was committed,
+ * and everything ForkLeaf adds lives in markdown next to it — which is the
+ * only form in which those additions are still readable in ten years, by
+ * something other than ForkLeaf.
+ */
+
+export interface PdfReaderProps {
+  reader: PdfReaderState;
+  /** Opens the reader on a particular passage, from a link in a note. */
+  initialCitation?: PdfCitation | null;
+  /**
+   * Puts a cited passage into the note being written.
+   *
+   * Absent when there is no note open, in which case the reader offers to copy
+   * the markdown to the clipboard instead — the same text, one paste away,
+   * rather than a disabled button with no explanation.
+   */
+  onCite?: (citation: PdfCitation, quote: boolean) => void;
+  onClose: () => void;
+}
+
+const ZOOM_STEPS = [0.5, 0.67, 0.8, 1, 1.25, 1.5, 2, 3];
+
+export function PdfReader({ reader, initialCitation, onCite, onClose }: PdfReaderProps) {
+  const { status, info, source, session, outline, pages, indexing, error } = reader;
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const [fitWidth, setFitWidth] = useState(true);
+  const [current, setCurrent] = useState(1);
+  const [visible, setVisible] = useState<ReadonlySet<number>>(new Set([1]));
+  const [panel, setPanel] = useState<"outline" | "search" | null>(null);
+  const [query, setQuery] = useState("");
+  /**
+   * Which search result the reader is on, and which query it belongs to.
+   *
+   * Stored together rather than resetting the index from an effect when the
+   * query changes. An effect would render once showing result 4 of the *old*
+   * search against the new results — which for a query with three matches is a
+   * moment of "4 of 3" — and then render again having fixed it.
+   */
+  const [hit, setHit] = useState({ query: "", index: 0 });
+  const [selection, setSelection] = useState<{ page: number; start: number; end: number } | null>(
+    null,
+  );
+  const [copied, setCopied] = useState(false);
+
+  const title = useMemo(
+    () => (info ? displayTitle(info.metadata, source?.name ?? "") : (source?.name ?? "PDF")),
+    [info, source],
+  );
+
+  const pageText = useCallback(
+    (page: number) => pages.find((candidate) => candidate.page === page) ?? null,
+    [pages],
+  );
+
+  // ─── Fit to width ─────────────────────────────────────────────────────────
+
+  /**
+   * Recomputed on resize rather than set once.
+   *
+   * A reader who opens the file tree, or turns their tablet, expects the page
+   * to still fit. Kept as a mode rather than a one-off calculation so that
+   * zooming by hand switches it off and stays off — a viewer that silently
+   * undoes the zoom you just chose the next time the window moves is worse
+   * than one that never fitted at all.
+   */
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container || !fitWidth || !info || info.sizes.length === 0) return;
+
+    const fit = () => {
+      const widest = Math.max(...info.sizes.map((size) => size.width));
+      // The gutter keeps the page off the scrollbar and off the panel edge.
+      const available = container.clientWidth - 48;
+      if (widest > 0 && available > 0) setScale(available / widest);
+    };
+
+    fit();
+    const observer = new ResizeObserver(fit);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [fitWidth, info]);
+
+  // ─── Which pages are worth drawing ────────────────────────────────────────
+
+  /**
+   * Tracks the pages near the viewport, and which one the reader is on.
+   *
+   * `rootMargin` is a full viewport in each direction, so the next page is
+   * already drawn by the time it is scrolled to. Without it, every page turn
+   * is a flash of blank paper followed by the page appearing — which reads as
+   * the app being slow even when the render itself takes 30 milliseconds.
+   */
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container || status !== "ready") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        setVisible((previous) => {
+          const next = new Set(previous);
+          for (const entry of entries) {
+            const page = Number((entry.target as HTMLElement).dataset.pdfPage);
+            if (entry.isIntersecting) next.add(page);
+            else next.delete(page);
+          }
+          return next;
+        });
+
+        // The page the reader is *on* is the topmost one actually on screen,
+        // which is not the same as the topmost one being drawn.
+        const onScreen = entries
+          .filter((entry) => entry.intersectionRatio > 0.1)
+          .map((entry) => Number((entry.target as HTMLElement).dataset.pdfPage));
+        if (onScreen.length > 0) setCurrent(Math.min(...onScreen));
+      },
+      { root: container, rootMargin: "100% 0px", threshold: [0, 0.1] },
+    );
+
+    for (const element of container.querySelectorAll("[data-pdf-page]")) {
+      observer.observe(element);
+    }
+    return () => observer.disconnect();
+  }, [status, info]);
+
+  const goToPage = useCallback((page: number) => {
+    const container = scrollRef.current;
+    const target = container?.querySelector<HTMLElement>(`[data-pdf-page="${page}"]`);
+    if (!container || !target) return;
+
+    container.scrollTo({ top: target.offsetTop - 16, behavior: "smooth" });
+    setCurrent(page);
+  }, []);
+
+  // ─── Search ───────────────────────────────────────────────────────────────
+
+  const hits = useMemo<PdfSearchHit[]>(
+    () => (query.trim().length < 2 ? [] : reader.search(query)),
+    [query, reader],
+  );
+
+  const hitIndex = hit.query === query ? hit.index : 0;
+
+  const goToHit = useCallback(
+    (index: number) => {
+      const found = hits[index];
+      if (!found) return;
+      setHit({ query, index });
+      goToPage(found.page);
+    },
+    [hits, query, goToPage],
+  );
+
+  // ─── The passage a link asked for ─────────────────────────────────────────
+
+  /**
+   * Resolves the citation the reader was opened with, once the text is in.
+   *
+   * Not on open: the text extraction that a citation needs finishes after the
+   * document does, and blocking the first page on it would make every cited
+   * link feel slow to open. So the page hint is honoured immediately and the
+   * exact passage is found and highlighted a moment later, which is invisible
+   * for a short document and honest for a long one.
+   */
+  const located = useMemo(() => {
+    if (!initialCitation || pages.length === 0) return null;
+
+    const match = reader.locate(initialCitation);
+    return match?.page && match.range
+      ? { page: match.page, range: match.range, quality: match.quality }
+      : null;
+  }, [initialCitation, pages, reader]);
+
+  /**
+   * Scrolls to the citation, when the document is ready to be scrolled.
+   *
+   * Separate from working out *where* the passage is, which is derived above.
+   * This half really is a side effect on something outside React — the scroll
+   * position of a container.
+   *
+   * It happens at most twice per citation: once to the page the link names, as
+   * soon as the document opens, and once more to wherever the passage actually
+   * turned out to be after the text was read. The key is what stops a third —
+   * without it, every change to the search results scrolls the reader back to
+   * where it came in, which makes searching a cited document impossible.
+   */
+  const jumped = useRef("");
+
+  useEffect(() => {
+    if (!initialCitation || status !== "ready") return;
+
+    const key = `${serializeCitation(initialCitation)}|${located ? "found" : "hint"}`;
+    if (jumped.current === key) return;
+    jumped.current = key;
+
+    goToPage(located ? located.page : initialCitation.page);
+  }, [initialCitation, status, located, goToPage]);
+
+  // ─── Citing ───────────────────────────────────────────────────────────────
+
+  const onSelect = useCallback((page: number, start: number, end: number) => {
+    setSelection({ page, start, end });
+    setCopied(false);
+  }, []);
+
+  const citationFor = useCallback((): PdfCitation | null => {
+    if (!selection) return null;
+    const text = pageText(selection.page);
+    return text ? createCitation(text, selection.start, selection.end) : null;
+  }, [selection, pageText]);
+
+  const cite = useCallback(
+    (withQuote: boolean) => {
+      const citation = citationFor();
+      if (!citation) return;
+
+      onCite?.(citation, withQuote);
+      setSelection(null);
+      window.getSelection()?.removeAllRanges();
+    },
+    [citationFor, onCite],
+  );
+
+  // ─── Keyboard ─────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        if (selection) {
+          setSelection(null);
+          return;
+        }
+        onClose();
+        return;
+      }
+
+      // Not while somebody is typing in the search box.
+      const target = event.target as HTMLElement | null;
+      if (target && /^(INPUT|TEXTAREA)$/.test(target.tagName)) return;
+
+      if ((event.metaKey || event.ctrlKey) && event.key === "f") {
+        event.preventDefault();
+        setPanel("search");
+        return;
+      }
+      if (event.key === "PageDown" || event.key === "ArrowRight") goToPage(current + 1);
+      if (event.key === "PageUp" || event.key === "ArrowLeft") goToPage(Math.max(1, current - 1));
+    };
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [current, goToPage, onClose, selection]);
+
+  const zoomBy = useCallback((direction: -1 | 1) => {
+    setFitWidth(false);
+    setScale((previous) => {
+      const index = ZOOM_STEPS.findIndex((step) => step > previous + 0.001);
+      const at = direction === 1 ? index : (index === -1 ? ZOOM_STEPS.length : index) - 1;
+      return ZOOM_STEPS[Math.min(Math.max(at, 0), ZOOM_STEPS.length - 1)] ?? previous;
+    });
+  }, []);
+
+  const section = useMemo(
+    () => (outline.length > 0 ? outlineEntryForPage(outline, current) : null),
+    [outline, current],
+  );
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <section
+      aria-label={`Reading ${title}`}
+      className="flex h-full min-h-0 flex-col bg-[var(--fl-elevated)]"
+    >
+      <header className="flex shrink-0 items-center gap-2 border-b border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-[var(--fl-text)]" title={title}>
+            {title}
+          </p>
+          <p className="truncate text-xs text-[var(--fl-muted)]">
+            {info ? `${info.pageCount} page${info.pageCount === 1 ? "" : "s"}` : "Opening…"}
+            {section ? ` · ${section.title}` : ""}
+            {indexing ? " · reading text…" : ""}
+          </p>
+        </div>
+
+        {status === "ready" && info ? (
+          <>
+            <PageJump current={current} total={info.pageCount} onGo={goToPage} />
+
+            <div className="flex items-center gap-px">
+              <ToolButton label="Zoom out" onClick={() => zoomBy(-1)}>
+                −
+              </ToolButton>
+              <ToolButton
+                label={fitWidth ? "Zoom to 100%" : "Fit to width"}
+                onClick={() => {
+                  if (fitWidth) {
+                    setFitWidth(false);
+                    setScale(1);
+                  } else {
+                    setFitWidth(true);
+                  }
+                }}
+              >
+                {fitWidth ? "Fit" : `${Math.round(scale * 100)}%`}
+              </ToolButton>
+              <ToolButton label="Zoom in" onClick={() => zoomBy(1)}>
+                +
+              </ToolButton>
+            </div>
+
+            <ToolButton
+              label="Find in document"
+              pressed={panel === "search"}
+              onClick={() => setPanel(panel === "search" ? null : "search")}
+            >
+              Find
+            </ToolButton>
+            {outline.length > 0 ? (
+              <ToolButton
+                label="Contents"
+                pressed={panel === "outline"}
+                onClick={() => setPanel(panel === "outline" ? null : "outline")}
+              >
+                Contents
+              </ToolButton>
+            ) : null}
+          </>
+        ) : null}
+
+        <ToolButton label="Close the reader" onClick={onClose}>
+          Close
+        </ToolButton>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        {panel ? (
+          <aside className="w-64 shrink-0 overflow-y-auto border-r border-[var(--fl-border)] bg-[var(--fl-surface)] p-2">
+            {panel === "outline" ? (
+              <Outline outline={outline} current={current} onGo={goToPage} />
+            ) : (
+              <Search
+                query={query}
+                onQuery={setQuery}
+                hits={hits}
+                index={hitIndex}
+                onGo={goToHit}
+                ready={pages.length > 0}
+                indexing={indexing}
+              />
+            )}
+          </aside>
+        ) : null}
+
+        <div ref={scrollRef} className="relative min-w-0 flex-1 overflow-auto p-4">
+          {status === "loading" ? <Notice>Opening the document…</Notice> : null}
+          {status === "password" ? (
+            <Notice tone="warn">
+              {error ?? "This PDF is protected by a password."}
+              <br />
+              ForkLeaf cannot open password-protected documents.
+            </Notice>
+          ) : null}
+          {status === "error" ? <Notice tone="danger">{error}</Notice> : null}
+
+          {status === "ready" && info && session ? (
+            <div className="flex flex-col items-center gap-4">
+              {info.sizes.map((size, index) => {
+                const page = index + 1;
+                return (
+                  <PdfPage
+                    key={page}
+                    session={session}
+                    page={page}
+                    size={size}
+                    scale={scale}
+                    text={pageText(page)}
+                    visible={visible.has(page)}
+                    highlights={highlightsFor(page, located, hits, hitIndex)}
+                    onSelect={onSelect}
+                  />
+                );
+              })}
+            </div>
+          ) : null}
+
+          {selection ? (
+            <CiteBar
+              canCite={Boolean(onCite)}
+              copied={copied}
+              onCite={cite}
+              onCopy={async () => {
+                const text = pageText(selection.page)?.text.slice(selection.start, selection.end);
+                if (!text) return;
+                await navigator.clipboard.writeText(text.replace(/\s+/g, " ").trim());
+                setCopied(true);
+              }}
+              onDismiss={() => setSelection(null)}
+            />
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/** The highlights a page should show, from the citation and the search. */
+function highlightsFor(
+  page: number,
+  located: { page: number; range: [number, number] } | null,
+  hits: readonly PdfSearchHit[],
+  hitIndex: number,
+): PdfHighlight[] {
+  const highlights: PdfHighlight[] = [];
+
+  if (located?.page === page) {
+    highlights.push({ range: located.range, kind: "citation" });
+  }
+
+  hits.forEach((hit, index) => {
+    if (hit.page === page) {
+      highlights.push({ range: hit.range, kind: "search", current: index === hitIndex });
+    }
+  });
+
+  return highlights;
+}
+
+/**
+ * The action bar over a selection.
+ *
+ * Pinned to the bottom of the reader rather than floating beside the
+ * selection. A floating bar has to be positioned from the selection's
+ * rectangle, which on a multi-line selection near a page edge means it
+ * covers either the start or the end of what was just selected — and the one
+ * thing this bar must not hide is the passage the reader is deciding whether
+ * to cite.
+ */
+function CiteBar({
+  canCite,
+  copied,
+  onCite,
+  onCopy,
+  onDismiss,
+}: {
+  canCite: boolean;
+  copied: boolean;
+  onCite: (withQuote: boolean) => void;
+  onCopy: () => void | Promise<void>;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="pointer-events-none sticky bottom-2 z-10 flex justify-center">
+      <div className="pointer-events-auto flex items-center gap-1 rounded-full border border-[var(--fl-border-strong)] bg-[var(--fl-surface)] px-1.5 py-1 shadow-[var(--fl-shadow-lg)]">
+        {canCite ? (
+          <>
+            <BarButton onClick={() => onCite(true)}>Quote into note</BarButton>
+            <BarButton onClick={() => onCite(false)}>Reference only</BarButton>
+          </>
+        ) : (
+          <span className="px-2 text-xs text-[var(--fl-muted)]">Open a note to cite into it</span>
+        )}
+        <BarButton onClick={() => void onCopy()}>{copied ? "Copied" : "Copy"}</BarButton>
+        <BarButton onClick={onDismiss} aria-label="Dismiss">
+          ×
+        </BarButton>
+      </div>
+    </div>
+  );
+}
+
+function Outline({
+  outline,
+  current,
+  onGo,
+}: {
+  outline: Parameters<typeof flattenOutline>[0];
+  current: number;
+  onGo: (page: number) => void;
+}) {
+  const rows = useMemo(() => flattenOutline(outline), [outline]);
+  const here = useMemo(() => outlineEntryForPage(outline, current)?.key, [outline, current]);
+
+  return (
+    <nav aria-label="Contents" className="flex flex-col">
+      {rows.map((row) => (
+        <button
+          key={row.key}
+          type="button"
+          disabled={row.page == null}
+          onClick={() => row.page != null && onGo(row.page)}
+          className={`flex items-baseline gap-2 rounded px-2 py-1 text-left text-xs hover:bg-[var(--fl-elevated)] disabled:cursor-default disabled:opacity-50 ${
+            row.key === here ? "bg-[var(--fl-accent-soft)] text-[var(--fl-text)]" : ""
+          }`}
+          style={{ paddingLeft: 8 + row.depth * 12 }}
+        >
+          <span className="min-w-0 flex-1 truncate">{row.title}</span>
+          {row.page != null ? (
+            <span className="shrink-0 tabular-nums text-[var(--fl-muted)]">{row.page}</span>
+          ) : null}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+function Search({
+  query,
+  onQuery,
+  hits,
+  index,
+  onGo,
+  ready,
+  indexing,
+}: {
+  query: string;
+  onQuery: (value: string) => void;
+  hits: readonly PdfSearchHit[];
+  index: number;
+  onGo: (index: number) => void;
+  ready: boolean;
+  indexing: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <input
+        type="search"
+        value={query}
+        data-autofocus
+        onChange={(event) => onQuery(event.target.value)}
+        placeholder="Find in document"
+        aria-label="Find in document"
+        className="w-full rounded border border-[var(--fl-border)] bg-[var(--fl-bg)] px-2 py-1 text-sm text-[var(--fl-text)]"
+      />
+
+      <p className="px-1 text-xs text-[var(--fl-muted)]">
+        {indexing
+          ? "Reading the document's text…"
+          : !ready
+            ? "This document has no text to search — it is probably a scan."
+            : query.trim().length < 2
+              ? "Type at least two characters."
+              : `${hits.length} match${hits.length === 1 ? "" : "es"}`}
+      </p>
+
+      {hits.map((hit, at) => (
+        <button
+          key={`${hit.page}-${hit.range[0]}`}
+          type="button"
+          onClick={() => onGo(at)}
+          className={`rounded px-2 py-1 text-left text-xs hover:bg-[var(--fl-elevated)] ${
+            at === index ? "bg-[var(--fl-accent-soft)]" : ""
+          }`}
+        >
+          <span className="block text-[var(--fl-muted)]">Page {hit.page}</span>
+          <span className="block text-[var(--fl-text)]">
+            {hit.snippet.slice(0, hit.snippetRange[0])}
+            <mark className="bg-[var(--fl-hl-yellow)] text-[var(--fl-text)]">
+              {hit.snippet.slice(...hit.snippetRange)}
+            </mark>
+            {hit.snippet.slice(hit.snippetRange[1])}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function PageJump({
+  current,
+  total,
+  onGo,
+}: {
+  current: number;
+  total: number;
+  onGo: (page: number) => void;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+
+  return (
+    <form
+      className="flex items-center gap-1 text-xs text-[var(--fl-muted)]"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const page = Number(draft);
+        if (Number.isInteger(page) && page >= 1 && page <= total) onGo(page);
+        setDraft(null);
+      }}
+    >
+      <input
+        aria-label="Page number"
+        // Uncontrolled while being typed in, so that clearing the box to type
+        // a new number does not snap it back to the page being scrolled past.
+        value={draft ?? String(current)}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={() => setDraft(null)}
+        inputMode="numeric"
+        className="w-12 rounded border border-[var(--fl-border)] bg-[var(--fl-bg)] px-1 py-0.5 text-center tabular-nums text-[var(--fl-text)]"
+      />
+      <span>of {total}</span>
+    </form>
+  );
+}
+
+function ToolButton({
+  label,
+  children,
+  onClick,
+  pressed,
+}: {
+  label: string;
+  children: React.ReactNode;
+  onClick: () => void;
+  pressed?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      aria-pressed={pressed}
+      onClick={onClick}
+      className={`rounded px-2 py-1 text-xs text-[var(--fl-text)] hover:bg-[var(--fl-elevated)] ${
+        pressed ? "bg-[var(--fl-accent-soft)]" : ""
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function BarButton({ children, onClick, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      {...rest}
+      className="rounded-full px-3 py-1 text-xs text-[var(--fl-text)] hover:bg-[var(--fl-elevated)]"
+    >
+      {children}
+    </button>
+  );
+}
+
+function Notice({
+  children,
+  tone = "muted",
+}: {
+  children: React.ReactNode;
+  tone?: "muted" | "warn" | "danger";
+}) {
+  const colour =
+    tone === "danger" ? "var(--fl-danger)" : tone === "warn" ? "var(--fl-warn)" : "var(--fl-muted)";
+
+  return (
+    <p
+      role={tone === "muted" ? undefined : "alert"}
+      className="p-8 text-sm"
+      style={{ color: colour }}
+    >
+      {children}
+    </p>
+  );
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import type { CursorPosition, ImageBridge, LinkBridge } from "@forkleaf/editor";
+import { displayTitle, parseCitation, type PdfCitation } from "@forkleaf/pdf";
 import type { EditorViewMode, Workspace } from "@forkleaf/types";
 import {
   deriveTitle,
@@ -21,7 +22,13 @@ import { useNotebook } from "@/hooks/useNotebook";
 import { usePublishedPages } from "@/hooks/usePublishedPages";
 import { useLinks } from "@/hooks/useLinks";
 import { useLocalFiles } from "@/hooks/useLocalFiles";
-import type { LocalFile } from "@/lib/local-files";
+import type { LocalFile, LocalPdf } from "@/lib/local-files";
+import { usePdfReader } from "@/hooks/usePdfReader";
+import { PdfReader } from "@/components/PdfReader";
+import { localSource, pdfLinkTarget, repoSource, type PdfSource } from "@/lib/pdf-source";
+import { readDroppedPdf } from "@/lib/local-files";
+import { insertionFor, quoteMarkdown } from "@/lib/pdf-quote";
+import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
 import { EditorSidebar } from "@/components/EditorSidebar";
 import { EditorRightPanel } from "@/components/EditorRightPanel";
@@ -269,6 +276,129 @@ export function EditorWorkspace() {
     [workspaceIdForLinks],
   );
 
+  // ── The reader ────────────────────────────────────────────────────────
+  //
+  // A PDF is not a note and never becomes one: it has no markdown body, cannot
+  // be edited, and would need its own branch at every place a note is written,
+  // saved, synced or exported. It gets a pane of its own beside the note
+  // instead — which is also the arrangement the feature exists for, since the
+  // point of opening a paper in a notes app is to write about it.
+  const reader = usePdfReader(workspace);
+  const [readerCitation, setReaderCitation] = useState<PdfCitation | null>(null);
+  /** The repo path of the document open in the reader, for writing links to. */
+  const [readerPath, setReaderPath] = useState<string | null>(null);
+  /** A PDF that could not even be read off the disk, before the reader saw it. */
+  const [readerError, setReaderError] = useState<string | null>(null);
+
+  const openInReader = useCallback(
+    (next: PdfSource, citation: PdfCitation | null, path: string | null) => {
+      setReaderCitation(citation);
+      setReaderPath(path);
+      reader.open(next);
+      // The reader shares the width with the note, so on a narrow screen the
+      // panels beside them have to give way or there is nothing left for
+      // either.
+      setDrawer(null);
+    },
+    [reader],
+  );
+
+  const openLocalPdf = useCallback(
+    (pdf: LocalPdf) => openInReader(localSource(pdf.name, pdf.bytes), null, null),
+    [openInReader],
+  );
+
+  /**
+   * A PDF dropped onto the window opens in the reader.
+   *
+   * Not a convenience. Firefox and Safari have no File System Access API, so
+   * the "Open a PDF…" command does not exist there at all — dropping the file
+   * is the only way in, and without it the whole feature would be a Chromium
+   * feature. Dropping also skips a native dialog for the case the dialog
+   * exists, which is the common one.
+   *
+   * Bound at the window rather than on a drop zone, because a drop zone that
+   * only accepts a file over one particular rectangle is a target people miss.
+   */
+  useEffect(() => {
+    const pdfFrom = (transfer: DataTransfer | null): File | null =>
+      Array.from(transfer?.files ?? []).find(
+        (file) => file.type === "application/pdf" || /\.pdf$/i.test(file.name),
+      ) ?? null;
+
+    const onDragOver = (event: DragEvent) => {
+      // The default action for a dropped file is for the browser to navigate
+      // to it, which throws away everything unsaved in the tab. Preventing the
+      // dragover is what makes the drop reach us at all.
+      if (event.dataTransfer?.types.includes("Files")) event.preventDefault();
+    };
+
+    const onDrop = (event: DragEvent) => {
+      const file = pdfFrom(event.dataTransfer);
+      if (!file) return;
+
+      event.preventDefault();
+      void readDroppedPdf(file)
+        .then((pdf) => openInReader(localSource(pdf.name, pdf.bytes), null, null))
+        .catch((problem: unknown) => {
+          setReaderError(
+            problem instanceof Error ? problem.message : "That PDF could not be opened.",
+          );
+        });
+    };
+
+    window.addEventListener("dragover", onDragOver);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      window.removeEventListener("dragover", onDragOver);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, [openInReader]);
+
+  /**
+   * Opens a PDF that lives in the repository, at a passage if one was asked for.
+   */
+  const openRepoPdf = useCallback(
+    (path: string, fragment: string) => {
+      if (!workspace) return;
+      openInReader(repoSource(workspace, path), fragment ? parseCitation(fragment) : null, path);
+    },
+    [workspace, openInReader],
+  );
+
+  /**
+   * Writes a cited passage into the note being read alongside.
+   *
+   * The link is written *relative to the note*, exactly as an image is, so the
+   * markdown that lands in the file is the markdown a person would have
+   * written by hand — and still resolves when the repository is opened in
+   * anything else.
+   */
+  const citeIntoNote = useCallback(
+    (citation: PdfCitation, withQuote: boolean) => {
+      if (!note) return;
+
+      const markdown = quoteMarkdown({
+        // A document from the user's own disk has no path this repository can
+        // resolve, so the quotation is attributed rather than linked.
+        target: readerPath ? relativeSrc(note.path, readerPath) : null,
+        title: reader.info
+          ? displayTitle(reader.info.metadata, reader.source?.name ?? "")
+          : (reader.source?.name ?? "PDF"),
+        citation,
+        includeQuote: withQuote,
+      });
+
+      // Appended at the end rather than at the caret: the caret is in the
+      // editor, which has not been focused since the reader was opened, so its
+      // recorded position is wherever it was several minutes and one document
+      // ago. The end of the note is where a passage being read into it goes.
+      const { text } = insertionFor(note.content, note.content.length, markdown);
+      notebook.saveNote(text);
+    },
+    [note, readerPath, reader.info, reader.source, notebook],
+  );
+
   const links = useLinks({
     workspaceId: workspaceIdForLinks,
     paths: markdownPaths,
@@ -318,8 +448,25 @@ export function EditorWorkspace() {
         if (path) notebook.openNote(path);
         else createLinked(target);
       },
+      /**
+       * An ordinary markdown link to a PDF in this repository opens the reader.
+       *
+       * Claimed here rather than left to the browser because following it would
+       * navigate the tab to a path that resolves against this app's origin and
+       * 404s — the link is correct, and correct for github.com, and simply not
+       * something a browser sitting on `/editor` can follow.
+       */
+      openHref: (href) => {
+        if (!workspace || workspace.isLocal || !notePath) return false;
+
+        const target = pdfLinkTarget(notePath, href);
+        if (!target) return false;
+
+        openRepoPdf(target.path, target.fragment);
+        return true;
+      },
     }),
-    [links, notebook, createLinked, workspace],
+    [links, notebook, createLinked, workspace, notePath, openRepoPdf],
   );
 
   /**
@@ -349,7 +496,7 @@ export function EditorWorkspace() {
     [notebook],
   );
 
-  const localFiles = useLocalFiles(adoptFile);
+  const localFiles = useLocalFiles(adoptFile, openLocalPdf);
 
   /**
    * Saves the note, and the file behind it when there is one.
@@ -1225,6 +1372,26 @@ export function EditorWorkspace() {
         keywords: "import disk local filesystem md markdown open with",
         run: () => void localFiles.openFile(),
       });
+
+      list.push({
+        id: "open-pdf",
+        label: "Open a PDF…",
+        group: "Notes",
+        hint: "Reads it beside your note, and quotes from it",
+        keywords:
+          "pdf paper document read reader cite citation quote source reference article book scan acrobat",
+        run: () => void localFiles.openPdf(),
+      });
+    }
+
+    if (reader.status !== "idle") {
+      list.push({
+        id: "close-pdf",
+        label: "Close the PDF",
+        group: "View",
+        keywords: "pdf close reader hide document",
+        run: () => reader.close(),
+      });
     }
 
     return list;
@@ -1250,6 +1417,7 @@ export function EditorWorkspace() {
     handleDelete,
     repairImages,
     localFiles,
+    reader,
   ]);
 
   // ── Keyboard shortcuts ──────────────────────────────────────────────────
@@ -1388,7 +1556,11 @@ export function EditorWorkspace() {
             tree={notebook.tree}
             activePath={note?.path ?? null}
             onOpenNote={(path) => {
-              notebook.openNote(path);
+              // A PDF in the tree opens in the reader. It is in the tree
+              // because ForkLeaf can open it; handing it to the notebook would
+              // make a note whose body is the raw bytes of a PDF.
+              if (isPdfPath(path)) openRepoPdf(path, "");
+              else notebook.openNote(path);
               // On a phone the drawer covers the note it just opened.
               setDrawer(null);
             }}
@@ -1610,6 +1782,7 @@ export function EditorWorkspace() {
           {[
             { text: notebook.error, dismiss: notebook.dismissError },
             { text: localFiles.error, dismiss: localFiles.clearError },
+            { text: readerError, dismiss: () => setReaderError(null) },
           ]
             .filter((banner) => banner.text)
             .map((banner) => (
@@ -1708,7 +1881,43 @@ export function EditorWorkspace() {
           </div>
         </main>
 
-        {(!panelCollapsed || drawer === "document") && (
+        {/*
+          The reader, beside the note.
+
+          Its own panel rather than a dialog over the editor, because the whole
+          point is to have both at once: a dialog would mean reading a
+          paragraph, dismissing the document, writing about it, and reopening
+          it — which is the workflow people use two windows to avoid.
+
+          It takes the properties panel's place at this width rather than
+          squeezing a third column in. Three columns of content on a laptop
+          leaves the note about forty characters wide, which is not a width
+          anybody writes at. Below `lg` it covers the window instead: a
+          document page beside a note on a phone is two unreadable columns.
+
+          One element, switched by class, and not two rendered at different
+          breakpoints. Two would both mount — Tailwind's `hidden` hides a
+          component, it does not stop it existing — so every page of the
+          document would be parsed, laid out and drawn to a canvas twice, and
+          the copy nobody can see would win half the races for the scroll
+          container that `goToPage` looks up by selector.
+        */}
+        {reader.status !== "idle" && (
+          <div className="fl-panel fixed inset-2 z-40 flex overflow-hidden shadow-[var(--fl-shadow-lg)] lg:static lg:z-auto lg:w-[min(46rem,45vw)] lg:shrink-0 lg:shadow-none">
+            <PdfReader
+              reader={reader}
+              initialCitation={readerCitation}
+              {...(note ? { onCite: citeIntoNote } : {})}
+              onClose={() => {
+                reader.close();
+                setReaderCitation(null);
+                setReaderPath(null);
+              }}
+            />
+          </div>
+        )}
+
+        {(!panelCollapsed || drawer === "document") && reader.status === "idle" && (
           <div
             className={`fl-panel ${
               drawer === "document"

--- a/apps/web/src/hooks/useLocalFiles.ts
+++ b/apps/web/src/hooks/useLocalFiles.ts
@@ -5,10 +5,13 @@ import {
   canEditLocalFiles,
   consumeLaunchedFiles,
   openLocalFile,
+  openPdfFile,
   readLocalFile,
   saveLocalFileAs,
   writeLocalFile,
+  type LocalDocument,
   type LocalFile,
+  type LocalPdf,
 } from "@/lib/local-files";
 
 /**
@@ -33,6 +36,8 @@ export interface LocalFilesState {
   fileFor: (notePath: string) => string | null;
   /** Opens the picker and adopts whatever is chosen. */
   openFile: () => Promise<void>;
+  /** Opens a PDF from this machine, in the reader rather than the notebook. */
+  openPdf: () => Promise<void>;
   /**
    * Writes a note back to its file. Returns false when it has none, so the
    * caller can fall back to "Save as" rather than reporting a failure.
@@ -52,6 +57,15 @@ export interface LocalFilesState {
  */
 export function useLocalFiles(
   adopt: (file: LocalFile, existingNotePath: string | null) => Promise<string | null>,
+  /**
+   * Hands a PDF to the reader.
+   *
+   * A separate route out of this hook rather than a second branch inside
+   * `adopt`, because a PDF does not become a note and never gets a note path —
+   * it has no place in the handle map, cannot be saved back, and would have to
+   * be special-cased at every use of the one that could.
+   */
+  openInReader?: (pdf: LocalPdf) => void,
 ): LocalFilesState {
   const handles = useRef(new Map<string, FileSystemFileHandle>());
   /** Mirrors the handle map's names, because a ref cannot drive a render. */
@@ -59,8 +73,10 @@ export function useLocalFiles(
   const [error, setError] = useState<string | null>(null);
 
   const adoptRef = useRef(adopt);
+  const readerRef = useRef(openInReader);
   useEffect(() => {
     adoptRef.current = adopt;
+    readerRef.current = openInReader;
   });
 
   /**
@@ -84,9 +100,14 @@ export function useLocalFiles(
   }, []);
 
   const take = useCallback(
-    async (files: LocalFile[]) => {
+    async (files: LocalDocument[]) => {
       for (const file of files) {
         try {
+          if (file.kind === "pdf") {
+            readerRef.current?.(file);
+            continue;
+          }
+
           const already = await findOpen(file.handle);
           const notePath = await adoptRef.current(file, already);
           if (!notePath) continue;
@@ -115,6 +136,15 @@ export function useLocalFiles(
       if (file) await take([file]);
     } catch (problem) {
       setError(problem instanceof Error ? problem.message : "That file could not be opened.");
+    }
+  }, [take]);
+
+  const openPdf = useCallback(async () => {
+    try {
+      const pdf = await openPdfFile();
+      if (pdf) await take([pdf]);
+    } catch (problem) {
+      setError(problem instanceof Error ? problem.message : "That PDF could not be opened.");
     }
   }, [take]);
 
@@ -154,6 +184,7 @@ export function useLocalFiles(
     supported: canEditLocalFiles(),
     fileFor,
     openFile,
+    openPdf,
     saveToFile,
     saveFileAs,
     error,

--- a/apps/web/src/hooks/usePdfReader.ts
+++ b/apps/web/src/hooks/usePdfReader.ts
@@ -1,0 +1,235 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  PdfOpenError,
+  openPdf,
+  resolveCitation,
+  searchPdf,
+  type PdfCitation,
+  type PdfCitationMatch,
+  type PdfDocumentInfo,
+  type PdfOutlineItem,
+  type PdfPageText,
+  type PdfSearchHit,
+  type PdfSession,
+} from "@forkleaf/pdf";
+import { fetchRepoPdf, type PdfSource } from "@/lib/pdf-source";
+import type { Workspace } from "@forkleaf/types";
+
+/**
+ * Opening a PDF, and keeping it open.
+ *
+ * The state machine is small and the lifetime rules are not, which is why this
+ * is a hook rather than three `useState`s in the component:
+ *
+ *   - A document owns a worker. Failing to destroy it leaks one per document
+ *     opened, and a reading session is a dozen documents.
+ *   - Opening is several awaits long, and the reader can be pointed at another
+ *     document part way through any of them. Every step therefore checks that
+ *     it is still the current request before writing anything, or a slow first
+ *     document overwrites a fast second one — the classic race, and the one
+ *     that shows the wrong paper.
+ *   - Text extraction is the expensive part and is *not* on the critical path
+ *     to showing page one. It runs behind the first render, because a reader
+ *     who wants to look at page one should not wait for page nine hundred.
+ */
+
+export type PdfStatus = "idle" | "loading" | "ready" | "error" | "password";
+
+export interface PdfReaderState {
+  status: PdfStatus;
+  source: PdfSource | null;
+  session: PdfSession | null;
+  info: PdfDocumentInfo | null;
+  outline: PdfOutlineItem[];
+  /** Page text, filled in behind the first render. Empty until extraction runs. */
+  pages: PdfPageText[];
+  /** True while text extraction is still running. */
+  indexing: boolean;
+  error: string | null;
+  /** Opens a document, replacing whatever is open. */
+  open: (source: PdfSource, password?: string) => void;
+  close: () => void;
+  /** Finds a phrase. Empty until the text has been extracted. */
+  search: (query: string) => PdfSearchHit[];
+  /** Locates a citation in the document that is open. */
+  locate: (citation: PdfCitation) => PdfCitationMatch | null;
+}
+
+/** Where the copied pdf.js fonts and character maps are served from. */
+const ASSETS_URL = "/pdfjs";
+
+export function usePdfReader(workspace: Workspace | null): PdfReaderState {
+  const [status, setStatus] = useState<PdfStatus>("idle");
+  const [source, setSource] = useState<PdfSource | null>(null);
+  const [session, setSession] = useState<PdfSession | null>(null);
+  const [info, setInfo] = useState<PdfDocumentInfo | null>(null);
+  const [outline, setOutline] = useState<PdfOutlineItem[]>([]);
+  const [pages, setPages] = useState<PdfPageText[]>([]);
+  const [indexing, setIndexing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * Which open request is current.
+   *
+   * A counter rather than comparing sources: opening the same document twice
+   * — which is what retrying with a password is — must still invalidate the
+   * first attempt, and two equal sources cannot tell those apart.
+   */
+  const request = useRef(0);
+  const live = useRef<PdfSession | null>(null);
+  const extraction = useRef<AbortController | null>(null);
+
+  /** Tears down whatever is open. Safe to call when nothing is. */
+  const teardown = useCallback(() => {
+    extraction.current?.abort();
+    extraction.current = null;
+
+    const open = live.current;
+    live.current = null;
+    // Not awaited: nothing downstream depends on the worker having stopped,
+    // and making every caller async to wait for a teardown would spread
+    // through the whole component.
+    void open?.destroy().catch(() => {});
+  }, []);
+
+  const workspaceRef = useRef(workspace);
+  useEffect(() => {
+    workspaceRef.current = workspace;
+  });
+
+  const open = useCallback(
+    (next: PdfSource, password?: string) => {
+      const ticket = (request.current += 1);
+      teardown();
+
+      setSource(next);
+      setStatus("loading");
+      setError(null);
+      setInfo(null);
+      setOutline([]);
+      setPages([]);
+
+      void (async () => {
+        try {
+          const bytes =
+            next.kind === "local"
+              ? next.bytes
+              : await fetchRepoPdf(requireWorkspace(workspaceRef.current), next.path);
+
+          if (ticket !== request.current) return;
+
+          const opened = await openPdf(bytes, { password, assetsUrl: ASSETS_URL });
+
+          // The document finished opening after the reader moved on. Nothing
+          // will ever show it, so it has to be destroyed here or its worker
+          // outlives the tab's usefulness.
+          if (ticket !== request.current) {
+            void opened.destroy().catch(() => {});
+            return;
+          }
+
+          live.current = opened;
+          setSession(opened);
+          setInfo(opened.info);
+          setStatus("ready");
+
+          void opened
+            .outline()
+            .then((items) => {
+              if (ticket === request.current) setOutline(items);
+            })
+            .catch(() => {
+              // A document with a broken outline is still a readable document.
+            });
+
+          extractText(opened, ticket);
+        } catch (problem) {
+          if (ticket !== request.current) return;
+
+          if (problem instanceof PdfOpenError && problem.reason === "password") {
+            setStatus("password");
+            setError(problem.message);
+            return;
+          }
+
+          setStatus("error");
+          setError(problem instanceof Error ? problem.message : "That PDF could not be opened.");
+        }
+      })();
+
+      /** Reads every page's text behind the first render. */
+      function extractText(opened: PdfSession, ticket: number) {
+        const controller = new AbortController();
+        extraction.current = controller;
+        setIndexing(true);
+
+        void opened
+          .allText({ signal: controller.signal })
+          .then((extracted) => {
+            if (ticket === request.current) setPages(extracted);
+          })
+          .catch(() => {
+            // Aborted, or a document whose text cannot be read — a pure scan
+            // with no text layer, most often. The pages still render; search
+            // and citation simply have nothing to work with, which the reader
+            // says in words rather than by appearing broken.
+          })
+          .finally(() => {
+            if (ticket === request.current) setIndexing(false);
+          });
+      }
+    },
+    [teardown],
+  );
+
+  const close = useCallback(() => {
+    request.current += 1;
+    teardown();
+
+    setSession(null);
+    setSource(null);
+    setInfo(null);
+    setOutline([]);
+    setPages([]);
+    setIndexing(false);
+    setError(null);
+    setStatus("idle");
+  }, [teardown]);
+
+  // The worker outlives React unless something stops it.
+  useEffect(() => teardown, [teardown]);
+
+  const search = useCallback(
+    (query: string) => (pages.length === 0 ? [] : searchPdf(pages, query)),
+    [pages],
+  );
+
+  const locate = useCallback(
+    (citation: PdfCitation) => (pages.length === 0 ? null : resolveCitation(pages, citation)),
+    [pages],
+  );
+
+  return {
+    status,
+    source,
+    session,
+    info,
+    outline,
+    pages,
+    indexing,
+    error,
+    open,
+    close,
+    search,
+    locate,
+  };
+}
+
+function requireWorkspace(workspace: Workspace | null): Workspace {
+  if (!workspace) {
+    throw new Error("Connect a repository before opening a PDF stored in one.");
+  }
+  return workspace;
+}

--- a/apps/web/src/lib/local-files.ts
+++ b/apps/web/src/lib/local-files.ts
@@ -19,7 +19,20 @@
  * so `canEditLocalFiles` is false there and the app hides the affordance
  * rather than offering something that throws — a download is still available
  * through the export dialog, which is the honest fallback.
+ *
+ * ## PDFs are a different kind of open
+ *
+ * A markdown file opened from disk becomes a note: it is text, ForkLeaf can
+ * edit it, and writing through the handle writes the user's own file. A PDF is
+ * none of those things. It is bytes ForkLeaf reads and cannot write, so it
+ * comes back as bytes and goes to the reader rather than to the notebook — and
+ * `openPdfFile` deliberately asks for read permission only, so opening a paper
+ * never produces a browser prompt asking to *edit* it. An editor that requests
+ * write access to a file it will never write has told the user something
+ * untrue about itself.
  */
+
+import { MAX_PDF_BYTES } from "@/lib/media";
 
 /** True when this browser can open and write files on this machine. */
 export function canEditLocalFiles(): boolean {
@@ -31,14 +44,27 @@ export function canReceiveLaunchedFiles(): boolean {
   return typeof window !== "undefined" && "launchQueue" in window;
 }
 
-/** A file on disk that ForkLeaf currently has open. */
+/** A text file on disk that ForkLeaf currently has open. */
 export interface LocalFile {
+  kind: "text";
   handle: FileSystemFileHandle;
   /** The file's own name, `meeting-notes.md`. */
   name: string;
   /** Its contents, as text. */
   text: string;
 }
+
+/** A PDF on disk that ForkLeaf currently has open. Read-only, by nature. */
+export interface LocalPdf {
+  kind: "pdf";
+  handle: FileSystemFileHandle;
+  name: string;
+  /** The file's bytes, for the reader to parse. */
+  bytes: Uint8Array;
+}
+
+/** Either kind of file the pickers and the operating system can hand over. */
+export type LocalDocument = LocalFile | LocalPdf;
 
 /**
  * The file types the pickers offer.
@@ -56,6 +82,16 @@ const PICKER_TYPES: FilePickerAcceptType[] = [
     },
   },
 ];
+
+/** The reader's own picker. Separate, because a PDF is not a note. */
+const PDF_PICKER_TYPES: FilePickerAcceptType[] = [
+  { description: "PDF", accept: { "application/pdf": [".pdf"] } },
+];
+
+/** True for a name the reader should take rather than the notebook. */
+export function isPdfName(name: string): boolean {
+  return /\.pdf$/i.test(name);
+}
 
 /**
  * Asks the user for a file and reads it.
@@ -82,10 +118,75 @@ export async function openLocalFile(): Promise<LocalFile | null> {
   return readLocalFile(handle);
 }
 
-/** Reads a handle's current contents. */
+/** Reads a handle's current contents as text. */
 export async function readLocalFile(handle: FileSystemFileHandle): Promise<LocalFile> {
   const file = await handle.getFile();
-  return { handle, name: file.name, text: await file.text() };
+  return { kind: "text", handle, name: file.name, text: await file.text() };
+}
+
+/**
+ * Asks the user for a PDF and reads its bytes.
+ *
+ * Returns null when the picker is dismissed, exactly as `openLocalFile` does.
+ */
+export async function openPdfFile(): Promise<LocalPdf | null> {
+  if (!canEditLocalFiles()) throw new Error(UNSUPPORTED);
+
+  let handle: FileSystemFileHandle;
+  try {
+    [handle] = await window.showOpenFilePicker({
+      types: PDF_PICKER_TYPES,
+      excludeAcceptAllOption: false,
+      multiple: false,
+    });
+  } catch (error) {
+    if (isDismissal(error)) return null;
+    throw error;
+  }
+
+  return readLocalPdf(handle);
+}
+
+/**
+ * Reads a handle's bytes, refusing one too large to open.
+ *
+ * The size is checked before the bytes are read rather than after. Reading a
+ * 600 MB file into memory in order to discover it is too big to hold in memory
+ * is a way of crashing the tab that also loses whatever was unsaved in it.
+ */
+export async function readLocalPdf(handle: FileSystemFileHandle): Promise<LocalPdf> {
+  const file = await handle.getFile();
+
+  if (file.size > MAX_PDF_BYTES) {
+    throw new Error(
+      `${file.name} is ${(file.size / (1024 * 1024)).toFixed(0)} MB. ForkLeaf can open PDFs up to ${MAX_PDF_BYTES / (1024 * 1024)} MB.`,
+    );
+  }
+
+  return {
+    kind: "pdf",
+    handle,
+    name: file.name,
+    bytes: new Uint8Array(await file.arrayBuffer()),
+  };
+}
+
+/**
+ * A PDF from anywhere that is not a file handle — a drop, a paste, an `<input>`.
+ *
+ * Firefox and Safari have no File System Access API, so the picker above does
+ * not exist there. Dragging a PDF onto the window still does, and this is what
+ * makes the reader work in those browsers at all: no handle, no writing back,
+ * but the document opens.
+ */
+export async function readDroppedPdf(file: File): Promise<Omit<LocalPdf, "handle">> {
+  if (file.size > MAX_PDF_BYTES) {
+    throw new Error(
+      `${file.name} is ${(file.size / (1024 * 1024)).toFixed(0)} MB. ForkLeaf can open PDFs up to ${MAX_PDF_BYTES / (1024 * 1024)} MB.`,
+    );
+  }
+
+  return { kind: "pdf", name: file.name, bytes: new Uint8Array(await file.arrayBuffer()) };
 }
 
 /**
@@ -148,20 +249,24 @@ export async function saveLocalFileAs(
  * one, double-clicking a file opens ForkLeaf on an empty editor and the file
  * is silently dropped.
  */
-export function consumeLaunchedFiles(onFiles: (files: LocalFile[]) => void): void {
+export function consumeLaunchedFiles(onFiles: (files: LocalDocument[]) => void): void {
   if (!canReceiveLaunchedFiles()) return;
 
   window.launchQueue?.setConsumer((params) => {
     if (!params.files || params.files.length === 0) return;
 
     void (async () => {
-      const opened: LocalFile[] = [];
+      const opened: LocalDocument[] = [];
 
       for (const entry of params.files) {
         // A directory can be launched too; there is nothing to edit in one.
         if (entry.kind !== "file") continue;
+        const handle = entry as FileSystemFileHandle;
         try {
-          opened.push(await readLocalFile(entry as FileSystemFileHandle));
+          // Routed by name, because the launch queue says nothing about type.
+          opened.push(
+            isPdfName(handle.name) ? await readLocalPdf(handle) : await readLocalFile(handle),
+          );
         } catch {
           // One unreadable file should not lose the others.
         }

--- a/apps/web/src/lib/media.test.ts
+++ b/apps/web/src/lib/media.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  documentTypeFor,
+  extensionForFile,
+  extensionOf,
+  imageTypeFor,
+  isPdfPath,
+  safeAssetName,
+  servableTypeFor,
+} from "@/lib/media";
+
+/**
+ * What ForkLeaf will serve back out of a repository.
+ *
+ * `servableTypeFor` is the gate the raw-asset route checks, and that route
+ * reads with the user's OAuth token — so anything it will serve is content the
+ * user's own repository can put on this app's origin. The tests that matter
+ * here are the refusals.
+ */
+describe("servableTypeFor", () => {
+  it("serves the image types notes embed", () => {
+    expect(servableTypeFor("assets/chart.png")).toBe("image/png");
+    expect(servableTypeFor("assets/photo.JPEG")).toBe("image/jpeg");
+  });
+
+  it("serves PDFs, which the reader opens", () => {
+    expect(servableTypeFor("papers/attention.pdf")).toBe("application/pdf");
+    expect(servableTypeFor("papers/ATTENTION.PDF")).toBe("application/pdf");
+  });
+
+  it("refuses HTML, which is the whole reason this is an allowlist", () => {
+    // Serving repository HTML from this origin would be stored XSS with the
+    // session cookie sitting right there.
+    expect(servableTypeFor("index.html")).toBeNull();
+    expect(servableTypeFor("page.htm")).toBeNull();
+  });
+
+  it("refuses SVG, which is a document format that can carry script", () => {
+    expect(servableTypeFor("logo.svg")).toBeNull();
+  });
+
+  it("refuses everything else in a repository", () => {
+    expect(servableTypeFor("scripts/deploy.sh")).toBeNull();
+    expect(servableTypeFor("notes/plan.md")).toBeNull();
+    expect(servableTypeFor("package.json")).toBeNull();
+    expect(servableTypeFor("Makefile")).toBeNull();
+  });
+
+  it("refuses a name that only looks like one of ours", () => {
+    expect(servableTypeFor("pdf")).toBeNull();
+    expect(servableTypeFor("report.pdf.exe")).toBeNull();
+  });
+});
+
+describe("isPdfPath", () => {
+  it("is true for a PDF whatever the case", () => {
+    expect(isPdfPath("a/b/c.pdf")).toBe(true);
+    expect(isPdfPath("a/b/c.PdF")).toBe(true);
+  });
+
+  it("is false for anything else", () => {
+    expect(isPdfPath("a.md")).toBe(false);
+    expect(isPdfPath("a.png")).toBe(false);
+    expect(isPdfPath("pdf/notes.md")).toBe(false);
+  });
+});
+
+describe("documentTypeFor and imageTypeFor stay separate", () => {
+  it("does not treat a PDF as an image", () => {
+    expect(imageTypeFor("a.pdf")).toBeNull();
+    expect(documentTypeFor("a.png")).toBeNull();
+  });
+});
+
+describe("extensionOf", () => {
+  it("takes the last extension, lowercased", () => {
+    expect(extensionOf("a/b/Report.PDF")).toBe("pdf");
+    expect(extensionOf("archive.tar.gz")).toBe("gz");
+  });
+
+  it("is empty for a name with no extension", () => {
+    expect(extensionOf("Makefile")).toBe("");
+  });
+
+  it("does not read an extension out of a folder name", () => {
+    expect(extensionOf("v1.2/README")).toBe("");
+  });
+});
+
+describe("extensionForFile", () => {
+  it("prefers the type the browser reported", () => {
+    expect(extensionForFile({ name: "screenshot", type: "image/png" })).toBe("png");
+  });
+
+  it("falls back to the name", () => {
+    expect(extensionForFile({ name: "a.webp", type: "" })).toBe("webp");
+  });
+
+  it("is null for a file ForkLeaf will not store as an image", () => {
+    expect(extensionForFile({ name: "paper.pdf", type: "application/pdf" })).toBeNull();
+  });
+});
+
+describe("safeAssetName", () => {
+  it("cannot escape the folder it is given", () => {
+    expect(safeAssetName("../../etc/passwd", "png")).toBe("passwd.png");
+  });
+
+  it("keeps accented names readable rather than reducing them to initials", () => {
+    expect(safeAssetName("Café Menu", "png")).toBe("cafe-menu.png");
+  });
+});

--- a/apps/web/src/lib/media.ts
+++ b/apps/web/src/lib/media.ts
@@ -32,6 +32,36 @@ export const IMAGE_TYPES: Record<string, string> = {
  */
 export const MAX_IMAGE_BYTES = 3 * 1024 * 1024;
 
+/**
+ * The document types ForkLeaf will read out of a repository.
+ *
+ * Separate from `IMAGE_TYPES` because the two are served under different
+ * rules. An image is handed to an `<img>` and rendered by the browser; a
+ * document here is fetched as bytes and parsed by code we ship, and is served
+ * with `Content-Disposition: attachment` so that a browser which decides to
+ * navigate to the URL directly downloads the file instead of rendering
+ * repository content on this app's own origin.
+ *
+ * PDF is the only entry, and the list exists rather than a boolean so that
+ * adding the next one is a line rather than a refactor.
+ */
+export const DOCUMENT_TYPES: Record<string, string> = {
+  pdf: "application/pdf",
+};
+
+/**
+ * Largest PDF ForkLeaf will open.
+ *
+ * Higher than the image ceiling, and for a different reason. A PDF is not
+ * committed through the JSON commit route, so the 4.5 MB body limit that caps
+ * images does not apply — this is a limit on what the browser can hold and
+ * parse without the tab dying. Above about 100 MB, pdf.js and the canvas
+ * layer together will exhaust memory on a modest laptop, and failing at the
+ * point the file is chosen is far kinder than failing halfway through
+ * rendering page 400.
+ */
+export const MAX_PDF_BYTES = 100 * 1024 * 1024;
+
 /** Extension of a path, lowercased and without the dot. */
 export function extensionOf(path: string): string {
   const name = path.split("/").pop() ?? path;
@@ -42,6 +72,28 @@ export function extensionOf(path: string): string {
 /** The MIME type for a path we are willing to serve, or null. */
 export function imageTypeFor(path: string): string | null {
   return IMAGE_TYPES[extensionOf(path)] ?? null;
+}
+
+/** The MIME type for a document path we are willing to serve, or null. */
+export function documentTypeFor(path: string): string | null {
+  return DOCUMENT_TYPES[extensionOf(path)] ?? null;
+}
+
+/**
+ * The MIME type for any repository file ForkLeaf serves back, or null.
+ *
+ * The single gate the raw-asset route checks. Anything not named here is
+ * refused, which is what keeps that route — which reads with the user's OAuth
+ * token — from being a way to serve arbitrary repository content, HTML very
+ * much included, from this app's origin.
+ */
+export function servableTypeFor(path: string): string | null {
+  return imageTypeFor(path) ?? documentTypeFor(path);
+}
+
+/** True for a path that is a PDF. */
+export function isPdfPath(path: string): boolean {
+  return documentTypeFor(path) === "application/pdf";
 }
 
 /** The extension to store a browser `File` under, from its type then its name. */

--- a/apps/web/src/lib/pdf-quote.test.ts
+++ b/apps/web/src/lib/pdf-quote.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { parseCitation, splitTarget } from "@forkleaf/pdf";
+import { insertionFor, quoteMarkdown, referenceMarkdown } from "@/lib/pdf-quote";
+
+const citation = {
+  quote: "The key result is that latency fell by half.",
+  prefix: "Filler about method.",
+  suffix: "More filler.",
+  page: 12,
+};
+
+describe("quoteMarkdown", () => {
+  it("produces a blockquote whose attribution is inside it", () => {
+    const markdown = quoteMarkdown({
+      target: "papers/attention.pdf",
+      title: "On Attention",
+      citation,
+    });
+
+    expect(markdown.split("\n").every((line) => line.startsWith(">"))).toBe(true);
+    expect(markdown).toContain("> The key result is that latency fell by half.");
+    expect(markdown).toContain("— [On Attention, p. 12](papers/attention.pdf#page=12");
+  });
+
+  it("writes a link that another PDF reader would still open at the right page", () => {
+    const markdown = quoteMarkdown({ target: "a.pdf", title: "A", citation });
+    // Adobe's own open parameter, so the link degrades rather than breaking.
+    expect(markdown).toMatch(/\(a\.pdf#page=12&/);
+  });
+
+  it("round-trips the citation through the link it writes", () => {
+    const markdown = quoteMarkdown({ target: "a.pdf", title: "A", citation });
+    const href = /\]\(([^)]+)\)/.exec(markdown)![1]!;
+
+    expect(parseCitation(splitTarget(href).fragment)).toEqual(citation);
+  });
+
+  it("quotes every line of a multi-line passage", () => {
+    const markdown = quoteMarkdown({
+      target: "a.pdf",
+      title: "A",
+      citation: { ...citation, quote: "first line\nsecond line" },
+    });
+
+    expect(markdown).toContain("> first line\n> second line");
+  });
+
+  it("gives a bare reference when the quotation is not wanted", () => {
+    const markdown = quoteMarkdown({
+      target: "a.pdf",
+      title: "A",
+      citation,
+      includeQuote: false,
+    });
+
+    expect(markdown.startsWith("[")).toBe(true);
+    expect(markdown).not.toContain(">");
+  });
+
+  it("gives a bare reference when there is nothing quoted", () => {
+    const markdown = quoteMarkdown({
+      target: "a.pdf",
+      title: "A",
+      citation: { ...citation, quote: "" },
+    });
+
+    expect(markdown.startsWith("[")).toBe(true);
+  });
+
+  it("escapes a title containing brackets rather than breaking the link", () => {
+    const markdown = referenceMarkdown({
+      target: "a.pdf",
+      title: "Results [draft]",
+      citation,
+    });
+
+    expect(markdown).toBe(
+      `[Results \\[draft\\], p. 12](a.pdf#page=12&q=${encodeURIComponent(citation.quote).replace(/\(/g, "%28")}&pre=Filler%20about%20method.&suf=More%20filler.)`,
+    );
+  });
+
+  it("escapes parentheses in the quotation so the link does not end early", () => {
+    const markdown = quoteMarkdown({
+      target: "a.pdf",
+      title: "A",
+      citation: { ...citation, quote: "a claim (qualified)" },
+    });
+
+    const href = /\]\(([^)]+)\)/.exec(markdown)![1]!;
+    expect(parseCitation(splitTarget(href).fragment)!.quote).toBe("a claim (qualified)");
+  });
+
+  it("flattens a title that arrived with line breaks in it", () => {
+    const markdown = referenceMarkdown({ target: "a.pdf", title: "Two\nlines", citation });
+    expect(markdown.startsWith("[Two lines, p. 12]")).toBe(true);
+  });
+});
+
+describe("a document that is not in the notebook", () => {
+  it("attributes a quotation instead of linking to a path that resolves nowhere", () => {
+    // A link to `/Users/somebody/Downloads/paper.pdf` works on one computer
+    // and is broken in the repository it gets committed to.
+    const markdown = quoteMarkdown({ target: null, title: "On Attention", citation });
+
+    expect(markdown).toContain("> — On Attention, p. 12");
+    expect(markdown).not.toContain("](");
+  });
+
+  it("still escapes a title that would break the markdown around it", () => {
+    expect(referenceMarkdown({ target: null, title: "Results [draft]", citation })).toBe(
+      "Results \\[draft\\], p. 12",
+    );
+  });
+});
+
+describe("insertionFor", () => {
+  it("separates a blockquote from the paragraph above it", () => {
+    // Without the blank line the renderer welds the quotation onto the
+    // sentence that was being written when it was inserted.
+    const { text } = insertionFor("A sentence.", 11, "> quoted");
+    expect(text).toBe("A sentence.\n\n> quoted\n");
+  });
+
+  it("does not add newlines that are already there", () => {
+    const { text } = insertionFor("A sentence.\n\n", 13, "> quoted");
+    expect(text).toBe("A sentence.\n\n> quoted\n");
+  });
+
+  it("adds only the one newline that is missing", () => {
+    const { text } = insertionFor("A sentence.\n", 12, "> quoted");
+    expect(text).toBe("A sentence.\n\n> quoted\n");
+  });
+
+  it("does not open an empty note with blank lines", () => {
+    expect(insertionFor("", 0, "> quoted").text).toBe("> quoted\n");
+  });
+
+  it("separates the quotation from what follows the caret", () => {
+    const { text } = insertionFor("before\nafter", 6, "> quoted");
+    expect(text).toBe("before\n\n> quoted\n\nafter");
+  });
+
+  it("reports a caret sitting after the inserted text", () => {
+    const { text, caret } = insertionFor("A sentence.", 11, "> quoted");
+    expect(text.slice(0, caret)).toBe("A sentence.\n\n> quoted\n");
+  });
+
+  it("clamps a caret outside the note rather than corrupting it", () => {
+    expect(insertionFor("abc", 900, "x").text).toBe("abc\n\nx\n");
+    expect(insertionFor("abc", -5, "x").text).toBe("x\n\nabc");
+  });
+});

--- a/apps/web/src/lib/pdf-quote.ts
+++ b/apps/web/src/lib/pdf-quote.ts
@@ -1,0 +1,121 @@
+import { citationLink, type PdfCitation } from "@forkleaf/pdf";
+
+/**
+ * Turning a passage of a PDF into markdown a note can hold.
+ *
+ * This is the join between the reader and the notebook, and the rule it exists
+ * to keep is ForkLeaf's oldest one: what lands in the file has to be plain
+ * markdown that renders correctly on github.com, in an IDE, and in anything
+ * else that opens the repository. So a citation is a blockquote and a link —
+ * two of the most ordinary constructs markdown has — and every clever part of
+ * it hides inside the link's fragment, where any tool that does not understand
+ * it will ignore it and still open the right page.
+ *
+ * The alternative, an `<forkleaf-citation>` element or a custom fence, would
+ * have been easier to parse back and would have made every note that used it
+ * unreadable everywhere but here. That is not a trade this app makes.
+ */
+
+export interface QuoteOptions {
+  /**
+   * Repo-relative path of the PDF, as it should appear in the note.
+   *
+   * Null for a document that is not in the notebook — one opened from the
+   * user's own disk, which has no path this repository could resolve. The
+   * quotation is still worth having; it just gets a plain attribution rather
+   * than a link, because a link to `/Users/somebody/Downloads/paper.pdf` is
+   * one that resolves on exactly one computer and is a broken link everywhere
+   * else, including in the same repository tomorrow.
+   */
+  target: string | null;
+  /** What to call the document in the link text. */
+  title: string;
+  citation: PdfCitation;
+  /** Include the quoted passage as a blockquote. Off gives a bare reference. */
+  includeQuote?: boolean;
+}
+
+/**
+ * The markdown for a cited passage.
+ *
+ * ```md
+ * > The key result is that latency fell by half.
+ * >
+ * > — [On Attention, p. 12](papers/attention.pdf#page=12&q=…)
+ * ```
+ *
+ * The attribution lives *inside* the blockquote rather than on a line below
+ * it. That is the difference between a quotation that can be moved, indented
+ * or nested with its source intact and one that loses its source the first
+ * time somebody reorganises the note around it.
+ */
+export function quoteMarkdown(options: QuoteOptions): string {
+  const { target, title, citation, includeQuote = true } = options;
+  const reference = referenceMarkdown({ target, title, citation });
+
+  if (!includeQuote || !citation.quote.trim()) return reference;
+
+  const body = citation.quote
+    .trim()
+    .split("\n")
+    .map((line) => `> ${line}`.trimEnd())
+    .join("\n");
+
+  return `${body}\n>\n> — ${reference}`;
+}
+
+/** Just the link: `[On Attention, p. 12](papers/attention.pdf#page=12&q=…)`. */
+export function referenceMarkdown(options: Omit<QuoteOptions, "includeQuote">): string {
+  const { target, title, citation } = options;
+  const label = escapeLinkText(`${title}, p. ${citation.page}`);
+
+  return target === null ? label : `[${label}](${citationLink(target, citation)})`;
+}
+
+/**
+ * Escapes the characters that would end a link's text early.
+ *
+ * A document called "Results [draft]" is not unusual, and pasting its title
+ * unescaped into `[…]` produces a link whose text is "Results [draft" followed
+ * by a stray `](…)` rendered as prose. Backslash escapes are the markdown
+ * spelling and survive every renderer.
+ */
+function escapeLinkText(text: string): string {
+  return text
+    .replace(/([[\]\\])/g, "\\$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Where in a note a citation should be inserted, given where the caret is.
+ *
+ * Blockquotes need a blank line before and after them or the renderer welds
+ * them onto the neighbouring paragraph — a quotation that swallows the
+ * sentence you were writing when you inserted it. This works out how many
+ * newlines are actually missing rather than always adding two, so citing into
+ * an empty note does not open it with three blank lines.
+ */
+export function insertionFor(
+  content: string,
+  caret: number,
+  snippet: string,
+): { text: string; caret: number } {
+  const at = Math.min(Math.max(caret, 0), content.length);
+  const before = content.slice(0, at);
+  const after = content.slice(at);
+
+  const lead = before === "" ? "" : "\n".repeat(Math.max(0, 2 - trailingNewlines(before)));
+  const tail = after === "" ? "\n" : "\n".repeat(Math.max(0, 2 - leadingNewlines(after)));
+
+  const inserted = `${lead}${snippet}${tail}`;
+  return { text: `${before}${inserted}${after}`, caret: at + inserted.length };
+}
+
+function trailingNewlines(text: string): number {
+  return /(\n*)$/.exec(text)?.[1]?.length ?? 0;
+}
+
+function leadingNewlines(text: string): number {
+  return /^(\n*)/.exec(text)?.[1]?.length ?? 0;
+}

--- a/apps/web/src/lib/pdf-source.test.ts
+++ b/apps/web/src/lib/pdf-source.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { Workspace } from "@forkleaf/types";
+import { localSource, pdfFetchUrl, pdfLinkTarget, repoSource } from "@/lib/pdf-source";
+
+const workspace: Workspace = {
+  id: "me/notes@main:docs",
+  name: "Notes",
+  repo: { owner: "me", repo: "notes", branch: "main", directory: "docs" },
+  isDefault: false,
+  isLocal: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastOpenedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("repoSource", () => {
+  it("names a document by its filename and identifies it by workspace and path", () => {
+    expect(repoSource(workspace, "papers/attention.pdf")).toEqual({
+      kind: "repo",
+      id: "me/notes@main:docs::papers/attention.pdf",
+      name: "attention.pdf",
+      workspaceId: workspace.id,
+      path: "papers/attention.pdf",
+    });
+  });
+
+  it("handles a PDF at the root of the workspace", () => {
+    expect(repoSource(workspace, "read-me.pdf").name).toBe("read-me.pdf");
+  });
+});
+
+describe("localSource", () => {
+  it("gives two files with the same name different identities", () => {
+    // Otherwise opening `paper.pdf` from a second folder shows the first one.
+    const first = localSource("paper.pdf", new Uint8Array([1]));
+    const second = localSource("paper.pdf", new Uint8Array([2]));
+    expect(first.id).not.toBe(second.id);
+  });
+});
+
+describe("pdfFetchUrl", () => {
+  it("goes through the app's own proxy, never to GitHub directly", () => {
+    const url = pdfFetchUrl(workspace, "papers/a.pdf");
+    expect(url.startsWith("/api/gh/raw?")).toBe(true);
+  });
+
+  it("carries the repository, branch and subdirectory", () => {
+    const params = new URLSearchParams(pdfFetchUrl(workspace, "papers/a.pdf").split("?")[1]);
+    expect(Object.fromEntries(params)).toEqual({
+      owner: "me",
+      repo: "notes",
+      branch: "main",
+      path: "papers/a.pdf",
+      dir: "docs",
+    });
+  });
+
+  it("omits the subdirectory for a workspace at the repository root", () => {
+    const root = { ...workspace, repo: { ...workspace.repo, directory: "" } };
+    expect(pdfFetchUrl(root, "a.pdf")).not.toContain("dir=");
+  });
+
+  it("escapes a path with a space in it", () => {
+    expect(pdfFetchUrl(workspace, "SOC 101/notes.pdf")).toContain("SOC+101%2Fnotes.pdf");
+  });
+});
+
+describe("pdfLinkTarget", () => {
+  it("resolves a relative link against the note holding it", () => {
+    expect(pdfLinkTarget("projects/2026/plan.md", "../papers/attention.pdf")).toEqual({
+      path: "projects/papers/attention.pdf",
+      fragment: "",
+    });
+  });
+
+  it("keeps the citation fragment", () => {
+    expect(pdfLinkTarget("plan.md", "a.pdf#page=12&q=hello")).toEqual({
+      path: "a.pdf",
+      fragment: "page=12&q=hello",
+    });
+  });
+
+  it("percent-decodes a folder name with a space, as the renderer wrote it", () => {
+    // The renderer writes URLs, not paths: a note in `SOC 101` links out as
+    // `../SOC%20101/…`, and resolving that literally asks for a file whose
+    // name really contains a per-cent sign.
+    expect(pdfLinkTarget("SOC 101/notes.md", "../SOC%20101/paper.pdf")?.path).toBe(
+      "SOC 101/paper.pdf",
+    );
+  });
+
+  it("claims a PDF regardless of how the extension is cased", () => {
+    expect(pdfLinkTarget("a.md", "Paper.PDF")).not.toBeNull();
+  });
+
+  it("does not claim a link to another kind of file", () => {
+    expect(pdfLinkTarget("a.md", "other.md")).toBeNull();
+    expect(pdfLinkTarget("a.md", "chart.png")).toBeNull();
+  });
+
+  it("does not claim a heading anchor that merely mentions pdf", () => {
+    expect(pdfLinkTarget("a.md", "#pdf-export")).toBeNull();
+  });
+
+  it("leaves a PDF on someone else's server alone", () => {
+    // Fetching it would mean telling this app's server which papers somebody
+    // reads. A link to another site stays a link to another site.
+    expect(pdfLinkTarget("a.md", "https://arxiv.org/pdf/1706.03762.pdf")).toBeNull();
+    expect(pdfLinkTarget("a.md", "//cdn.example.com/a.pdf")).toBeNull();
+  });
+
+  it("leaves a site-absolute path alone", () => {
+    expect(pdfLinkTarget("a.md", "/public/a.pdf")).toBeNull();
+  });
+
+  it("is null for an empty href", () => {
+    expect(pdfLinkTarget("a.md", "")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/pdf-source.ts
+++ b/apps/web/src/lib/pdf-source.ts
@@ -1,0 +1,131 @@
+import type { Workspace } from "@forkleaf/types";
+import { isPdfTarget, splitTarget } from "@forkleaf/pdf";
+import { resolveAgainstNote, isRepoRelative } from "@/lib/assets";
+import { isPdfPath, MAX_PDF_BYTES } from "@/lib/media";
+
+/**
+ * Where a PDF's bytes come from.
+ *
+ * There are three ways into the reader and they have almost nothing in common
+ * except that a document comes out:
+ *
+ *   - a file on this machine, chosen in a picker or handed over by the
+ *     operating system, which is already bytes;
+ *   - a file in the connected repository, which is a path that has to be read
+ *     through the same authenticated proxy that serves images;
+ *   - a link inside a note, which is a *relative* path that means nothing
+ *     until it is resolved against the note holding it.
+ *
+ * Collapsing those into one description here is what keeps the reader itself
+ * from knowing about any of it. It is handed a source and gets bytes.
+ */
+
+export type PdfSource =
+  | {
+      kind: "local";
+      /** Stable identity for a document with no repository path. */
+      id: string;
+      name: string;
+      bytes: Uint8Array;
+    }
+  | {
+      kind: "repo";
+      id: string;
+      name: string;
+      workspaceId: string;
+      /** Repo-relative path, the form everything else in ForkLeaf uses. */
+      path: string;
+    };
+
+/** A source for a PDF held in the connected repository. */
+export function repoSource(workspace: Workspace, path: string): PdfSource {
+  return {
+    kind: "repo",
+    id: `${workspace.id}::${path}`,
+    name: path.split("/").pop() ?? path,
+    workspaceId: workspace.id,
+    path,
+  };
+}
+
+/**
+ * A source for a PDF from this machine.
+ *
+ * The id includes the size and a counter rather than only the name, because
+ * two different files called `paper.pdf` from two different folders are two
+ * documents, and opening the second should not silently show the first.
+ */
+let localCounter = 0;
+
+export function localSource(name: string, bytes: Uint8Array): PdfSource {
+  localCounter += 1;
+  return { kind: "local", id: `local:${localCounter}:${name}`, name, bytes };
+}
+
+/**
+ * The URL the reader should fetch a repository PDF from.
+ *
+ * The same proxy that serves images, for the same two reasons: a repo-relative
+ * path is not something the browser can resolve, and for a private repository
+ * the token needed to read it never leaves the server.
+ */
+export function pdfFetchUrl(workspace: Workspace, path: string): string {
+  const params = new URLSearchParams({
+    owner: workspace.repo.owner,
+    repo: workspace.repo.repo,
+    branch: workspace.repo.branch,
+    path,
+  });
+  if (workspace.repo.directory) params.set("dir", workspace.repo.directory);
+
+  return `/api/gh/raw?${params.toString()}`;
+}
+
+/**
+ * Fetches a repository PDF, refusing one too large to hold.
+ *
+ * The size is taken from the response header before the body is read, so a
+ * 400 MB scan is declined rather than downloaded and then declined.
+ */
+export async function fetchRepoPdf(workspace: Workspace, path: string): Promise<Uint8Array> {
+  const response = await fetch(pdfFetchUrl(workspace, path));
+
+  if (!response.ok) {
+    // The proxy answers in plain text, and its messages are written to be
+    // read by a person — an expired sign-in says so.
+    throw new Error((await response.text()) || "That PDF could not be read from the repository.");
+  }
+
+  const declared = Number(response.headers.get("content-length") ?? "0");
+  if (declared > MAX_PDF_BYTES) {
+    throw new Error(
+      `That PDF is ${(declared / (1024 * 1024)).toFixed(0)} MB, which is larger than ForkLeaf can open.`,
+    );
+  }
+
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+/**
+ * What a link in a note points at, when it points at a PDF.
+ *
+ * Returns null for every other link, which is most of them — this runs on
+ * every click in the preview, so saying "not mine" quickly matters.
+ *
+ * An absolute URL to a PDF somewhere on the web is deliberately *not* claimed.
+ * ForkLeaf would have to fetch it through a proxy to read it, which means
+ * telling this app's server which papers somebody is reading; a link to
+ * another site stays a link to another site.
+ */
+export function pdfLinkTarget(
+  notePath: string,
+  href: string,
+): { path: string; fragment: string } | null {
+  if (!href || !isPdfTarget(href)) return null;
+  if (!isRepoRelative(href)) return null;
+
+  const { path, fragment } = splitTarget(href);
+  const resolved = resolveAgainstNote(notePath, path);
+
+  return isPdfPath(resolved) ? { path: resolved, fragment } : null;
+}

--- a/packages/editor/src/Preview.tsx
+++ b/packages/editor/src/Preview.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState, useRef } from "react";
 import { markdownToHtml, extractMermaidBlocks } from "@forkleaf/markdown-engine";
 import { renderDiagram, LIGHT_THEME, DARK_THEME } from "@forkleaf/diagrams";
 import { useDocumentTheme } from "./useDocumentTheme";
-import { handleWikilinkClick, type LinkBridge } from "./links";
+import { handleLinkClick, type LinkBridge } from "./links";
 
 export interface PreviewProps {
   markdown: string;
@@ -149,7 +149,7 @@ export function Preview({
     if (!container) return;
 
     const handler = (event: MouseEvent) => {
-      if (handleWikilinkClick(event, links)) return;
+      if (handleLinkClick(event, links)) return;
       if (!onDiagramClick) return;
 
       const figure = (event.target as HTMLElement).closest<HTMLElement>("[data-diagram-index]");

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -31,7 +31,7 @@ export { Modal, type ModalProps } from "./ui/Modal";
 export { ImageDialog, type ImageDialogProps } from "./ui/ImageDialog";
 export { LinkDialog, type LinkDialogProps } from "./ui/LinkDialog";
 export { type ImageBridge, imagesFrom, isEditableImage, IMAGE_ACCEPT } from "./images";
-export { type LinkBridge, wikilinkResolver, handleWikilinkClick } from "./links";
+export { type LinkBridge, wikilinkResolver, handleLinkClick, handleWikilinkClick } from "./links";
 export { Wikilink, type WikilinkOptions } from "./extensions/Wikilink";
 export { EnterIsALineBreak } from "./extensions/EnterIsALineBreak";
 export { ResolvedImage, type ResolvedImageOptions } from "./extensions/ResolvedImage";

--- a/packages/editor/src/links.test.ts
+++ b/packages/editor/src/links.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { handleLinkClick, type LinkBridge } from "./links";
+
+/**
+ * Clicking a link in rendered markdown.
+ *
+ * The delegation here decides what the browser is allowed to do with a click,
+ * so the cases that matter most are the ones where it must keep its hands off:
+ * a modifier held down, a middle click, an ordinary link the app has no
+ * opinion about. Getting those wrong means "open in new tab" silently doing
+ * nothing, which reads as the app being broken in a way nobody can describe.
+ */
+
+function bridgeWith(overrides: Partial<LinkBridge> = {}): LinkBridge {
+  return { resolve: () => null, open: vi.fn(), ...overrides };
+}
+
+/** Builds a click on an anchor inside a container, as the DOM would deliver it. */
+function clickOn(html: string, init: MouseEventInit = {}) {
+  document.body.innerHTML = `<div id="root">${html}</div>`;
+  const anchor = document.querySelector("a")!;
+  const event = new MouseEvent("click", { bubbles: true, cancelable: true, button: 0, ...init });
+  Object.defineProperty(event, "target", { value: anchor });
+  return event;
+}
+
+describe("wikilinks", () => {
+  it("opens the target and stops the browser following the link", () => {
+    const open = vi.fn();
+    const event = clickOn(`<a data-wikilink="Roadmap" href="#">Roadmap</a>`);
+
+    expect(handleLinkClick(event, bridgeWith({ open }))).toBe(true);
+    expect(open).toHaveBeenCalledWith("Roadmap", null);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("passes the anchor along", () => {
+    const open = vi.fn();
+    const event = clickOn(
+      `<a data-wikilink="Roadmap" data-wikilink-anchor="q3" href="#">Roadmap</a>`,
+    );
+
+    handleLinkClick(event, bridgeWith({ open }));
+    expect(open).toHaveBeenCalledWith("Roadmap", "q3");
+  });
+
+  it("is claimed before any opinion about the href is asked for", () => {
+    const openHref = vi.fn(() => true);
+    const event = clickOn(`<a data-wikilink="Paper" href="paper.pdf">Paper</a>`);
+
+    handleLinkClick(event, bridgeWith({ openHref }));
+    expect(openHref).not.toHaveBeenCalled();
+  });
+});
+
+describe("ordinary links", () => {
+  it("is claimed when the app says it wants it", () => {
+    const openHref = vi.fn(() => true);
+    const event = clickOn(`<a href="papers/x.pdf#page=12">the paper</a>`);
+
+    expect(handleLinkClick(event, bridgeWith({ openHref }))).toBe(true);
+    expect(openHref).toHaveBeenCalledWith("papers/x.pdf#page=12");
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("is left to the browser when the app declines it", () => {
+    const event = clickOn(`<a href="https://example.com">a site</a>`);
+
+    expect(handleLinkClick(event, bridgeWith({ openHref: () => false }))).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("offers the href exactly as the note wrote it", () => {
+    // Not `anchor.href`, which the DOM has already resolved against this page —
+    // turning a repository-relative path into an absolute URL to this app,
+    // which is not a path anything can look up in a repository.
+    const openHref = vi.fn(() => true);
+    handleLinkClick(clickOn(`<a href="../papers/x.pdf">x</a>`), bridgeWith({ openHref }));
+
+    expect(openHref).toHaveBeenCalledWith("../papers/x.pdf");
+  });
+
+  it("finds the link when the click landed on something inside it", () => {
+    const openHref = vi.fn(() => true);
+    document.body.innerHTML = `<a href="a.pdf"><em id="inner">x</em></a>`;
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 });
+    Object.defineProperty(event, "target", { value: document.getElementById("inner") });
+
+    expect(handleLinkClick(event, bridgeWith({ openHref }))).toBe(true);
+  });
+
+  it("does nothing for a bridge with no opinion at all", () => {
+    const event = clickOn(`<a href="a.pdf">x</a>`);
+    expect(handleLinkClick(event, bridgeWith())).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe("clicks that are not ours", () => {
+  it.each([
+    ["a ⌘-click", { metaKey: true }],
+    ["a ctrl-click", { ctrlKey: true }],
+    ["a shift-click", { shiftKey: true }],
+    ["an alt-click", { altKey: true }],
+    ["a middle click", { button: 1 }],
+    ["a right click", { button: 2 }],
+  ])("leaves %s to the browser", (_name, init) => {
+    // "Open in a new tab" and "save link as" are affordances people rely on,
+    // and an app that swallows them has broken something it did not write.
+    const openHref = vi.fn(() => true);
+    const open = vi.fn();
+    const event = clickOn(`<a data-wikilink="Roadmap" href="a.pdf">x</a>`, init);
+
+    expect(handleLinkClick(event, bridgeWith({ open, openHref }))).toBe(false);
+    expect(open).not.toHaveBeenCalled();
+    expect(openHref).not.toHaveBeenCalled();
+  });
+
+  it("leaves an already-handled click alone", () => {
+    const event = clickOn(`<a href="a.pdf">x</a>`);
+    event.preventDefault();
+
+    expect(handleLinkClick(event, bridgeWith({ openHref: () => true }))).toBe(false);
+  });
+
+  it("does nothing at all without a bridge", () => {
+    expect(handleLinkClick(clickOn(`<a href="a.pdf">x</a>`), undefined)).toBe(false);
+  });
+
+  it("ignores a click that is not on a link", () => {
+    document.body.innerHTML = `<p id="text">not a link</p>`;
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 });
+    Object.defineProperty(event, "target", { value: document.getElementById("text") });
+
+    expect(handleLinkClick(event, bridgeWith({ openHref: () => true }))).toBe(false);
+  });
+});

--- a/packages/editor/src/links.ts
+++ b/packages/editor/src/links.ts
@@ -27,6 +27,27 @@ export interface LinkBridge {
    * open a tab rather than navigating away from unsaved work.
    */
   open: (target: string, anchor: string | null) => void;
+
+  /**
+   * A click on an ordinary markdown link, offered to the app first.
+   *
+   * Returning true claims the click and stops the browser following it;
+   * returning false — or not supplying this at all — leaves the link to behave
+   * exactly as it did before.
+   *
+   * This exists for links to files the app can open itself rather than
+   * navigate to. A PDF beside a note is the case it was added for: `[the
+   * paper](papers/x.pdf#page=12)` is a perfectly ordinary markdown link, it
+   * renders as one on github.com, and in ForkLeaf it should open the reader on
+   * page 12 rather than navigating the tab away from unsaved work to a URL the
+   * browser cannot resolve anyway.
+   *
+   * Deliberately a *veto*, not a handler. The bridge sees every link click and
+   * claims the few it recognises, so nothing has to enumerate in advance which
+   * hrefs are special — and an app that supplies no `openHref` behaves as
+   * though this were never added.
+   */
+  openHref?: (href: string) => boolean;
 }
 
 /** The resolver `markdownToHtml` wants, from a bridge that may not be there. */
@@ -35,24 +56,45 @@ export function wikilinkResolver(bridge: LinkBridge | undefined) {
 }
 
 /**
- * Turns a click anywhere inside rendered markdown into a wikilink open.
+ * Turns a click anywhere inside rendered markdown into an open.
  *
  * Delegated from a container rather than bound per link: the HTML is injected
  * with `dangerouslySetInnerHTML`, so there is no React element to put a
- * handler on. Returns true when the click was a wikilink and has been handled.
+ * handler on. Returns true when the click has been handled and the browser
+ * should not follow it.
+ *
+ * Wikilinks are checked first because they are unambiguous — a `data-wikilink`
+ * anchor is one by construction. An ordinary link is only claimed if the app
+ * says it wants it.
  */
-export function handleWikilinkClick(event: MouseEvent, bridge: LinkBridge | undefined): boolean {
+export function handleLinkClick(event: MouseEvent, bridge: LinkBridge | undefined): boolean {
   if (!bridge) return false;
   // Leave the browser's own affordances alone: ⌘-click, middle-click and
   // right-click should still do what they do everywhere else.
   if (event.defaultPrevented || event.button !== 0) return false;
   if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false;
 
-  const anchor = (event.target as HTMLElement | null)?.closest<HTMLElement>("a[data-wikilink]");
-  const target = anchor?.dataset.wikilink;
-  if (!target) return false;
+  const element = event.target as HTMLElement | null;
+
+  const wikilink = element?.closest<HTMLElement>("a[data-wikilink]");
+  const target = wikilink?.dataset.wikilink;
+  if (target) {
+    event.preventDefault();
+    bridge.open(target, wikilink?.dataset.wikilinkAnchor ?? null);
+    return true;
+  }
+
+  const anchor = element?.closest<HTMLAnchorElement>("a[href]");
+  // `getAttribute` rather than `.href`, which the DOM has already resolved
+  // into an absolute URL against this page — turning the relative path the
+  // note actually contains into `https://forkleaf.app/papers/x.pdf`, which is
+  // not a path the app can look up in a repository.
+  const href = anchor?.getAttribute("href");
+  if (!href || !bridge.openHref?.(href)) return false;
 
   event.preventDefault();
-  bridge.open(target, anchor?.dataset.wikilinkAnchor ?? null);
   return true;
 }
+
+/** @deprecated Use `handleLinkClick`, which also offers ordinary links. */
+export const handleWikilinkClick = handleLinkClick;

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -857,13 +857,23 @@ export class GitHubClient {
   }
 
   /**
-   * Reads the full markdown file tree for a workspace.
+   * Reads the file tree for a workspace.
    *
    * Uses one recursive tree call rather than walking directories, so a repo with
    * hundreds of notes costs a single request. Conditional via ETag, so polling
    * for remote changes is nearly free.
+   *
+   * `include` decides what counts as part of the notebook:
+   *
+   *   - `"notes"` (the default) is markdown and PDF. A repository holds a great
+   *     deal that is not a note — configuration, code, images — and listing all
+   *     of it turns the sidebar into a file manager. PDFs are in because
+   *     ForkLeaf can open one, and a paper filed beside the notes about it is
+   *     part of the notebook in every sense that matters to the person reading.
+   *   - `"all"` is every blob, which the link repair needs: it can only find
+   *     the image a broken note meant if it can see the images.
    */
-  async listTree(repo: RepoRef, options: { markdownOnly?: boolean } = {}): Promise<TreeNode[]> {
+  async listTree(repo: RepoRef, options: { include?: "notes" | "all" } = {}): Promise<TreeNode[]> {
     const head = await this.getBranchHead(repo);
     const path = `/repos/${repo.owner}/${repo.repo}/git/trees/${head}?recursive=1`;
 
@@ -895,7 +905,7 @@ export class GitHubClient {
     const flat = tree.tree.filter((entry) => {
       if (entry.type !== "blob") return false;
       if (!inDirectory(entry.path)) return false;
-      if (options.markdownOnly !== false && !/\.mdx?$/i.test(entry.path)) return false;
+      if (options.include !== "all" && !/\.(mdx?|pdf)$/i.test(entry.path)) return false;
       return true;
     });
 

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@forkleaf/pdf",
+  "version": "1.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@forkleaf/types": "workspace:*",
+    "pdfjs-dist": "^6.3.289"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/pdf/src/citation.test.ts
+++ b/packages/pdf/src/citation.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from "vitest";
+import {
+  citationLink,
+  compose,
+  createCitation,
+  isPdfTarget,
+  MAX_QUOTE_LENGTH,
+  parseCitation,
+  resolveCitation,
+  serializeCitation,
+  splitTarget,
+  stripPunctuation,
+} from "./citation";
+import { normalizeForMatch } from "./text";
+import type { PdfPageText } from "./types";
+
+/** A page of plain prose, with no geometry — the resolver never looks at it. */
+function page(number: number, text: string): PdfPageText {
+  return { page: number, text, runs: [] };
+}
+
+describe("createCitation", () => {
+  const source = page(4, "Before the quote. The important claim goes here. After the quote.");
+
+  it("records the selected text as the quotation", () => {
+    const at = source.text.indexOf("The important claim goes here.");
+    const citation = createCitation(source, at, at + "The important claim goes here.".length);
+
+    expect(citation.quote).toBe("The important claim goes here.");
+    expect(citation.page).toBe(4);
+  });
+
+  it("records the words either side, which is what tells occurrences apart", () => {
+    const at = source.text.indexOf("The important claim");
+    const citation = createCitation(source, at, at + "The important claim".length);
+
+    expect(citation.prefix).toBe("Before the quote.");
+    expect(citation.suffix).toBe("goes here. After the quote.");
+  });
+
+  it("flattens the layout whitespace a PDF selection drags in", () => {
+    const wrapped = page(1, "a claim\nsplit   across\nlines");
+    expect(createCitation(wrapped, 0, wrapped.text.length).quote).toBe(
+      "a claim split across lines",
+    );
+  });
+
+  it("accepts a backwards selection", () => {
+    const at = source.text.indexOf("important");
+    const forwards = createCitation(source, at, at + 9);
+    const backwards = createCitation(source, at + 9, at);
+    expect(backwards).toEqual(forwards);
+  });
+
+  it("clamps a range that runs past the end of the page", () => {
+    const citation = createCitation(source, 0, 10_000);
+    expect(citation.quote).toBe(source.text);
+    expect(citation.suffix).toBe("");
+  });
+
+  it("truncates a quotation nobody wants inside a URL", () => {
+    const long = page(1, "x".repeat(2000));
+    expect(createCitation(long, 0, 2000).quote).toHaveLength(MAX_QUOTE_LENGTH);
+  });
+
+  it("has no context at the very start of a page", () => {
+    expect(createCitation(source, 0, 6).prefix).toBe("");
+  });
+});
+
+describe("serializeCitation and parseCitation", () => {
+  it("round-trips a full citation", () => {
+    const citation = {
+      quote: "the important claim",
+      prefix: "before it",
+      suffix: "after it",
+      page: 12,
+    };
+    expect(parseCitation(serializeCitation(citation))).toEqual(citation);
+  });
+
+  it("round-trips text that would otherwise break a markdown link", () => {
+    const citation = {
+      quote: "a claim (with parentheses) and 100% of the ampersands & spaces",
+      prefix: "",
+      suffix: "",
+      page: 1,
+    };
+
+    const link = citationLink("papers/paper.pdf", citation);
+    expect(link).not.toMatch(/[()]/);
+    expect(parseCitation(splitTarget(link).fragment)).toEqual(citation);
+  });
+
+  it("leads with the parameter every other PDF reader understands", () => {
+    expect(serializeCitation({ quote: "x", prefix: "", suffix: "", page: 9 })).toMatch(/^page=9&/);
+  });
+
+  it("omits context that is not there", () => {
+    const fragment = serializeCitation({ quote: "x", prefix: "", suffix: "", page: 2 });
+    expect(fragment).toBe("page=2&q=x");
+  });
+
+  it("reads a plain page fragment written by another tool", () => {
+    expect(parseCitation("#page=7")).toEqual({ quote: "", prefix: "", suffix: "", page: 7 });
+  });
+
+  it("reads the bare number a person types", () => {
+    expect(parseCitation("#12")?.page).toBe(12);
+  });
+
+  it("accepts the short spelling of the page key", () => {
+    expect(parseCitation("p=3&q=hi")?.page).toBe(3);
+  });
+
+  it("is not fooled into claiming a heading anchor", () => {
+    expect(parseCitation("#results-and-discussion")).toBeNull();
+  });
+
+  it("returns null for an empty fragment", () => {
+    expect(parseCitation("")).toBeNull();
+  });
+
+  it("survives a malformed percent escape rather than losing the citation", () => {
+    expect(parseCitation("page=2&q=100%zz")?.quote).toBe("100%zz");
+  });
+
+  it("falls back to page one when the page is nonsense but a quote is there", () => {
+    expect(parseCitation("page=abc&q=hello")?.page).toBe(1);
+  });
+
+  it("refuses page zero, which no document has", () => {
+    expect(parseCitation("#0")).toBeNull();
+  });
+});
+
+describe("splitTarget and isPdfTarget", () => {
+  it("splits on the last hash, so a file may contain one", () => {
+    expect(splitTarget("q&a#1.pdf#page=2")).toEqual({ path: "q&a#1.pdf", fragment: "page=2" });
+  });
+
+  it("handles a target with no fragment", () => {
+    expect(splitTarget("a.pdf")).toEqual({ path: "a.pdf", fragment: "" });
+  });
+
+  it("recognises a PDF with and without a fragment", () => {
+    expect(isPdfTarget("papers/x.PDF")).toBe(true);
+    expect(isPdfTarget("papers/x.pdf#page=2&q=hi")).toBe(true);
+    expect(isPdfTarget("notes/x.md#pdf")).toBe(false);
+  });
+});
+
+describe("resolveCitation", () => {
+  const pages = [
+    page(1, "An introduction, which mentions the key result in passing."),
+    page(2, "Filler about method. The key result is that latency fell by half. More filler."),
+    page(3, "A conclusion restating that the key result is important."),
+  ];
+
+  const citation = {
+    quote: "The key result is that latency fell by half.",
+    prefix: "Filler about method.",
+    suffix: "More filler.",
+    page: 2,
+  };
+
+  it("finds a quotation exactly where it was left", () => {
+    const match = resolveCitation(pages, citation);
+
+    expect(match.quality).toBe("exact");
+    expect(match.page).toBe(2);
+    expect(pages[1]!.text.slice(...match.range!)).toBe(citation.quote);
+  });
+
+  it("follows a quotation that moved to another page", () => {
+    // The case a second edition creates, and the case a page number cannot
+    // survive: the words are unchanged, the pagination is not.
+    const reprinted = [
+      page(1, "An introduction, which mentions the key result in passing."),
+      page(2, "A newly inserted figure and its caption."),
+      page(3, "Filler about method. The key result is that latency fell by half. More filler."),
+    ];
+
+    const match = resolveCitation(reprinted, citation);
+    expect(match.quality).toBe("moved");
+    expect(match.page).toBe(3);
+  });
+
+  it("uses context to pick between two identical occurrences", () => {
+    const repeated = [
+      page(1, "As noted, see below. The same sentence appears twice. Once here."),
+      page(2, "Different lead-in. The same sentence appears twice. And again there."),
+    ];
+
+    const match = resolveCitation(repeated, {
+      quote: "The same sentence appears twice.",
+      prefix: "Different lead-in.",
+      suffix: "And again there.",
+      page: 2,
+    });
+
+    expect(match.page).toBe(2);
+    expect(repeated[1]!.text.slice(...match.range!)).toBe("The same sentence appears twice.");
+  });
+
+  it("lets context beat a stale page hint", () => {
+    // The hint says page 1; the surrounding words say page 2. The words win,
+    // because they identify the passage and the number only says where it was.
+    const repeated = [
+      page(1, "As noted, see below. The same sentence appears twice. Once here."),
+      page(2, "Different lead-in. The same sentence appears twice. And again there."),
+    ];
+
+    const match = resolveCitation(repeated, {
+      quote: "The same sentence appears twice.",
+      prefix: "Different lead-in.",
+      suffix: "And again there.",
+      page: 1,
+    });
+
+    expect(match.page).toBe(2);
+  });
+
+  it("finds a quotation through hyphenation the reader never saw", () => {
+    const typeset = [page(1, "the measurements were regu-\nlar and repeatable")];
+    const match = resolveCitation(typeset, {
+      quote: "regular and repeatable",
+      prefix: "",
+      suffix: "",
+      page: 1,
+    });
+
+    expect(match.quality).toBe("exact");
+    expect(typeset[0]!.text.slice(...match.range!)).toBe("regu-\nlar and repeatable");
+  });
+
+  it("finds a quotation through ligatures and smart quotes", () => {
+    const typeset = [page(1, "we “ﬁnd” a diﬀerence")];
+    const match = resolveCitation(typeset, {
+      quote: '"find" a difference',
+      prefix: "",
+      suffix: "",
+      page: 1,
+    });
+
+    expect(match.quality).toBe("exact");
+  });
+
+  it("falls back to matching without punctuation when a document is re-typeset", () => {
+    const reset = [page(1, "the result-set, however, was empty")];
+    const match = resolveCitation(reset, {
+      quote: "the result set however was empty",
+      prefix: "",
+      suffix: "",
+      page: 1,
+    });
+
+    expect(match.quality).toBe("fuzzy");
+    expect(reset[0]!.text.slice(...match.range!)).toContain("result-set");
+  });
+
+  it("keeps hold of a passage whose tail was edited away", () => {
+    const edited = [page(1, "The key result is that latency fell substantially in every trial.")];
+    const match = resolveCitation(edited, citation);
+
+    expect(match.quality).toBe("fuzzy");
+    expect(edited[0]!.text.slice(...match.range!)).toBe("The key result is that latency fell");
+  });
+
+  it("admits when the passage is simply gone", () => {
+    const rewritten = [page(1, "This document is about something else entirely.")];
+    expect(resolveCitation(rewritten, citation)).toEqual({
+      quality: "lost",
+      page: null,
+      range: null,
+    });
+  });
+
+  it("does not invent a match out of a couple of common words", () => {
+    // "of the" would match almost any document. A citation that lands on the
+    // wrong paragraph is worse than one that says it could not be found.
+    const unrelated = [page(1, "Some of the other things discussed in this report.")];
+    expect(
+      resolveCitation(unrelated, {
+        quote: "of the specific mechanism described in section four",
+        prefix: "",
+        suffix: "",
+        page: 1,
+      }).quality,
+    ).toBe("lost");
+  });
+
+  it("treats a citation with no quotation as a page link", () => {
+    const match = resolveCitation(pages, { quote: "", prefix: "", suffix: "", page: 3 });
+    expect(match).toEqual({ quality: "exact", page: 3, range: [0, 0] });
+  });
+
+  it("reports a page link past the end of the document as lost", () => {
+    expect(resolveCitation(pages, { quote: "", prefix: "", suffix: "", page: 99 }).quality).toBe(
+      "lost",
+    );
+  });
+
+  it("survives an empty document", () => {
+    expect(resolveCitation([], citation).quality).toBe("lost");
+  });
+
+  it("survives a whitespace-only quotation", () => {
+    expect(resolveCitation(pages, { quote: "   ", prefix: "", suffix: "", page: 1 }).quality).toBe(
+      "exact",
+    );
+  });
+
+  it("round-trips a citation built from a page and then resolved against it", () => {
+    // The property that matters most: anything this package writes, it can
+    // read back and point at the same characters.
+    const at = pages[1]!.text.indexOf("latency fell by half");
+    const built = createCitation(pages[1]!, at, at + "latency fell by half".length);
+
+    const parsed = parseCitation(serializeCitation(built))!;
+    const match = resolveCitation(pages, parsed);
+
+    expect(match.quality).toBe("exact");
+    expect(pages[1]!.text.slice(...match.range!)).toBe("latency fell by half");
+  });
+});
+
+describe("stripPunctuation", () => {
+  it("keeps letters, digits and word gaps and nothing else", () => {
+    expect(stripPunctuation("Hello, world! (42)").text).toBe("Hello world 42");
+  });
+
+  it("does not leave a leading or trailing gap", () => {
+    expect(stripPunctuation("...middle...").text).toBe("middle");
+  });
+
+  it("maps back to the original offsets", () => {
+    const source = "a, b";
+    const stripped = stripPunctuation(source);
+    expect(stripped.text).toBe("a b");
+    expect(stripped.map[2]).toBe(3);
+  });
+});
+
+describe("compose", () => {
+  it("chains two normalisations back to the original text", () => {
+    const source = "The  ﬁrst, result.";
+    const outer = normalizeForMatch(source);
+    const inner = stripPunctuation(outer.text);
+    const chained = compose(outer, inner);
+
+    expect(chained.text).toBe("the first result");
+
+    const at = chained.text.indexOf("first");
+    // Offsets survive both passes and still land on the ligature in the source.
+    expect(source[chained.map[at]!]).toBe("ﬁ");
+  });
+});

--- a/packages/pdf/src/citation.ts
+++ b/packages/pdf/src/citation.ts
@@ -1,0 +1,490 @@
+import { normalizeForMatch, toSourceRange, type NormalizedText } from "./text";
+import type { PdfCitation, PdfCitationMatch, PdfPageText } from "./types";
+
+/**
+ * Citations that keep pointing at the right sentence.
+ *
+ * The problem this solves: you quote a paragraph from page 12 of a paper into
+ * a note, and six months later the author publishes v3, which adds a figure to
+ * page 4. Your citation now points at page 12 of a document where the sentence
+ * you quoted is on page 13. Every tool that stores "page 12" is now lying, and
+ * lying silently — the link still opens, it just shows the wrong text.
+ *
+ * So a ForkLeaf citation records the sentence, not the page. Resolving one
+ * means searching the document for those exact words, using the words either
+ * side of them to tell two occurrences apart, and treating the page number as
+ * a hint about where to start looking. When the document has genuinely changed
+ * out from under the quotation, that is *reported* — `"lost"` — rather than
+ * quietly rendered as a link to whatever happens to be on page 12 now.
+ *
+ * This is the same selector model as W3C Web Annotation's `TextQuoteSelector`,
+ * for the same reason ForkLeaf's wikilinks are Obsidian's dialect: the anchors
+ * get written into plain markdown files whose entire point is that other
+ * software can read them. An invented format would have made every one of
+ * those files a little bit less portable.
+ */
+
+/**
+ * How much text either side of a quotation is kept.
+ *
+ * Long enough to tell apart two occurrences of a repeated phrase — which in a
+ * technical document is most phrases — and short enough that a citation stays
+ * a readable thing to have in a markdown file. Forty-eight characters is
+ * roughly a line of prose either side.
+ */
+export const CONTEXT_LENGTH = 48;
+
+/**
+ * The longest quotation a citation will store.
+ *
+ * A citation is a pointer, not a copy. Someone who selects nine pages and
+ * clicks "cite" wants a link to that passage, not nine pages of it embedded in
+ * a URL — and a fragment that long is unusable in markdown and refused by some
+ * tools outright. The anchor keeps the head of the selection, which is what
+ * the resolver needs to find it again; the full text, if it is wanted, belongs
+ * in the note as a quotation.
+ */
+export const MAX_QUOTE_LENGTH = 512;
+
+// ─── Building ───────────────────────────────────────────────────────────────
+
+/**
+ * Builds a citation from a selected range on a page.
+ *
+ * `start` and `end` are offsets into that page's assembled text.
+ */
+export function createCitation(pageText: PdfPageText, start: number, end: number): PdfCitation {
+  const from = clamp(Math.min(start, end), 0, pageText.text.length);
+  const to = clamp(Math.max(start, end), 0, pageText.text.length);
+
+  const quote = tidy(pageText.text.slice(from, to)).slice(0, MAX_QUOTE_LENGTH);
+  const prefix = tidy(pageText.text.slice(Math.max(0, from - CONTEXT_LENGTH), from));
+  const suffix = tidy(pageText.text.slice(to, to + CONTEXT_LENGTH));
+
+  return { quote, prefix, suffix, page: pageText.page };
+}
+
+/** Whitespace in a PDF is layout, not content; a stored quotation is content. */
+function tidy(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(Math.max(value, low), high);
+}
+
+// ─── Serialising ────────────────────────────────────────────────────────────
+
+/**
+ * A citation as a URL fragment.
+ *
+ * `page=` first and spelled that way on purpose: it is Adobe's own open
+ * parameter, so `paper.pdf#page=12` opens page 12 in Acrobat, in Chrome's
+ * built-in viewer, and in every PDF reader written since 2003. A ForkLeaf
+ * citation degrades to exactly that everywhere else — the extra parameters are
+ * ignored by readers that do not know them, and the reader still lands on the
+ * right page. A bespoke fragment scheme would have degraded to nothing.
+ */
+export function serializeCitation(citation: PdfCitation): string {
+  const parts = [`page=${Math.max(1, Math.trunc(citation.page))}`];
+
+  if (citation.quote) parts.push(`q=${encodeFragment(citation.quote)}`);
+  if (citation.prefix) parts.push(`pre=${encodeFragment(citation.prefix)}`);
+  if (citation.suffix) parts.push(`suf=${encodeFragment(citation.suffix)}`);
+
+  return parts.join("&");
+}
+
+/**
+ * Reads a fragment back, or null when it is not one of ours.
+ *
+ * Tolerant by design. A fragment written by hand, or by another tool, or by an
+ * older version of this code, should still open the document at a sensible
+ * place rather than being rejected: `#page=4` alone is a perfectly good
+ * citation with no quotation in it, and `#4` is what somebody types.
+ */
+export function parseCitation(fragment: string): PdfCitation | null {
+  const raw = fragment.startsWith("#") ? fragment.slice(1) : fragment;
+  if (!raw) return null;
+
+  // A bare number is the shorthand every reader eventually tries.
+  if (/^\d+$/.test(raw)) {
+    const page = Number.parseInt(raw, 10);
+    return page >= 1 ? { quote: "", prefix: "", suffix: "", page } : null;
+  }
+
+  const fields = new Map<string, string>();
+  for (const pair of raw.split("&")) {
+    const equals = pair.indexOf("=");
+    if (equals === -1) continue;
+    fields.set(pair.slice(0, equals).toLowerCase(), decodeFragment(pair.slice(equals + 1)));
+  }
+
+  const pageValue = fields.get("page") ?? fields.get("p");
+  const page = pageValue ? Number.parseInt(pageValue, 10) : Number.NaN;
+  const quote = fields.get("q") ?? fields.get("quote") ?? "";
+
+  // Neither a page nor a quotation means this fragment is about something
+  // else entirely — a heading anchor, say — and is not ours to interpret.
+  if (!Number.isFinite(page) && !quote) return null;
+
+  return {
+    quote: quote.slice(0, MAX_QUOTE_LENGTH),
+    prefix: (fields.get("pre") ?? "").slice(0, CONTEXT_LENGTH),
+    suffix: (fields.get("suf") ?? "").slice(0, CONTEXT_LENGTH),
+    page: Number.isFinite(page) && page >= 1 ? page : 1,
+  };
+}
+
+/** A markdown-safe link target: `papers/attention.pdf#page=12&q=…`. */
+export function citationLink(pdfPath: string, citation: PdfCitation): string {
+  return `${encodePath(pdfPath)}#${serializeCitation(citation)}`;
+}
+
+/**
+ * Splits a link target into its path and fragment.
+ *
+ * The last `#` rather than the first: a file really can be called `q&a#1.pdf`,
+ * and the fragment is always what follows the final one.
+ */
+export function splitTarget(target: string): { path: string; fragment: string } {
+  const hash = target.lastIndexOf("#");
+  if (hash === -1) return { path: target, fragment: "" };
+  return { path: target.slice(0, hash), fragment: target.slice(hash + 1) };
+}
+
+/** True for a link target naming a PDF, fragment or not. */
+export function isPdfTarget(target: string): boolean {
+  return /\.pdf$/i.test(splitTarget(target).path);
+}
+
+/**
+ * Percent-encoding for a value going inside a markdown link.
+ *
+ * `encodeURIComponent` leaves `(`, `)` and `'` alone, and the first two end a
+ * markdown link early — `[x](a.pdf#q=see%20(b))` links to `a.pdf#q=see%20(b`
+ * and leaves `)` as text. Escaping them here rather than trusting each caller
+ * to remember is the difference between quoting a sentence with a parenthesis
+ * in it working and looking broken.
+ */
+function encodeFragment(value: string): string {
+  return encodeURIComponent(value).replace(/\(/g, "%28").replace(/\)/g, "%29").replace(/'/g, "%27");
+}
+
+function decodeFragment(value: string): string {
+  try {
+    return decodeURIComponent(value.replace(/\+/g, " "));
+  } catch {
+    // A malformed escape is not worth losing the whole citation over.
+    return value;
+  }
+}
+
+function encodePath(path: string): string {
+  return path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment).replace(/\(/g, "%28").replace(/\)/g, "%29"))
+    .join("/");
+}
+
+// ─── Resolving ──────────────────────────────────────────────────────────────
+
+/**
+ * Finds a citation in a document, and says how sure it is.
+ *
+ * The search runs in tiers, most confident first:
+ *
+ *   1. The exact quotation, on the page the citation names.
+ *   2. The exact quotation, anywhere else in the document — the case a new
+ *      edition of the file creates, and the case a page number alone gets
+ *      wrong. Reported as `"moved"`, because the reader deserves to know the
+ *      document is not the one the note was written against.
+ *   3. The quotation ignoring punctuation, which is what survives a document
+ *      being re-typeset with different quote marks and dashes.
+ *   4. The longest leading run of the quotation's words that still appears,
+ *      for a passage that has been edited rather than moved. Reported as
+ *      `"fuzzy"` — it points somewhere real, and it might be pointing at a
+ *      sentence that no longer says what the note claims it does.
+ *
+ * When several occurrences match, the recorded prefix and suffix choose
+ * between them. That is what context is for, and it is why it is stored: in a
+ * document that says "as discussed above" forty times, the quotation alone
+ * identifies nothing.
+ */
+export function resolveCitation(
+  pages: readonly PdfPageText[],
+  citation: PdfCitation,
+): PdfCitationMatch {
+  if (pages.length === 0) return lost();
+
+  // With nothing to match on, a citation is exactly as good as its page hint.
+  if (!citation.quote.trim()) {
+    const page = pages.find((candidate) => candidate.page === citation.page);
+    return page
+      ? { quality: "exact", page: page.page, range: [0, 0] }
+      : { quality: "lost", page: null, range: null };
+  }
+
+  const normalized = pages.map((page) => ({ page, text: normalizeForMatch(page.text) }));
+  const context = {
+    prefix: normalizeForMatch(citation.prefix).text.trim(),
+    suffix: normalizeForMatch(citation.suffix).text.trim(),
+  };
+
+  const needle = normalizeForMatch(citation.quote).text.trim();
+  if (!needle) return lost();
+
+  // Tiers 1 and 2 differ only in which page won, so they are one search.
+  const exact = bestMatch(normalized, needle, context, citation.page);
+  if (exact) {
+    return {
+      quality: exact.page === citation.page ? "exact" : "moved",
+      page: exact.page,
+      range: exact.range,
+    };
+  }
+
+  // Tier 3: the same words, with the typesetter's punctuation discounted.
+  const loose = normalized.map((entry) => ({
+    page: entry.page,
+    text: compose(entry.text, stripPunctuation(entry.text.text)),
+  }));
+  const looseNeedle = stripPunctuation(needle).text.trim();
+
+  if (looseNeedle) {
+    const found = bestMatch(
+      loose,
+      looseNeedle,
+      {
+        prefix: stripPunctuation(context.prefix).text.trim(),
+        suffix: stripPunctuation(context.suffix).text.trim(),
+      },
+      citation.page,
+    );
+    if (found) return { quality: "fuzzy", page: found.page, range: found.range };
+  }
+
+  // Tier 4: as much of the opening of the quotation as still exists.
+  const partial = longestLeadingMatch(normalized, needle, context, citation.page);
+  if (partial) return { quality: "fuzzy", page: partial.page, range: partial.range };
+
+  return lost();
+}
+
+function lost(): PdfCitationMatch {
+  return { quality: "lost", page: null, range: null };
+}
+
+interface Candidate {
+  page: PdfPageText;
+  text: NormalizedText;
+}
+
+interface Found {
+  page: number;
+  range: [number, number];
+}
+
+interface Context {
+  prefix: string;
+  suffix: string;
+}
+
+/**
+ * The best occurrence of `needle` across the document.
+ *
+ * Every occurrence on every page is scored, rather than returning the first —
+ * "first match wins" is what makes a citation to the second mention of a term
+ * jump to the first one, every time, forever. Context is worth more than the
+ * page hint, because context identifies the passage while the page only says
+ * where it used to be.
+ */
+function bestMatch(
+  pages: readonly Candidate[],
+  needle: string,
+  context: Context,
+  hintedPage: number,
+): Found | null {
+  let best: Found | null = null;
+  let bestScore = -1;
+
+  for (const candidate of pages) {
+    const haystack = candidate.text.text;
+    let at = haystack.indexOf(needle);
+
+    while (at !== -1) {
+      const score =
+        contextScore(haystack, at, at + needle.length, context) +
+        (candidate.page.page === hintedPage ? 1 : 0);
+
+      if (score > bestScore) {
+        bestScore = score;
+        best = {
+          page: candidate.page.page,
+          range: toSourceRange(candidate.text, at, at + needle.length),
+        };
+      }
+
+      at = haystack.indexOf(needle, at + 1);
+    }
+  }
+
+  return best;
+}
+
+/**
+ * How well the text around an occurrence matches the recorded context.
+ *
+ * Scored by how much of the stored context still agrees rather than as a
+ * yes/no, so a paragraph whose opening was reworded still beats an unrelated
+ * occurrence on the other side of the document. Worth up to 4, so it outranks
+ * the page hint's 1 — a passage that has moved is still the passage.
+ */
+function contextScore(haystack: string, start: number, end: number, context: Context): number {
+  let score = 0;
+
+  if (context.prefix) {
+    score +=
+      2 * overlapRatio(windowBefore(haystack, start, context.prefix.length), context.prefix, "end");
+  }
+  if (context.suffix) {
+    score +=
+      2 * overlapRatio(windowAfter(haystack, end, context.suffix.length), context.suffix, "start");
+  }
+
+  return score;
+}
+
+/**
+ * The stored context is trimmed; the text around a match is not.
+ *
+ * A quotation almost always has a space in front of it and another behind it,
+ * so comparing `"different lead-in."` against the raw `"different lead-in. "`
+ * disagrees on the very first character compared and scores zero — which made
+ * context worth nothing at all, and left the page hint quietly deciding every
+ * ambiguous citation on its own. The windows are taken with slack and trimmed
+ * on the side that faces the quotation, so the comparison starts on a real
+ * character.
+ */
+const CONTEXT_SLACK = 4;
+
+function windowBefore(haystack: string, start: number, length: number): string {
+  return haystack.slice(Math.max(0, start - length - CONTEXT_SLACK), start).trimEnd();
+}
+
+function windowAfter(haystack: string, end: number, length: number): string {
+  return haystack.slice(end, end + length + CONTEXT_SLACK).trimStart();
+}
+
+/** The fraction of `wanted` that `actual` reproduces, from one end. */
+function overlapRatio(actual: string, wanted: string, from: "start" | "end"): number {
+  if (!wanted) return 0;
+
+  let shared = 0;
+  while (shared < actual.length && shared < wanted.length) {
+    const a = from === "end" ? actual[actual.length - 1 - shared] : actual[shared];
+    const b = from === "end" ? wanted[wanted.length - 1 - shared] : wanted[shared];
+    if (a !== b) break;
+    shared += 1;
+  }
+
+  return shared / wanted.length;
+}
+
+/**
+ * The longest opening run of the quotation's words that still appears.
+ *
+ * Words rather than characters, and only from the start: a match that begins
+ * mid-word is not a match a reader would accept, and a match on some arbitrary
+ * middle fragment of a long quotation is more likely to be a coincidence than
+ * the passage. Short runs are refused outright for that reason — "the" appears
+ * on every page and finding it proves nothing.
+ */
+function longestLeadingMatch(
+  pages: readonly Candidate[],
+  needle: string,
+  context: Context,
+  hintedPage: number,
+): Found | null {
+  const words = needle.split(" ").filter(Boolean);
+  if (words.length < 2) return null;
+
+  for (let count = words.length - 1; count >= 2; count -= 1) {
+    const attempt = words.slice(0, count).join(" ");
+    if (attempt.length < MIN_PARTIAL_LENGTH) return null;
+
+    const found = bestMatch(pages, attempt, context, hintedPage);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+/**
+ * Shortest partial match worth reporting.
+ *
+ * Below this, a "match" is a common phrase rather than the passage, and a
+ * citation that lands on the wrong paragraph is worse than one that admits it
+ * cannot find the right one.
+ */
+const MIN_PARTIAL_LENGTH = 16;
+
+// ─── Normalisation helpers ──────────────────────────────────────────────────
+
+/**
+ * Drops everything that is not a letter, a digit or a space.
+ *
+ * The second, looser pass. Between two builds of the same document the words
+ * are the same and the punctuation is whatever the new toolchain felt like —
+ * en dashes become hyphens, quotes turn straight, a stray footnote marker
+ * appears mid-sentence. Ignoring all of it finds the passage; it is a weaker
+ * claim than an exact match, which is why the result is reported as fuzzy.
+ */
+export function stripPunctuation(source: string): NormalizedText {
+  let text = "";
+  const map: number[] = [];
+  let pendingSpace = -1;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]!;
+
+    if (/\s/.test(character)) {
+      if (pendingSpace === -1) pendingSpace = index;
+      continue;
+    }
+    if (!/[\p{L}\p{N}]/u.test(character)) {
+      // Punctuation between words leaves the word gap behind it.
+      if (pendingSpace === -1) pendingSpace = index;
+      continue;
+    }
+
+    if (pendingSpace !== -1) {
+      if (text !== "") {
+        text += " ";
+        map.push(pendingSpace);
+      }
+      pendingSpace = -1;
+    }
+
+    text += character;
+    map.push(index);
+  }
+
+  map.push(source.length);
+  return { text, map };
+}
+
+/**
+ * Chains two normalisations, so offsets still lead back to the original text.
+ *
+ * `inner` was computed from `outer.text`, so its map holds offsets into that
+ * intermediate string; composing rewrites them as offsets into whatever
+ * `outer` was built from. Without this the second pass could find a match and
+ * then be unable to say where on the page it is.
+ */
+export function compose(outer: NormalizedText, inner: NormalizedText): NormalizedText {
+  return {
+    text: inner.text,
+    map: inner.map.map((offset) => outer.map[offset] ?? outer.map[outer.map.length - 1] ?? 0),
+  };
+}

--- a/packages/pdf/src/document.test.ts
+++ b/packages/pdf/src/document.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import { buildPdf } from "./fixture";
+import { openPdf, PdfOpenError } from "./document";
+import { createCitation, parseCitation, resolveCitation, serializeCitation } from "./citation";
+import { searchPdf } from "./search";
+
+/**
+ * The seam between pdf.js and this package, tested against a real document.
+ *
+ * Everything else here is tested against plain data, which proves the logic and
+ * not the assumption underneath it: that the runs pdf.js hands back are the
+ * runs `assemblePageText` expects. This is the test that fails if a pdf.js
+ * upgrade changes the shape of a text item, and it is the only one that could.
+ *
+ * ## Two polyfills
+ *
+ * pdf.js 6 targets current browsers and uses two methods Node does not have
+ * yet. Its own guidance for Node is to use the `legacy` build, which is a
+ * second, transpiled copy of the whole library; three lines here are cheaper
+ * and leave the app running the build it actually ships.
+ */
+const proto = Map.prototype as unknown as Record<string, unknown>;
+proto.getOrInsertComputed ??= function <K, V>(this: Map<K, V>, key: K, make: (key: K) => V): V {
+  if (!this.has(key)) this.set(key, make(key));
+  return this.get(key)!;
+};
+const maths = Math as unknown as Record<string, unknown>;
+maths.sumPrecise ??= (values: Iterable<number>) => [...values].reduce((a, b) => a + b, 0);
+
+const DOCUMENT = buildPdf([
+  {
+    lines: [
+      { text: "The Testing of Documents", x: 72, y: 720, size: 18 },
+      { text: "An introduction, which mentions the key result in passing.", x: 72, y: 690 },
+      { text: "Filler about method. The key result is that latency", x: 72, y: 670 },
+      { text: "fell by half. More filler follows here.", x: 72, y: 650 },
+    ],
+  },
+  {
+    lines: [
+      { text: "A second page, restating the key result once more.", x: 72, y: 720 },
+      { text: "It also mentions latency, separately.", x: 72, y: 700 },
+    ],
+  },
+]);
+
+async function open() {
+  return openPdf(DOCUMENT);
+}
+
+describe("openPdf", () => {
+  it("reports how many pages the document has", async () => {
+    const session = await open();
+    expect(session.info.pageCount).toBe(2);
+    await session.destroy();
+  });
+
+  it("reports each page's size in points", async () => {
+    const session = await open();
+    expect(session.info.sizes[0]).toEqual({ width: 612, height: 792, rotation: 0 });
+    expect(session.info.sizes).toHaveLength(2);
+    await session.destroy();
+  });
+
+  it("does not detach the caller's bytes", async () => {
+    // pdf.js transfers the buffer it is given to the worker. Without the
+    // defensive copy in `openPdf`, the caller's array is zero-length the
+    // instant the document opens — which is baffling from the outside and
+    // happens exactly when the same bytes are needed twice.
+    const bytes = new Uint8Array(DOCUMENT);
+    const session = await openPdf(bytes);
+    expect(bytes.length).toBe(DOCUMENT.length);
+    await session.destroy();
+  });
+
+  it("refuses something that is not a PDF, and says which problem it is", async () => {
+    await expect(openPdf(new TextEncoder().encode("this is not a PDF"))).rejects.toMatchObject({
+      name: "PdfOpenError",
+      reason: "corrupt",
+    });
+  });
+
+  it("raises a PdfOpenError rather than a bare failure", async () => {
+    await expect(openPdf(new Uint8Array([1, 2, 3]))).rejects.toBeInstanceOf(PdfOpenError);
+  });
+});
+
+describe("text extraction", () => {
+  it("reads the words that were written on the page", async () => {
+    const session = await open();
+    const page = await session.textOf(1);
+
+    expect(page.page).toBe(1);
+    expect(page.text).toContain("The Testing of Documents");
+    expect(page.text).toContain("An introduction, which mentions the key result in passing.");
+    await session.destroy();
+  });
+
+  it("separates lines rather than welding them together", async () => {
+    // The failure this guards is silent: "latencyfell" instead of
+    // "latency fell" means every phrase search across a line break fails, and
+    // the document looks like it does not contain words that are printed in it.
+    const session = await open();
+    const page = await session.textOf(1);
+
+    expect(page.text).not.toContain("latencyfell");
+    expect(page.text.replace(/\s+/g, " ")).toContain("latency fell by half");
+    await session.destroy();
+  });
+
+  it("gives every run a range that indexes the page text", async () => {
+    const session = await open();
+    const page = await session.textOf(1);
+
+    expect(page.runs.length).toBeGreaterThan(0);
+    for (const run of page.runs) {
+      expect(run.end).toBeGreaterThan(run.start);
+      expect(run.end).toBeLessThanOrEqual(page.text.length);
+    }
+    await session.destroy();
+  });
+
+  it("places runs where the page drew them", async () => {
+    const session = await open();
+    const page = await session.textOf(1);
+    const heading = page.runs[0]!;
+
+    expect(heading.x).toBeCloseTo(72, 0);
+    expect(heading.y).toBeCloseTo(720, 0);
+    await session.destroy();
+  });
+
+  it("reads the same page twice without reading it twice", async () => {
+    const session = await open();
+    const [first, second] = await Promise.all([session.textOf(1), session.textOf(1)]);
+    expect(second).toBe(first);
+    await session.destroy();
+  });
+
+  it("reads every page in order", async () => {
+    const session = await open();
+    const pages = await session.allText();
+
+    expect(pages.map((page) => page.page)).toEqual([1, 2]);
+    expect(pages[1]!.text).toContain("A second page");
+    await session.destroy();
+  });
+
+  it("reports progress while reading", async () => {
+    const session = await open();
+    const seen: [number, number][] = [];
+    await session.allText({ onProgress: (done, total) => seen.push([done, total]) });
+
+    expect(seen).toEqual([
+      [1, 2],
+      [2, 2],
+    ]);
+    await session.destroy();
+  });
+
+  it("stops reading when the reader moves on", async () => {
+    const session = await open();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(session.allText({ signal: controller.signal })).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    await session.destroy();
+  });
+});
+
+describe("citing a real document", () => {
+  it("finds a passage again after a full round trip through markdown", async () => {
+    // The end-to-end property the feature rests on: text extracted from a real
+    // document, cited, written into a link, parsed back out and found again,
+    // pointing at the same characters.
+    const session = await open();
+    const pages = await session.allText();
+
+    const at = pages[0]!.text.indexOf("The key result");
+    expect(at).toBeGreaterThan(-1);
+
+    const citation = createCitation(pages[0]!, at, at + "The key result is that latency".length);
+    const parsed = parseCitation(serializeCitation(citation))!;
+    const match = resolveCitation(pages, parsed);
+
+    expect(match.quality).toBe("exact");
+    expect(match.page).toBe(1);
+    expect(pages[0]!.text.slice(...match.range!)).toBe(citation.quote);
+    await session.destroy();
+  });
+
+  it("follows a passage that has moved to a different page", async () => {
+    const session = await open();
+    const pages = await session.allText();
+
+    const at = pages[1]!.text.indexOf("restating the key result");
+    const citation = { ...createCitation(pages[1]!, at, at + 24), page: 1 };
+
+    const match = resolveCitation(pages, citation);
+    expect(match.quality).toBe("moved");
+    expect(match.page).toBe(2);
+    await session.destroy();
+  });
+
+  it("finds a phrase across the line break it is printed over", async () => {
+    const session = await open();
+    const pages = await session.allText();
+
+    const hits = searchPdf(pages, "latency fell by half");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.page).toBe(1);
+    await session.destroy();
+  });
+
+  it("finds a word that appears on more than one page", async () => {
+    const session = await open();
+    const pages = await session.allText();
+
+    expect(searchPdf(pages, "latency").map((hit) => hit.page)).toEqual([1, 2]);
+    await session.destroy();
+  });
+});
+
+describe("the outline", () => {
+  it("is empty for a document that has none, rather than failing", async () => {
+    const session = await open();
+    expect(await session.outline()).toEqual([]);
+    await session.destroy();
+  });
+});

--- a/packages/pdf/src/document.test.ts
+++ b/packages/pdf/src/document.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildPdf } from "./fixture";
 import { openPdf, PdfOpenError } from "./document";
 import { createCitation, parseCitation, resolveCitation, serializeCitation } from "./citation";
@@ -12,20 +12,21 @@ import { searchPdf } from "./search";
  * runs `assemblePageText` expects. This is the test that fails if a pdf.js
  * upgrade changes the shape of a text item, and it is the only one that could.
  *
- * ## Two polyfills
+ * ## Which pdf.js build runs here
  *
- * pdf.js 6 targets current browsers and uses two methods Node does not have
- * yet. Its own guidance for Node is to use the `legacy` build, which is a
- * second, transpiled copy of the whole library; three lines here are cheaper
- * and leave the app running the build it actually ships.
+ * The suite aliases `pdfjs-dist` to its `legacy` build (see
+ * `vitest.config.ts`). The default entry point targets current browsers and
+ * uses whatever V8 has shipped most recently; Node lags that, and the failure
+ * mode is silent — `getDocument` simply never settles. The app still ships the
+ * modern build to browsers, where it belongs.
+ *
+ * That build is transpiled and takes a beat to start: the first document
+ * costs well over a second, and every one after it a couple of milliseconds.
+ * The default five-second timeout leaves too little room for that on a shared
+ * runner, so this file asks for more — a slow first parse is not a failure,
+ * and a suite that goes red on a busy afternoon teaches everyone to ignore it.
  */
-const proto = Map.prototype as unknown as Record<string, unknown>;
-proto.getOrInsertComputed ??= function <K, V>(this: Map<K, V>, key: K, make: (key: K) => V): V {
-  if (!this.has(key)) this.set(key, make(key));
-  return this.get(key)!;
-};
-const maths = Math as unknown as Record<string, unknown>;
-maths.sumPrecise ??= (values: Iterable<number>) => [...values].reduce((a, b) => a + b, 0);
+vi.setConfig({ testTimeout: 30_000 });
 
 const DOCUMENT = buildPdf([
   {

--- a/packages/pdf/src/document.ts
+++ b/packages/pdf/src/document.ts
@@ -1,0 +1,368 @@
+import type {
+  PDFDocumentLoadingTask,
+  PDFDocumentProxy,
+  PDFPageProxy,
+} from "pdfjs-dist/types/src/display/api";
+import { readMetadata } from "./metadata";
+import { buildOutline, type RawOutlineItem } from "./outline";
+import { assemblePageText, type RawTextItem } from "./text";
+import type { PdfDocumentInfo, PdfOutlineItem, PdfPageSize, PdfPageText } from "./types";
+
+/**
+ * The one file in this package that talks to pdf.js.
+ *
+ * Everything else here is pure functions over plain data, which is what makes
+ * the interesting behaviour — citation anchoring, search, outline navigation —
+ * testable without a rendering engine or a real PDF. This module is the seam:
+ * it turns a document into that plain data and hands back a handle for the one
+ * thing that genuinely needs the engine, which is drawing pixels.
+ *
+ * ## Why pdf.js and not the browser's own viewer
+ *
+ * Every browser can display a PDF in an `<iframe>` or `<embed>`, in three
+ * lines. ForkLeaf cannot use it, for two reasons that both matter:
+ *
+ *   - The editor's Content Security Policy sets `object-src 'none'` and allows
+ *     exactly one frame origin. Relaxing either to show a document would widen
+ *     the policy that protects a page which renders markdown from repositories
+ *     the user does not control.
+ *   - The built-in viewer is a black box. It cannot be asked what text is on
+ *     page 12, cannot report a selection, and cannot be told to highlight a
+ *     range — so citations, search across the document, and quoting into a
+ *     note are all impossible with it. Those are the entire point.
+ *
+ * ## Worker, and staying inside the policy
+ *
+ * pdf.js parses in a worker, which the policy already allows (`worker-src
+ * 'self' blob:`). The worker is created here rather than at module scope so
+ * importing this file on the server does not reach for `Worker`.
+ *
+ * `useWasm: false` is the one deliberate capability given up. pdf.js 6 uses
+ * WebAssembly for JPEG 2000 images and colour management, and instantiating
+ * wasm under CSP needs `'wasm-unsafe-eval'` in `script-src`. That would mean
+ * widening the policy that guards the route which renders markdown from
+ * repositories the user does not control — to improve the rendering of an
+ * image format that appears in a small minority of scanned documents. The
+ * trade is not close: the policy stays as it is, and a JPEG 2000 image inside
+ * a PDF renders blank rather than the whole editor's defences being relaxed.
+ * Text, fonts, vector graphics and every common image format are unaffected.
+ */
+
+/** A live document. Not serialisable, and not meant to outlive its viewer. */
+export interface PdfSession {
+  readonly info: PdfDocumentInfo;
+  /** The document's table of contents, resolved to page numbers. */
+  outline(): Promise<PdfOutlineItem[]>;
+  /** One page's text, extracted once and remembered. */
+  textOf(page: number): Promise<PdfPageText>;
+  /**
+   * Every page's text, in order.
+   *
+   * Reports progress because on a long document this is seconds, not
+   * milliseconds, and a reader staring at a spinner with no idea whether it is
+   * a moment or a minute will close the tab.
+   */
+  allText(options?: {
+    signal?: AbortSignal;
+    onProgress?: (done: number, total: number) => void;
+  }): Promise<PdfPageText[]>;
+  /** Draws a page into a canvas at `scale`, and resolves when it is on screen. */
+  renderPage(page: number, canvas: HTMLCanvasElement, scale: number): Promise<void>;
+  /** Releases the document and its worker. */
+  destroy(): Promise<void>;
+}
+
+export interface OpenPdfOptions {
+  /** A password, for a document that asked for one. */
+  password?: string;
+  /**
+   * Where pdf.js can fetch the fourteen standard fonts and the CJK character
+   * maps it does not embed.
+   *
+   * Without them, a document that relies on a non-embedded font renders as
+   * boxes or as the wrong typeface, and a Japanese document extracts no text
+   * at all. Passed in rather than hardcoded because only the app knows where
+   * it serves its static files from.
+   */
+  assetsUrl?: string;
+}
+
+/** Raised when the file is not a PDF, or is one ForkLeaf cannot open. */
+export class PdfOpenError extends Error {
+  constructor(
+    message: string,
+    /** `password` means the caller should ask for one and try again. */
+    readonly reason: "password" | "corrupt" | "unknown",
+  ) {
+    super(message);
+    this.name = "PdfOpenError";
+  }
+}
+
+/**
+ * Opens a PDF from its bytes.
+ *
+ * The bytes are copied first. pdf.js transfers the buffer it is given to the
+ * worker, which *detaches* it — the caller's `Uint8Array` becomes zero-length
+ * the instant the document opens. That is a genuinely baffling bug to meet
+ * from the outside ("the file I just read is empty"), and it happens exactly
+ * when the same bytes are needed twice, such as opening a document and also
+ * saving it to the repository.
+ */
+export async function openPdf(
+  bytes: ArrayBuffer | Uint8Array,
+  options: OpenPdfOptions = {},
+): Promise<PdfSession> {
+  const pdfjs = await import("pdfjs-dist");
+  ensureWorker(pdfjs);
+
+  const source = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  const copy = new Uint8Array(source.length);
+  copy.set(source);
+
+  const assets = options.assetsUrl ? withSlash(options.assetsUrl) : undefined;
+
+  let loading: PDFDocumentLoadingTask;
+  let document: PDFDocumentProxy;
+  try {
+    loading = pdfjs.getDocument({
+      data: copy,
+      password: options.password,
+      // See the note above: wasm would need a wider CSP than this app has.
+      useWasm: false,
+      ...(assets
+        ? {
+            standardFontDataUrl: `${assets}standard_fonts/`,
+            cMapUrl: `${assets}cmaps/`,
+            cMapPacked: true,
+          }
+        : {}),
+    });
+    document = await loading.promise;
+  } catch (error) {
+    throw asOpenError(error);
+  }
+
+  return createSession(loading, document, options.password != null);
+}
+
+function withSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+/**
+ * Points pdf.js at its worker, once per page load.
+ *
+ * `workerPort` with a bundler-resolved URL rather than `workerSrc` with a CDN
+ * path: the policy is `worker-src 'self'`, and a notes app that quietly loads
+ * a megabyte of parser from someone else's server is not one whose privacy
+ * claims mean anything.
+ */
+let workerStarted = false;
+
+function ensureWorker(pdfjs: { GlobalWorkerOptions: { workerPort: Worker | null } }): void {
+  if (workerStarted || typeof Worker === "undefined") return;
+
+  pdfjs.GlobalWorkerOptions.workerPort = new Worker(
+    new URL("pdfjs-dist/build/pdf.worker.mjs", import.meta.url),
+    { type: "module" },
+  );
+  workerStarted = true;
+}
+
+/** Turns pdf.js's exceptions into something a user interface can act on. */
+function asOpenError(error: unknown): PdfOpenError {
+  const name = (error as { name?: string } | null)?.name ?? "";
+  const message = (error as { message?: string } | null)?.message ?? "";
+
+  if (name === "PasswordException") {
+    return new PdfOpenError("This PDF is protected by a password.", "password");
+  }
+  if (name === "InvalidPDFException" || /invalid pdf/i.test(message)) {
+    return new PdfOpenError("That file is not a PDF, or is damaged.", "corrupt");
+  }
+  return new PdfOpenError(message || "That PDF could not be opened.", "unknown");
+}
+
+async function createSession(
+  loading: PDFDocumentLoadingTask,
+  document: PDFDocumentProxy,
+  encrypted: boolean,
+): Promise<PdfSession> {
+  const texts = new Map<number, Promise<PdfPageText>>();
+  const pages = new Map<number, Promise<PDFPageProxy>>();
+  /** The render task in flight per canvas, so a redraw can cancel the last. */
+  const rendering = new WeakMap<HTMLCanvasElement, { cancel(): void }>();
+  /**
+   * Which draw currently owns each canvas.
+   *
+   * A counter, and not merely the task above, because a draw is not atomic:
+   * it has to `await getPage` before it has a task to record. Two draws
+   * starting inside that window — which is every zoom, and every effect React
+   * runs twice in development — both get past the cancellation, both create a
+   * task, and pdf.js refuses the second with "cannot use the same canvas
+   * during multiple render operations". The symptom is a page that paints and
+   * then reports failure, so the viewer leaves it hidden: a blank page, no
+   * error, nothing in the console.
+   *
+   * Claiming a number synchronously, before the await, gives every draw a way
+   * to find out on the other side that it has been superseded.
+   */
+  const owner = new WeakMap<HTMLCanvasElement, number>();
+
+  let outlineCache: Promise<PdfOutlineItem[]> | null = null;
+
+  const pageAt = (number: number): Promise<PDFPageProxy> => {
+    let existing = pages.get(number);
+    if (!existing) {
+      existing = document.getPage(number);
+      pages.set(number, existing);
+    }
+    return existing;
+  };
+
+  const info: PdfDocumentInfo = {
+    pageCount: document.numPages,
+    metadata: readMetadata(
+      ((await document.getMetadata().catch(() => null))?.info ?? null) as never,
+    ),
+    sizes: await readPageSizes(document, pageAt),
+    encrypted,
+  };
+
+  const textOf = (number: number): Promise<PdfPageText> => {
+    let existing = texts.get(number);
+    if (!existing) {
+      existing = pageAt(number)
+        .then((page) => page.getTextContent())
+        .then((content) => assemblePageText(number, content.items as RawTextItem[]));
+      texts.set(number, existing);
+    }
+    return existing;
+  };
+
+  return {
+    info,
+    textOf,
+
+    outline() {
+      outlineCache ??= document.getOutline().then((items: RawOutlineItem[] | null) =>
+        buildOutline((items ?? []) as RawOutlineItem[], async (destination) => {
+          const resolved =
+            typeof destination === "string"
+              ? await document.getDestination(destination)
+              : (destination as unknown[] | null);
+          if (!resolved || resolved.length === 0) return null;
+
+          const index = await document.getPageIndex(resolved[0] as never);
+          return index + 1;
+        }),
+      );
+      return outlineCache;
+    },
+
+    async allText({ signal, onProgress } = {}) {
+      const total = document.numPages;
+      const collected: PdfPageText[] = [];
+
+      for (let number = 1; number <= total; number += 1) {
+        // Checked between pages rather than not at all: extracting a 900-page
+        // document should stop when the reader closes it, not finish first.
+        if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+        collected.push(await textOf(number));
+        onProgress?.(number, total);
+      }
+
+      return collected;
+    },
+
+    async renderPage(number, canvas, scale) {
+      // A page can be asked to redraw while the last draw is still going —
+      // zooming twice quickly is the ordinary case. Two render tasks writing
+      // to one canvas is a pdf.js error and a half-drawn page; cancelling the
+      // first is what the library expects.
+      const claim = (owner.get(canvas) ?? 0) + 1;
+      owner.set(canvas, claim);
+      rendering.get(canvas)?.cancel();
+
+      const page = await pageAt(number);
+      // Superseded while the page was being fetched. Everything from here to
+      // `page.render` below is synchronous, so passing this check really does
+      // mean this draw is the only one about to touch the canvas.
+      if (owner.get(canvas) !== claim) return;
+
+      rendering.get(canvas)?.cancel();
+
+      const viewport = page.getViewport({ scale });
+
+      canvas.width = Math.max(1, Math.floor(viewport.width));
+      canvas.height = Math.max(1, Math.floor(viewport.height));
+
+      // `canvas` alone, never alongside `canvasContext`. pdf.js 6 treats the
+      // two as alternatives — the context form is the backwards-compatible one
+      // and requires `canvas` to be null — and given both it starts a render
+      // whose promise never settles. The page paints and then hangs, so a
+      // viewer that waits for the promise before revealing the canvas shows a
+      // blank page for ever, with nothing thrown and nothing logged.
+      const task = page.render({ canvas, viewport });
+      rendering.set(canvas, task);
+
+      try {
+        await task.promise;
+      } catch (error) {
+        // A cancelled render is the expected outcome of zooming, not a fault.
+        if ((error as { name?: string })?.name !== "RenderingCancelledException") throw error;
+      } finally {
+        if (rendering.get(canvas) === task) rendering.delete(canvas);
+      }
+    },
+
+    async destroy() {
+      texts.clear();
+      pages.clear();
+      // The loading task owns the worker, not the document proxy — destroying
+      // the proxy alone leaves the worker running for the life of the tab, and
+      // a reader who opens twenty documents in a session ends up with twenty
+      // of them.
+      await loading.destroy();
+    },
+  };
+}
+
+/**
+ * Every page's dimensions, which the viewer needs before it draws anything.
+ *
+ * The scroll has to be the right length from the first frame — a scrollbar
+ * that grows as pages arrive makes a long document impossible to navigate,
+ * because the place you were dragging towards keeps moving.
+ *
+ * Fetched in batches rather than one at a time. `getPage` is a round trip to
+ * the worker, and nine hundred of them in series is a visible pause before the
+ * document appears; nine hundred at once floods the worker's message queue and
+ * is slower again. Thirty-two in flight is neither.
+ */
+async function readPageSizes(
+  document: PDFDocumentProxy,
+  pageAt: (number: number) => Promise<PDFPageProxy>,
+): Promise<PdfPageSize[]> {
+  const BATCH = 32;
+  const sizes: PdfPageSize[] = [];
+
+  for (let first = 1; first <= document.numPages; first += BATCH) {
+    const last = Math.min(first + BATCH - 1, document.numPages);
+    const numbers = [];
+    for (let number = first; number <= last; number += 1) numbers.push(number);
+
+    const batch = await Promise.all(
+      numbers.map(async (number) => {
+        const page = await pageAt(number);
+        const viewport = page.getViewport({ scale: 1 });
+        return { width: viewport.width, height: viewport.height, rotation: page.rotate ?? 0 };
+      }),
+    );
+
+    sizes.push(...batch);
+  }
+
+  return sizes;
+}

--- a/packages/pdf/src/fixture.ts
+++ b/packages/pdf/src/fixture.ts
@@ -1,0 +1,121 @@
+/**
+ * A PDF, built by hand, for tests.
+ *
+ * The rest of this package is tested against plain data, which is the right
+ * way to test the logic and proves nothing at all about the one assumption
+ * everything rests on: that pdf.js hands back what `assemblePageText` thinks
+ * it does. A fixture whose exact words and layout are known here closes that
+ * gap, in CI, without committing a binary or depending on whatever documents
+ * happen to be on the machine running the suite.
+ *
+ * Written out longhand rather than pulled from a library. A PDF generator is a
+ * large dependency to add for a test file of a few hundred bytes, and the
+ * format's structure — a header, numbered objects, a cross-reference table
+ * pointing at each one's byte offset, a trailer — is short enough to write
+ * exactly once and read afterwards.
+ */
+
+export interface FixtureLine {
+  text: string;
+  /** Points from the left of the page. */
+  x: number;
+  /** Points from the bottom, the way PDF measures. */
+  y: number;
+  size?: number;
+}
+
+export interface FixturePage {
+  lines: FixtureLine[];
+}
+
+const PAGE_WIDTH = 612;
+const PAGE_HEIGHT = 792;
+
+/** Builds a one-font, uncompressed PDF containing exactly these pages. */
+export function buildPdf(pages: readonly FixturePage[]): Uint8Array {
+  const objects: string[] = [];
+  /** Reserves an object number, 1-based, and returns it. */
+  const add = (body: string): number => {
+    objects.push(body);
+    return objects.length;
+  };
+
+  // Object numbers have to be known before the objects that reference them are
+  // written, so the tree is laid out first and filled in after.
+  const catalogId = 1;
+  const pagesId = 2;
+  const fontId = 3;
+  objects.push("", "", "");
+
+  objects[fontId - 1] =
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>";
+
+  const pageIds: number[] = [];
+
+  for (const page of pages) {
+    const stream = page.lines
+      .map(
+        (line) =>
+          `BT /F1 ${line.size ?? 12} Tf 1 0 0 1 ${line.x} ${line.y} Tm (${escapeText(line.text)}) Tj ET`,
+      )
+      .join("\n");
+
+    const contentId = add(`<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`);
+    pageIds.push(
+      add(
+        `<< /Type /Page /Parent ${pagesId} 0 R /MediaBox [0 0 ${PAGE_WIDTH} ${PAGE_HEIGHT}] ` +
+          `/Resources << /Font << /F1 ${fontId} 0 R >> >> /Contents ${contentId} 0 R >>`,
+      ),
+    );
+  }
+
+  objects[pagesId - 1] =
+    `<< /Type /Pages /Count ${pageIds.length} /Kids [${pageIds.map((id) => `${id} 0 R`).join(" ")}] >>`;
+  objects[catalogId - 1] = `<< /Type /Catalog /Pages ${pagesId} 0 R >>`;
+
+  // ── Serialise ─────────────────────────────────────────────────────────────
+  //
+  // The cross-reference table is a list of byte offsets, so the file has to be
+  // assembled as bytes while it is being written rather than as a string that
+  // is encoded afterwards — a multi-byte character anywhere in the content
+  // would put every offset out and the reader would refuse the file.
+
+  const parts: Uint8Array[] = [];
+  let length = 0;
+  const write = (text: string) => {
+    const bytes = new TextEncoder().encode(text);
+    parts.push(bytes);
+    length += bytes.length;
+  };
+
+  write("%PDF-1.7\n");
+
+  const offsets: number[] = [];
+  objects.forEach((body, index) => {
+    offsets.push(length);
+    write(`${index + 1} 0 obj\n${body}\nendobj\n`);
+  });
+
+  const xref = length;
+  write(`xref\n0 ${objects.length + 1}\n`);
+  write("0000000000 65535 f \n");
+  for (const offset of offsets) {
+    write(`${String(offset).padStart(10, "0")} 00000 n \n`);
+  }
+  write(
+    `trailer\n<< /Size ${objects.length + 1} /Root ${catalogId} 0 R >>\nstartxref\n${xref}\n%%EOF\n`,
+  );
+
+  const file = new Uint8Array(length);
+  let at = 0;
+  for (const part of parts) {
+    file.set(part, at);
+    at += part.length;
+  }
+  return file;
+}
+
+/** Escapes the three characters that end a PDF string early. */
+function escapeText(text: string): string {
+  return text.replace(/([\\()])/g, "\\$1");
+}

--- a/packages/pdf/src/index.ts
+++ b/packages/pdf/src/index.ts
@@ -1,0 +1,61 @@
+/**
+ * `@forkleaf/pdf` — reading PDFs, and citing them.
+ *
+ * The split to know about: everything except `document.ts` is pure functions
+ * over plain data, so the behaviour that actually matters — where a quotation
+ * lives, whether it is still there, what page a phrase is on — is testable
+ * without a rendering engine. `document.ts` is the only file that imports
+ * pdf.js, and the only one that needs a browser.
+ */
+
+export type {
+  PdfCitation,
+  PdfCitationMatch,
+  PdfDocumentInfo,
+  PdfMatchQuality,
+  PdfMetadata,
+  PdfOutlineItem,
+  PdfPageSize,
+  PdfPageText,
+  PdfSearchHit,
+  PdfTextRun,
+} from "./types";
+
+export {
+  assemblePageText,
+  normalizeForMatch,
+  rectsForRange,
+  toSourceRange,
+  type AssembleOptions,
+  type NormalizedText,
+  type RawTextItem,
+} from "./text";
+
+export {
+  CONTEXT_LENGTH,
+  MAX_QUOTE_LENGTH,
+  citationLink,
+  compose,
+  createCitation,
+  isPdfTarget,
+  parseCitation,
+  resolveCitation,
+  serializeCitation,
+  splitTarget,
+  stripPunctuation,
+} from "./citation";
+
+export { countMatches, pagesMatching, searchPdf, type PdfSearchOptions } from "./search";
+
+export { displayTitle, parsePdfDate, readMetadata, type RawPdfInfo } from "./metadata";
+
+export {
+  buildOutline,
+  flattenOutline,
+  outlineEntryForPage,
+  outlineKeys,
+  type FlatOutlineItem,
+  type RawOutlineItem,
+} from "./outline";
+
+export { PdfOpenError, openPdf, type OpenPdfOptions, type PdfSession } from "./document";

--- a/packages/pdf/src/metadata.test.ts
+++ b/packages/pdf/src/metadata.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { displayTitle, parsePdfDate, readMetadata } from "./metadata";
+import type { PdfMetadata } from "./types";
+
+describe("parsePdfDate", () => {
+  it("reads a full PDF date with a timezone offset", () => {
+    expect(parsePdfDate("D:20240115103000+05'30'")).toBe("2024-01-15T05:00:00.000Z");
+  });
+
+  it("reads a negative offset", () => {
+    expect(parsePdfDate("D:20240115103000-05'00'")).toBe("2024-01-15T15:30:00.000Z");
+  });
+
+  it("reads an offset written without apostrophes", () => {
+    expect(parsePdfDate("D:202401151030+0530")).toBe("2024-01-15T05:00:00.000Z");
+  });
+
+  it("reads Zulu time", () => {
+    expect(parsePdfDate("D:20240115103000Z")).toBe("2024-01-15T10:30:00.000Z");
+  });
+
+  it("reads a date with no time at all", () => {
+    expect(parsePdfDate("D:20240115")).toBe("2024-01-15T00:00:00.000Z");
+  });
+
+  it("reads a year on its own", () => {
+    expect(parsePdfDate("D:2024")).toBe("2024-01-01T00:00:00.000Z");
+  });
+
+  it("tolerates the missing D: prefix that real files have", () => {
+    expect(parsePdfDate("20240115103000")).toBe("2024-01-15T10:30:00.000Z");
+  });
+
+  it("refuses the zero month producers write for 'unspecified'", () => {
+    expect(parsePdfDate("D:20240015")).toBeNull();
+  });
+
+  it("refuses a date that does not exist rather than rolling it over", () => {
+    // `Date.UTC` would answer 2 March. A wrong date presented confidently is
+    // worse than no date.
+    expect(parsePdfDate("D:20240230")).toBeNull();
+  });
+
+  it("refuses an impossible time", () => {
+    expect(parsePdfDate("D:20240115256000")).toBeNull();
+  });
+
+  it("is null for anything that is not a string", () => {
+    expect(parsePdfDate(undefined)).toBeNull();
+    expect(parsePdfDate(1_700_000_000)).toBeNull();
+  });
+
+  it("is null for free text", () => {
+    expect(parsePdfDate("last Tuesday")).toBeNull();
+  });
+});
+
+describe("readMetadata", () => {
+  it("reads the fields a well-behaved producer writes", () => {
+    const metadata = readMetadata({
+      Title: "On Attention",
+      Author: "A. Researcher",
+      Subject: "Machine learning",
+      Keywords: "attention; transformers, machine learning",
+      Producer: "pdfTeX",
+      CreationDate: "D:20240115103000Z",
+    });
+
+    expect(metadata.title).toBe("On Attention");
+    expect(metadata.keywords).toEqual(["attention", "transformers", "machine learning"]);
+    expect(metadata.createdAt).toBe("2024-01-15T10:30:00.000Z");
+    expect(metadata.producer).toBe("pdfTeX");
+  });
+
+  it("treats blank and whitespace-only fields as absent", () => {
+    expect(readMetadata({ Title: "   ", Author: "" }).title).toBeNull();
+  });
+
+  it("strips the byte-order mark some producers leave in every field", () => {
+    expect(readMetadata({ Title: "﻿Report" }).title).toBe("Report");
+  });
+
+  it("ignores fields that are not strings", () => {
+    expect(readMetadata({ Title: { text: "x" } as never }).title).toBeNull();
+  });
+
+  it("falls back to Creator when there is no Producer", () => {
+    expect(readMetadata({ Creator: "Scrivener" }).producer).toBe("Scrivener");
+  });
+
+  it("de-duplicates keywords", () => {
+    expect(readMetadata({ Keywords: "a, a, b" }).keywords).toEqual(["a", "b"]);
+  });
+
+  it("survives no metadata at all", () => {
+    expect(readMetadata(null)).toEqual({
+      title: null,
+      author: null,
+      subject: null,
+      keywords: [],
+      createdAt: null,
+      modifiedAt: null,
+      producer: null,
+    });
+  });
+});
+
+describe("displayTitle", () => {
+  const base: PdfMetadata = {
+    title: null,
+    author: null,
+    subject: null,
+    keywords: [],
+    createdAt: null,
+    modifiedAt: null,
+    producer: null,
+  };
+
+  it("uses a real embedded title", () => {
+    expect(displayTitle({ ...base, title: "On Attention" }, "1706.03762.pdf")).toBe("On Attention");
+  });
+
+  it("falls back to the filename when there is no title", () => {
+    expect(displayTitle(base, "quarterly-report.pdf")).toBe("quarterly-report");
+  });
+
+  it("rejects the filename-shaped titles Word and LaTeX write", () => {
+    expect(displayTitle({ ...base, title: "report.doc" }, "quarterly.pdf")).toBe("quarterly");
+    expect(displayTitle({ ...base, title: "Microsoft Word - draft.doc" }, "final.pdf")).toBe(
+      "final",
+    );
+  });
+
+  it("rejects a path masquerading as a title", () => {
+    expect(displayTitle({ ...base, title: "/Users/x/Desktop/thing" }, "thing.pdf")).toBe("thing");
+  });
+
+  it("rejects a literal 'Untitled'", () => {
+    expect(displayTitle({ ...base, title: "Untitled" }, "notes.pdf")).toBe("notes");
+  });
+
+  it("has something to say even for a file with no name", () => {
+    expect(displayTitle(base, "")).toBe("Untitled");
+  });
+});

--- a/packages/pdf/src/metadata.ts
+++ b/packages/pdf/src/metadata.ts
@@ -1,0 +1,151 @@
+import type { PdfMetadata } from "./types";
+
+/**
+ * What a PDF says about itself, made trustworthy.
+ *
+ * The document information dictionary is free text written by whatever
+ * produced the file, so every field here is treated as untrusted and optional.
+ * Two things in particular are worth the code:
+ *
+ * `Title` is very often *not* the title. Word writes the first paragraph,
+ * LaTeX writes nothing, and scanners write the model number of the scanner —
+ * so a blank, whitespace-only or obviously-a-filename title is rejected in
+ * favour of saying nothing, and the caller falls back to the filename, which
+ * at least the user chose.
+ *
+ * Dates are in PDF's own format, not ISO, and are the reason this file is not
+ * three lines long.
+ */
+
+/** The shape pdf.js returns from `getMetadata()`. Every field may be missing. */
+export interface RawPdfInfo {
+  Title?: unknown;
+  Author?: unknown;
+  Subject?: unknown;
+  Keywords?: unknown;
+  Producer?: unknown;
+  Creator?: unknown;
+  CreationDate?: unknown;
+  ModDate?: unknown;
+}
+
+export function readMetadata(info: RawPdfInfo | null | undefined): PdfMetadata {
+  const raw = info ?? {};
+
+  return {
+    title: text(raw.Title),
+    author: text(raw.Author),
+    subject: text(raw.Subject),
+    keywords: keywords(raw.Keywords),
+    createdAt: parsePdfDate(raw.CreationDate),
+    modifiedAt: parsePdfDate(raw.ModDate),
+    producer: text(raw.Producer) ?? text(raw.Creator),
+  };
+}
+
+/** A string field, or null when it is absent, blank or not a string at all. */
+function text(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  // Some producers pad every field with the BOM they read the source with.
+  const trimmed = value.replace(/^﻿/, "").trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * `Keywords` is one string, and no two producers agree on the separator.
+ *
+ * Commas, semicolons and plain spaces are all in the wild, sometimes in the
+ * same file. Splitting on the first two and leaving spaces alone keeps
+ * multi-word keywords — "machine learning" is one keyword, not two.
+ */
+function keywords(value: unknown): string[] {
+  const raw = text(value);
+  if (!raw) return [];
+
+  return [
+    ...new Set(
+      raw
+        .split(/[;,]/)
+        .map((keyword) => keyword.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+/**
+ * PDF dates, which are their own format: `D:YYYYMMDDHHmmSSOHH'mm'`.
+ *
+ * Everything after the year is optional, the `D:` prefix is optional in
+ * practice though the spec requires it, the timezone offset may be `Z`, `+`,
+ * `-` or absent, and the apostrophes in the offset are sometimes there and
+ * sometimes not. Files in the wild have all of these combinations.
+ *
+ * A date that cannot be read is null, not "now" and not the epoch. A note
+ * saying a paper was published on 1 January 1970 is worse than one that does
+ * not claim to know.
+ */
+export function parsePdfDate(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+
+  const match =
+    /^(?:D:)?(\d{4})(\d{2})?(\d{2})?(\d{2})?(\d{2})?(\d{2})?(?:(Z)|([+-])(\d{2})'?(?:(\d{2})'?)?)?/.exec(
+      value.trim(),
+    );
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2] ?? "1");
+  const day = Number(match[3] ?? "1");
+  const hour = Number(match[4] ?? "0");
+  const minute = Number(match[5] ?? "0");
+  const second = Number(match[6] ?? "0");
+
+  // Producers do write month 00 and day 00 when they mean "unspecified".
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  if (hour > 23 || minute > 59 || second > 59) return null;
+
+  const offsetMinutes =
+    match[7] === "Z" || !match[8]
+      ? 0
+      : (match[8] === "-" ? -1 : 1) * (Number(match[9] ?? "0") * 60 + Number(match[10] ?? "0"));
+
+  const wall = Date.UTC(year, month - 1, day, hour, minute, second);
+  if (!Number.isFinite(wall)) return null;
+
+  // Rejects 31 February and friends, which `Date.UTC` rolls forward instead of
+  // refusing — a rolled-over date is a wrong date presented as a right one.
+  // Checked against the written fields before the offset is applied, since the
+  // offset legitimately moves the date across midnight.
+  const wallDate = new Date(wall);
+  if (
+    wallDate.getUTCFullYear() !== year ||
+    wallDate.getUTCMonth() !== month - 1 ||
+    wallDate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return new Date(wall - offsetMinutes * 60_000).toISOString();
+}
+
+/**
+ * The name to show for a document.
+ *
+ * The embedded title wins only when it looks like a title somebody wrote. A
+ * "title" that is the filename with its extension still attached, or a bare
+ * path, is metadata the producer invented, and the filename it was invented
+ * from is the better answer — shorter, and the one the reader recognises.
+ */
+export function displayTitle(metadata: PdfMetadata, fileName: string): string {
+  const fallback = fileName.replace(/\.pdf$/i, "") || "Untitled";
+  const title = metadata.title;
+
+  if (!title) return fallback;
+  if (/\.(pdf|docx?|tex|indd|pages)$/i.test(title)) return fallback;
+  if (title.includes("/") || title.includes("\\")) return fallback;
+  // "Microsoft Word - report.doc" is what Word writes when there is no title.
+  if (/^microsoft word\s*-/i.test(title)) return fallback;
+  if (/^untitled$/i.test(title)) return fallback;
+
+  return title;
+}

--- a/packages/pdf/src/outline.test.ts
+++ b/packages/pdf/src/outline.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildOutline,
+  flattenOutline,
+  outlineEntryForPage,
+  outlineKeys,
+  type RawOutlineItem,
+} from "./outline";
+import type { PdfOutlineItem } from "./types";
+
+const raw: RawOutlineItem[] = [
+  {
+    title: "Introduction",
+    dest: "intro",
+    items: [{ title: "Background", dest: "background", items: [] }],
+  },
+  { title: "Method", dest: "method", items: null },
+];
+
+const destinations: Record<string, number> = { intro: 1, background: 2, method: 5 };
+const pageFor = async (destination: unknown) => destinations[String(destination)] ?? null;
+
+describe("buildOutline", () => {
+  it("resolves each entry to the page it points at", async () => {
+    const outline = await buildOutline(raw, pageFor);
+
+    expect(outline).toHaveLength(2);
+    expect(outline[0]!.title).toBe("Introduction");
+    expect(outline[0]!.page).toBe(1);
+    expect(outline[0]!.children[0]!.page).toBe(2);
+    expect(outline[1]!.page).toBe(5);
+  });
+
+  it("keeps an entry whose destination is broken, without a page", async () => {
+    // A heading with a dead bookmark is still a heading. Dropping it leaves a
+    // hole in the contents where a section used to be.
+    const outline = await buildOutline([{ title: "Appendix", dest: "missing" }], pageFor);
+    expect(outline[0]).toMatchObject({ title: "Appendix", page: null });
+  });
+
+  it("keeps an entry whose destination lookup throws", async () => {
+    const outline = await buildOutline([{ title: "Broken", dest: "x" }], async () => {
+      throw new Error("no such destination");
+    });
+    expect(outline[0]!.page).toBeNull();
+  });
+
+  it("does not ask about an entry with no destination", async () => {
+    const spy = vi.fn(pageFor);
+    await buildOutline([{ title: "Heading only" }], spy);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("names an entry that has no title", async () => {
+    expect((await buildOutline([{ dest: "intro" }], pageFor))[0]!.title).toBe("Untitled section");
+  });
+
+  it("flattens the line breaks bookmarks pick up from headings", async () => {
+    const outline = await buildOutline([{ title: "A very\n  long   heading" }], pageFor);
+    expect(outline[0]!.title).toBe("A very long heading");
+  });
+
+  it("is empty for a document with no outline", async () => {
+    expect(await buildOutline(null, pageFor)).toEqual([]);
+    expect(await buildOutline([], pageFor)).toEqual([]);
+  });
+});
+
+const outline: PdfOutlineItem[] = [
+  {
+    title: "One",
+    page: 1,
+    children: [
+      { title: "One A", page: 2, children: [] },
+      { title: "One B", page: 4, children: [] },
+    ],
+  },
+  { title: "Two", page: 6, children: [] },
+];
+
+describe("flattenOutline", () => {
+  it("returns every row with its depth", () => {
+    expect(flattenOutline(outline).map((row) => [row.title, row.depth])).toEqual([
+      ["One", 0],
+      ["One A", 1],
+      ["One B", 1],
+      ["Two", 0],
+    ]);
+  });
+
+  it("gives each row a stable key from its position", () => {
+    expect(flattenOutline(outline).map((row) => row.key)).toEqual(["0", "0.0", "0.1", "1"]);
+  });
+
+  it("skips the contents of a collapsed branch entirely", () => {
+    expect(flattenOutline(outline, new Set(["0"])).map((row) => row.title)).toEqual(["One", "Two"]);
+  });
+
+  it("is empty for an empty outline", () => {
+    expect(flattenOutline([])).toEqual([]);
+  });
+});
+
+describe("outlineEntryForPage", () => {
+  it("finds the section a page falls inside", () => {
+    expect(outlineEntryForPage(outline, 3)?.title).toBe("One A");
+  });
+
+  it("prefers the deepest section that begins on the page", () => {
+    expect(outlineEntryForPage(outline, 2)?.title).toBe("One A");
+  });
+
+  it("stays in the last section past the final heading", () => {
+    expect(outlineEntryForPage(outline, 99)?.title).toBe("Two");
+  });
+
+  it("has no answer before the first heading", () => {
+    const late: PdfOutlineItem[] = [{ title: "Chapter", page: 10, children: [] }];
+    expect(outlineEntryForPage(late, 3)).toBeNull();
+  });
+
+  it("ignores entries whose destination never resolved", () => {
+    const broken: PdfOutlineItem[] = [
+      { title: "Unresolved", page: null, children: [] },
+      { title: "Real", page: 1, children: [] },
+    ];
+    expect(outlineEntryForPage(broken, 5)?.title).toBe("Real");
+  });
+});
+
+describe("outlineKeys", () => {
+  it("lists only the rows that have something to expand", () => {
+    expect(outlineKeys(outline)).toEqual(["0"]);
+  });
+});

--- a/packages/pdf/src/outline.ts
+++ b/packages/pdf/src/outline.ts
@@ -1,0 +1,125 @@
+import type { PdfOutlineItem } from "./types";
+
+/**
+ * The document's own table of contents.
+ *
+ * Worth having for the obvious reason — a 300-page specification is unusable
+ * without one — and worth a file of its own for a less obvious one: a PDF
+ * outline entry does not contain a page number. It contains a *destination*,
+ * which is either a name that has to be looked up in the document's name tree,
+ * or an explicit array whose first element is a reference to a page object.
+ * Turning either into "page 47" needs the document, and can fail.
+ *
+ * This module is the pure half: the shape of the tree, the flattening, and
+ * finding where a reader currently is in it. Resolving destinations to page
+ * numbers is the caller's job, because only the caller has the document.
+ */
+
+/** An outline entry as pdf.js hands it over, before destinations are resolved. */
+export interface RawOutlineItem {
+  title?: unknown;
+  dest?: unknown;
+  items?: RawOutlineItem[] | null;
+}
+
+/**
+ * Builds the outline, asking `pageFor` where each entry points.
+ *
+ * `pageFor` returns null for a destination that cannot be resolved, and that
+ * is a normal outcome rather than an error: broken bookmarks are common in
+ * documents assembled from several sources. The entry stays in the tree with
+ * no page — it is still a heading, and dropping it would leave a hole in the
+ * contents where a section used to be.
+ */
+export async function buildOutline(
+  items: readonly RawOutlineItem[] | null | undefined,
+  pageFor: (destination: unknown) => Promise<number | null>,
+): Promise<PdfOutlineItem[]> {
+  if (!items || items.length === 0) return [];
+
+  const built: PdfOutlineItem[] = [];
+
+  for (const item of items) {
+    const title = typeof item.title === "string" ? item.title.replace(/\s+/g, " ").trim() : "";
+
+    let page: number | null = null;
+    try {
+      page = item.dest == null ? null : await pageFor(item.dest);
+    } catch {
+      // A destination that throws is a broken bookmark, not a broken document.
+      page = null;
+    }
+
+    built.push({
+      title: title || "Untitled section",
+      page,
+      children: await buildOutline(item.items, pageFor),
+    });
+  }
+
+  return built;
+}
+
+/** One row of a flattened outline, for rendering an indented list. */
+export interface FlatOutlineItem extends PdfOutlineItem {
+  depth: number;
+  /** Path of indices from the root, which is a stable key and a stable id. */
+  key: string;
+}
+
+/**
+ * Flattens the outline for display, optionally hiding collapsed branches.
+ *
+ * Rendering a tree as a flat list rather than nested components is what lets
+ * a 2,000-entry contents scroll at all — and `collapsed` is checked on the way
+ * down, so a collapsed branch costs nothing rather than being rendered and
+ * hidden.
+ */
+export function flattenOutline(
+  items: readonly PdfOutlineItem[],
+  collapsed: ReadonlySet<string> = new Set(),
+): FlatOutlineItem[] {
+  const rows: FlatOutlineItem[] = [];
+
+  const walk = (nodes: readonly PdfOutlineItem[], depth: number, prefix: string) => {
+    nodes.forEach((node, index) => {
+      const key = prefix ? `${prefix}.${index}` : String(index);
+      rows.push({ ...node, depth, key });
+      if (!collapsed.has(key)) walk(node.children, depth + 1, key);
+    });
+  };
+
+  walk(items, 0, "");
+  return rows;
+}
+
+/**
+ * The deepest outline entry at or before a page — where the reader is.
+ *
+ * Chosen by "last entry whose page is not after this one" rather than by an
+ * exact match, because most pages are not the first page of a section. Ties go
+ * to the deepest entry: on the page where a chapter and its first subsection
+ * both begin, the subsection is the more useful answer.
+ */
+export function outlineEntryForPage(
+  items: readonly PdfOutlineItem[],
+  page: number,
+): FlatOutlineItem | null {
+  let best: FlatOutlineItem | null = null;
+
+  for (const row of flattenOutline(items)) {
+    if (row.page == null || row.page > page) continue;
+    if (!best || row.page > best.page! || (row.page === best.page && row.depth > best.depth)) {
+      best = row;
+    }
+  }
+
+  return best;
+}
+
+/** Every entry key in the tree, for expanding or collapsing all of it. */
+export function outlineKeys(items: readonly PdfOutlineItem[]): string[] {
+  return flattenOutline(items)
+    .filter((row) => row.children.length > 0)
+    .map((row) => row.key);
+}

--- a/packages/pdf/src/search.test.ts
+++ b/packages/pdf/src/search.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { countMatches, pagesMatching, searchPdf } from "./search";
+import type { PdfPageText } from "./types";
+
+function page(number: number, text: string): PdfPageText {
+  return { page: number, text, runs: [] };
+}
+
+const pages = [
+  page(1, "The quick brown fox. A fox is quick."),
+  page(2, "Nothing of interest here."),
+  page(3, "Another fox, and a foxglove too."),
+];
+
+describe("searchPdf", () => {
+  it("finds every occurrence, in page order", () => {
+    const hits = searchPdf(pages, "fox");
+    expect(hits.map((hit) => hit.page)).toEqual([1, 1, 3, 3]);
+  });
+
+  it("reports ranges that point at the real characters", () => {
+    for (const hit of searchPdf(pages, "fox")) {
+      const source = pages.find((candidate) => candidate.page === hit.page)!;
+      expect(source.text.slice(...hit.range).toLowerCase()).toContain("fox");
+    }
+  });
+
+  it("ignores case", () => {
+    expect(searchPdf(pages, "FOX")).toHaveLength(4);
+  });
+
+  it("matches a phrase that a line break interrupts", () => {
+    // The failure this prevents: a viewer that searches the raw extracted
+    // string reports "not found" for a phrase printed plainly on the page.
+    const wrapped = [page(1, "the quick\nbrown fox")];
+    expect(searchPdf(wrapped, "quick brown")).toHaveLength(1);
+  });
+
+  it("matches through hyphenation", () => {
+    expect(searchPdf([page(1, "measured regu-\nlarly")], "regularly")).toHaveLength(1);
+  });
+
+  it("matches through ligatures", () => {
+    expect(searchPdf([page(1, "we ﬁnd that")], "find")).toHaveLength(1);
+  });
+
+  it("can be held to whole words", () => {
+    expect(searchPdf(pages, "fox", { wholeWord: true }).map((hit) => hit.page)).toEqual([1, 1, 3]);
+  });
+
+  it("builds a snippet with the match marked inside it", () => {
+    const [hit] = searchPdf([page(1, "the quick brown fox jumps")], "brown");
+    expect(hit!.snippet.slice(...hit!.snippetRange)).toBe("brown");
+  });
+
+  it("flattens the layout newlines out of a snippet", () => {
+    const [hit] = searchPdf([page(1, "line one\nline two\nline three")], "two");
+    expect(hit!.snippet).not.toContain("\n");
+  });
+
+  it("marks a snippet that was cut from a longer page", () => {
+    const [hit] = searchPdf([page(1, `${"a ".repeat(100)}needle${" b".repeat(100)}`)], "needle");
+    expect(hit!.snippet.startsWith("…")).toBe(true);
+    expect(hit!.snippet.endsWith("…")).toBe(true);
+  });
+
+  it("does not pretend a short page is an excerpt", () => {
+    const [hit] = searchPdf([page(1, "needle")], "needle");
+    expect(hit!.snippet).toBe("needle");
+  });
+
+  it("returns nothing for an empty query", () => {
+    expect(searchPdf(pages, "   ")).toEqual([]);
+  });
+
+  it("returns nothing when the phrase is absent", () => {
+    expect(searchPdf(pages, "elephant")).toEqual([]);
+  });
+
+  it("stops at the limit rather than building thousands of snippets", () => {
+    const busy = [page(1, "a ".repeat(500))];
+    expect(searchPdf(busy, "a", { limit: 10 })).toHaveLength(10);
+  });
+
+  it("finds overlapping occurrences", () => {
+    expect(searchPdf([page(1, "aaaa")], "aa")).toHaveLength(3);
+  });
+});
+
+describe("countMatches", () => {
+  it("counts without the cost of snippets", () => {
+    expect(countMatches(pages, "fox")).toBe(4);
+  });
+
+  it("is zero for an empty query", () => {
+    expect(countMatches(pages, "")).toBe(0);
+  });
+});
+
+describe("pagesMatching", () => {
+  it("lists only the pages that contain the phrase", () => {
+    expect(pagesMatching(pages, "fox")).toEqual([1, 3]);
+  });
+
+  it("is empty for an empty query", () => {
+    expect(pagesMatching(pages, "")).toEqual([]);
+  });
+});

--- a/packages/pdf/src/search.ts
+++ b/packages/pdf/src/search.ts
@@ -1,0 +1,145 @@
+import { normalizeForMatch, toSourceRange } from "./text";
+import type { PdfPageText, PdfSearchHit } from "./types";
+
+/**
+ * Finding a phrase inside a PDF.
+ *
+ * Built on the same normalisation the citation resolver uses, and that is the
+ * whole trick: searching a PDF is the thing every reader tries first and the
+ * thing most viewers do badly, because they search the raw extracted string.
+ * In that string the word "significant" is often `signiﬁcant`, "regular"
+ * broken across a line is `regu-\nlar`, and every word may be separated by a
+ * newline. A literal `indexOf` finds none of them, and the reader concludes
+ * the phrase is not in the document when it is printed twice on page 3.
+ *
+ * Matching against the normalised form and mapping back to the real offsets
+ * finds all three, and still highlights the exact characters on the page.
+ */
+
+export interface PdfSearchOptions {
+  /** Stop after this many hits. Defaults to 200. */
+  limit?: number;
+  /** Characters of context either side of a hit in its snippet. */
+  context?: number;
+  /**
+   * Only match whole words.
+   *
+   * Off by default, because a reader typing three letters into a find box is
+   * usually still typing.
+   */
+  wholeWord?: boolean;
+}
+
+const DEFAULT_LIMIT = 200;
+const DEFAULT_CONTEXT = 40;
+
+/** Every occurrence of `query`, in page order. */
+export function searchPdf(
+  pages: readonly PdfPageText[],
+  query: string,
+  options: PdfSearchOptions = {},
+): PdfSearchHit[] {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const context = options.context ?? DEFAULT_CONTEXT;
+
+  const needle = normalizeForMatch(query).text.trim();
+  if (!needle) return [];
+
+  const hits: PdfSearchHit[] = [];
+
+  for (const page of pages) {
+    const normalized = normalizeForMatch(page.text);
+    const haystack = normalized.text;
+
+    let at = haystack.indexOf(needle);
+    while (at !== -1 && hits.length < limit) {
+      const end = at + needle.length;
+
+      if (!options.wholeWord || isWholeWord(haystack, at, end)) {
+        const [start, stop] = toSourceRange(normalized, at, end);
+        hits.push({
+          page: page.page,
+          range: [start, stop],
+          ...snippetAround(page.text, start, stop, context),
+        });
+      }
+
+      at = haystack.indexOf(needle, at + 1);
+    }
+
+    if (hits.length >= limit) break;
+  }
+
+  return hits;
+}
+
+/** How many times a phrase appears, without building a snippet for each. */
+export function countMatches(pages: readonly PdfPageText[], query: string): number {
+  const needle = normalizeForMatch(query).text.trim();
+  if (!needle) return 0;
+
+  let total = 0;
+  for (const page of pages) {
+    const haystack = normalizeForMatch(page.text).text;
+    let at = haystack.indexOf(needle);
+    while (at !== -1) {
+      total += 1;
+      at = haystack.indexOf(needle, at + 1);
+    }
+  }
+  return total;
+}
+
+/** The pages a phrase appears on, for a page-strip indicator. */
+export function pagesMatching(pages: readonly PdfPageText[], query: string): number[] {
+  const needle = normalizeForMatch(query).text.trim();
+  if (!needle) return [];
+
+  return pages
+    .filter((page) => normalizeForMatch(page.text).text.includes(needle))
+    .map((page) => page.page);
+}
+
+function isWholeWord(haystack: string, start: number, end: number): boolean {
+  const before = start > 0 ? haystack[start - 1]! : " ";
+  const after = end < haystack.length ? haystack[end]! : " ";
+  return !isWordCharacter(before) && !isWordCharacter(after);
+}
+
+function isWordCharacter(character: string): boolean {
+  return /[\p{L}\p{N}]/u.test(character);
+}
+
+/**
+ * A readable line around a match.
+ *
+ * Whitespace is flattened, because the source text's newlines are column
+ * layout rather than sentence structure and a snippet full of them reads as
+ * three broken fragments. The ellipses are added only when something really
+ * was cut, so a short line does not pretend to be an excerpt of a longer one.
+ */
+function snippetAround(
+  source: string,
+  start: number,
+  end: number,
+  context: number,
+): { snippet: string; snippetRange: [number, number] } {
+  const from = Math.max(0, start - context);
+  const to = Math.min(source.length, end + context);
+
+  const lead = flatten(source.slice(from, start));
+  const middle = flatten(source.slice(start, end));
+  const tail = flatten(source.slice(end, to));
+
+  const prefix = from > 0 ? "…" : "";
+  const suffix = to < source.length ? "…" : "";
+
+  const snippet = `${prefix}${lead}${middle}${tail}${suffix}`;
+  const offset = prefix.length + lead.length;
+
+  return { snippet, snippetRange: [offset, offset + middle.length] };
+}
+
+function flatten(value: string): string {
+  return value.replace(/\s+/g, " ");
+}

--- a/packages/pdf/src/text.test.ts
+++ b/packages/pdf/src/text.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  assemblePageText,
+  normalizeForMatch,
+  rectsForRange,
+  toSourceRange,
+  type RawTextItem,
+} from "./text";
+
+/** A pdf.js-shaped run at a position, so the tests read like a page layout. */
+function run(
+  str: string,
+  x: number,
+  y: number,
+  width: number,
+  options: { hasEOL?: boolean; height?: number } = {},
+): RawTextItem {
+  return {
+    str,
+    hasEOL: options.hasEOL ?? false,
+    transform: [1, 0, 0, 1, x, y],
+    width,
+    height: options.height ?? 10,
+  };
+}
+
+describe("assemblePageText", () => {
+  it("keeps runs that already touch as one word", () => {
+    const page = assemblePageText(1, [run("Fork", 0, 700, 20), run("Leaf", 20, 700, 20)]);
+    expect(page.text).toBe("ForkLeaf");
+  });
+
+  it("infers a space across a visible gap", () => {
+    const page = assemblePageText(1, [run("hello", 0, 700, 30), run("world", 36, 700, 30)]);
+    expect(page.text).toBe("hello world");
+  });
+
+  it("breaks the line where the run says the line ends", () => {
+    const page = assemblePageText(1, [
+      run("the end", 0, 700, 40, { hasEOL: true }),
+      run("Chapter two", 0, 686, 60),
+    ]);
+    // The bug this guards: without the break, phrase search for "end chapter"
+    // matches and search for "the end" at a line end does not.
+    expect(page.text).toBe("the end\nChapter two");
+  });
+
+  it("treats a changed baseline as a line break the run forgot to flag", () => {
+    const page = assemblePageText(1, [run("first", 0, 700, 30), run("second", 0, 686, 30)]);
+    expect(page.text).toBe("first second");
+  });
+
+  it("does not double a space the runs already supply", () => {
+    const page = assemblePageText(1, [run("hello ", 0, 700, 34), run("world", 40, 700, 30)]);
+    expect(page.text).toBe("hello world");
+  });
+
+  it("ignores marked-content items that carry no text", () => {
+    const page = assemblePageText(1, [run("a", 0, 700, 6), { str: "" }, run("b", 10, 700, 6)]);
+    expect(page.text).toBe("a b");
+    expect(page.runs).toHaveLength(2);
+  });
+
+  it("records a range for every run that lines up with the text", () => {
+    const page = assemblePageText(1, [run("hello", 0, 700, 30), run("world", 36, 700, 30)]);
+    for (const item of page.runs) {
+      expect(page.text.slice(item.start, item.end)).not.toBe("");
+    }
+    expect(page.text.slice(page.runs[1]!.start, page.runs[1]!.end)).toBe("world");
+  });
+
+  it("carries the page number through", () => {
+    expect(assemblePageText(7, [run("x", 0, 0, 5)]).page).toBe(7);
+  });
+
+  it("handles a page with no text at all", () => {
+    const page = assemblePageText(3, []);
+    expect(page).toEqual({ page: 3, text: "", runs: [] });
+  });
+});
+
+describe("normalizeForMatch", () => {
+  it("folds ligatures into the letters a reader would type", () => {
+    expect(normalizeForMatch("ﬁnd the diﬀerence").text).toBe("find the difference");
+  });
+
+  it("folds typographic quotes and dashes", () => {
+    expect(normalizeForMatch("“don’t”—really").text).toBe('"don\'t"-really');
+  });
+
+  it("rejoins a word hyphenated across a line break", () => {
+    expect(normalizeForMatch("regu-\nlar expression").text).toBe("regular expression");
+  });
+
+  it("leaves an ordinary hyphenated compound alone", () => {
+    expect(normalizeForMatch("well-known result").text).toBe("well-known result");
+  });
+
+  it("leaves a hyphen that is not followed by a letter alone", () => {
+    expect(normalizeForMatch("page 3 -\n4").text).toBe("page 3 - 4");
+  });
+
+  it("collapses the whitespace that column layout leaves behind", () => {
+    expect(normalizeForMatch("one   \n\n  two").text).toBe("one two");
+  });
+
+  it("drops soft hyphens and zero-width characters", () => {
+    expect(normalizeForMatch("in­visible​here").text).toBe("invisiblehere");
+  });
+
+  it("folds case", () => {
+    expect(normalizeForMatch("MixedCase").text).toBe("mixedcase");
+  });
+
+  it("does not emit a leading space for text that starts with whitespace", () => {
+    expect(normalizeForMatch("   leading").text).toBe("leading");
+  });
+
+  it("does not emit a trailing space for text that ends with whitespace", () => {
+    expect(normalizeForMatch("trailing   ").text).toBe("trailing");
+  });
+
+  it("maps every normalised character back to where it came from", () => {
+    const source = "ﬁne  print";
+    const normalized = normalizeForMatch(source);
+
+    expect(normalized.text).toBe("fine print");
+    // Both letters of the expanded ligature point at the one source character.
+    expect(normalized.map[0]).toBe(0);
+    expect(normalized.map[1]).toBe(0);
+    expect(normalized.map[2]).toBe(1);
+    expect(normalized.map[normalized.text.length]).toBe(source.length);
+  });
+
+  it("maps back across a rejoined hyphenation", () => {
+    const source = "regu-\nlar";
+    const normalized = normalizeForMatch(source);
+    const [start, end] = toSourceRange(normalized, 0, normalized.text.length);
+
+    expect(normalized.text).toBe("regular");
+    expect(source.slice(start, end)).toBe(source);
+  });
+
+  it("is idempotent on text it has already normalised", () => {
+    const once = normalizeForMatch("ﬁrst   line-\nbreak").text;
+    expect(normalizeForMatch(once).text).toBe(once);
+  });
+});
+
+describe("toSourceRange", () => {
+  it("recovers the exact source substring of a normalised match", () => {
+    const source = "The ﬁnal   answer";
+    const normalized = normalizeForMatch(source);
+    const at = normalized.text.indexOf("final");
+
+    const [start, end] = toSourceRange(normalized, at, at + "final".length);
+    expect(source.slice(start, end)).toBe("ﬁnal");
+  });
+
+  it("never returns an inverted range", () => {
+    const normalized = normalizeForMatch("abc");
+    const [start, end] = toSourceRange(normalized, 2, 0);
+    expect(end).toBeGreaterThanOrEqual(start);
+  });
+});
+
+describe("rectsForRange", () => {
+  const page = assemblePageText(1, [run("hello", 0, 700, 50), run("world", 60, 700, 50)]);
+
+  it("returns one rectangle per run the range touches", () => {
+    expect(rectsForRange(page, 0, page.text.length)).toHaveLength(2);
+  });
+
+  it("clips a rectangle to the part of a run actually covered", () => {
+    // "he" — the first two of five characters of a 50-point-wide run.
+    const [rect] = rectsForRange(page, 0, 2);
+    expect(rect!.x).toBeCloseTo(0);
+    expect(rect!.width).toBeCloseTo(20);
+  });
+
+  it("offsets a rectangle that starts partway into a run", () => {
+    const [rect] = rectsForRange(page, 3, 5);
+    expect(rect!.x).toBeCloseTo(30);
+    expect(rect!.width).toBeCloseTo(20);
+  });
+
+  it("returns nothing for a range outside the text", () => {
+    expect(rectsForRange(page, 500, 600)).toEqual([]);
+  });
+
+  it("returns nothing for an empty range", () => {
+    expect(rectsForRange(page, 3, 3)).toEqual([]);
+  });
+});

--- a/packages/pdf/src/text.ts
+++ b/packages/pdf/src/text.ts
@@ -1,0 +1,395 @@
+import type { PdfPageText, PdfTextRun } from "./types";
+
+/**
+ * Turning a PDF's positioned glyph runs into text you can search.
+ *
+ * A PDF does not contain sentences. It contains instructions to draw runs of
+ * glyphs at coordinates, and any resemblance to a paragraph is something the
+ * reader's eye supplies. pdf.js hands those runs back faithfully, which means
+ * the naive `items.map((i) => i.str).join("")` produces text where the last
+ * word of one line is welded to the first word of the next — `the endChapter
+ * two` — and every phrase search that crosses a line break silently fails.
+ *
+ * So the runs are assembled with the spacing the layout implies, and then
+ * *separately* normalised for matching. Those are two different jobs and this
+ * file keeps them apart on purpose:
+ *
+ *   - `assemblePageText` produces the text a human reads and selects, with the
+ *     line breaks and spaces the page actually has.
+ *   - `normalizeForMatch` produces a flattened form for comparison — folded
+ *     ligatures, rejoined hyphenation, collapsed whitespace — and, critically,
+ *     an index map back to the original, so a match found in the flattened
+ *     form can be reported as a range in the real text and drawn on the page.
+ *
+ * Without that map, fuzzy matching could tell you *that* a quotation is still
+ * in the document but never *where*, which is not much use to a reader.
+ */
+
+/** The subset of a pdf.js text item this package needs. */
+export interface RawTextItem {
+  str: string;
+  /** True when this run ends a line. */
+  hasEOL?: boolean;
+  /** pdf.js text matrix; `[4]` and `[5]` are x and y in PDF points. */
+  transform?: readonly number[];
+  width?: number;
+  height?: number;
+}
+
+export interface AssembleOptions {
+  /**
+   * How wide a gap between two runs on the same line counts as a space,
+   * as a fraction of the run's height.
+   *
+   * Many generators emit one run per word with no space characters at all, so
+   * *something* has to infer the spaces or every line becomes one long word.
+   * A fraction of the text height rather than an absolute number of points,
+   * because a gap that is a word break in 9pt footnotes is kerning in a 30pt
+   * title.
+   */
+  spaceRatio?: number;
+}
+
+const DEFAULT_SPACE_RATIO = 0.22;
+
+/**
+ * Assembles one page's runs into readable text plus the geometry behind it.
+ *
+ * Runs are taken in the order pdf.js gives them, which is the order the page
+ * draws them — not reading order for a multi-column layout, and deliberately
+ * not re-sorted here. Guessing columns from coordinates gets the two-column
+ * paper right and the figure caption, the sidebar and the table wrong, and a
+ * wrong guess is worse than the document's own order: the document's order is
+ * at least the order its author's tooling chose.
+ */
+export function assemblePageText(
+  page: number,
+  items: readonly RawTextItem[],
+  options: AssembleOptions = {},
+): PdfPageText {
+  const spaceRatio = options.spaceRatio ?? DEFAULT_SPACE_RATIO;
+
+  let text = "";
+  const runs: PdfTextRun[] = [];
+
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index]!;
+    // pdf.js also emits marked-content boundaries, which carry no string and
+    // no transform. They are structure, not text.
+    if (typeof item.str !== "string" || item.str === "") {
+      if (item.hasEOL && text !== "" && !text.endsWith("\n")) text += "\n";
+      continue;
+    }
+
+    const start = text.length;
+    text += item.str;
+    const end = text.length;
+
+    const transform = item.transform ?? [];
+    runs.push({
+      start,
+      end,
+      x: transform[4] ?? 0,
+      y: transform[5] ?? 0,
+      width: item.width ?? 0,
+      height: item.height ?? 0,
+    });
+
+    if (item.hasEOL) {
+      text += "\n";
+      continue;
+    }
+
+    // The *next run with text*, not simply the next item: pdf.js interleaves
+    // marked-content boundaries that carry neither a string nor a position,
+    // and comparing against one of those makes every gap look like no gap —
+    // which welded "a" and "b" into "ab" whenever structure happened to be
+    // tagged between them.
+    const next = nextTextItem(items, index + 1);
+    if (next && needsSpace(item, next, spaceRatio) && !endsOpen(text) && !startsOpen(next.str)) {
+      text += " ";
+    }
+  }
+
+  return { page, text, runs };
+}
+
+/** The next item that actually draws something, skipping structure markers. */
+function nextTextItem(items: readonly RawTextItem[], from: number): RawTextItem | undefined {
+  for (let index = from; index < items.length; index += 1) {
+    const item = items[index]!;
+    if (typeof item.str === "string" && item.str !== "") return item;
+    // A structure marker that ends the line is still a line ending, and the
+    // break it implies is not a space this function should be filling in.
+    if (item.hasEOL) return undefined;
+  }
+  return undefined;
+}
+
+/** True when a visible gap separates two runs drawn on the same line. */
+function needsSpace(item: RawTextItem, next: RawTextItem, ratio: number): boolean {
+  const x = item.transform?.[4];
+  const y = item.transform?.[5];
+  const nextX = next.transform?.[4];
+  const nextY = next.transform?.[5];
+
+  if (x == null || nextX == null) return false;
+  // Different baselines are a line break the item forgot to flag, and a space
+  // is the safe reading — welding two lines into one word is never right.
+  if (y != null && nextY != null && Math.abs(y - nextY) > 0.5) return true;
+
+  const gap = nextX - (x + (item.width ?? 0));
+  const scale = Math.max(item.height ?? 0, next.height ?? 0, 1);
+  return gap > scale * ratio;
+}
+
+/** True when the text already ends in whitespace, so no space is owed. */
+function endsOpen(text: string): boolean {
+  return text === "" || /\s$/.test(text);
+}
+
+/** True when the next run supplies its own leading space. */
+function startsOpen(str: string): boolean {
+  return /^\s/.test(str);
+}
+
+// ─── Normalisation ──────────────────────────────────────────────────────────
+
+/**
+ * Text flattened for comparison, with the way back.
+ *
+ * `map[i]` is the offset in the source text that normalised character `i` came
+ * from, and `map[text.length]` is the source length — so a normalised range
+ * `[a, b)` becomes the source range `[map[a], map[b])`.
+ */
+export interface NormalizedText {
+  text: string;
+  map: number[];
+}
+
+/**
+ * Ligatures, which are one character in the file and several to a reader.
+ *
+ * A PDF typeset in almost any serif face stores "find" as `ﬁ` + `nd`. Somebody
+ * searching for "find" is not going to type U+FB01, and a citation copied out
+ * of one build of a paper must still match a build whose fonts differ.
+ */
+const LIGATURES: Record<string, string> = {
+  ﬀ: "ff",
+  ﬁ: "fi",
+  ﬂ: "fl",
+  ﬃ: "ffi",
+  ﬄ: "ffl",
+  ﬅ: "ft",
+  ﬆ: "st",
+  Œ: "oe",
+  œ: "oe",
+  Æ: "ae",
+  æ: "ae",
+};
+
+/**
+ * Punctuation a typesetter changed on the way in.
+ *
+ * Quoting a sentence containing an apostrophe is the single most common thing
+ * anyone does, and the apostrophe in a typeset PDF is U+2019 while the one on
+ * the keyboard is U+0027. Folding them together is the difference between
+ * "search works" and "search works except on sentences with contractions".
+ */
+const PUNCTUATION: Record<string, string> = {
+  "‘": "'",
+  "’": "'",
+  "‚": "'",
+  "‛": "'",
+  "′": "'",
+  "“": '"',
+  "”": '"',
+  "„": '"',
+  "‟": '"',
+  "″": '"',
+  "‐": "-",
+  "‑": "-",
+  "‒": "-",
+  "–": "-",
+  "—": "-",
+  "―": "-",
+  "−": "-",
+  "…": "...",
+};
+
+/** Characters that carry no meaning and no width. */
+const INVISIBLE = /[­​‌‍﻿]/;
+
+/**
+ * Flattens text for matching, keeping a map back to where each character came
+ * from.
+ *
+ * The transformations, and why each one is here:
+ *
+ *   - **Ligatures and typographic punctuation** are folded, because the reader
+ *     typing the query has a keyboard and the document had a typesetter.
+ *   - **Hyphenation at a line break is rejoined.** A word split as `regu-\nlar`
+ *     is one word; leaving it split means no search for "regular" ever finds
+ *     the page it is printed on. Only a break *at end of line* is rejoined —
+ *     an ordinary hyphen inside `well-known` is left exactly alone.
+ *   - **Whitespace collapses to one space.** Column gutters and justified text
+ *     produce runs of spaces and newlines that no reader perceives, and that
+ *     no reader will reproduce when typing a query.
+ *   - **Case is folded**, because nobody searching means it.
+ *
+ * Everything else is left alone. Normalisation that strips punctuation, or
+ * accents, or stop words, makes matches that are not really matches — and this
+ * function's output decides where a citation points, so a false match here is
+ * a citation that silently points at the wrong sentence. Cautious is correct.
+ */
+export function normalizeForMatch(source: string): NormalizedText {
+  let text = "";
+  const map: number[] = [];
+
+  /** Emits `value` as coming from source offset `at`. */
+  const push = (value: string, at: number) => {
+    for (const character of value) {
+      text += character;
+      map.push(at);
+    }
+  };
+
+  let index = 0;
+  let pendingSpace = -1;
+
+  while (index < source.length) {
+    const character = source[index]!;
+
+    if (INVISIBLE.test(character)) {
+      index += 1;
+      continue;
+    }
+
+    if (isWhitespace(character)) {
+      // Remembered rather than emitted, so a run of them costs one space and
+      // trailing whitespace costs nothing at all.
+      if (pendingSpace === -1) pendingSpace = index;
+      index += 1;
+      continue;
+    }
+
+    const dash = PUNCTUATION[character] === "-" || character === "-";
+    if (dash && pendingSpace === -1) {
+      const joined = skipLineHyphen(source, index);
+      if (joined !== -1) {
+        // A word broken across a line: drop the hyphen and the break, and
+        // carry on with the rest of the word as though it were never split.
+        index = joined;
+        continue;
+      }
+    }
+
+    if (pendingSpace !== -1) {
+      // A space is only worth emitting once something follows it.
+      if (text !== "") push(" ", pendingSpace);
+      pendingSpace = -1;
+    }
+
+    const expanded = LIGATURES[character] ?? PUNCTUATION[character] ?? character;
+    push(expanded.toLowerCase(), index);
+    index += 1;
+  }
+
+  map.push(source.length);
+  return { text, map };
+}
+
+/**
+ * If `index` is a hyphen ending a line, returns the offset of the first
+ * character of the word's continuation. Otherwise -1.
+ *
+ * The continuation must be a letter, and the break must contain an actual
+ * newline: `end-\nof line` is hyphenation, `a - b` is a dash between words and
+ * `foo-bar` is a compound. Getting this wrong in the permissive direction
+ * welds unrelated words together, so the test is strict.
+ */
+function skipLineHyphen(source: string, index: number): number {
+  let cursor = index + 1;
+  let sawNewline = false;
+
+  while (cursor < source.length) {
+    const character = source[cursor]!;
+    if (character === "\n" || character === "\r") {
+      sawNewline = true;
+      cursor += 1;
+      continue;
+    }
+    if (isWhitespace(character) || INVISIBLE.test(character)) {
+      cursor += 1;
+      continue;
+    }
+    break;
+  }
+
+  if (!sawNewline || cursor >= source.length) return -1;
+  return /\p{L}/u.test(source[cursor]!) ? cursor : -1;
+}
+
+function isWhitespace(character: string): boolean {
+  return /\s/.test(character) || character === " ";
+}
+
+/**
+ * Maps a range in normalised text back to the source.
+ *
+ * `end` reads `map[end]` rather than `map[end - 1] + 1`: the last normalised
+ * character may have come from a source character that expanded into several
+ * — `ﬁ` is one character and two — and adding one to its start would cut the
+ * highlight through the middle of a glyph.
+ */
+export function toSourceRange(
+  normalized: NormalizedText,
+  start: number,
+  end: number,
+): [number, number] {
+  const from = normalized.map[start] ?? 0;
+  const to = normalized.map[end] ?? normalized.map[normalized.map.length - 1] ?? from;
+  return [from, Math.max(from, to)];
+}
+
+/**
+ * The rectangles covering a character range, in PDF points.
+ *
+ * One rectangle per run the range touches, clipped to the part actually
+ * covered — a highlight over half a run should cover half of it, which means
+ * assuming the run's characters are evenly spaced. They are not, quite, but
+ * the alternative is measuring every glyph, and the error is smaller than the
+ * padding a highlight is drawn with.
+ */
+export function rectsForRange(
+  pageText: PdfPageText,
+  start: number,
+  end: number,
+): { x: number; y: number; width: number; height: number }[] {
+  // An empty range covers nothing. Without this, a collapsed selection — a
+  // caret rather than a highlight — produced a zero-width rectangle on every
+  // run it touched, which draws as a stray line down the page.
+  if (end <= start) return [];
+
+  const rects: { x: number; y: number; width: number; height: number }[] = [];
+
+  for (const run of pageText.runs) {
+    if (run.end <= start || run.start >= end) continue;
+
+    const length = run.end - run.start;
+    if (length <= 0) continue;
+
+    const from = Math.max(start, run.start) - run.start;
+    const to = Math.min(end, run.end) - run.start;
+    const unit = run.width / length;
+
+    rects.push({
+      x: run.x + unit * from,
+      y: run.y,
+      width: Math.max(unit * (to - from), 0),
+      height: run.height,
+    });
+  }
+
+  return rects;
+}

--- a/packages/pdf/src/types.ts
+++ b/packages/pdf/src/types.ts
@@ -1,0 +1,143 @@
+/**
+ * The shape of a PDF, as ForkLeaf needs it.
+ *
+ * Deliberately independent of pdf.js. Everything below is plain serialisable
+ * data — no class instances, no live document handles — for the same reason
+ * the rest of the domain model is: these values travel into IndexedDB through
+ * `structuredClone`, into React state, and into the markdown a note is made
+ * of. A `PDFDocumentProxy` can do none of that.
+ *
+ * The separation also buys the thing that matters most here: every interesting
+ * decision in this package — where a quotation lives, which page a phrase is
+ * on, whether two versions of a paper still say the same thing — is a pure
+ * function of these values, and so can be tested without a rendering engine,
+ * a canvas, or a real PDF.
+ */
+
+/** What the file says about itself. Every field is optional; PDFs lie and omit. */
+export interface PdfMetadata {
+  title: string | null;
+  author: string | null;
+  subject: string | null;
+  keywords: string[];
+  /** ISO timestamp, when the file carried a parseable one. */
+  createdAt: string | null;
+  modifiedAt: string | null;
+  producer: string | null;
+}
+
+/** A page's dimensions in PDF points, at the page's own rotation. */
+export interface PdfPageSize {
+  width: number;
+  height: number;
+  /** 0, 90, 180 or 270. */
+  rotation: number;
+}
+
+/**
+ * One run of text on a page, with where it sits.
+ *
+ * `start` and `end` are offsets into the page's assembled `text`, which is what
+ * lets a character range found by search or selection be turned back into
+ * rectangles to draw over the page.
+ */
+export interface PdfTextRun {
+  /** Offset of this run's first character in the page text. */
+  start: number;
+  /** Offset one past its last character. */
+  end: number;
+  /** Left edge, in PDF points from the page's left. */
+  x: number;
+  /** Bottom edge, in PDF points from the page's bottom. */
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** A page's text, and the geometry behind it. */
+export interface PdfPageText {
+  /** 1-based, the way PDFs and people both number pages. */
+  page: number;
+  /**
+   * The page's text as one string.
+   *
+   * Assembled rather than concatenated: pdf.js hands back positioned runs, and
+   * gluing them with nothing at all welds "the end" to "Chapter" across a line
+   * break. See `assemblePageText`.
+   */
+  text: string;
+  runs: PdfTextRun[];
+}
+
+/** An entry in the document's own table of contents. */
+export interface PdfOutlineItem {
+  title: string;
+  /** 1-based page, or null when the destination could not be resolved. */
+  page: number | null;
+  children: PdfOutlineItem[];
+}
+
+/** Everything ForkLeaf knows about an opened PDF, minus the rendered pixels. */
+export interface PdfDocumentInfo {
+  pageCount: number;
+  metadata: PdfMetadata;
+  sizes: PdfPageSize[];
+  /** True when the file asks for a password ForkLeaf does not have. */
+  encrypted: boolean;
+}
+
+/**
+ * A pointer into a PDF that keeps pointing at the right words.
+ *
+ * This is the reason the package exists. A citation written as "page 12" is
+ * wrong the moment the author adds a paragraph to page 3, and a citation
+ * written as a byte offset is wrong the moment anything at all changes. What
+ * does not change is *the sentence being quoted* and the words on either side
+ * of it — so that is what gets recorded, with the page number kept only as a
+ * hint about where to look first.
+ *
+ * The shape is W3C Web Annotation's `TextQuoteSelector` plus a page hint,
+ * which is a standard rather than an invention for exactly the reason the
+ * wikilink dialect is Obsidian's: these anchors end up written into plain
+ * markdown files whose whole point is that other tools can read them.
+ */
+export interface PdfCitation {
+  /** The quoted text itself, as it appeared on the page. */
+  quote: string;
+  /** Up to `CONTEXT_LENGTH` characters immediately before the quote. */
+  prefix: string;
+  /** Up to `CONTEXT_LENGTH` characters immediately after it. */
+  suffix: string;
+  /** Where it was when it was written. A hint, never the authority. */
+  page: number;
+}
+
+/** How confidently a citation was found again. */
+export type PdfMatchQuality =
+  /** Quote and both context windows matched exactly, on the page recorded. */
+  | "exact"
+  /** Quote and context matched exactly, but on a different page. */
+  | "moved"
+  /** The quote matched only after normalising hyphenation, ligatures or space. */
+  | "fuzzy"
+  /** Nothing in the document matches. */
+  | "lost";
+
+/** Where a citation turned out to live. */
+export interface PdfCitationMatch {
+  quality: PdfMatchQuality;
+  /** 1-based page, or null when `quality` is `"lost"`. */
+  page: number | null;
+  /** Character range in that page's text, or null when lost. */
+  range: [start: number, end: number] | null;
+}
+
+/** One occurrence of a search term. */
+export interface PdfSearchHit {
+  page: number;
+  range: [start: number, end: number];
+  /** A line of surrounding text, for the results list. */
+  snippet: string;
+  /** Where the match sits inside `snippet`. */
+  snippetRange: [start: number, end: number];
+}

--- a/packages/pdf/tsconfig.json
+++ b/packages/pdf/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@forkleaf/markdown-engine':
         specifier: workspace:*
         version: link:../../packages/markdown-engine
+      '@forkleaf/pdf':
+        specifier: workspace:*
+        version: link:../../packages/pdf
       '@forkleaf/store':
         specifier: workspace:*
         version: link:../../packages/store
@@ -77,6 +80,9 @@ importers:
       next:
         specifier: 16.3.1
         version: 16.3.1(@babel/core@7.29.7)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      pdfjs-dist:
+        specifier: ^6.3.289
+        version: 6.3.289
       posthog-js:
         specifier: ^1.421.1
         version: 1.421.1(@types/react@19.2.18)(react@19.2.8)
@@ -326,6 +332,19 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.13.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/pdf:
+    dependencies:
+      '@forkleaf/types':
+        specifier: workspace:*
+        version: link:../types
+      pdfjs-dist:
+        specifier: ^6.3.289
+        version: 6.3.289
+    devDependencies:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1315,6 +1334,76 @@ packages:
 
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
+
+  '@napi-rs/canvas-android-arm64@1.0.8':
+    resolution: {integrity: sha512-5+nkh8i3gt6lqS/d2jTZ1xAn6tdgtB4Lf1mW6T0Qm5/rXNwBuV1sAEyLEWan5o9gJPU/GuvHR3rvSeZ+FaGrbw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.8':
+    resolution: {integrity: sha512-7jQ47gi+fZ7KJmfc/5rNyy1CYw/cu4kZ0KPIYbo9UUgSdW0bKQJpt+WihEor6s4Lyp7+xc3a+3HeyXmAEbbnPg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.8':
+    resolution: {integrity: sha512-rRjDMZs9pIRKGxgijwezplKc1RnJsqUokrA9h88bbTkqQ+7ePj0ZN4ZnZDy8Vu0tXs7KRlI2tQLaK4mx9QlxHg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.8':
+    resolution: {integrity: sha512-jGcCd+8ra6Q61xKqZeiItujTpp9a9eRLcQ0jW6qYNku+WpupqOPFPY0SrsuSnXFviJwkpKYT9p7QrB4lsf3LNQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.8':
+    resolution: {integrity: sha512-od6I2Y7kU7i1SwZYG2EKW8rWz6JiedtPpko4WEe1DDsiikrfaotVBCRaUTM5/yeZKaZ92EatoAS+5xG+6uJlYA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.8':
+    resolution: {integrity: sha512-yYkPbJDJiWj6N0gASA3CAvRypZmVpJnxU0DQg3aBhneLDQde9TPLKADsQkobNoJUtTT/lj46aWpzT48PDb3Qcg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.8':
+    resolution: {integrity: sha512-PB00MSKAp4VwK/xwe6duKxRKmH8UH4GIl1pqHSbxng0jnU9Dr7FwaDypDiqwNFZ774N+8G7mJLGuLtg9NTcQsg==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.8':
+    resolution: {integrity: sha512-TWM2XWJoitLiIPCvgJh7SriC+L/T9qkYCVzC66AidsZy0QP1hkKzBzVwshCdcA3q6fIn3yE0ISbq4lMJSy8jFw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.8':
+    resolution: {integrity: sha512-hb20MxKXXb5IB7AAwN8UHz9WRsa2HmdZfjsDCzjElwJoeV1aotVEwFU4FrFQcYQVzsJQLeaCc/2Qdt/0Q72mMg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.8':
+    resolution: {integrity: sha512-WwPN08IXE4SkL+FhJyPz/iFnycMAUkbphFIT4cmKLlvbSU0Zfn1R7BGJ3Hqky1S89QUYc0Q4IOScXb/42Re9wQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.8':
+    resolution: {integrity: sha512-XkrVqKb+pxyba7kjy2LJvABFVBTE0DNpEl7MrG4OYUmaWarrXH+t54z/Czj2YxCKtizYTV4mg6phNm3x24qjhQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.8':
+    resolution: {integrity: sha512-/SaLcvlqGWdm0HSCWMgHu7cjJiQXfP8/mOY+6dUyV9flQz7sPBBZ+ed2zYtoukojPmxOaL7bm+d/G4GeWWoN7g==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
@@ -3938,6 +4027,10 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pdfjs-dist@6.3.289:
+    resolution: {integrity: sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5931,6 +6024,54 @@ snapshots:
   '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
+
+  '@napi-rs/canvas-android-arm64@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.8':
+    optional: true
+
+  '@napi-rs/canvas@1.0.8':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.8
+      '@napi-rs/canvas-darwin-arm64': 1.0.8
+      '@napi-rs/canvas-darwin-x64': 1.0.8
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.8
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.8
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.8
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.8
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.8
+      '@napi-rs/canvas-linux-x64-musl': 1.0.8
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.8
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.8
+    optional: true
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
@@ -8942,6 +9083,10 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pdfjs-dist@6.3.289:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.8
 
   picocolors@1.1.1: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       "@forkleaf/diagrams": r("./packages/diagrams/src/index.ts"),
       "@forkleaf/exporter": r("./packages/exporter/src/index.ts"),
       "@forkleaf/editor": r("./packages/editor/src/index.ts"),
+      "@forkleaf/pdf": r("./packages/pdf/src/index.ts"),
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,18 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 const r = (p: string) => fileURLToPath(new URL(p, import.meta.url));
+
+/**
+ * Resolved rather than written as a path: pnpm does not hoist, so
+ * `pdfjs-dist` lives under the one workspace package that depends on it and
+ * nowhere a relative path from here could reliably reach.
+ */
+const legacyPdfJs = createRequire(r("./packages/pdf/package.json")).resolve(
+  "pdfjs-dist/legacy/build/pdf.mjs",
+);
 
 export default defineConfig({
   plugins: [react()],
@@ -30,6 +40,23 @@ export default defineConfig({
       "@forkleaf/exporter": r("./packages/exporter/src/index.ts"),
       "@forkleaf/editor": r("./packages/editor/src/index.ts"),
       "@forkleaf/pdf": r("./packages/pdf/src/index.ts"),
+      /**
+       * pdf.js's Node build, for the tests only.
+       *
+       * The default entry point targets current browsers and reaches for
+       * whatever V8 has shipped most recently — `Map.getOrInsertComputed` and
+       * `Math.sumPrecise` among them. Node lags that by a release or two, and
+       * the failure mode is the worst kind: `getDocument` never settles, so
+       * every test in `document.test.ts` sits there until the timeout with
+       * nothing thrown and nothing logged but pdf.js's own advice, which is
+       * exactly this — "please use the `legacy` build in Node.js".
+       *
+       * Scoped to the test runner deliberately. The app still bundles and
+       * ships the modern build to browsers, which is where it belongs; only
+       * the suite, which has no browser, takes the transpiled one. Guessing at
+       * polyfills instead would work until the next V8 feature pdf.js adopts.
+       */
+      "pdfjs-dist": legacyPdfJs,
     },
   },
 });


### PR DESCRIPTION
## What this changes

ForkLeaf can now open PDFs — in a pane beside the note you are writing from them, with a way to quote a passage into that note such that **the quotation still points at the right words a year later**.

Four ways in: drag one onto the window, **Open a PDF…** in the command palette, click a `.pdf` in the repository file tree, or click an ordinary markdown link to one in a note. Install the app and `.pdf` joins `.md` in the operating system's "Open with" list.

Adds `@forkleaf/pdf`. Everything in it except `document.ts` is pure functions over plain data, so text assembly, citation anchoring, search and outline handling are tested without a rendering engine.

## Why

A citation stored as "page 12" is wrong the moment the author adds a figure to page 4 — and wrong *silently*, because the link still opens. Every reading tool stores a page number and has this problem.

So a ForkLeaf citation records **the sentence, not the page**: the quoted text plus the words either side of it, with the page kept only as a hint about where to look first. Resolving one searches the document as it stands today and uses the context to tell repeated phrases apart. It resolves in four tiers — `exact` → `moved` → punctuation-insensitive → longest leading phrase — and reports `lost` rather than papering over a passage that has genuinely gone.

What lands in the note is an ordinary markdown link:

```md
> The key result is that latency fell by half.
>
> — [On Attention, p. 12](papers/attention.pdf#page=12&q=…&pre=…&suf=…)
```

The anchor is W3C Web Annotation's `TextQuoteSelector` plus Adobe's `#page=` open parameter — a dialect rather than an invention, for the same reason the wikilinks are Obsidian's. It renders on github.com and opens page 12 in Acrobat, Preview and any browser's own viewer; tools that don't know the extra parameters ignore them and still land on the right page.

## How it was tested

`pnpm check` passes: format, typecheck, lint, **1,844 tests** (149 new in the package, 35 in existing ones), and a production build.

**Real documents, in Node** — a 418-page book, a one-page spreadsheet export and a résumé: metadata, outline→page resolution, text extraction, search, and citation round-trip.

**A committed integration test** — `packages/pdf/src/fixture.ts` builds a valid PDF byte by byte, so CI exercises the real pdf.js seam without a binary in the repo. This is the test that fails if a pdf.js upgrade changes the shape of a text item.

**By hand in the browser, dev and production** — opened the 418-page book, navigated by its contents, searched "cross-site scripting" (18 matches, correctly matching `CROSS-SITE SCRIPTING` and a letter-spaced heading), selected a passage on page 22 and quoted it into a note. Production build confirmed the worker and the copied fonts load with **no CSP violations**.

### Bugs found while building this, each with a regression test

- Marked-content items broke word-space inference, welding `"a b"` into `"ab"`.
- Context scoring never matched across the whitespace either side of a quotation, so the page hint was quietly deciding every ambiguous citation on its own.
- `parsePdfDate` rolled 31 February forward instead of refusing it.
- Two concurrent renders could race on one canvas — the cancellation happened before an `await`, so both got past it.
- **Passing `canvas` and `canvasContext` together to pdf.js 6 starts a render whose promise never settles.** The page paints and then hangs, with nothing thrown and nothing logged. The reveal no longer waits on that promise at all, which also fixes background tabs: pdf.js renders through `requestAnimationFrame`, which a hidden tab does not get.

## What a reviewer should know

**Security.** `/api/gh/raw` now serves PDFs as well as images, gated by an explicit allowlist (`servableTypeFor`) with tests for the refusals — HTML and SVG included, since that route reads with the user's token and serves from this app's origin. Non-images additionally get `Content-Disposition: attachment` on top of the existing `nosniff` and sandbox CSP.

**The CSP is unchanged.** pdf.js 6 uses WebAssembly for JPEG 2000 and colour management, which would need `'wasm-unsafe-eval'` in `script-src` — on the route that renders markdown from repositories the user does not control. `useWasm: false` gives that up instead. Cost: a JPEG 2000 image inside a PDF renders blank. Text, fonts, vector graphics and every common image format are unaffected.

**`listTree` now returns PDFs alongside markdown** so one appears in the sidebar beside the notes about it. The dashboard already filtered to markdown (`useLibrary`) and is unaffected. The option was renamed `markdownOnly` → `include: "notes" | "all"` because the old name would have become a lie.

**`LinkBridge` gains an optional `openHref`**, a *veto* rather than a handler: the app sees every ordinary link click and claims the few it recognises. `handleWikilinkClick` is kept as a deprecated alias. `packages/editor/src/links.test.ts` covers the cases where the browser must keep its hands off — ⌘-click, middle-click, an already-handled event.

**pdf.js's fonts and character maps are copied into `public/pdfjs` at build time**, not committed, so they cannot drift from the installed version. They are served by us rather than from a CDN — a notes app that reports every document you open to a third party has no business claiming your notes are yours.

**Nothing is ever written back to a PDF.** No annotating, signing or form-filling: the file in the repository stays exactly as committed, and everything the app adds lives in markdown next to it.

### Not covered by this PR

The repo-backed citation *click path* — link in a note → reader reopens at the highlighted passage — was not exercised against a live repository, since that needs GitHub sign-in. The resolver behind it is unit-tested and was verified against the real 418-page book; the wiring (`pdfLinkTarget` → `parseCitation` → `resolveCitation`) is tested, but the end-to-end click has not been clicked.

A PDF opened from disk rather than from the repository is quoted with a plain attribution instead of a link, because a link to a path on one computer is a broken link everywhere else. Offering to commit it to the notebook would close that gap and is deliberately left for a follow-up.

## Checklist

- [x] `pnpm check` passes locally
- [x] Tests added for new logic (text assembly, citation anchoring and resolution, search, PDF date parsing, outline handling, the served-type allowlist, link-click delegation)
- [x] Comments explain *why* for anything non-obvious
- [x] No new `any`
- [x] Touches rendering of untrusted content and a route that reads with the user's token — read the relevant sections of `docs/architecture.md` and `SECURITY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
