### PR TITLE
Start a note from a paper, and a ⌘K that knows where you are standing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,25 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Start a note from a paper
+
+**Write about this** in the reader makes a note that is already about the
+document: its title, its author and the date it was published in the
+frontmatter, and its own table of contents as the note's headings — each one
+linked to the page that section starts on. The document then moves aside and
+sits beside the note you are writing.
+
+Nothing is invented. A paper with no contents list of its own gets a single
+"Notes" heading rather than a structure somebody would have to argue with.
+
+### Search knows what you are working on
+
+⌘K now weighs which notes are connected to the one you are in. Searching
+"setup" in the middle of a project finds that project's setup rather than the
+other five. A note you linked to and a note that linked to you count the same,
+and the effect fades with distance — but it never beats a better kind of match,
+so a note actually called what you typed still wins.
+
 ### Citations that check themselves
 
 Every other tool stores a page number, and a page number quietly stops being

--- a/apps/web/src/components/CommandPalette.test.tsx
+++ b/apps/web/src/components/CommandPalette.test.tsx
@@ -99,3 +99,30 @@ describe("CommandPalette — searching inside documents", () => {
     expect(screen.queryByText("Documents")).toBeNull();
   });
 });
+
+describe("CommandPalette — knowing what you are working on", () => {
+  const tree = [
+    { kind: "file" as const, name: "setup.md", path: "projects/website/setup.md" },
+    { kind: "file" as const, name: "setup.md", path: "old/setup.md" },
+  ];
+
+  it("puts the connected note first among equals", () => {
+    open({
+      tree,
+      documents: [],
+      nearby: new Map([["projects/website/setup.md", 1]]),
+    });
+    search("setup");
+
+    const rows = screen.getAllByRole("option");
+    expect(rows[0]?.textContent).toContain("projects/website/setup.md");
+  });
+
+  it("ranks the same way as before when no note is open", () => {
+    open({ tree, documents: [] });
+    search("setup");
+
+    // Nothing to be near, so the usual order stands and nothing is lost.
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+  });
+});

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -49,6 +49,15 @@ export interface CommandPaletteProps {
   documents?: readonly PdfTextEntry[];
   /** Opens a document at the page a phrase was found on. */
   onOpenDocument?: (pdfPath: string, page: number) => void;
+  /**
+   * The notes around the one being written, by path, with their distance.
+   *
+   * What makes a search know where it is being made from: "setup" typed while
+   * writing about a project finds that project's setup rather than the other
+   * five. Absent when no note is open, which is when there is nowhere to be
+   * near.
+   */
+  nearby?: ReadonlyMap<string, number>;
   commands: Command[];
 }
 
@@ -60,6 +69,7 @@ export function CommandPalette({
   onOpenNote,
   documents = [],
   onOpenDocument,
+  nearby,
   commands,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
@@ -89,8 +99,9 @@ export function CommandPalette({
   }, [tree, openNotes, workspace]);
 
   const noteResults = useMemo(
-    () => queryIndex(noteEntries, { query, sort: "recent" }).slice(0, 8),
-    [noteEntries, query],
+    () =>
+      queryIndex(noteEntries, { query, sort: "recent", ...(nearby ? { nearby } : {}) }).slice(0, 8),
+    [noteEntries, query, nearby],
   );
 
   /**

--- a/apps/web/src/components/PdfReader.test.tsx
+++ b/apps/web/src/components/PdfReader.test.tsx
@@ -21,6 +21,21 @@ beforeAll(() => {
     },
   );
 
+  // A ready document watches its pages to know which are on screen. jsdom has
+  // no IntersectionObserver either, and the reader wires one up as soon as it
+  // has pages to watch.
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    },
+  );
+
   // Every element in jsdom is nought pixels wide, and the reader reads that as
   // "too narrow to dock anything" — so without a width the docked layout can
   // never be under test. A laptop's worth of room.
@@ -146,5 +161,45 @@ describe("PdfReader — what the notebook says about this document", () => {
     render(<PdfReader reader={loading} layout="document" mentions={null} onClose={null} />);
 
     expect(screen.queryByRole("button", { name: NOTES_TAB })).toBeNull();
+  });
+});
+
+describe("PdfReader — starting a note from the paper", () => {
+  const ready: PdfReaderState = {
+    ...loading,
+    status: "ready",
+    info: {
+      pageCount: 15,
+      metadata: {
+        title: "Attention Is All You Need",
+        author: "Vaswani et al.",
+        subject: null,
+        keywords: [],
+        createdAt: null,
+        modifiedAt: null,
+        producer: null,
+      },
+      // No sizes, so no page is drawn to a canvas jsdom does not have.
+      sizes: [],
+      encrypted: false,
+    },
+  };
+
+  it("offers to write about the paper, and says so in the reader's own words", () => {
+    const onStartNote = vi.fn();
+    render(<PdfReader reader={ready} layout="document" onStartNote={onStartNote} onClose={null} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Start a note about this paper, with its headings/ }),
+    );
+    expect(onStartNote).toHaveBeenCalled();
+  });
+
+  it("offers nothing of the kind while the document is still opening", () => {
+    // The title and the contents are the whole point of the button, and a note
+    // made before they arrive would be called "untitled" and be empty.
+    render(<PdfReader reader={loading} layout="document" onStartNote={vi.fn()} onClose={null} />);
+
+    expect(screen.queryByRole("button", { name: /Start a note about this paper/ })).toBeNull();
   });
 });

--- a/apps/web/src/components/PdfReader.tsx
+++ b/apps/web/src/components/PdfReader.tsx
@@ -72,6 +72,14 @@ export interface PdfReaderProps {
    */
   onOpenInTab?: (() => void) | null;
   /**
+   * Starts a note about this paper, with its headings already in it.
+   *
+   * Absent while the document is still opening: the title and the contents are
+   * the whole point of the button, and a note made before they arrive would be
+   * called "untitled" and be empty.
+   */
+  onStartNote?: (() => void) | null;
+  /**
    * Commits this document into the repository, so it can be linked to.
    *
    * Absent when there is nowhere to put it. `saveHint` explains why, in words,
@@ -154,6 +162,7 @@ export function PdfReader({
   onSave,
   saveHint,
   saving = false,
+  onStartNote = null,
   mentions = null,
   onOpenMention = null,
   titleForNote,
@@ -553,6 +562,15 @@ export function PdfReader({
                   onClick={() => setPanel(panel === "notes" ? null : "notes")}
                 >
                   {`Notes ${mentions.length}`}
+                </ToolButton>
+              ) : null}
+
+              {onStartNote ? (
+                <ToolButton
+                  label="Start a note about this paper, with its headings in it"
+                  onClick={onStartNote}
+                >
+                  Write about this
                 </ToolButton>
               ) : null}
 

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -18,6 +18,7 @@ import {
   dirname,
   documentStats,
   joinPath,
+  neighbourhood,
   parseRepoTarget,
   referencedPaths,
   type RepoTarget,
@@ -822,6 +823,17 @@ export function EditorWorkspace() {
     repo: workspace && !workspace.isLocal ? workspace.repo : null,
   });
 
+  /**
+   * The notes around the one being written, for ⌘K to weigh.
+   *
+   * The link graph is built for backlinks and answers this for free: a note
+   * you linked to and a note that linked to you are equally near, because in
+   * both cases somebody decided they belonged together.
+   */
+  const nearbyNotes = useMemo(
+    () => (note && links.ready ? neighbourhood(links.graph, note.path) : null),
+    [note, links.ready, links.graph],
+  );
 
   /**
    * Creates the note a link points at but that nobody has written yet.
@@ -2774,6 +2786,7 @@ export function EditorWorkspace() {
           // A notebook with no repository has no documents to reach: nothing
           // could have been read from one, and a result that opened nothing
           // would be worse than no result.
+          {...(nearbyNotes ? { nearby: nearbyNotes } : {})}
           documents={workspace && !workspace.isLocal ? documentTexts : []}
           onOpenDocument={(path, page) => openRepoPdf(path, `page=${page}`)}
           commands={commands}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -49,6 +49,7 @@ import { insertionFor, quoteMarkdown } from "@/lib/pdf-quote";
 import { mentionsOfPdf, type PdfMention } from "@/lib/pdf-mentions";
 import { pagesOf, readDocumentText } from "@/lib/pdf-index";
 import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
+import { paperNote } from "@/lib/note-from-paper";
 import { CitationsDialog } from "@/components/CitationsDialog";
 import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
@@ -705,6 +706,59 @@ export function EditorWorkspace() {
   );
 
   /**
+   * Starts a note about the paper on screen, with its headings already in it.
+   *
+   * Two writes rather than one, deliberately: the note's links are written
+   * relative to *its own* path, and that path is only decided — slugified from
+   * the title, made unique against everything else — once the note exists. So
+   * it is created, and then filled in now that there is somewhere to write
+   * from. The two land in one commit, since the queue coalesces them.
+   */
+  const startNoteFromPaper = useCallback(async () => {
+    if (!reader.info) return;
+
+    const draft = paperNote({
+      metadata: reader.info.metadata,
+      filename: reader.source?.name ?? "Paper",
+      outline: reader.outline,
+      pageCount: reader.info.pageCount,
+      pdfPath: readerPath,
+      // A placeholder: the real path replaces it below, and the links are
+      // rewritten against it.
+      notePath: "",
+    });
+
+    // Beside the note you were last in, not beside the PDF: `papers/` is where
+    // the files live, and a note about a paper is writing, not a file.
+    const created = await notebook.createNote(
+      draft.title,
+      currentFolder,
+      draft.content,
+      draft.frontmatter,
+    );
+    if (!created) return;
+
+    const filled = paperNote({
+      metadata: reader.info.metadata,
+      filename: reader.source?.name ?? "Paper",
+      outline: reader.outline,
+      pageCount: reader.info.pageCount,
+      pdfPath: readerPath,
+      notePath: created.path,
+    });
+    await notebook.rewriteNote(created.path, () => filled.content);
+
+    // The note it just made is what the reader wants to look at, so the
+    // document steps aside from the middle column and reads beside it.
+    // Moved rather than reopened: the document is already parsed and rendered,
+    // and reopening it would fetch and lay out the whole file again to end up
+    // exactly where it is.
+    if (readerLayout === "document") setReaderLayout("beside");
+
+    setNotice(`Started ${created.path} from this paper`);
+  }, [reader, readerPath, readerLayout, notebook, currentFolder]);
+
+  /**
    * What this notebook has already said about the document being read.
    *
    * Null rather than empty for a document with no repository path: a note
@@ -767,6 +821,7 @@ export function EditorWorkspace() {
     hrefFor: hrefForPath,
     repo: workspace && !workspace.isLocal ? workspace.repo : null,
   });
+
 
   /**
    * Creates the note a link points at but that nobody has written yet.
@@ -2017,6 +2072,7 @@ export function EditorWorkspace() {
       onSave={canSavePdf ? () => void savePdfToNotebook() : null}
       saveHint={pdfSaveHint}
       saving={savingPdf}
+      onStartNote={reader.status === "ready" ? () => void startNoteFromPaper() : null}
       mentions={pdfMentions}
       onOpenMention={(path) => {
         notebook.openNote(path);

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_SYNC_PREFERENCE,
   type LocalAsset,
   type Note,
+  type NoteFrontmatter,
   type PendingChange,
   type RepoRef,
   type SyncMode,
@@ -945,7 +946,7 @@ export function useNotebook(request: NotebookRequest = {}) {
   );
 
   const createNote = useCallback(
-    async (title: string, folder = "", content?: string) => {
+    async (title: string, folder = "", content?: string, frontmatter?: NoteFrontmatter) => {
       const workspace = state.activeWorkspace;
       const notes = repoRef.current;
       if (!workspace || !notes) return;
@@ -957,8 +958,10 @@ export function useNotebook(request: NotebookRequest = {}) {
         title,
         existingPaths: existing,
         // Given for a note that comes from somewhere else — a file opened from
-        // this machine — rather than one being started from nothing.
+        // this machine, a paper being written about — rather than one being
+        // started from nothing.
         ...(content !== undefined ? { content } : {}),
+        ...(frontmatter !== undefined ? { frontmatter } : {}),
       });
 
       const open = [...state.openNotes, note].slice(-MAX_OPEN_NOTES);

--- a/apps/web/src/lib/library.test.ts
+++ b/apps/web/src/lib/library.test.ts
@@ -220,6 +220,70 @@ describe("queryIndex", () => {
     ]);
   });
 
+  /**
+   * "Setup" typed in the middle of a project should find that project's setup,
+   * not the other five. The notebook already knows which notes belong
+   * together, because somebody linked them.
+   */
+  describe("knowing what you are working on", () => {
+    const setups = buildIndex(
+      workspace,
+      ["projects/website/setup.md", "projects/api/setup.md", "old/setup.md"],
+      [
+        note("projects/website/setup.md", "# Setup\n\nWebsite.", "2026-01-01T00:00:00.000Z"),
+        note("projects/api/setup.md", "# Setup\n\nApi.", "2026-03-01T00:00:00.000Z"),
+        note("old/setup.md", "# Setup\n\nOld.", "2026-02-01T00:00:00.000Z"),
+      ],
+    );
+
+    it("floats a connected note above one that merely matches as well", () => {
+      const nearby = new Map([["projects/website/setup.md", 1]]);
+
+      const [first] = queryIndex(setups, { query: "setup", nearby });
+      expect(first!.path).toBe("projects/website/setup.md");
+    });
+
+    it("prefers the nearer of two connected notes", () => {
+      const nearby = new Map([
+        ["old/setup.md", 2],
+        ["projects/api/setup.md", 1],
+      ]);
+
+      expect(queryIndex(setups, { query: "setup", nearby }).map((entry) => entry.path)).toEqual([
+        "projects/api/setup.md",
+        "old/setup.md",
+        "projects/website/setup.md",
+      ]);
+    });
+
+    it("never lets nearness beat a better kind of match", () => {
+      const mixed = buildIndex(
+        workspace,
+        ["planning.md", "notes/mentions-planning.md"],
+        [
+          note("planning.md", "# Planning", "2026-01-01T00:00:00.000Z"),
+          note(
+            "notes/mentions-planning.md",
+            "# Elsewhere\n\nAbout planning.",
+            "2026-02-01T00:00:00.000Z",
+          ),
+        ],
+      );
+
+      // The nearby note only mentions the word; the far one is called it.
+      const nearby = new Map([["notes/mentions-planning.md", 1]]);
+      const [first] = queryIndex(mixed, { query: "planning", nearby });
+
+      expect(first!.path).toBe("planning.md");
+    });
+
+    it("changes nothing when there is nowhere to be near", () => {
+      expect(queryIndex(setups, { query: "setup" }).map((entry) => entry.path)).toEqual(
+        queryIndex(setups, { query: "setup", nearby: new Map() }).map((entry) => entry.path),
+      );
+    });
+  });
+
   it("sorts unread notes last rather than treating a missing date as 1970", () => {
     const mixed = buildIndex(
       workspace,

--- a/apps/web/src/lib/library.ts
+++ b/apps/web/src/lib/library.ts
@@ -263,22 +263,41 @@ export function buildIndex(
  * it. The score itself only orders body matches among themselves, capped so a
  * long note repeating a word cannot climb past a title match.
  */
-export function scoreEntry(entry: IndexEntry, needle: string, textScore?: number): number {
+export function scoreEntry(
+  entry: IndexEntry,
+  needle: string,
+  textScore?: number,
+  /**
+   * How many links away this note is from the one being written, if any.
+   *
+   * Searching "setup" while in the middle of a project should find *that*
+   * project's setup, not the other five — and the notebook already knows which
+   * notes belong together, because somebody linked them. The bonus is smaller
+   * than the gap between any two bands below, so a connected note can win a
+   * tie and can rise within its band, but a note whose title matches never
+   * loses to one whose only claim is being nearby.
+   */
+  nearness?: number,
+): number {
   if (!needle) return 1;
 
   const title = entry.title.toLowerCase();
   const path = entry.path.toLowerCase();
+  const near = nearness === undefined ? 0 : Math.max(0, NEAR_BONUS - (nearness - 1) * 4);
 
-  if (title === needle) return 100;
-  if (title.startsWith(needle)) return 80;
-  if (title.includes(needle)) return 60;
-  if (entry.tags.some((tag) => tag.toLowerCase().includes(needle))) return 50;
-  if (textScore !== undefined) return 45 + Math.min(textScore, 9) / 10;
-  if (path.includes(needle)) return 40;
-  if (entry.excerpt.toLowerCase().includes(needle)) return 20;
+  if (title === needle) return 100 + near;
+  if (title.startsWith(needle)) return 80 + near;
+  if (title.includes(needle)) return 60 + near;
+  if (entry.tags.some((tag) => tag.toLowerCase().includes(needle))) return 50 + near;
+  if (textScore !== undefined) return 45 + Math.min(textScore, 9) / 10 + near;
+  if (path.includes(needle)) return 40 + near;
+  if (entry.excerpt.toLowerCase().includes(needle)) return 20 + near;
 
   return 0;
 }
+
+/** What a directly linked note is worth. Two hops away is worth less. */
+const NEAR_BONUS = 8;
 
 export interface QueryOptions {
   query?: string;
@@ -294,11 +313,19 @@ export interface QueryOptions {
    * indexes what the dashboard knows about a note, not what is in it.
    */
   textScores?: Map<string, number>;
+  /**
+   * Notes connected to the one being written, by path, with their distance.
+   *
+   * From the link graph, which is built for backlinks and answers this for
+   * free. Absent everywhere there is no "current note" to be near — the
+   * dashboard is not standing anywhere in particular.
+   */
+  nearby?: ReadonlyMap<string, number>;
 }
 
 export function queryIndex(entries: IndexEntry[], options: QueryOptions = {}): IndexEntry[] {
   const needle = (options.query ?? "").trim().toLowerCase();
-  const { folder, tag, sort = "recent", textScores } = options;
+  const { folder, tag, sort = "recent", textScores, nearby } = options;
 
   const scored = entries
     .filter((entry) => {
@@ -308,7 +335,10 @@ export function queryIndex(entries: IndexEntry[], options: QueryOptions = {}): I
       if (tag && !entry.tags.includes(tag)) return false;
       return true;
     })
-    .map((entry) => ({ entry, score: scoreEntry(entry, needle, textScores?.get(entry.id)) }))
+    .map((entry) => ({
+      entry,
+      score: scoreEntry(entry, needle, textScores?.get(entry.id), nearby?.get(entry.path)),
+    }))
     .filter((candidate) => candidate.score > 0);
 
   // While searching, relevance leads and the chosen sort breaks ties; with no

--- a/apps/web/src/lib/note-from-paper.test.ts
+++ b/apps/web/src/lib/note-from-paper.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { PdfMetadata, PdfOutlineItem } from "@forkleaf/pdf";
+import { paperNote } from "./note-from-paper";
+
+const metadata = (over: Partial<PdfMetadata> = {}): PdfMetadata => ({
+  title: "Attention Is All You Need",
+  author: "Vaswani et al.",
+  subject: null,
+  keywords: [],
+  createdAt: "2017-06-12T00:00:00.000Z",
+  modifiedAt: null,
+  producer: null,
+  ...over,
+});
+
+const heading = (title: string, page: number | null, children: PdfOutlineItem[] = []) =>
+  ({ title, page, children }) as PdfOutlineItem;
+
+const build = (over: Partial<Parameters<typeof paperNote>[0]> = {}) =>
+  paperNote({
+    metadata: metadata(),
+    filename: "attention.pdf",
+    outline: [heading("Introduction", 1), heading("Method", 3), heading("Results", 8)],
+    pageCount: 15,
+    pdfPath: "papers/attention.pdf",
+    notePath: "reading/attention-is-all-you-need.md",
+    ...over,
+  });
+
+describe("paperNote — what it fills in", () => {
+  it("takes the title from the paper, not from the filename", () => {
+    expect(build().title).toBe("Attention Is All You Need");
+    expect(build().frontmatter.title).toBe("Attention Is All You Need");
+  });
+
+  it("falls back to the filename for a paper whose metadata has no title", () => {
+    expect(build({ metadata: metadata({ title: null }) }).title).toBe("attention");
+  });
+
+  it("records the author and the date the paper carries", () => {
+    const { frontmatter } = build();
+
+    expect(frontmatter.author).toBe("Vaswani et al.");
+    // The paper's date, not today's: `created` already records when the note
+    // was started, and the two are different facts.
+    expect(frontmatter.published).toBe("2017-06-12");
+    expect(frontmatter.tags).toEqual(["paper"]);
+  });
+
+  it("leaves out what the paper does not say", () => {
+    const { frontmatter } = build({
+      metadata: metadata({ author: null, createdAt: null }),
+    });
+
+    expect("author" in frontmatter).toBe(false);
+    expect("published" in frontmatter).toBe(false);
+  });
+});
+
+describe("paperNote — the headings", () => {
+  it("turns the paper's contents into headings, each linked to its page", () => {
+    const { content } = build();
+
+    expect(content).toContain("## Introduction");
+    expect(content).toContain("## Method");
+    expect(content).toContain("[p. 3](../papers/attention.pdf#page=3)");
+  });
+
+  it("writes links relative to the note, so they resolve on github.com too", () => {
+    const { content } = build({ notePath: "a/b/c/note.md" });
+    expect(content).toContain("(../../../papers/attention.pdf#page=1)");
+  });
+
+  it("invents no structure for a paper that has no contents list", () => {
+    const { content } = build({ outline: [] });
+
+    expect(content).toContain("## Notes");
+    expect(content).not.toContain("## Introduction");
+  });
+
+  it("goes one level deeper when everything hangs off a single root", () => {
+    const { content } = build({
+      outline: [heading("Contents", null, [heading("One", 1), heading("Two", 4)])],
+    });
+
+    expect(content).toContain("## One");
+    expect(content).toContain("## Two");
+  });
+
+  it("does not open with ninety empty headings", () => {
+    const many = Array.from({ length: 90 }, (_, index) => heading(`Section ${index}`, index + 1));
+    const headings = build({ outline: many }).content.match(/^## /gm) ?? [];
+
+    expect(headings.length).toBeLessThanOrEqual(24);
+  });
+
+  it("names a page it could not link to rather than dropping it", () => {
+    // A heading whose destination the document does not resolve.
+    const { content } = build({ outline: [heading("Preface", null), heading("One", 2)] });
+
+    expect(content).toContain("## Preface");
+    expect(content).not.toContain("#page=null");
+  });
+});
+
+describe("paperNote — a document from a desktop", () => {
+  it("names the paper instead of linking to a file that is not in the notebook", () => {
+    const { content, frontmatter } = build({ pdfPath: null });
+
+    expect(content).not.toContain("](");
+    expect(content).toContain("Attention Is All You Need · Vaswani et al. · 15 pages");
+    expect("source" in frontmatter).toBe(false);
+  });
+});

--- a/apps/web/src/lib/note-from-paper.ts
+++ b/apps/web/src/lib/note-from-paper.ts
@@ -1,0 +1,120 @@
+import { displayTitle, flattenOutline, type PdfMetadata, type PdfOutlineItem } from "@forkleaf/pdf";
+import type { NoteFrontmatter } from "@forkleaf/types";
+import { relativeSrc } from "@/lib/assets";
+
+/**
+ * Starting a note from a paper, rather than from a blank page.
+ *
+ * Everything this fills in is already known: the title and author are in the
+ * file's own metadata, the section headings are its table of contents, and the
+ * page each one begins on is what the outline resolves to. Typing that out by
+ * hand is twenty minutes of transcription before a single thought gets
+ * written down — and it is transcription, so it is also where the page numbers
+ * come out wrong.
+ *
+ * The headings matter more than the metadata. A blank page asks you to have an
+ * opinion about the whole paper at once; a page that already says
+ * "Introduction", "Method", "Results" asks you three smaller questions, each
+ * beside a link to the pages that answer it.
+ *
+ * Nothing is invented. A paper with no table of contents gets no headings —
+ * inventing a structure for it would be worse than the blank page, because it
+ * would be a structure the reader then has to argue with.
+ */
+
+export interface PaperNote {
+  /** What the note is called, which also decides its filename. */
+  title: string;
+  frontmatter: NoteFrontmatter;
+  /** The body, written relative to `notePath`. */
+  content: string;
+}
+
+/**
+ * How deep into the paper's contents to go.
+ *
+ * The top level, which is the sections. Unless the top level is one entry —
+ * some documents wrap everything in a single root — in which case the level
+ * below it is the one that is actually the sections.
+ */
+function sectionsOf(outline: readonly PdfOutlineItem[]) {
+  const rows = flattenOutline(outline);
+  const top = rows.filter((row) => row.depth === 0);
+  return top.length >= 2 ? top : rows.filter((row) => row.depth <= 1);
+}
+
+/**
+ * The most headings worth starting with.
+ *
+ * A paper whose contents list every numbered subsection would otherwise open
+ * as ninety empty headings, which is not a page anybody writes on.
+ */
+const MAX_HEADINGS = 24;
+
+export function paperNote(options: {
+  metadata: PdfMetadata;
+  /** The document's filename, for a paper whose metadata has no title. */
+  filename: string;
+  outline: readonly PdfOutlineItem[];
+  pageCount: number;
+  /**
+   * Where the paper lives in the repository, or null for one opened from a
+   * desktop — which has no path a note could link to, so the note names it
+   * rather than linking to it.
+   */
+  pdfPath: string | null;
+  /** Where the note itself will live, since its links are written relative. */
+  notePath: string;
+}): PaperNote {
+  const title = displayTitle(options.metadata, options.filename);
+  const link = (page?: number) => {
+    if (!options.pdfPath) return null;
+    const target = relativeSrc(options.notePath, options.pdfPath);
+    return page ? `${target}#page=${page}` : target;
+  };
+
+  const frontmatter: NoteFrontmatter = {
+    title,
+    tags: ["paper"],
+    ...(options.metadata.author ? { author: options.metadata.author } : {}),
+    // The date the paper carries, not today's — `created` already records when
+    // the note was started, and the two are different facts.
+    ...(options.metadata.createdAt ? { published: options.metadata.createdAt.slice(0, 10) } : {}),
+    ...(options.pdfPath ? { source: options.pdfPath } : {}),
+  };
+
+  const paperLink = link();
+  const lines: string[] = [
+    `# ${title}`,
+    "",
+    [
+      paperLink ? `[${title}](${paperLink})` : title,
+      options.metadata.author,
+      `${options.pageCount} page${options.pageCount === 1 ? "" : "s"}`,
+    ]
+      .filter(Boolean)
+      .join(" · "),
+    "",
+  ];
+
+  const headings = sectionsOf(options.outline).slice(0, MAX_HEADINGS);
+
+  if (headings.length === 0) {
+    // No contents to work from, so no structure is invented — an empty
+    // heading somebody has to argue with is worse than a blank page.
+    lines.push("## Notes", "", "");
+  } else {
+    for (const heading of headings) {
+      lines.push(`## ${heading.title}`, "");
+
+      const pageLink = heading.page == null ? null : link(heading.page);
+      if (pageLink) lines.push(`[p. ${heading.page}](${pageLink})`, "");
+      else if (heading.page != null) lines.push(`p. ${heading.page}`, "");
+
+      // A blank line under each heading: the place the writing goes.
+      lines.push("");
+    }
+  }
+
+  return { title, frontmatter, content: `${lines.join("\n").trimEnd()}\n` };
+}

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -34,9 +34,9 @@ Ticked entries link to nothing; the git history is the record.
       freshness check already exists; this is the notebook-wide roll-up
 - [ ] **Borrow somebody else's notebook** — Big. Link into their notes, pinned
       to a version, rather than copying and going stale
-- [ ] **Search that knows what you are working on** — Small. Notes connected to
-      the one you are in float to the top. The link graph is already built for
-      backlinks; this uses it for ranking
+- [x] **Search that knows what you are working on** — Small. Notes linked to
+      the one you are in float to the top of ⌘K, by however many hops away
+      they are
 - [ ] **Diagrams you can click through** — Medium. A box in a diagram can be a
       note, so a diagram becomes a map of the notebook
 
@@ -56,8 +56,9 @@ Ticked entries link to nothing; the git history is the record.
       say whether the page you quoted is one of the ones that changed
 - [ ] **Highlights that are just text files** — Medium. A highlight is an
       ordinary file beside the PDF, drawn over the page when you read
-- [ ] **Start a note from a paper** — Small. Title, author and date fill
-      themselves in; the paper's headings become the note's headings
+- [x] **Start a note from a paper** — Small. Title, author and date fill
+      themselves in; the paper's headings become the note's headings, each
+      linked to the page it starts on
 - [ ] **Read scanned documents** — Big. Recognise the text once and keep it
       beside the file, so the work is shared with every device
 - [ ] **Publish your reading, not just your notes** — Big. A public page of

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -42,6 +42,7 @@ export {
   resolveWikilink,
   wikilinkToPath,
   buildLinkGraph,
+  neighbourhood,
   remarkWikilink,
   type WikiLink,
   type LinkCandidate,

--- a/packages/markdown-engine/src/wikilinks.test.ts
+++ b/packages/markdown-engine/src/wikilinks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildLinkGraph,
+  neighbourhood,
   extractWikilinks,
   resolveWikilink,
   wikilinkTargets,
@@ -148,5 +149,63 @@ describe("rendering", () => {
       resolveWikilink: () => ({ href: "javascript:alert(1)", exists: true }),
     });
     expect(html).not.toContain("javascript:");
+  });
+});
+
+/**
+ * The graph exists for backlinks and answers a second question for free:
+ * which notes are about the same thing as this one?
+ */
+describe("neighbourhood", () => {
+  const graph = () =>
+    buildLinkGraph([
+      { path: "project.md", title: "Project", content: "See [[Setup]] and [[Deploy]]." },
+      { path: "setup.md", title: "Setup", content: "Uses [[Postgres]]." },
+      { path: "deploy.md", title: "Deploy", content: "Nothing yet." },
+      { path: "postgres.md", title: "Postgres", content: "A database." },
+      { path: "mentions.md", title: "Mentions", content: "About [[Project]]." },
+      { path: "elsewhere.md", title: "Elsewhere", content: "Unrelated." },
+    ]);
+
+  it("counts a note you linked to as one hop away", () => {
+    expect(neighbourhood(graph(), "project.md").get("setup.md")).toBe(1);
+  });
+
+  it("counts a note that linked to you as just as near", () => {
+    // Both directions mean the same thing: somebody decided these belonged
+    // together.
+    expect(neighbourhood(graph(), "project.md").get("mentions.md")).toBe(1);
+  });
+
+  it("reaches the second ring, and knows it is further away", () => {
+    expect(neighbourhood(graph(), "project.md").get("postgres.md")).toBe(2);
+  });
+
+  it("stops where it is told to", () => {
+    expect(neighbourhood(graph(), "project.md", 1).has("postgres.md")).toBe(false);
+  });
+
+  it("leaves out a note nothing connects to", () => {
+    expect(neighbourhood(graph(), "project.md").has("elsewhere.md")).toBe(false);
+  });
+
+  it("does not report the note as near itself", () => {
+    expect(neighbourhood(graph(), "project.md").has("project.md")).toBe(false);
+  });
+
+  it("takes the shortest way round, not the first one found", () => {
+    // `c` is reachable in two hops through `b` and in one directly; the
+    // shorter distance is the true one.
+    const small = buildLinkGraph([
+      { path: "a.md", title: "A", content: "[[B]] and [[C]]." },
+      { path: "b.md", title: "B", content: "[[C]]." },
+      { path: "c.md", title: "C", content: "." },
+    ]);
+
+    expect(neighbourhood(small, "a.md").get("c.md")).toBe(1);
+  });
+
+  it("says nothing about a note with no links at all", () => {
+    expect(neighbourhood(graph(), "elsewhere.md").size).toBe(0);
   });
 });

--- a/packages/markdown-engine/src/wikilinks.ts
+++ b/packages/markdown-engine/src/wikilinks.ts
@@ -362,3 +362,47 @@ function lineAt(content: string, offset: number): string {
   const end = content.indexOf("\n", offset);
   return content.slice(start, end === -1 ? content.length : end).trim();
 }
+
+/**
+ * The notes around one note, and how far away each of them is.
+ *
+ * A link graph is built for backlinks — "what points at this?" — and answers a
+ * second question for free that nothing was asking it: which notes are *about
+ * the same thing* as the one somebody is looking at. Links run both ways here,
+ * because a note you linked to and a note that linked to you are equally near
+ * in the only sense that matters: you decided they belonged together.
+ *
+ * Breadth-first, so the first distance found for a note is its shortest, and
+ * bounded by `hops` because the third ring out of a well-linked notebook is
+ * most of the notebook — at which point "nearby" has stopped meaning anything.
+ *
+ * The starting note is not in the result. It is not near itself; it is itself,
+ * and every caller has it already.
+ */
+export function neighbourhood(graph: LinkGraph, from: string, hops = 2): Map<string, number> {
+  const distances = new Map<string, number>();
+  let frontier = [from];
+
+  for (let distance = 1; distance <= hops && frontier.length > 0; distance += 1) {
+    const next: string[] = [];
+
+    for (const path of frontier) {
+      const linked = [
+        ...(graph.outgoing.get(path) ?? []).map((ref) => ref.to),
+        ...(graph.backlinks.get(path) ?? []).map((ref) => ref.from),
+      ];
+
+      for (const neighbour of linked) {
+        // An unresolved link points at nothing, and a cycle back to the start
+        // is not a discovery about the neighbourhood.
+        if (!neighbour || neighbour === from || distances.has(neighbour)) continue;
+        distances.set(neighbour, distance);
+        next.push(neighbour);
+      }
+    }
+
+    frontier = next;
+  }
+
+  return distances;
+}

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -297,6 +297,14 @@ export class NoteRepository {
     folder: string;
     title: string;
     content?: string;
+    /**
+     * Fields to record beside the ones every note gets.
+     *
+     * For a note that is *about* something — a paper's author and the date it
+     * was published — where the facts are known at the moment of creation and
+     * would otherwise have to be typed in again by hand.
+     */
+    frontmatter?: NoteFrontmatter;
     existingPaths: string[];
   }): Promise<Note> {
     const filename = `${slugifyFilename(options.title)}.md`;
@@ -308,6 +316,10 @@ export class NoteRepository {
     const frontmatter: NoteFrontmatter = this.stamp({
       title: options.title,
       created: timestamp,
+      // Merged over the defaults rather than under them, so a caller that
+      // knows the note's real title — a paper's, rather than the filename it
+      // was created from — is the one that wins.
+      ...options.frontmatter,
     });
     const content = options.content ?? `# ${options.title}\n\n`;
 


### PR DESCRIPTION
Two more from [docs/ideas.md](docs/ideas.md). **Stacked on [#62](https://github.com/praneeth132006/ForkLeaf/pull/62)**, which is stacked on [#61](https://github.com/praneeth132006/ForkLeaf/pull/61) — merge in that order, or say the word and I'll rebase this onto `main` once the others land.

## Start a note from a paper

Everything a note about a paper opens with is already in the file: the title and author are its metadata, the section headings are its own table of contents, the page each starts on is what those headings resolve to. Typing it out is transcription — which is also where page numbers come out wrong.

**Write about this** in the reader makes the note: title, author and publication date in the frontmatter, the paper's sections as headings each linked to the page they begin on, and a blank line under each to write in. The document then moves aside and sits beside the note — moved rather than reopened, since it is already parsed and rendered.

Nothing is invented: a paper with no contents list gets a single "Notes" heading, because a structure the reader has to argue with is worse than a blank page. A paper opened from a desktop is named rather than linked — it has no path a note could point at.

## ⌘K knows which note you are working in

Searching "setup" in the middle of a project found the other five projects' setup notes just as readily. The notebook already knew which notes belong together, because you linked them.

`neighbourhood` walks the link graph outward and reports how many hops away everything within reach is — both directions, since a note you linked to and one that linked to you are equally near. ⌘K weighs it. The bonus is deliberately smaller than the gap between any two existing scoring bands: a connected note wins a tie and rises within its band, but a note actually *called* what you typed never loses to one whose only claim is being nearby. With no note open, ranking is exactly what it was.

Nothing new is stored — the graph was already being built for backlinks.

## Checks

`pnpm test` — 2000 passing (27 new). Lint, typecheck and build clean.

Verified in the browser: a PDF with a real outline dropped into the editor, **Write about this** producing a note with `# A Sample Paper`, the byline, and Introduction / Method / Results with their pages — frontmatter carrying the paper's own publication date, not today's — and the document stepping aside to sit beside it. Then a seeded three-note link graph, where ⌘K "setup" put the linked `projects/website/setup.md` above `old/setup.md`, which sorts first without it.