### PR TITLE
fix(security): a notebook belongs to the account that connected it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ full record.
 
 ## Unreleased
 
+### Fixed — another account could read this browser's notebook
+
+Signing out and signing in as a different GitHub account on the same browser
+left the previous account's workspaces and notes in place: their repository
+names, their folder structure, the full text of every note they had opened,
+and an editor willing to let the new arrival type into them.
+
+GitHub itself was never exposed — every request is authorised server-side by
+the session cookie, which is why a repository the new account could not read
+reported "Not Found" rather than handing over its contents. What leaked was the
+local cache, which is where the words are.
+
+A repository workspace now records the account that connected it and is listed
+for nobody else, across the editor, the dashboard and the profile page. Nothing
+is deleted: a notebook is hidden from other accounts and comes back intact when
+its own account signs in. Being offline is treated as "could not ask" rather
+than "signed out", so a notebook still opens without a network.
+
 ### Reading PDFs
 
 ForkLeaf opens PDFs, beside the note you are writing from them.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,27 @@ All repository paths are normalised server-side before reaching the GitHub API:
 `..` segments are dropped, leading slashes removed, and owner/repo names are
 pattern-checked. Writes are capped at 5 MB per file and 100 changes per commit.
 
+### Local storage and accounts
+
+IndexedDB belongs to a browser, not to a person, and two people can share one.
+So a repository workspace records the GitHub account that connected it, and is
+listed only for that account: the workspace list, the note bodies cached in it,
+the search index built from them and the storage summary on the profile page
+are all scoped to whoever is signed in.
+
+Nothing is deleted when the account changes — a notebook is hidden from other
+accounts and comes back intact when its own account signs in again. The account
+is matched on GitHub's numeric id rather than the login, because a login is a
+display name that can be changed and reused.
+
+Being offline is treated as "we could not ask", not as "signed out", so a
+notebook still opens without a network. Signing out deliberately hides it.
+
+**A way to read another account's cached notes through the application is a
+vulnerability.** Reading them out of IndexedDB with developer tools is not:
+local storage is protected by the operating system's own user accounts, and
+anyone with the browser profile can read the browser profile.
+
 ### Commit history
 
 Commit squashing force-updates a git ref. It is deliberately constrained: it

--- a/apps/web/src/components/ProfilePanel.tsx
+++ b/apps/web/src/components/ProfilePanel.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { EditorViewMode, SessionUser, SyncPreference, Workspace } from "@forkleaf/types";
+import { visibleWorkspaces } from "@/lib/workspaces";
 import { DEFAULT_SYNC_PREFERENCE } from "@forkleaf/types";
 import { openLocalDatabase, type LocalDatabase } from "@forkleaf/store";
 import { documentStats } from "@forkleaf/markdown-engine";
@@ -88,7 +89,15 @@ export function ProfilePanel({ user, githubAvailable }: ProfilePanelProps) {
           return;
         }
 
-        const workspaces = await database.listWorkspaces();
+        /**
+         * Only this account's notebooks.
+         *
+         * This panel reports every workspace's name, note count and word
+         * count, which is precisely the summary that must not be shown to
+         * somebody else — IndexedDB belongs to the browser, and two accounts
+         * can share one. See `visibleWorkspaces`.
+         */
+        const workspaces = visibleWorkspaces(await database.listWorkspaces(), user?.id ?? null);
         const queue = await database.listQueue();
 
         const summaries = await Promise.all(
@@ -141,7 +150,9 @@ export function ProfilePanel({ user, githubAvailable }: ProfilePanelProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+    // Re-read when the account changes: the summary below is per account, and
+    // an effect that ran once would keep showing the previous one's figures.
+  }, [user?.id]);
 
   const handleSignOut = useCallback(async () => {
     // Forgotten before the session goes, so the next person on this

--- a/apps/web/src/hooks/useLibrary.ts
+++ b/apps/web/src/hooks/useLibrary.ts
@@ -21,7 +21,7 @@ import {
 } from "@/lib/gateway";
 import { buildIndex, flattenTree, isMarkdown, orphanedNotes, type IndexEntry } from "@/lib/library";
 import { deriveTitle, extractTags } from "@forkleaf/markdown-engine";
-import { LOCAL_WORKSPACE } from "@/lib/workspaces";
+import { LOCAL_WORKSPACE, claimUnowned, ownedBy, visibleWorkspaces } from "@/lib/workspaces";
 
 /**
  * Reads the whole library — every connected repository and every note in it —
@@ -213,11 +213,13 @@ export function useLibrary() {
 
     const load = async () => {
       try {
-        const session = await fetchSession().catch((): SessionResponse => ({
-          mode: "local",
-          user: null,
-          githubAvailable: false,
-        }));
+        // See `useNotebook`: being offline is not the same as being signed
+        // out, and the notebook filter below has to tell them apart.
+        let sessionKnown = true;
+        const session = await fetchSession().catch((): SessionResponse => {
+          sessionKnown = false;
+          return { mode: "local", user: null, githubAvailable: false };
+        });
         if (cancelled) return;
 
         // Never throws: a browser that refuses IndexedDB gets an in-memory
@@ -242,6 +244,26 @@ export function useLibrary() {
         repoRef.current = notes;
 
         let workspaces = await db.listWorkspaces();
+
+        // The dashboard lists workspaces on its own rather than through the
+        // editor's hook, so the account filter has to be applied here too —
+        // and this screen is the one that shows a repository's name, its note
+        // count and its word count, which is exactly what must not be visible
+        // to somebody else's account. See `visibleWorkspaces`.
+        const claimedAt = await db.getMeta<number>("notebookClaimedBy");
+        const accountId = session.user?.id ?? (sessionKnown ? null : (claimedAt ?? null));
+
+        const claimed = claimUnowned(workspaces, accountId, claimedAt != null);
+        if (claimed.length > 0) {
+          for (const workspace of claimed) await notes.addWorkspace(workspace);
+          const byId = new Map(claimed.map((workspace) => [workspace.id, workspace]));
+          workspaces = workspaces.map((workspace) => byId.get(workspace.id) ?? workspace);
+        }
+        if (accountId != null && claimedAt == null) {
+          await db.putMeta("notebookClaimedBy", accountId);
+        }
+
+        workspaces = visibleWorkspaces(workspaces, accountId);
 
         // First visit, from either direction: there is always somewhere to
         // write, even before a repository has been chosen.
@@ -379,11 +401,12 @@ export function useLibrary() {
       const gateway = gatewayRef.current;
       if (!db || !notes || !gateway) return;
 
-      await notes.addWorkspace(workspace);
-      if (gateway instanceof GitHubGateway) gateway.register(workspace);
+      const owned = ownedBy(workspace, state.session?.user?.id ?? null);
+      await notes.addWorkspace(owned);
+      if (gateway instanceof GitHubGateway) gateway.register(owned);
 
       const queue = await db.listQueue();
-      const slice = await readWorkspace(db, workspace, queue);
+      const slice = await readWorkspace(db, owned, queue);
 
       setState((current) => ({
         ...current,
@@ -400,7 +423,7 @@ export function useLibrary() {
       forgetNotes(fresh.dropped);
       patchWorkspace(workspace.id, { entries: fresh.entries, error: fresh.error });
     },
-    [patchWorkspace, forgetNotes],
+    [patchWorkspace, forgetNotes, state.session?.user?.id],
   );
 
   /**

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -32,7 +32,13 @@ import {
   onSessionExpired,
   type SessionResponse,
 } from "@/lib/gateway";
-import { LOCAL_WORKSPACE, collapseBranchDuplicates } from "@/lib/workspaces";
+import {
+  LOCAL_WORKSPACE,
+  claimUnowned,
+  collapseBranchDuplicates,
+  ownedBy,
+  visibleWorkspaces,
+} from "@/lib/workspaces";
 import { forgetLock, isPathLocked, lockedKey, renameLock, toggleLock } from "@/lib/locks";
 import { assetFrom, assetObjectUrl } from "@/lib/assets";
 import {
@@ -321,11 +327,21 @@ export function useNotebook(request: NotebookRequest = {}) {
 
     const boot = async () => {
       try {
-        const session = await fetchSession().catch((): SessionResponse => ({
-          mode: "local",
-          user: null,
-          githubAvailable: false,
-        }));
+        /**
+         * Whether the server actually answered.
+         *
+         * Being offline is not the same as being signed out, and the notebook
+         * filter below depends on telling them apart: the cookie may be
+         * perfectly valid and simply unaskable. Treating a failed request as
+         * "nobody is signed in" would empty somebody's own notebook the moment
+         * their train went into a tunnel, which is the opposite of what a
+         * local-first app is for.
+         */
+        let sessionKnown = true;
+        const session = await fetchSession().catch((): SessionResponse => {
+          sessionKnown = false;
+          return { mode: "local", user: null, githubAvailable: false };
+        });
         if (cancelled) return;
         sessionRef.current = session;
 
@@ -364,6 +380,42 @@ export function useNotebook(request: NotebookRequest = {}) {
 
         // Restore known workspaces, or set one up on first run.
         let workspaces = await notes.listWorkspaces();
+
+        /**
+         * Hand this browser's notebook to the account that owns it, and to
+         * nobody else.
+         *
+         * IndexedDB belongs to a browser rather than to a person, so signing
+         * out and signing in as somebody else used to leave every workspace
+         * and every cached note from the previous account in place — their
+         * repository names, their folders, the text of every note they had
+         * opened, and an editor happy to let the new arrival type into them.
+         *
+         * GitHub was never exposed: each request is authorised server-side by
+         * the session cookie, which is why a repository the new account cannot
+         * read reported "Not Found" rather than handing over its contents. The
+         * leak was the local copy — and the local copy is where the words are.
+         *
+         * Filtering here rather than at each screen because this is the one
+         * place every workspace list starts from; a filter applied per view is
+         * a filter somebody forgets to apply to the next view.
+         */
+        const claimedAt = await db.getMeta<number>("notebookClaimedBy");
+        // Signed out on purpose hides the notebook; unable to ask falls back to
+        // whoever this browser's notebook belongs to, so it still opens offline.
+        const accountId = session.user?.id ?? (sessionKnown ? null : (claimedAt ?? null));
+
+        const claimed = claimUnowned(workspaces, accountId, claimedAt != null);
+        if (claimed.length > 0) {
+          for (const workspace of claimed) await notes.addWorkspace(workspace);
+          const byId = new Map(claimed.map((workspace) => [workspace.id, workspace]));
+          workspaces = workspaces.map((workspace) => byId.get(workspace.id) ?? workspace);
+        }
+        if (accountId != null && claimedAt == null) {
+          await db.putMeta("notebookClaimedBy", accountId);
+        }
+
+        workspaces = visibleWorkspaces(workspaces, accountId);
 
         if (session.mode === "github" && gateway instanceof GitHubGateway) {
           for (const workspace of workspaces) gateway.register(workspace);
@@ -1422,14 +1474,16 @@ export function useNotebook(request: NotebookRequest = {}) {
       const notes = repoRef.current;
       if (!notes) return;
 
-      await notes.addWorkspace(workspace);
+      const owned = ownedBy(workspace, sessionRef.current?.user?.id ?? null);
+
+      await notes.addWorkspace(owned);
       if (gatewayRef.current instanceof GitHubGateway) {
-        gatewayRef.current.register(workspace);
+        gatewayRef.current.register(owned);
       }
 
       patch({
-        workspaces: [...state.workspaces.filter((w) => w.id !== workspace.id), workspace],
-        activeWorkspace: workspace,
+        workspaces: [...state.workspaces.filter((w) => w.id !== owned.id), owned],
+        activeWorkspace: owned,
         openNotes: [],
         activePath: null,
         tree: [],

--- a/apps/web/src/lib/workspaces.test.ts
+++ b/apps/web/src/lib/workspaces.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { workspaceId, type PendingChange, type RepoRef, type Workspace } from "@forkleaf/types";
 import type { LocalDatabase, NoteRepository } from "@forkleaf/store";
-import { LOCAL_WORKSPACE, collapseBranchDuplicates, repositoryKey } from "./workspaces";
+import {
+  LOCAL_WORKSPACE,
+  claimUnowned,
+  collapseBranchDuplicates,
+  repositoryKey,
+  visibleWorkspaces,
+} from "./workspaces";
 
 const NOTES: RepoRef = { owner: "me", repo: "notes", branch: "main", directory: "" };
 
@@ -127,5 +133,99 @@ describe("collapseBranchDuplicates", () => {
       }),
     ).toEqual(workspaces);
     expect(removeWorkspace).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Whose notebook is this? ────────────────────────────────────────────────
+
+/** A repository workspace belonging to `ownerId`, or to nobody. */
+function ownedBy(ownerId: number | undefined, name = "notes"): Workspace {
+  const reference: RepoRef = { ...NOTES, repo: name };
+  return {
+    id: workspaceId(reference),
+    name,
+    repo: reference,
+    isDefault: false,
+    isLocal: false,
+    ...(ownerId === undefined ? {} : { ownerId }),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    lastOpenedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("visibleWorkspaces", () => {
+  const mine = ownedBy(1, "my-notes");
+  const theirs = ownedBy(2, "their-notes");
+
+  it("shows an account its own repositories", () => {
+    expect(visibleWorkspaces([mine], 1)).toEqual([mine]);
+  });
+
+  it("hides another account's repositories", () => {
+    // The bug this exists for: signing in as somebody else on the same browser
+    // listed the previous account's repositories, with every note they had
+    // opened cached and editable underneath.
+    expect(visibleWorkspaces([mine, theirs], 1)).toEqual([mine]);
+  });
+
+  it("hides every repository from a signed-out browser", () => {
+    expect(visibleWorkspaces([mine, theirs], null)).toEqual([]);
+  });
+
+  it("always keeps the on-device workspace", () => {
+    // It belongs to the browser, not to an account, and hiding it would hide
+    // notes that exist nowhere else.
+    expect(visibleWorkspaces([LOCAL_WORKSPACE, theirs], 1)).toEqual([LOCAL_WORKSPACE]);
+    expect(visibleWorkspaces([LOCAL_WORKSPACE], null)).toEqual([LOCAL_WORKSPACE]);
+  });
+
+  it("hides a workspace nobody has claimed", () => {
+    expect(visibleWorkspaces([ownedBy(undefined)], 1)).toEqual([]);
+  });
+
+  it("does not match an account against a missing id", () => {
+    // `undefined === undefined` would have made every unowned workspace
+    // visible to every signed-out browser, which is the leak again.
+    expect(visibleWorkspaces([ownedBy(undefined)], null)).toEqual([]);
+  });
+
+  it("keeps the order it was given", () => {
+    const second = { ...ownedBy(1, "other"), name: "other" };
+    expect(visibleWorkspaces([mine, second], 1).map((w) => w.name)).toEqual(["my-notes", "other"]);
+  });
+
+  it("is empty for an empty list", () => {
+    expect(visibleWorkspaces([], 1)).toEqual([]);
+  });
+});
+
+describe("claimUnowned", () => {
+  it("claims the workspaces an upgrade left without an owner", () => {
+    const claimed = claimUnowned([ownedBy(undefined)], 7, false);
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0]!.ownerId).toBe(7);
+  });
+
+  it("claims nothing once the database has been claimed", () => {
+    // The one-time window is the upgrade itself. A second account signing in
+    // afterwards inherits nothing.
+    expect(claimUnowned([ownedBy(undefined)], 2, true)).toEqual([]);
+  });
+
+  it("claims nothing for a signed-out browser", () => {
+    expect(claimUnowned([ownedBy(undefined)], null, false)).toEqual([]);
+  });
+
+  it("never takes a workspace that already has an owner", () => {
+    expect(claimUnowned([ownedBy(2)], 1, false)).toEqual([]);
+  });
+
+  it("never claims the on-device workspace", () => {
+    expect(claimUnowned([LOCAL_WORKSPACE], 1, false)).toEqual([]);
+  });
+
+  it("returns only what changed, so nothing else is rewritten", () => {
+    const claimed = claimUnowned([ownedBy(1, "a"), ownedBy(undefined, "b")], 1, false);
+    expect(claimed.map((w) => w.name)).toEqual(["b"]);
   });
 });

--- a/apps/web/src/lib/workspaces.ts
+++ b/apps/web/src/lib/workspaces.ts
@@ -87,3 +87,81 @@ export async function collapseBranchDuplicates(options: {
 
   return workspaces.filter((workspace) => !removed.has(workspace.id));
 }
+
+// ─── Whose notebook is this? ────────────────────────────────────────────────
+
+/**
+ * Which of these workspaces the signed-in account is allowed to see.
+ *
+ * IndexedDB is per-browser, not per-person. Before this, signing out and
+ * signing in as somebody else left every workspace and every cached note from
+ * the previous account sitting there: their repository names, their folder
+ * structure, the full text of every note they had opened, and an editor
+ * perfectly willing to let the new arrival type into them.
+ *
+ * GitHub itself was never exposed — every request is authorised server-side by
+ * the session cookie, which is why a repository the new account cannot read
+ * showed "Not Found" rather than its contents. The leak was the local copy,
+ * and the local copy is where the words are.
+ *
+ * So a repository workspace now belongs to the account that connected it, and
+ * is listed for nobody else. The on-device workspace is deliberately exempt:
+ * it belongs to the browser, has no account behind it, and hiding it from a
+ * signed-in user would hide notes that exist nowhere else.
+ */
+export function visibleWorkspaces(
+  workspaces: readonly Workspace[],
+  /** GitHub's numeric account id, or null when signed out. */
+  accountId: number | null,
+): Workspace[] {
+  return workspaces.filter((workspace) => {
+    if (workspace.isLocal) return true;
+    // Unowned rows are pre-migration and are handled by `claimUnowned`, which
+    // runs before this. Anything still unowned here belongs to a signed-out
+    // browser, and a repository workspace is not usable signed out anyway.
+    if (workspace.ownerId == null) return false;
+    return workspace.ownerId === accountId;
+  });
+}
+
+/**
+ * Stamps the workspaces an upgrade left without an owner.
+ *
+ * Everything connected before this field existed has no `ownerId`, and there
+ * is no way to work out from the data which account connected it. Refusing to
+ * show them would mean everybody losing their notebooks on upgrade, so they
+ * are claimed once, by the first account to open the app afterwards.
+ *
+ * `alreadyClaimed` is what keeps that "once" honest: after the first signed-in
+ * boot the database records who claimed it, and a later, different account
+ * claims nothing. The one-time window is real and unavoidable — it is the
+ * upgrade itself — and it is far narrower than the behaviour it replaces,
+ * which was every account seeing every other account's notes for ever.
+ */
+export function claimUnowned(
+  workspaces: readonly Workspace[],
+  accountId: number | null,
+  alreadyClaimed: boolean,
+): Workspace[] {
+  if (accountId == null || alreadyClaimed) return [];
+
+  return workspaces
+    .filter((workspace) => !workspace.isLocal && workspace.ownerId == null)
+    .map((workspace) => ({ ...workspace, ownerId: accountId }));
+}
+
+/**
+ * Stamps a workspace with the account connecting it.
+ *
+ * Applied at the one place each screen adds a workspace, rather than asked of
+ * every caller that builds one: the connect dialog, the repository chooser and
+ * the branch switcher all construct `Workspace` objects, and an ownership
+ * field that three call sites have to remember is a field that will be missing
+ * from the fourth.
+ *
+ * The on-device workspace is returned untouched — it belongs to the browser.
+ */
+export function ownedBy(workspace: Workspace, accountId: number | null): Workspace {
+  if (workspace.isLocal || accountId == null) return workspace;
+  return { ...workspace, ownerId: accountId };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -55,6 +55,23 @@ export interface Workspace {
   /** True for the offline-only workspace used in local mode. */
   isLocal: boolean;
   /**
+   * The GitHub account this workspace was connected by.
+   *
+   * IndexedDB belongs to a browser, not to a person, so without this a
+   * notebook cached by one account stays readable — and writable — by the next
+   * account to sign in on the same machine. The repository itself was always
+   * safe, because every request is authorised server-side by the session
+   * cookie; what leaked was the *local cache* of it, which is the note bodies.
+   *
+   * GitHub's numeric id rather than the login, because a login is a display
+   * name someone can change and reuse. The numeric id is the account.
+   *
+   * Absent on the on-device workspace, which belongs to the browser rather
+   * than to an account, and on workspaces connected before this field existed
+   * — see `claimUnowned`.
+   */
+  ownerId?: number;
+  /**
    * Where published pages go, when that is not this workspace's own repository.
    *
    * Absent on every workspace that has not been split, which is all of them


### PR DESCRIPTION
## What this changes

Signing out and signing in as a **different GitHub account on the same browser** left everything the previous account had cached sitting there: repository names, folder structure, note and word counts, the full text of every note they had ever opened — and an editor perfectly willing to let the new arrival type into it.

A workspace now records the account that connected it and is listed for nobody else.

## Why it happened

IndexedDB belongs to a browser, not to a person, and nothing in the local store had ever recorded *which* person. Signing out cleared the session cookie and PostHog, and left the database untouched.

**GitHub itself was never exposed.** Every request is authorised server-side by the session cookie — which is why a repository the new account could not read reported `Not Found` rather than handing over its contents. What leaked was the local cache, and the local cache is where the words are.

## The fix

`Workspace` gains `ownerId` — GitHub's numeric account id, not the login, because a login is a display name somebody can change and somebody else can then register.

The filter is applied at the three places a workspace list is actually built:

| Where | What was exposed |
| --- | --- |
| `useNotebook` (editor) | The workspace switcher, the file tree, and every cached note in it |
| `useLibrary` (dashboard) | Repository cards with note and word counts, plus the search index built from those notes |
| `ProfilePanel` | The per-workspace storage summary |

Everything else is reached *through* a workspace id, so notes, the search index, the queue and the cached trees are all scoped by the same decision rather than by three filters that could drift apart.

### Nothing is deleted

Hiding rather than clearing, deliberately. Wiping local data on sign-out would destroy **unpushed notes** — which the rest of this codebase goes to some trouble to protect — and would do it at the moment nobody is watching. A hidden notebook comes back intact when its own account signs in again.

### Offline is not signed out

`fetchSession` falls back to local mode when the request fails, so treating "no user" as "nobody" would empty someone's own notebook the moment their train went into a tunnel. The boot now tells apart a server that answered *signed out* from a server that could not be asked, and in the second case falls back to the account this browser's notebook already belongs to.

### The upgrade path

Workspaces connected before this field existed have no owner, and there is no way to work out from the data whose they were. They are claimed **once**, by the first signed-in account to open the app afterwards, and the database records that it has been claimed so a later account inherits nothing.

That one-time window is the upgrade itself. It is far narrower than the behaviour it replaces, which was every account seeing every other account's notes for ever.

## How it was tested

`pnpm check` passes: format, typecheck, lint, **1,884 tests** (14 new), clean production build.

**Reproduced the reported condition directly**, by seeding IndexedDB with a workspace owned by another account (with a note in it) plus an unowned legacy row, then loading each screen:

```
seeded:  LEGACY-NOTES(owner=none), SECRET-NOTES(owner=999), On this device
editor:  leaksSecret false · leaksLegacy false · leaksAliceText false
dashboard: "1 note across 1 workspace" — only "On this device"
after:   all three rows still in IndexedDB, the other account's note intact
```

Before the fix all three appeared, with the note readable and editable. The last line is the point of the design: hidden, not destroyed.

The unit tests cover the cases that are awkward to reach by hand — another account's rows hidden, a signed-out browser shown nothing, the on-device workspace always kept, `undefined === undefined` never matching an unowned workspace to a signed-out browser, and claiming happening exactly once.

## What a reviewer should know

**The on-device workspace is deliberately exempt.** It belongs to the browser, has no account behind it, and hiding it from a signed-in user would hide notes that exist nowhere else.

**This is an application-level boundary, not a storage-level one.** Anyone with the browser profile and developer tools can still read IndexedDB; that is what operating-system user accounts are for, and `SECURITY.md` now says so explicitly rather than implying a guarantee the design does not make.

**Sign-out is unchanged.** It still only clears the cookie. The protection is on the read path, which is what makes it work for the cases sign-out never sees — a cookie that simply expires, or a second person who just signs in.

### Not covered

Two live GitHub accounts were not available in this environment, so the account-switch was reproduced at the storage layer rather than by signing in twice. The filtering, claiming and offline fallback are unit-tested; the actual OAuth round trip between two accounts is worth clicking through once before merging.

## Checklist

- [x] `pnpm check` passes locally
- [x] Tests added for new logic (visibility filtering, one-time claiming, the signed-out and unowned edge cases)
- [x] Comments explain *why* for anything non-obvious
- [x] No new `any`
- [x] Security-relevant — `SECURITY.md` gains a "Local storage and accounts" section stating the boundary and what is explicitly out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
