### PR TITLE
Citations that check themselves, and ⌘K that reaches inside the papers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,31 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Citations that check themselves
+
+Every other tool stores a page number, and a page number quietly stops being
+true: the author adds a figure to page 4 and every citation after it points one
+page short. Nothing tells you. A ForkLeaf citation records the sentence, so the
+question has an answer — and now there is somewhere to ask it.
+
+- **Check my citations against their documents** in the palette reads every
+  paper you have quoted and reports what it found: quotations that have moved
+  to another page, quotations that matched only loosely, and the ones that are
+  no longer in the document at all
+- A moved quotation can have its page number corrected in place, one press per
+  citation. The words, the context and the path are left exactly as they were —
+  it is the page hint beside them that had gone stale
+- A document that could not be read is reported as unread, never as a document
+  full of broken citations
+
+### ⌘K searches inside your documents
+
+The reader has always extracted every page's text — that is what makes
+find-in-document work through hyphenation and ligatures — and then threw it
+away when the document closed. It is now kept beside the notebook, so ⌘K
+searches the papers as well as the notes and jumps straight to the page. A
+document is indexed the first time it is opened, and by the citation check.
+
 ### A picture too big to send can be resized instead of deleted
 
 When an image cannot be pushed — a screenshot is larger than GitHub will take

--- a/apps/web/src/components/CitationsDialog.test.tsx
+++ b/apps/web/src/components/CitationsDialog.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { PdfPageText } from "@forkleaf/pdf";
+import { CitationsDialog } from "./CitationsDialog";
+
+afterEach(cleanup);
+
+const page = (number: number, text: string): PdfPageText => ({ page: number, text, runs: [] });
+
+/** A note quoting one passage, written the way ForkLeaf writes citations. */
+const note = (quote: string, at: number, path = "reading.md") => ({
+  path,
+  content: [
+    `> ${quote}`,
+    ">",
+    `> — [Paper, p. ${at}](papers/attention.pdf#page=${at}&q=${encodeURIComponent(quote)})`,
+  ].join("\n"),
+});
+
+function open(over: Partial<React.ComponentProps<typeof CitationsDialog>> = {}) {
+  const props = {
+    onClose: vi.fn(),
+    loadNotes: vi.fn(async () => [note("attention is all you need", 2)]),
+    pagesFor: vi.fn(async () => [page(1, "Introduction."), page(2, "attention is all you need")]),
+    onOpenNote: vi.fn(),
+    onOpenDocument: vi.fn(),
+    onFix: vi.fn(async () => {}),
+    ...over,
+  };
+
+  render(<CitationsDialog {...props} />);
+  return props;
+}
+
+/** Presses the button that starts the sweep. */
+const check = () => fireEvent.click(screen.getByRole("button", { name: /Check my citations/ }));
+
+describe("CitationsDialog — checking", () => {
+  it("reads nothing until it is asked to", () => {
+    const props = open();
+    expect(props.pagesFor).not.toHaveBeenCalled();
+  });
+
+  it("says everything is where it should be, without listing all of it", async () => {
+    open();
+    check();
+
+    expect(await screen.findByText(/1 quotation checked/)).toBeTruthy();
+    expect(screen.getByText(/exactly where your notes say/)).toBeTruthy();
+  });
+
+  it("names a quotation that is no longer in the document", async () => {
+    open({ pagesFor: vi.fn(async () => [page(1, "Something else entirely.")]) });
+    check();
+
+    expect(await screen.findByText(/not in the document any more/)).toBeTruthy();
+    expect(screen.getByText(/1 points at text that is no longer there/)).toBeTruthy();
+  });
+});
+
+describe("CitationsDialog — a passage that has moved", () => {
+  const moved = () =>
+    open({
+      pagesFor: vi.fn(async () => [
+        page(1, "Introduction."),
+        page(2, "A figure that was not here before."),
+        page(3, "attention is all you need"),
+      ]),
+    });
+
+  it("says where it is now, and what the note still claims", async () => {
+    moved();
+    check();
+
+    expect(await screen.findByText(/Still there, now on page 3/)).toBeTruthy();
+  });
+
+  it("corrects the page number only when asked, and says it did", async () => {
+    const props = moved();
+    check();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Correct the page number/ }));
+
+    await waitFor(() => expect(props.onFix).toHaveBeenCalled());
+    // The check it was handed is the one that moved, with the new page on it.
+    expect(vi.mocked(props.onFix).mock.calls[0]?.[0]?.page).toBe(3);
+    expect(await screen.findByText(/Page number corrected to 3/)).toBeTruthy();
+    // Offered once. A second press would rewrite a link that is already right.
+    expect(screen.queryByRole("button", { name: /Correct the page number/ })).toBeNull();
+  });
+
+  it("goes to the passage, and to the note that quoted it", async () => {
+    const props = moved();
+    check();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Read page 3/ }));
+    expect(props.onOpenDocument).toHaveBeenCalledWith("papers/attention.pdf", 3);
+
+    fireEvent.click(screen.getByRole("button", { name: /reading\.md, line 3/ }));
+    expect(props.onOpenNote).toHaveBeenCalledWith("reading.md");
+  });
+});
+
+describe("CitationsDialog — when things go wrong", () => {
+  /**
+   * The one message that must never be wrong. A document that could not be
+   * fetched is not a document whose every quotation has been deleted.
+   */
+  it("reports a document it could not read as unread, not as broken", async () => {
+    open({
+      pagesFor: vi.fn(async () => {
+        throw new Error("That PDF could not be read from the repository.");
+      }),
+    });
+    check();
+
+    expect(await screen.findByText(/its citations were not checked/)).toBeTruthy();
+    expect(screen.queryByText(/no longer there/)).toBeNull();
+  });
+
+  it("says so when the notes themselves cannot be read", async () => {
+    open({
+      loadNotes: vi.fn(async () => {
+        throw new Error("The notebook could not be opened.");
+      }),
+    });
+    check();
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByText(/The notebook could not be opened\./)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/CitationsDialog.tsx
+++ b/apps/web/src/components/CitationsDialog.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Dialog } from "@/components/Dialog";
+import type { AuditSummary, CitationCheck, PagesFor } from "@/lib/citation-audit";
+import { auditCitations } from "@/lib/citation-audit";
+import type { MentionSource } from "@/lib/pdf-mentions";
+
+/**
+ * Are these quotations still true?
+ *
+ * The one question a notebook full of citations cannot normally answer. Every
+ * other tool stores a page number, which quietly stops being right the moment
+ * the author adds a figure to page four — the link still opens, it just shows
+ * the wrong paragraph, and nothing tells you. A ForkLeaf citation records the
+ * sentence, so the question has an answer, and this is where it gets asked of
+ * the whole notebook at once.
+ *
+ * A check and then a decision, never one action. What was found is shown, and
+ * correcting a page number is a separate press per citation. Rewriting
+ * somebody's notes on the strength of a text match, without showing them the
+ * match first, is not a thing a notes app should do on one click.
+ */
+
+export interface CitationsDialogProps {
+  onClose: () => void;
+  /** Every note in the notebook, read once when the check starts. */
+  loadNotes: () => Promise<MentionSource[]>;
+  /** Reads a document's text, from the cache or from the repository. */
+  pagesFor: PagesFor;
+  /** Opens a note at the line a citation sits on. */
+  onOpenNote: (path: string) => void;
+  /** Opens the document at the passage, so it can be read in place. */
+  onOpenDocument: (pdfPath: string, page: number) => void;
+  /** Writes a corrected page number into the note holding the citation. */
+  onFix: (check: CitationCheck) => Promise<void>;
+}
+
+type State =
+  | { kind: "idle" }
+  | { kind: "reading"; done: number; total: number; pdfPath: string }
+  | { kind: "done"; summary: AuditSummary }
+  | { kind: "error"; message: string };
+
+export function CitationsDialog({
+  onClose,
+  loadNotes,
+  pagesFor,
+  onOpenNote,
+  onOpenDocument,
+  onFix,
+}: CitationsDialogProps) {
+  const [state, setState] = useState<State>({ kind: "idle" });
+  /** Citations already corrected, so a fixed row stops offering the fix. */
+  const [fixed, setFixed] = useState<Set<string>>(new Set());
+
+  const run = useCallback(async () => {
+    setState({ kind: "reading", done: 0, total: 0, pdfPath: "" });
+    setFixed(new Set());
+
+    try {
+      const notes = await loadNotes();
+      const summary = await auditCitations(notes, pagesFor, {
+        onProgress: (done, total, pdfPath) => setState({ kind: "reading", done, total, pdfPath }),
+      });
+      setState({ kind: "done", summary });
+    } catch (problem: unknown) {
+      setState({
+        kind: "error",
+        message:
+          problem instanceof Error
+            ? problem.message
+            : "Your notes could not be read. Nothing was changed.",
+      });
+    }
+  }, [loadNotes, pagesFor]);
+
+  return (
+    <Dialog
+      title="Citations"
+      subtitle="Every quotation in your notes, checked against the document it came from"
+      onClose={onClose}
+      wide
+    >
+      {state.kind === "idle" && (
+        <div className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+          <p className="max-w-2xl">
+            A ForkLeaf citation records the sentence you quoted, not just the page it was on. So
+            when a paper is revised, the quotation can be looked for again — and this says which of
+            yours have moved, and which are no longer in the document at all.
+          </p>
+          <p className="mt-2 max-w-2xl">
+            Every document you have quoted is read, one at a time. Nothing is changed unless you ask
+            for it, citation by citation.
+          </p>
+          <button type="button" onClick={() => void run()} className="fl-btn fl-btn-primary mt-4">
+            Check my citations
+          </button>
+        </div>
+      )}
+
+      {state.kind === "reading" && (
+        <p role="status" className="text-[13px] text-[var(--fl-muted)]">
+          {state.total > 0
+            ? `Reading ${state.pdfPath} — document ${Math.min(state.done + 1, state.total)} of ${state.total}…`
+            : "Reading your notes…"}
+        </p>
+      )}
+
+      {state.kind === "error" && (
+        <p role="alert" className="text-[13px] text-[var(--fl-danger)]">
+          {state.message}
+        </p>
+      )}
+
+      {state.kind === "done" && (
+        <Report
+          summary={state.summary}
+          fixed={fixed}
+          onOpenNote={onOpenNote}
+          onOpenDocument={onOpenDocument}
+          onFix={async (check) => {
+            await onFix(check);
+            setFixed((current) => new Set(current).add(keyOf(check)));
+          }}
+          onAgain={() => void run()}
+        />
+      )}
+    </Dialog>
+  );
+}
+
+/** Identifies one citation among all of them: which note, which line, which words. */
+function keyOf(check: CitationCheck): string {
+  return `${check.mention.notePath}:${check.mention.line}:${check.mention.citation?.quote ?? ""}`;
+}
+
+function Report({
+  summary,
+  fixed,
+  onOpenNote,
+  onOpenDocument,
+  onFix,
+  onAgain,
+}: {
+  summary: AuditSummary;
+  fixed: ReadonlySet<string>;
+  onOpenNote: (path: string) => void;
+  onOpenDocument: (pdfPath: string, page: number) => void;
+  onFix: (check: CitationCheck) => Promise<void>;
+  onAgain: () => void;
+}) {
+  // Only what is worth reading about. A citation that is exactly where it says
+  // it is needs no row of its own — the count at the top already says how many
+  // of those there are, and a list of two hundred correct things is a list
+  // nobody scrolls to the end of.
+  const documents = summary.documents
+    .map((document) => ({
+      ...document,
+      checks: document.checks.filter((check) => check.quality !== "exact"),
+    }))
+    .filter((document) => document.checks.length > 0 || document.error !== null);
+
+  return (
+    <div className="text-[13px] leading-relaxed">
+      <p className="text-[var(--fl-text)]">
+        {summary.checked === 0
+          ? "No quotations to check yet."
+          : `${summary.checked} ${summary.checked === 1 ? "quotation" : "quotations"} checked.`}{" "}
+        <span className="text-[var(--fl-muted)]">
+          {summary.lost > 0
+            ? `${summary.lost} point${summary.lost === 1 ? "s" : ""} at text that is no longer there. `
+            : ""}
+          {summary.moved > 0 ? `${summary.moved} moved to a different page. ` : ""}
+          {summary.fuzzy > 0 ? `${summary.fuzzy} matched only loosely. ` : ""}
+          {summary.unreadable > 0
+            ? `${summary.unreadable} document${summary.unreadable === 1 ? "" : "s"} could not be read. `
+            : ""}
+          {summary.checked > 0 && documents.length === 0
+            ? "Every one of them is exactly where your notes say it is."
+            : ""}
+        </span>
+      </p>
+
+      <div className="mt-3 space-y-3">
+        {documents.map((document) => (
+          <section key={document.pdfPath}>
+            <h4 className="break-all font-mono text-[11.5px] text-[var(--fl-text)]">
+              {document.pdfPath}
+            </h4>
+
+            {document.error ? (
+              <p className="mt-1 text-[12px] text-[var(--fl-muted)]">
+                Could not be read, so its citations were not checked. {document.error}
+              </p>
+            ) : (
+              <ul className="mt-1.5 space-y-1.5">
+                {document.checks.map((check) => (
+                  <li
+                    key={keyOf(check)}
+                    className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-2"
+                  >
+                    <Verdict check={check} fixed={fixed.has(keyOf(check))} />
+
+                    <blockquote className="mt-1 border-l-2 border-[var(--fl-border)] pl-2 text-[12px] text-[var(--fl-text)]">
+                      {check.mention.citation?.quote}
+                    </blockquote>
+
+                    <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-[var(--fl-muted)]">
+                      <button
+                        type="button"
+                        onClick={() => onOpenNote(check.mention.notePath)}
+                        className="max-w-full truncate underline decoration-dotted underline-offset-2 hover:text-[var(--fl-text)]"
+                      >
+                        {check.mention.notePath}, line {check.mention.line}
+                      </button>
+
+                      {check.page != null && (
+                        <button
+                          type="button"
+                          onClick={() => onOpenDocument(document.pdfPath, check.page!)}
+                          className="underline decoration-dotted underline-offset-2 hover:text-[var(--fl-text)]"
+                        >
+                          Read page {check.page}
+                        </button>
+                      )}
+
+                      {check.stale && !fixed.has(keyOf(check)) && (
+                        <button
+                          type="button"
+                          onClick={() => void onFix(check)}
+                          className="rounded border border-[var(--fl-border)] px-1.5 py-0.5 font-medium text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-surface)]"
+                        >
+                          Correct the page number
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        ))}
+      </div>
+
+      <button type="button" onClick={onAgain} className="fl-btn fl-btn-ghost mt-4 !py-1.5">
+        Check again
+      </button>
+    </div>
+  );
+}
+
+/** One line saying what is actually the matter, in the reader's terms. */
+function Verdict({ check, fixed }: { check: CitationCheck; fixed: boolean }) {
+  if (fixed) {
+    return (
+      <p className="text-[12px] font-medium text-[var(--fl-text)]">
+        Page number corrected to {check.page}.
+      </p>
+    );
+  }
+
+  if (check.quality === "lost") {
+    return (
+      <p className="text-[12px] font-medium text-[var(--fl-danger)]">
+        These words are not in the document any more.
+      </p>
+    );
+  }
+
+  if (check.quality === "moved") {
+    return (
+      <p className="text-[12px] font-medium text-[var(--fl-text)]">
+        Still there, now on page {check.page} — your note says page {check.mention.citation?.page}.
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-[12px] font-medium text-[var(--fl-text)]">
+      Found on page {check.page}, but not word for word. The passage may have been edited.
+    </p>
+  );
+}

--- a/apps/web/src/components/CommandPalette.test.tsx
+++ b/apps/web/src/components/CommandPalette.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Workspace } from "@forkleaf/types";
+import { CommandPalette } from "./CommandPalette";
+import { entryFrom } from "@/lib/pdf-index";
+
+afterEach(cleanup);
+
+// jsdom has no `scrollIntoView`, and the palette calls it to keep the
+// highlighted row in view. Without this every render throws before anything
+// under test happens.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {};
+});
+
+const WORKSPACE: Workspace = {
+  id: "w",
+  name: "me/notes",
+  repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
+  isDefault: true,
+  isLocal: false,
+  createdAt: "",
+  lastOpenedAt: "",
+};
+
+const DOCUMENTS = [
+  entryFrom("w", "papers/attention.pdf", [
+    { page: 1, text: "We show that attention is all you need." },
+    { page: 2, text: "The rest is engineering." },
+  ]),
+];
+
+function open(over: Partial<React.ComponentProps<typeof CommandPalette>> = {}) {
+  const props = {
+    onClose: vi.fn(),
+    tree: [{ kind: "file" as const, name: "plan.md", path: "plan.md" }],
+    openNotes: [],
+    workspace: WORKSPACE,
+    onOpenNote: vi.fn(),
+    onOpenDocument: vi.fn(),
+    documents: DOCUMENTS,
+    commands: [],
+    ...over,
+  };
+
+  render(<CommandPalette {...props} />);
+  return props;
+}
+
+/** Types into the palette the way somebody looking for something does. */
+function search(text: string) {
+  fireEvent.change(screen.getByRole("combobox"), { target: { value: text } });
+}
+
+describe("CommandPalette — searching inside documents", () => {
+  it("finds a phrase in a paper and says which page it is on", () => {
+    open();
+    search("all you need");
+
+    expect(screen.getByText("Documents")).toBeTruthy();
+    expect(screen.getByText("attention.pdf · p. 1")).toBeTruthy();
+    // The sentence, not the path: the path is on the line above, and the words
+    // are what tell you whether this is the passage you meant.
+    expect(screen.getByText(/attention is all you need/)).toBeTruthy();
+  });
+
+  it("opens the document at the page the phrase is on", () => {
+    const props = open();
+    search("engineering");
+
+    fireEvent.click(screen.getByText("attention.pdf · p. 2"));
+
+    expect(props.onOpenDocument).toHaveBeenCalledWith("papers/attention.pdf", 2);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("lists nothing from the documents until something has been typed", () => {
+    open();
+    expect(screen.queryByText("Documents")).toBeNull();
+  });
+
+  it("says it can search documents, but only when it has some", () => {
+    open();
+    expect(screen.getByRole("combobox").getAttribute("placeholder")).toMatch(/documents/i);
+
+    cleanup();
+    open({ documents: [] });
+    expect(screen.getByRole("combobox").getAttribute("placeholder")).not.toMatch(/documents/i);
+  });
+
+  it("leaves documents out entirely where there is nowhere to open one", () => {
+    // The standalone case: no handler, so a result nobody could act on is
+    // better not offered.
+    open({ onOpenDocument: undefined });
+    search("all you need");
+
+    expect(screen.queryByText("Documents")).toBeNull();
+  });
+});

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import type { Note, TreeNode, Workspace } from "@forkleaf/types";
+import type { Note, PdfTextEntry, TreeNode, Workspace } from "@forkleaf/types";
 import { entryFromNote, entryFromPath, queryIndex } from "@/lib/library";
+import { searchDocuments } from "@/lib/pdf-index";
 
 /**
  * ⌘K — go anywhere, do anything.
@@ -37,6 +38,17 @@ export interface CommandPaletteProps {
   openNotes: Note[];
   workspace: Workspace | null;
   onOpenNote: (path: string) => void;
+  /**
+   * The documents whose text this notebook has kept, for searching inside.
+   *
+   * A PDF's text is extracted the first time it is read and stored beside the
+   * notebook, so ⌘K can look inside the papers as well as at the notes. Empty
+   * until something has been read, which is honest: a document nobody has
+   * opened has not been read by anybody, this app included.
+   */
+  documents?: readonly PdfTextEntry[];
+  /** Opens a document at the page a phrase was found on. */
+  onOpenDocument?: (pdfPath: string, page: number) => void;
   commands: Command[];
 }
 
@@ -46,6 +58,8 @@ export function CommandPalette({
   openNotes,
   workspace,
   onOpenNote,
+  documents = [],
+  onOpenDocument,
   commands,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
@@ -79,6 +93,18 @@ export function CommandPalette({
     [noteEntries, query],
   );
 
+  /**
+   * What the papers say, not only what the notes about them say.
+   *
+   * Only once something has been typed: an empty query would otherwise list
+   * the first few pages of every document that has ever been opened, above the
+   * commands, for no reason.
+   */
+  const documentResults = useMemo(
+    () => (onOpenDocument ? searchDocuments(documents, query) : []),
+    [documents, query, onOpenDocument],
+  );
+
   const commandResults = useMemo(() => {
     const needle = query.trim().toLowerCase();
     if (!needle) return commands;
@@ -92,9 +118,10 @@ export function CommandPalette({
   const rows = useMemo(
     () => [
       ...noteResults.map((entry) => ({ kind: "note" as const, entry })),
+      ...documentResults.map((hit) => ({ kind: "document" as const, hit })),
       ...commandResults.map((command) => ({ kind: "command" as const, command })),
     ],
-    [noteResults, commandResults],
+    [noteResults, documentResults, commandResults],
   );
 
   // Clamped rather than reset: typing narrows the list, and snapping the
@@ -109,11 +136,13 @@ export function CommandPalette({
       onClose();
       if (row.kind === "note") {
         onOpenNote(row.entry.path);
+      } else if (row.kind === "document") {
+        onOpenDocument?.(row.hit.path, row.hit.page);
       } else {
         await row.command.run();
       }
     },
-    [rows, onClose, onOpenNote],
+    [rows, onClose, onOpenNote, onOpenDocument],
   );
 
   // Keep the highlighted row in view when it moves past the fold.
@@ -167,8 +196,12 @@ export function CommandPalette({
           aria-expanded
           aria-controls="command-palette-list"
           aria-activedescendant={rows[selected] ? `palette-row-${selected}` : undefined}
-          placeholder="Search notes, or type a command…"
-          aria-label="Search notes and commands"
+          placeholder={
+            documents.length > 0
+              ? "Search notes and documents, or type a command…"
+              : "Search notes, or type a command…"
+          }
+          aria-label="Search notes, documents and commands"
           className="w-full border-b border-[var(--fl-border)] bg-transparent px-4 py-3.5 text-[15px] text-[var(--fl-text)] outline-none placeholder:text-[var(--fl-muted)]"
         />
 
@@ -187,12 +220,11 @@ export function CommandPalette({
           {rows.map((row, index) => {
             const isActive = index === selected;
             const previous = rows[index - 1];
-            const group = row.kind === "note" ? "Notes" : row.command.group;
-            const previousGroup =
-              previous == null ? null : previous.kind === "note" ? "Notes" : previous.command.group;
+            const group = groupOf(row);
+            const previousGroup = previous == null ? null : groupOf(previous);
 
             return (
-              <li key={row.kind === "note" ? row.entry.id : row.command.id}>
+              <li key={keyOf(row, index)}>
                 {group !== previousGroup && (
                   <p className="px-2.5 pb-1 pt-2.5 text-[10.5px] font-semibold uppercase tracking-[0.13em] text-[var(--fl-muted)]">
                     {group}
@@ -215,10 +247,21 @@ export function CommandPalette({
 
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-[14px] text-[var(--fl-text)]">
-                      {row.kind === "note" ? row.entry.title : row.command.label}
+                      {row.kind === "note"
+                        ? row.entry.title
+                        : row.kind === "document"
+                          ? `${filename(row.hit.path)} · p. ${row.hit.page}`
+                          : row.command.label}
                     </span>
                     <span className="block truncate text-[11.5px] text-[var(--fl-muted)]">
-                      {row.kind === "note" ? row.entry.path : (row.command.hint ?? "")}
+                      {row.kind === "note"
+                        ? row.entry.path
+                        : row.kind === "document"
+                          ? // The sentence it was found in, not the path: the
+                            // path is in the line above and the words are what
+                            // tell you whether this is the passage you meant.
+                            row.hit.snippet
+                          : (row.command.hint ?? "")}
                     </span>
                   </span>
                 </button>
@@ -237,6 +280,25 @@ export function CommandPalette({
   );
 }
 
+type Row =
+  | { kind: "note"; entry: { id: string; path: string; title: string } }
+  | { kind: "document"; hit: { path: string; page: number; snippet: string } }
+  | { kind: "command"; command: Command };
+
+function groupOf(row: Row): string {
+  if (row.kind === "note") return "Notes";
+  if (row.kind === "document") return "Documents";
+  return row.command.group;
+}
+
+function keyOf(row: Row, index: number): string {
+  if (row.kind === "note") return row.entry.id;
+  if (row.kind === "document") return `${row.hit.path}:${row.hit.page}:${index}`;
+  return row.command.id;
+}
+
+const filename = (path: string) => path.split("/").pop() ?? path;
+
 function Key({ children }: { children: ReactNode }) {
   return (
     <span className="inline-flex items-center gap-1">
@@ -247,7 +309,7 @@ function Key({ children }: { children: ReactNode }) {
   );
 }
 
-function Glyph({ kind }: { kind: "note" | "command" }) {
+function Glyph({ kind }: { kind: "note" | "document" | "command" }) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -262,6 +324,13 @@ function Glyph({ kind }: { kind: "note" | "command" }) {
         <>
           <path d="M3.25 2.75h6l3.5 3.5v7a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5Z" />
           <path d="M9 2.75v3.5h3.5" />
+        </>
+      ) : kind === "document" ? (
+        // A page with lines of type on it: a document, as against a note,
+        // which is the same outline with a folded corner.
+        <>
+          <rect x="2.75" y="2.75" width="10.5" height="10.5" rx="1.25" />
+          <path d="M5.25 6h5.5M5.25 8.5h5.5M5.25 11h3" />
         </>
       ) : (
         <path d="M5.5 6 3 8l2.5 2M10.5 6 13 8l-2.5 2M9.25 4l-2.5 8" />

--- a/apps/web/src/components/PdfReader.test.tsx
+++ b/apps/web/src/components/PdfReader.test.tsx
@@ -58,6 +58,8 @@ const NOTES_TAB = "What your notes say about this document";
 
 const mention = (overrides: Partial<PdfMention> = {}): PdfMention => ({
   notePath: "reading/attention.md",
+  pdfPath: "papers/attention.pdf",
+  citation: { quote: "Attention is all you need.", prefix: "", suffix: "", page: 12 },
   line: 6,
   label: "Attention, p. 12",
   page: 12,

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -29,6 +29,7 @@ import { useNotebook } from "@/hooks/useNotebook";
 import { usePublishedPages } from "@/hooks/usePublishedPages";
 import { useLinks } from "@/hooks/useLinks";
 import { useLocalFiles } from "@/hooks/useLocalFiles";
+import type { PdfTextEntry } from "@forkleaf/types";
 import type { LocalFile, LocalPdf } from "@/lib/local-files";
 import { usePdfReader } from "@/hooks/usePdfReader";
 import { PdfReader } from "@/components/PdfReader";
@@ -46,6 +47,9 @@ import { commitToBranch } from "@/lib/gateway";
 import { readDroppedPdf } from "@/lib/local-files";
 import { insertionFor, quoteMarkdown } from "@/lib/pdf-quote";
 import { mentionsOfPdf, type PdfMention } from "@/lib/pdf-mentions";
+import { pagesOf, readDocumentText } from "@/lib/pdf-index";
+import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
+import { CitationsDialog } from "@/components/CitationsDialog";
 import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
 import { ColumnResizer } from "@/components/ColumnResizer";
@@ -257,6 +261,7 @@ export function EditorWorkspace() {
     | "capture"
     | "propose"
     | "publish"
+    | "citations"
     | null
   >(null);
   /**
@@ -601,6 +606,103 @@ export function EditorWorkspace() {
       live = false;
     };
   }, [reader.status, readerPath, loadAllNotes]);
+
+  /**
+   * The documents whose text this notebook has kept, for ⌘K to search.
+   *
+   * Loaded when the palette opens rather than held all the time: this is every
+   * word of every paper that has been read, which belongs in memory for as
+   * long as somebody is searching it and no longer.
+   */
+  const [documentTexts, setDocumentTexts] = useState<PdfTextEntry[]>([]);
+
+  const loadDocumentText = notebook.allDocumentText;
+
+  useEffect(() => {
+    if (!paletteOpen) return;
+
+    let live = true;
+    void loadDocumentText()
+      .then((entries) => {
+        if (live) setDocumentTexts(entries);
+      })
+      .catch(() => {
+        // Nothing kept is the same as nothing to search: ⌘K still finds notes.
+        if (live) setDocumentTexts([]);
+      });
+
+    return () => {
+      live = false;
+    };
+  }, [paletteOpen, loadDocumentText]);
+
+  /**
+   * Keeps the text of a document the reader has just finished reading.
+   *
+   * The extraction has already happened — it is what makes find-in-document
+   * work — so this only writes down what was going to be thrown away. Once per
+   * document per open, tracked by a ref, since `pages` changes identity on
+   * every render of a document that is still being read.
+   */
+  const savedText = useRef<string | null>(null);
+  const saveDocumentText = notebook.saveDocumentText;
+
+  useEffect(() => {
+    if (reader.status !== "ready" || reader.indexing || !readerPath) return;
+    if (reader.pages.length === 0) return;
+
+    const key = `${workspaceIdForLinks ?? ""}::${readerPath}`;
+    if (savedText.current === key) return;
+    savedText.current = key;
+
+    void saveDocumentText(
+      readerPath,
+      reader.pages.map((page) => ({ page: page.page, text: page.text })),
+    ).catch(() => {
+      // Not worth telling anybody about: the document is open and readable,
+      // and the only thing lost is that ⌘K will not reach inside it yet.
+      savedText.current = null;
+    });
+  }, [
+    reader.status,
+    reader.indexing,
+    reader.pages,
+    readerPath,
+    workspaceIdForLinks,
+    saveDocumentText,
+  ]);
+
+  /**
+   * A document's text for the citation check: from the cache, or read now.
+   *
+   * Reading it here also fills the cache, so checking your citations is also
+   * what makes those papers searchable from ⌘K.
+   */
+  const pagesForDocument = useCallback(
+    async (pdfPath: string) => {
+      if (!workspace || workspace.isLocal) {
+        throw new Error("This notebook has no repository, so its documents cannot be read.");
+      }
+
+      const cached = await notebook.documentText(pdfPath);
+      if (cached && cached.pages.length > 0) return pagesOf(cached);
+
+      const pages = await readDocumentText(workspace, pdfPath);
+      await notebook.saveDocumentText(pdfPath, pages);
+      return pagesOf({ id: "", workspaceId: workspace.id, path: pdfPath, pages, indexedAt: "" });
+    },
+    [workspace, notebook],
+  );
+
+  /** Writes a corrected page number into the note holding the citation. */
+  const correctCitationPage = useCallback(
+    async (check: CitationCheck) => {
+      await notebook.rewriteNote(check.mention.notePath, (content) =>
+        withCorrectedPage(content, check),
+      );
+    },
+    [notebook],
+  );
 
   /**
    * What this notebook has already said about the document being read.
@@ -1701,6 +1803,18 @@ export function EditorWorkspace() {
       });
     }
 
+    if (workspace && !workspace.isLocal) {
+      list.push({
+        id: "citations",
+        label: "Check my citations against their documents",
+        group: "Notes",
+        hint: "Finds quotations that have moved, and ones that are no longer there",
+        keywords:
+          "citation citations quote quotation check verify audit broken stale page pdf paper source reference sweep",
+        run: () => setDialog("citations"),
+      });
+    }
+
     // All three placements, always, with the current one marked — rather than
     // one command whose label is the *other* state. A toggle reads as an
     // instruction ("open PDFs in their own tab") that gives no hint about
@@ -2601,7 +2715,31 @@ export function EditorWorkspace() {
           openNotes={notebook.openNotes}
           workspace={workspace}
           onOpenNote={notebook.openNote}
+          // A notebook with no repository has no documents to reach: nothing
+          // could have been read from one, and a result that opened nothing
+          // would be worse than no result.
+          documents={workspace && !workspace.isLocal ? documentTexts : []}
+          onOpenDocument={(path, page) => openRepoPdf(path, `page=${page}`)}
           commands={commands}
+        />
+      )}
+
+      {openDialog === "citations" && workspace && !workspace.isLocal && (
+        <CitationsDialog
+          onClose={() => setDialog(null)}
+          loadNotes={async () =>
+            (await notebook.allNotes()).map(({ path, content }) => ({ path, content }))
+          }
+          pagesFor={pagesForDocument}
+          onOpenNote={(path) => {
+            setDialog(null);
+            notebook.openNote(path);
+          }}
+          onOpenDocument={(pdfPath, page) => {
+            setDialog(null);
+            openRepoPdf(pdfPath, `page=${page}`);
+          }}
+          onFix={correctCitationPage}
         />
       )}
 

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -41,6 +41,7 @@ import {
 } from "@/lib/workspaces";
 import { forgetLock, isPathLocked, lockedKey, renameLock, toggleLock } from "@/lib/locks";
 import { assetBlob, assetFrom, assetObjectUrl, blobAsBase64, isImagePath } from "@/lib/assets";
+import { entryFrom, pdfTextId } from "@/lib/pdf-index";
 import { shrinkImage, ShrinkError } from "@/lib/shrink-image";
 import {
   DEFAULT_TREE_ORDER,
@@ -1624,6 +1625,34 @@ export function useNotebook(request: NotebookRequest = {}) {
   );
 
   /**
+   * Rewrites any note in this workspace, whether or not it is open.
+   *
+   * `saveNote` writes the note the editor is showing and `replaceNoteContent`
+   * writes one that happens to be in a tab. Repairing a link means writing to
+   * a note nobody has looked at today, which is neither of those — so the note
+   * is read from storage first, and any tab holding it is brought along.
+   */
+  const rewriteNote = useCallback(
+    async (path: string, change: (content: string) => string): Promise<boolean> => {
+      const notes = repoRef.current;
+      const workspace = state.activeWorkspace;
+      if (!notes || !workspace) return false;
+
+      const open = state.openNotes.find((note) => note.path === path);
+      const note = open ?? (await notes.openNote(workspace.id, path));
+      if (!note) return false;
+
+      const next = change(note.content);
+      if (next === note.content) return false;
+
+      await notes.saveNote(note, next);
+      patchOpenNote(path, { content: next, dirty: true });
+      return true;
+    },
+    [state.activeWorkspace, state.openNotes, patchOpenNote],
+  );
+
+  /**
    * Drops one stuck change, so the queue behind it can move.
    *
    * The way out of a change that can never be pushed. Needs a refresh of the
@@ -1840,6 +1869,46 @@ export function useNotebook(request: NotebookRequest = {}) {
     [state.activeWorkspace, state.sync.unpushed, urlForAsset],
   );
 
+  // ── The words documents are made of ─────────────────────────────────────
+
+  /**
+   * Keeps a document's text after it has been read once.
+   *
+   * The reader extracts it anyway — that is what makes find-in-document work —
+   * and used to throw it away when the document closed, so the words were
+   * searchable for exactly as long as somebody was looking at them. Kept, they
+   * are what ⌘K searches and what a citation is checked against.
+   */
+  const saveDocumentText = useCallback(
+    async (path: string, pages: { page: number; text: string }[]) => {
+      const db = dbRef.current;
+      const workspace = state.activeWorkspace;
+      if (!db || !workspace || workspace.isLocal) return;
+
+      await db.putPdfText(entryFrom(workspace.id, path, pages));
+    },
+    [state.activeWorkspace],
+  );
+
+  const documentText = useCallback(
+    async (path: string) => {
+      const db = dbRef.current;
+      const workspace = state.activeWorkspace;
+      if (!db || !workspace) return undefined;
+
+      return db.getPdfText(pdfTextId(workspace.id, path));
+    },
+    [state.activeWorkspace],
+  );
+
+  const allDocumentText = useCallback(async () => {
+    const db = dbRef.current;
+    const workspace = state.activeWorkspace;
+    if (!db || !workspace) return [];
+
+    return db.listPdfText(workspace.id);
+  }, [state.activeWorkspace]);
+
   /** Remembers which folders are open, for the next visit. */
   const setExpandedFolders = useCallback(
     (paths: string[]) => {
@@ -1904,6 +1973,10 @@ export function useNotebook(request: NotebookRequest = {}) {
       discardPending,
       discardChange,
       shrinkChange,
+      rewriteNote,
+      saveDocumentText,
+      documentText,
+      allDocumentText,
       setSyncMode,
       resolveConflict,
       allNotes,
@@ -1962,6 +2035,10 @@ export function useNotebook(request: NotebookRequest = {}) {
       pendingChanges,
       discardPending,
       discardChange,
+      allDocumentText,
+      documentText,
+      saveDocumentText,
+      rewriteNote,
       shrinkChange,
       setSyncMode,
       resolveConflict,

--- a/apps/web/src/lib/citation-audit.test.ts
+++ b/apps/web/src/lib/citation-audit.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PdfPageText } from "@forkleaf/pdf";
+import { auditCitations, checkAgainst, summarise, withCorrectedPage } from "./citation-audit";
+import { allPdfMentions } from "./pdf-mentions";
+
+const page = (number: number, text: string): PdfPageText => ({ page: number, text, runs: [] });
+
+/** A note citing one passage of one paper, the way ForkLeaf writes them. */
+function citing(options: {
+  quote: string;
+  page: number;
+  path?: string;
+  notePath?: string;
+  prefix?: string;
+  suffix?: string;
+}) {
+  const fragment = [
+    `page=${options.page}`,
+    `q=${encodeURIComponent(options.quote)}`,
+    options.prefix ? `pre=${encodeURIComponent(options.prefix)}` : "",
+    options.suffix ? `suf=${encodeURIComponent(options.suffix)}` : "",
+  ]
+    .filter(Boolean)
+    .join("&");
+
+  return {
+    path: options.notePath ?? "reading.md",
+    content: [
+      `> ${options.quote}`,
+      ">",
+      `> — [Paper, p. ${options.page}](${options.path ?? "papers/attention.pdf"}#${fragment})`,
+    ].join("\n"),
+  };
+}
+
+describe("checkAgainst", () => {
+  it("says a quotation is exactly where the note claims", () => {
+    const notes = [citing({ quote: "attention is all you need", page: 2 })];
+    const pages = [page(1, "Introduction."), page(2, "We show that attention is all you need.")];
+
+    const [check] = checkAgainst(pages, allPdfMentions(notes));
+
+    expect(check?.quality).toBe("exact");
+    expect(check?.page).toBe(2);
+    expect(check?.stale).toBe(false);
+  });
+
+  /**
+   * The failure every other tool has silently: the author adds a figure, the
+   * passage moves, and the stored page number is now pointing at the wrong
+   * paragraph. Here the words are the anchor, so it is found and reported.
+   */
+  it("finds a passage that has moved, and says the page number is stale", () => {
+    const notes = [citing({ quote: "attention is all you need", page: 2 })];
+    const pages = [
+      page(1, "Introduction."),
+      page(2, "A figure that was not here before."),
+      page(3, "We show that attention is all you need."),
+    ];
+
+    const [check] = checkAgainst(pages, allPdfMentions(notes));
+
+    expect(check?.quality).toBe("moved");
+    expect(check?.page).toBe(3);
+    expect(check?.stale).toBe(true);
+  });
+
+  it("reports a passage that is not in the document any more", () => {
+    const notes = [citing({ quote: "a sentence since deleted", page: 2 })];
+    const pages = [page(1, "Introduction."), page(2, "Something else entirely.")];
+
+    const [check] = checkAgainst(pages, allPdfMentions(notes));
+
+    expect(check?.quality).toBe("lost");
+    expect(check?.page).toBeNull();
+  });
+
+  it("skips a link that records no words, since there is nothing to check", () => {
+    // `#page=4` is a perfectly good link and makes no claim this could test.
+    const notes = [{ path: "a.md", content: "[the paper](papers/attention.pdf#page=4)" }];
+
+    expect(checkAgainst([page(1, "x")], allPdfMentions(notes))).toEqual([]);
+  });
+});
+
+describe("auditCitations", () => {
+  it("reads each document once, however many notes quote it", async () => {
+    const notes = [
+      citing({ quote: "first passage", page: 1, notePath: "one.md" }),
+      citing({ quote: "second passage", page: 2, notePath: "two.md" }),
+    ];
+
+    const pagesFor = vi.fn(async () => [page(1, "first passage"), page(2, "second passage")]);
+    const summary = await auditCitations(notes, pagesFor);
+
+    expect(pagesFor).toHaveBeenCalledTimes(1);
+    expect(summary.checked).toBe(2);
+    expect(summary.lost).toBe(0);
+  });
+
+  it("counts what is wrong, across every document", async () => {
+    const notes = [
+      citing({ quote: "still here", page: 1 }),
+      citing({ quote: "has moved", page: 1, notePath: "b.md" }),
+      citing({ quote: "gone entirely", page: 1, notePath: "c.md" }),
+    ];
+
+    const summary = await auditCitations(notes, async () => [
+      page(1, "still here"),
+      page(2, "has moved"),
+    ]);
+
+    expect(summary.checked).toBe(3);
+    expect(summary.moved).toBe(1);
+    expect(summary.lost).toBe(1);
+  });
+
+  /**
+   * A document that cannot be read is not a document full of broken
+   * citations. Treating a failed fetch as "no pages" would report every
+   * quotation in it as lost, which is the one message that must never be
+   * wrong.
+   */
+  it("reports a document it could not read as unread, not as broken", async () => {
+    const notes = [citing({ quote: "still here", page: 1 })];
+
+    const summary = await auditCitations(notes, async () => {
+      throw new Error("That PDF could not be read from the repository.");
+    });
+
+    expect(summary.unreadable).toBe(1);
+    expect(summary.lost).toBe(0);
+    expect(summary.checked).toBe(0);
+    expect(summary.documents[0]?.error).toMatch(/could not be read/);
+  });
+
+  it("opens nothing at all for a notebook with no citations in it", async () => {
+    const pagesFor = vi.fn();
+    const summary = await auditCitations([{ path: "a.md", content: "# nothing here" }], pagesFor);
+
+    expect(pagesFor).not.toHaveBeenCalled();
+    expect(summary.documents).toEqual([]);
+  });
+
+  it("says which document it is on, and when it has finished", async () => {
+    const seen: string[] = [];
+    const notes = [
+      citing({ quote: "a", page: 1, path: "papers/one.pdf" }),
+      citing({ quote: "b", page: 1, path: "papers/two.pdf", notePath: "b.md" }),
+    ];
+
+    await auditCitations(notes, async () => [page(1, "a b")], {
+      onProgress: (done, total, pdfPath) => seen.push(`${done}/${total} ${pdfPath}`),
+    });
+
+    expect(seen).toEqual([
+      "0/2 papers/one.pdf",
+      "1/2 papers/one.pdf",
+      "1/2 papers/two.pdf",
+      "2/2 papers/two.pdf",
+    ]);
+  });
+});
+
+describe("withCorrectedPage", () => {
+  it("moves the page number on and leaves the quotation alone", () => {
+    const note = citing({ quote: "attention is all you need", page: 2 });
+    const [check] = checkAgainst(
+      [page(1, "x"), page(2, "y"), page(3, "attention is all you need")],
+      allPdfMentions([note]),
+    );
+
+    const fixed = withCorrectedPage(note.content, check!);
+
+    expect(fixed).toContain("page=3");
+    expect(fixed).toContain(`q=${encodeURIComponent("attention is all you need")}`);
+    // The words of the note are the reader's, not ours to rewrite.
+    expect(fixed).toContain("> attention is all you need");
+  });
+
+  it("rewrites the citation that moved, not its neighbour on the same line", () => {
+    const content = "[A](papers/x.pdf#page=2&q=alpha) and [B](papers/x.pdf#page=9&q=beta)";
+    const [alpha] = checkAgainst(
+      [page(1, "alpha"), page(9, "beta")],
+      allPdfMentions([{ path: "n.md", content }]),
+    );
+
+    const fixed = withCorrectedPage(content, alpha!);
+
+    expect(fixed).toContain("page=1&q=alpha");
+    expect(fixed).toContain("page=9&q=beta");
+  });
+
+  it("changes nothing for a passage that is nowhere to be found", () => {
+    const note = citing({ quote: "gone", page: 2 });
+    const [check] = checkAgainst([page(1, "something else")], allPdfMentions([note]));
+
+    expect(withCorrectedPage(note.content, check!)).toBe(note.content);
+  });
+});
+
+describe("summarise", () => {
+  it("adds nothing up when there is nothing to add up", () => {
+    expect(summarise([])).toEqual({
+      documents: [],
+      checked: 0,
+      lost: 0,
+      moved: 0,
+      fuzzy: 0,
+      unreadable: 0,
+    });
+  });
+});

--- a/apps/web/src/lib/citation-audit.ts
+++ b/apps/web/src/lib/citation-audit.ts
@@ -1,0 +1,194 @@
+"use client";
+
+import { resolveCitation, type PdfMatchQuality } from "@forkleaf/pdf";
+import type { PdfPageText } from "@forkleaf/pdf";
+import { allPdfMentions, type MentionSource, type PdfMention } from "@/lib/pdf-mentions";
+
+/**
+ * Checking that every quotation still says what the note says it says.
+ *
+ * Every other tool stores a page number, and a page number is a claim that
+ * quietly stops being true: the author adds a figure to page 4 and every
+ * citation after it points one page short. Nothing tells you. The link still
+ * opens, it just shows the wrong paragraph — and you find out, if you ever
+ * do, when somebody checks your reference.
+ *
+ * A ForkLeaf citation records the sentence, so the question "is this still
+ * true?" has an answer, and this is the sweep that asks it of the whole
+ * notebook at once. Four outcomes, and they are genuinely different things:
+ *
+ *   - `exact` — the words are there, on the page the note recorded
+ *   - `moved` — the words are there, on a different page. Nothing is wrong
+ *     with the quotation; the link's page number is stale and can be corrected
+ *   - `fuzzy` — the words are there after allowing for hyphenation, ligatures
+ *     and spacing. Worth an eye: it can also mean the passage was edited
+ *   - `lost` — the words are not in the document any more. This is the one
+ *     that matters, and the one no other reader can tell you about
+ *
+ * A pure function over text, with the reading of documents handed in. That is
+ * what makes the interesting half testable without a rendering engine, and it
+ * is why the caller decides whether a document comes from the cache or off
+ * the network.
+ */
+
+export interface CitationCheck {
+  mention: PdfMention;
+  quality: PdfMatchQuality;
+  /** Where the passage is now, or null when it is nowhere. */
+  page: number | null;
+  /** True when the citation's page number no longer matches where it is. */
+  stale: boolean;
+}
+
+export interface DocumentAudit {
+  pdfPath: string;
+  checks: CitationCheck[];
+  /** Why this document could not be checked, when it could not be. */
+  error: string | null;
+}
+
+export interface AuditSummary {
+  documents: DocumentAudit[];
+  /** Citations checked, across every document. */
+  checked: number;
+  lost: number;
+  moved: number;
+  fuzzy: number;
+  /** Documents that could not be read at all. */
+  unreadable: number;
+}
+
+/** Reads a document's text, from wherever the caller keeps it. */
+export type PagesFor = (pdfPath: string) => Promise<PdfPageText[]>;
+
+/**
+ * Checks one document's citations.
+ *
+ * Mentions with no quotation are skipped rather than reported. A link written
+ * as `#page=4` records no words, so there is nothing to look for and nothing
+ * that could have gone wrong with it that this could detect — reporting it as
+ * "fine" would be a claim nobody checked.
+ */
+export function checkAgainst(
+  pages: PdfPageText[],
+  mentions: readonly PdfMention[],
+): CitationCheck[] {
+  const checks: CitationCheck[] = [];
+
+  for (const mention of mentions) {
+    const citation = mention.citation;
+    if (!citation || !citation.quote.trim()) continue;
+
+    const match = resolveCitation(pages, citation);
+    checks.push({
+      mention,
+      quality: match.quality,
+      page: match.page,
+      stale: match.page != null && match.page !== citation.page,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * The whole notebook, document by document.
+ *
+ * Sequential on purpose. Each document means fetching a file and running a
+ * pdf.js worker over every page of it, and doing forty of those at once is how
+ * a browser tab runs out of memory — the reader would rather wait and be told
+ * where it has got to.
+ */
+export async function auditCitations(
+  notes: readonly MentionSource[],
+  pagesFor: PagesFor,
+  options: { onProgress?: (done: number, total: number, pdfPath: string) => void } = {},
+): Promise<AuditSummary> {
+  const mentions = allPdfMentions(notes);
+
+  const byDocument = new Map<string, PdfMention[]>();
+  for (const mention of mentions) {
+    // A mention with no quotation cannot be checked, and a document mentioned
+    // only by such links is a document there is no reason to open.
+    if (!mention.citation?.quote.trim()) continue;
+    byDocument.set(mention.pdfPath, [...(byDocument.get(mention.pdfPath) ?? []), mention]);
+  }
+
+  const paths = [...byDocument.keys()].sort();
+  const documents: DocumentAudit[] = [];
+  let done = 0;
+
+  for (const pdfPath of paths) {
+    options.onProgress?.(done, paths.length, pdfPath);
+
+    try {
+      const pages = await pagesFor(pdfPath);
+      documents.push({
+        pdfPath,
+        checks: checkAgainst(pages, byDocument.get(pdfPath) ?? []),
+        error: null,
+      });
+    } catch (problem: unknown) {
+      // A document that cannot be read is reported as unread, never as a
+      // notebook full of broken citations — which is what treating a failed
+      // fetch as "no pages" would produce.
+      documents.push({
+        pdfPath,
+        checks: [],
+        error: problem instanceof Error ? problem.message : "That document could not be read.",
+      });
+    }
+
+    done += 1;
+    options.onProgress?.(done, paths.length, pdfPath);
+  }
+
+  return summarise(documents);
+}
+
+export function summarise(documents: DocumentAudit[]): AuditSummary {
+  const all = documents.flatMap((document) => document.checks);
+
+  return {
+    documents,
+    checked: all.length,
+    lost: all.filter((check) => check.quality === "lost").length,
+    moved: all.filter((check) => check.quality === "moved").length,
+    fuzzy: all.filter((check) => check.quality === "fuzzy").length,
+    unreadable: documents.filter((document) => document.error !== null).length,
+  };
+}
+
+/**
+ * The note with one citation's page number brought up to date.
+ *
+ * Only the `page=` field, and only on links that resolve to this document at
+ * this passage — the quotation, the context and the path are what identify the
+ * link and are left exactly as they were. A citation whose words have moved is
+ * still a correct citation; it is the page hint beside it that has gone stale,
+ * and rewriting anything else would be editing somebody's note rather than
+ * repairing a link in it.
+ */
+export function withCorrectedPage(content: string, check: CitationCheck): string {
+  const { mention, page } = check;
+  if (page == null) return content;
+
+  const lines = content.split("\n");
+  const index = mention.line - 1;
+  const line = lines[index];
+  if (line === undefined) return content;
+
+  const quote = mention.citation?.quote ?? "";
+  const encoded = encodeURIComponent(quote);
+
+  const repaired = line.replace(/\(([^()\s]*\.pdf#[^()\s]*)\)/gi, (whole, target: string) => {
+    // The right link on a line that may hold several: the one quoting these
+    // words. Comparing the encoded quotation rather than re-parsing keeps
+    // this honest about which link is being rewritten.
+    if (quote && !target.includes(encoded) && !target.includes(quote)) return whole;
+    return `(${target.replace(/(^|[#&])(page|p)=\d+/i, `$1$2=${page}`)})`;
+  });
+
+  lines[index] = repaired;
+  return lines.join("\n");
+}

--- a/apps/web/src/lib/pdf-index.test.ts
+++ b/apps/web/src/lib/pdf-index.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { PdfTextEntry } from "@forkleaf/types";
+import { entryFrom, pagesOf, pdfTextId, searchDocuments } from "./pdf-index";
+
+const entry = (path: string, pages: string[]): PdfTextEntry =>
+  entryFrom(
+    "w",
+    path,
+    pages.map((text, index) => ({ page: index + 1, text })),
+  );
+
+describe("entryFrom", () => {
+  it("keys a document by workspace and path, like everything else stored here", () => {
+    expect(entryFrom("w", "papers/x.pdf", []).id).toBe(pdfTextId("w", "papers/x.pdf"));
+  });
+
+  it("records when it was read, so a stale copy can be recognised", () => {
+    const at = new Date("2026-03-14T10:00:00.000Z");
+    expect(entryFrom("w", "papers/x.pdf", [], at).indexedAt).toBe("2026-03-14T10:00:00.000Z");
+  });
+});
+
+describe("pagesOf", () => {
+  it("hands back pages the search and citation code can take", () => {
+    const pages = pagesOf(entry("papers/x.pdf", ["hello"]));
+    expect(pages).toEqual([{ page: 1, text: "hello", runs: [] }]);
+  });
+});
+
+describe("searchDocuments", () => {
+  const shelf = [
+    entry("papers/attention.pdf", ["Attention is all you need.", "A second page of it."]),
+    entry("papers/other.pdf", ["Nothing about attention here — well, one mention."]),
+  ];
+
+  it("finds a phrase inside a document, and says which page", () => {
+    const [hit] = searchDocuments(shelf, "all you need");
+
+    expect(hit?.path).toBe("papers/attention.pdf");
+    expect(hit?.page).toBe(1);
+    expect(hit?.snippet).toContain("all you need");
+  });
+
+  it("reaches every document, not just the first", () => {
+    const paths = searchDocuments(shelf, "attention").map((hit) => hit.path);
+    expect(new Set(paths)).toEqual(new Set(["papers/attention.pdf", "papers/other.pdf"]));
+  });
+
+  /**
+   * A three-hundred-page paper using the word "model" on every page would
+   * otherwise fill the list before the second document was reached — and
+   * somebody searching their notebook is looking for *which* document, not for
+   * four hundred occurrences in one of them.
+   */
+  it("takes only a few hits from any one document", () => {
+    const repetitive = entry(
+      "papers/repeat.pdf",
+      Array.from({ length: 20 }, () => "model model model"),
+    );
+
+    expect(searchDocuments([repetitive], "model", { perDocument: 2 })).toHaveLength(2);
+  });
+
+  it("stops at the overall limit", () => {
+    expect(searchDocuments(shelf, "attention", { limit: 1 })).toHaveLength(1);
+  });
+
+  it("says nothing at all until there is a question", () => {
+    expect(searchDocuments(shelf, "")).toEqual([]);
+    expect(searchDocuments(shelf, " ")).toEqual([]);
+    // One character is still typing, not searching.
+    expect(searchDocuments(shelf, "a")).toEqual([]);
+  });
+
+  it("finds a word the document broke across a line", () => {
+    // The reason searching PDFs is done through the normaliser: a literal
+    // search finds none of these, and the reader concludes the phrase is not
+    // in a document that says it twice.
+    const hyphenated = entry("papers/typeset.pdf", ["the regu-\nlar expression"]);
+
+    expect(searchDocuments([hyphenated], "regular")).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/pdf-index.ts
+++ b/apps/web/src/lib/pdf-index.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import { openPdf, searchPdf, type PdfPageText, type PdfSearchHit } from "@forkleaf/pdf";
+import type { PdfTextEntry, Workspace } from "@forkleaf/types";
+import { fetchRepoPdf } from "@/lib/pdf-source";
+
+/**
+ * Keeping the words a document is made of.
+ *
+ * The reader has always extracted every page's text — that is what makes
+ * find-in-document work through hyphenation and ligatures — and then thrown it
+ * away when the document closed. So the words were searchable for as long as
+ * somebody was looking at them and nowhere else: not from ⌘K, not while
+ * checking whether a citation still points at anything.
+ *
+ * Extracting them again is seconds of work per document. Keeping them is a few
+ * hundred kilobytes. This is the small module that turns the second into the
+ * first: read once, stored beside the notebook, and used by everything that
+ * has a question about what a document says.
+ *
+ * Only the text is kept. The positioned runs behind it are for drawing a
+ * highlight on a page and are far larger; anything that needs them has the
+ * document open in front of it.
+ */
+
+/** Where pdf.js finds its standard fonts and character maps. */
+export const PDFJS_ASSETS = "/pdfjs";
+
+export const pdfTextId = (workspaceId: string, path: string) => `${workspaceId}::${path}`;
+
+/**
+ * Stored pages as the search and citation code want them.
+ *
+ * Both take `PdfPageText`, whose `runs` they never read — the runs exist to
+ * turn a character range into rectangles on a canvas, which is a question only
+ * an open document can answer.
+ */
+export function pagesOf(entry: PdfTextEntry): PdfPageText[] {
+  return entry.pages.map((page) => ({ page: page.page, text: page.text, runs: [] }));
+}
+
+/** The text of a repository document, read out of the file itself. */
+export async function readDocumentText(
+  workspace: Workspace,
+  path: string,
+  onProgress?: (done: number, total: number) => void,
+): Promise<{ page: number; text: string }[]> {
+  const bytes = await fetchRepoPdf(workspace, path);
+  const session = await openPdf(bytes, { assetsUrl: PDFJS_ASSETS });
+
+  try {
+    const pages = await (onProgress ? session.allText({ onProgress }) : session.allText());
+    return pages.map((page) => ({ page: page.page, text: page.text }));
+  } finally {
+    // A worker per document, held open for as long as this takes and not one
+    // moment longer. Indexing a shelf of papers otherwise ends with a dozen
+    // pdf.js workers alive at once.
+    await session.destroy().catch(() => {});
+  }
+}
+
+export function entryFrom(
+  workspaceId: string,
+  path: string,
+  pages: { page: number; text: string }[],
+  now = new Date(),
+): PdfTextEntry {
+  return {
+    id: pdfTextId(workspaceId, path),
+    workspaceId,
+    path,
+    pages,
+    indexedAt: now.toISOString(),
+  };
+}
+
+/** One occurrence of a phrase, in one document. */
+export interface DocumentHit {
+  path: string;
+  page: number;
+  /** A line of the page around the match, for the result list. */
+  snippet: string;
+  /** Where the match sits inside `snippet`. */
+  snippetRange: [start: number, end: number];
+}
+
+/**
+ * Every occurrence of a phrase across the documents whose text is kept.
+ *
+ * Capped per document as well as overall, deliberately. A three-hundred-page
+ * paper that uses the word "model" on every page would otherwise fill the
+ * whole result list before the second document was reached, which is the
+ * opposite of what somebody searching their notebook wants — they are looking
+ * for *which* document, not for all four hundred occurrences in one of them.
+ */
+export function searchDocuments(
+  entries: readonly PdfTextEntry[],
+  query: string,
+  options: { perDocument?: number; limit?: number } = {},
+): DocumentHit[] {
+  const needle = query.trim();
+  // Two characters is where "find as you type" stops being a search of every
+  // word in every document and starts being a question.
+  if (needle.length < 2) return [];
+
+  const perDocument = options.perDocument ?? 3;
+  const limit = options.limit ?? 12;
+  const found: DocumentHit[] = [];
+
+  for (const entry of entries) {
+    const hits: PdfSearchHit[] = searchPdf(pagesOf(entry), needle, { limit: perDocument });
+
+    for (const hit of hits) {
+      found.push({
+        path: entry.path,
+        page: hit.page,
+        snippet: hit.snippet,
+        snippetRange: hit.snippetRange,
+      });
+      if (found.length >= limit) return found;
+    }
+  }
+
+  return found;
+}

--- a/apps/web/src/lib/pdf-mentions.ts
+++ b/apps/web/src/lib/pdf-mentions.ts
@@ -1,4 +1,4 @@
-import { parseCitation } from "@forkleaf/pdf";
+import { parseCitation, type PdfCitation } from "@forkleaf/pdf";
 import { pdfLinkTarget } from "@/lib/pdf-source";
 
 /**
@@ -22,6 +22,17 @@ import { pdfLinkTarget } from "@/lib/pdf-source";
 export interface PdfMention {
   /** The note the mention was found in. */
   notePath: string;
+  /** The document it points at, repository-relative. */
+  pdfPath: string;
+  /**
+   * The passage this points at, as the link records it.
+   *
+   * Null for a link with no fragment at all — "the paper", rather than a
+   * particular sentence in it. Kept whole rather than reduced to a page
+   * number, because checking whether a citation still holds means matching the
+   * words, and the page is only ever a hint about where to start looking.
+   */
+  citation: PdfCitation | null;
   /** 1-based, so it can be reported and jumped to. */
   line: number;
   /** The link's own text — usually "Title, p. 12". */
@@ -57,6 +68,21 @@ export interface MentionSource {
 }
 
 export function mentionsOfPdf(notes: readonly MentionSource[], pdfPath: string): PdfMention[] {
+  return scan(notes, (path) => path === pdfPath);
+}
+
+/**
+ * Every mention of every document, across the whole notebook.
+ *
+ * The same scan without the filter, for the sweep that checks all of them at
+ * once. One pass over the notes rather than one pass per document: a notebook
+ * with forty papers in it would otherwise be read forty times.
+ */
+export function allPdfMentions(notes: readonly MentionSource[]): PdfMention[] {
+  return scan(notes, () => true);
+}
+
+function scan(notes: readonly MentionSource[], wanted: (pdfPath: string) => boolean): PdfMention[] {
   const found: PdfMention[] = [];
 
   for (const note of notes) {
@@ -71,12 +97,14 @@ export function mentionsOfPdf(notes: readonly MentionSource[], pdfPath: string):
       for (const match of line.matchAll(LINK)) {
         const [, rawLabel = "", href = ""] = match;
         const target = pdfLinkTarget(note.path, href);
-        if (!target || target.path !== pdfPath) continue;
+        if (!target || !wanted(target.path)) continue;
 
         const citation = target.fragment ? parseCitation(target.fragment) : null;
 
         found.push({
           notePath: note.path,
+          pdfPath: target.path,
+          citation,
           line: index + 1,
           label: unescapeLinkText(rawLabel),
           page: citation?.page ?? pageFromFragment(target.fragment),
@@ -92,6 +120,7 @@ export function mentionsOfPdf(notes: readonly MentionSource[], pdfPath: string):
   // the passage is, so reading down the list is reading through the paper —
   // mentions with no page at all go last rather than pretending to be page 0.
   return found.sort((a, b) => {
+    if (a.pdfPath !== b.pdfPath) return a.pdfPath.localeCompare(b.pdfPath);
     if (a.page !== b.page) return (a.page ?? Infinity) - (b.page ?? Infinity);
     if (a.notePath !== b.notePath) return a.notePath.localeCompare(b.notePath);
     return a.line - b.line;

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -44,14 +44,13 @@ Ticked entries link to nothing; the git history is the record.
 
 - [x] **Save this PDF into my notebook** — shipped before this list existed
 - [x] **Open a PDF and see everything you have written about it** — Small
-- [ ] **Search inside your PDFs from ⌘K** — Small. The text is already
-      extracted for find-in-document; it just is not kept
+- [x] **Search inside your PDFs from ⌘K** — Small. The text is kept the first
+      time a document is read, so ⌘K reaches inside the papers as well
 - [ ] **Scroll one pane, the other follows** — Small. Scroll the note and the
       document moves to the page you are writing about, and back again
-- [ ] **A list of citations that have broken** — Medium. Check every quotation
-      in the notebook against the document as it stands now. The hard part —
-      finding the sentence again — already works and is already tested. If one
-      thing on this list gets built, it should be this one
+- [x] **A list of citations that have broken** — Medium. Every quotation in the
+      notebook, checked against the document as it stands now: what has moved,
+      what is gone, and a one-press fix for a stale page number
 - [ ] **See what changed between two versions of a PDF** — Medium. The file is
       in a repository, so old versions are kept: show page 12 then and now, and
       say whether the page you quoted is one of the ones that changed

--- a/packages/store/src/idb-db.test.ts
+++ b/packages/store/src/idb-db.test.ts
@@ -134,7 +134,7 @@ describe("openLocalDatabase", () => {
       const request = indexedDB.open(DB_NAME, 99);
       request.onupgradeneeded = () => {
         const db = request.result;
-        for (const name of ["notes", "queue", "assets"]) {
+        for (const name of ["notes", "queue", "assets", "pdftext"]) {
           db.createObjectStore(name, { keyPath: "id" }).createIndex("by-workspace", "workspaceId");
         }
         db.createObjectStore("workspaces", { keyPath: "id" });

--- a/packages/store/src/idb-db.ts
+++ b/packages/store/src/idb-db.ts
@@ -1,5 +1,12 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
-import type { LocalAsset, Note, PendingChange, TreeNode, Workspace } from "@forkleaf/types";
+import type {
+  LocalAsset,
+  Note,
+  PdfTextEntry,
+  PendingChange,
+  TreeNode,
+  Workspace,
+} from "@forkleaf/types";
 import type { LocalDatabase } from "./ports";
 import { tabChannel, type TabChannel } from "./tab-channel";
 
@@ -38,11 +45,16 @@ interface ForkLeafSchema extends DBSchema {
     key: string;
     value: { key: string; value: unknown };
   };
+  pdftext: {
+    key: string;
+    value: PdfTextEntry;
+    indexes: { "by-workspace": string };
+  };
 }
 
 const DB_NAME = "forkleaf";
 /**
- * Bumped to 2 for the `assets` store.
+ * Bumped to 3 for the `pdftext` store, and to 2 before that for `assets`.
  *
  * Every store is created behind a `contains` check rather than in a
  * version-numbered branch, so an existing database gains the new store and
@@ -53,7 +65,7 @@ const DB_NAME = "forkleaf";
  * make a second tab briefly unable to open it. Only bump it when a new store
  * actually requires it.
  */
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 /**
  * How long to wait for the database to open before giving up on it.
@@ -72,7 +84,15 @@ const OPEN_TIMEOUT_MS = 8_000;
 const RELEASE_TIMEOUT_MS = 1_500;
 
 /** Every store the code below reads from. Checked when no upgrade can run. */
-const REQUIRED_STORES = ["notes", "workspaces", "queue", "trees", "assets", "meta"] as const;
+const REQUIRED_STORES = [
+  "notes",
+  "workspaces",
+  "queue",
+  "trees",
+  "assets",
+  "meta",
+  "pdftext",
+] as const;
 
 export class IndexedDbDatabase implements LocalDatabase {
   readonly persistent = true;
@@ -187,7 +207,7 @@ export class IndexedDbDatabase implements LocalDatabase {
          */
         upgrade(db, _oldVersion, _newVersion, tx) {
           const store = <
-            Name extends "notes" | "queue" | "assets" | "workspaces" | "trees" | "meta",
+            Name extends "notes" | "queue" | "assets" | "workspaces" | "trees" | "meta" | "pdftext",
           >(
             name: Name,
             keyPath: string,
@@ -196,7 +216,7 @@ export class IndexedDbDatabase implements LocalDatabase {
               ? tx.objectStore(name)
               : db.createObjectStore(name, { keyPath });
 
-          for (const name of ["notes", "queue", "assets"] as const) {
+          for (const name of ["notes", "queue", "assets", "pdftext"] as const) {
             const created = store(name, "id");
             if (!created.indexNames.contains("by-workspace")) {
               created.createIndex("by-workspace", "workspaceId");
@@ -393,6 +413,22 @@ export class IndexedDbDatabase implements LocalDatabase {
 
   async listAssets(workspaceId: string): Promise<LocalAsset[]> {
     return (await this.db).getAllFromIndex("assets", "by-workspace", workspaceId);
+  }
+
+  async getPdfText(id: string): Promise<PdfTextEntry | undefined> {
+    return (await this.db).get("pdftext", id);
+  }
+
+  async putPdfText(entry: PdfTextEntry): Promise<void> {
+    await (await this.db).put("pdftext", entry);
+  }
+
+  async deletePdfText(id: string): Promise<void> {
+    await (await this.db).delete("pdftext", id);
+  }
+
+  async listPdfText(workspaceId: string): Promise<PdfTextEntry[]> {
+    return (await this.db).getAllFromIndex("pdftext", "by-workspace", workspaceId);
   }
 
   async getMeta<T>(key: string): Promise<T | undefined> {

--- a/packages/store/src/memory-db.ts
+++ b/packages/store/src/memory-db.ts
@@ -1,4 +1,11 @@
-import type { LocalAsset, Note, PendingChange, TreeNode, Workspace } from "@forkleaf/types";
+import type {
+  LocalAsset,
+  Note,
+  PdfTextEntry,
+  PendingChange,
+  TreeNode,
+  Workspace,
+} from "@forkleaf/types";
 import type { LocalDatabase } from "./ports";
 
 /**
@@ -17,6 +24,7 @@ export class MemoryDatabase implements LocalDatabase {
   private queue = new Map<string, PendingChange>();
   private trees = new Map<string, TreeNode[]>();
   private assets = new Map<string, LocalAsset>();
+  private pdfText = new Map<string, PdfTextEntry>();
   private meta = new Map<string, unknown>();
 
   async getNote(id: string): Promise<Note | undefined> {
@@ -95,6 +103,22 @@ export class MemoryDatabase implements LocalDatabase {
 
   async listAssets(workspaceId: string): Promise<LocalAsset[]> {
     return [...this.assets.values()].filter((asset) => asset.workspaceId === workspaceId);
+  }
+
+  async getPdfText(id: string): Promise<PdfTextEntry | undefined> {
+    return clone(this.pdfText.get(id));
+  }
+
+  async putPdfText(entry: PdfTextEntry): Promise<void> {
+    this.pdfText.set(entry.id, clone(entry)!);
+  }
+
+  async deletePdfText(id: string): Promise<void> {
+    this.pdfText.delete(id);
+  }
+
+  async listPdfText(workspaceId: string): Promise<PdfTextEntry[]> {
+    return [...this.pdfText.values()].filter((entry) => entry.workspaceId === workspaceId);
   }
 
   async getMeta<T>(key: string): Promise<T | undefined> {

--- a/packages/store/src/ports.ts
+++ b/packages/store/src/ports.ts
@@ -1,4 +1,11 @@
-import type { LocalAsset, Note, PendingChange, TreeNode, Workspace } from "@forkleaf/types";
+import type {
+  LocalAsset,
+  Note,
+  PdfTextEntry,
+  PendingChange,
+  TreeNode,
+  Workspace,
+} from "@forkleaf/types";
 
 /**
  * Ports the sync engine depends on.
@@ -40,6 +47,11 @@ export interface LocalDatabase {
   putAsset(asset: LocalAsset): Promise<void>;
   deleteAsset(id: string): Promise<void>;
   listAssets(workspaceId: string): Promise<LocalAsset[]>;
+
+  getPdfText(id: string): Promise<PdfTextEntry | undefined>;
+  putPdfText(entry: PdfTextEntry): Promise<void>;
+  deletePdfText(id: string): Promise<void>;
+  listPdfText(workspaceId: string): Promise<PdfTextEntry[]>;
 
   getMeta<T>(key: string): Promise<T | undefined>;
   putMeta<T>(key: string, value: T): Promise<void>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -385,6 +385,33 @@ export interface LocalAsset {
   pushed: boolean;
 }
 
+// ─── Documents ──────────────────────────────────────────────────────────────
+
+/**
+ * The text of a PDF, kept after it has been read once.
+ *
+ * Extracting the text of a three-hundred-page paper takes seconds, and it was
+ * being done on every open and thrown away on every close — so the words were
+ * searchable inside the reader, for as long as the reader was looking at them,
+ * and nowhere else. Keeping them is what lets the notebook's own search reach
+ * inside documents, and what lets a citation be checked without opening the
+ * paper it points at.
+ *
+ * The positioned runs are deliberately not kept. They exist to draw a
+ * highlight on a page and are far larger than the text; anything that needs
+ * them has the document open in front of it.
+ */
+export interface PdfTextEntry {
+  /** `${workspaceId}::${path}`, like every other stored thing here. */
+  id: string;
+  workspaceId: string;
+  /** Repository-relative path of the document the text came out of. */
+  path: string;
+  pages: { page: number; text: string }[];
+  /** When it was read, so a stale copy can be recognised as one. */
+  indexedAt: string;
+}
+
 // ─── Export ─────────────────────────────────────────────────────────────────
 
 export type ExportFormat = "md" | "html" | "pdf" | "docx" | "txt" | "json";


### PR DESCRIPTION
Two features from [docs/ideas.md](docs/ideas.md), which they tick off. **Stacked on [#61](https://github.com/praneeth132006/ForkLeaf/pull/61)** — merge that first, or retarget this at `main` after it lands.

## Citations that check themselves

Every other tool stores a page number, and a page number quietly stops being true: the author adds a figure to page 4 and every citation after it points one page short. Nothing tells you — the link still opens, it just shows the wrong paragraph.

A ForkLeaf citation records the sentence, so the question has an answer. **Check my citations against their documents** (⌘K) reads every paper you have quoted and reports what it found: quotations that have moved, ones that matched only loosely, and ones that are no longer in the document at all.

A moved quotation can have its page number corrected in place, one press per citation — only the `page=` field, on the link quoting those words. Nothing is rewritten without being shown first.

A document that could not be read is reported as unread, never as a document full of broken citations. Treating a failed fetch as "no pages" would report every quotation in it as lost, which is the one message that must not be wrong.

## ⌘K reaches inside the documents

The reader has always extracted every page's text and thrown it away on close. It is now kept, so the palette searches the papers as well as the notes and jumps straight to the page, with the sentence it found underneath. A document is indexed the first time it is opened — and by the citation check, so the two features pay for each other.

## The foundation

A fourth IndexedDB store, `pdftext`, holding page text only (the positioned runs are for drawing and are far larger). Database version 3. Verified in a real browser that an existing v2 database upgrades in place and comes back with all seven stores.

## Checks

`pnpm test` — 1973 passing, 121 files (35 new across `citation-audit`, `pdf-index`, `CitationsDialog` and `CommandPalette`). Lint, typecheck and build clean.

Verified in the browser: the v2 → v3 upgrade, and ⌘K finding a phrase inside a document and offering it as a "Documents" result at the right page. The citation sweep is covered by tests at every layer but has not been run against a real repository of papers, which needs a GitHub connection.