### PR TITLE
Ten features from the ideas list, and a help dialog that knows about them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,33 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### A diagram can be a map of your notebook
+
+Write a `[[wikilink]]` in a box's label — `A["[[Deploy runbook]]"]` — and the
+box becomes the way to that note. The label reads as the words you wrote, and
+clicking it in the preview opens the note.
+
+It stays plain text in the file: an ordinary mermaid label, so the diagram
+still renders on github.com and in every other mermaid tool, showing the
+brackets exactly as a `[[wikilink]]` in prose does there. Aliases work
+(`[[deploy/runbook|The runbook]]`), and so do anchors.
+
+In the rich editor a click on a diagram still opens it for editing, which is
+what a click there has always meant — but the labels read correctly there too,
+and in exports and published pages.
+
+### What has gone stale, across the whole notebook
+
+The freshness panel beside a note answers the question for the note you happen
+to have open. **Check which of my notes have gone stale** answers it for all of
+them: notes pointing at a file that is not in the repository, `[[links]]`
+matching no note, and datable claims — version numbers, CVEs,
+&ldquo;currently&rdquo; — in a note nobody has touched in a long time.
+
+The first two are facts and are labelled as such; the third is an inference and
+is reported as one. Nothing is changed: every row opens the note and gets out
+of the way. **It is fine** takes a note off the list until it is edited again.
+
 ### Start a note from a paper
 
 **Write about this** in the reader makes a note that is already about the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,25 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Start a note from a paper
+
+**Write about this** in the reader makes a note that is already about the
+document: its title, its author and the date it was published in the
+frontmatter, and its own table of contents as the note's headings — each one
+linked to the page that section starts on. The document then moves aside and
+sits beside the note you are writing.
+
+Nothing is invented. A paper with no contents list of its own gets a single
+"Notes" heading rather than a structure somebody would have to argue with.
+
+### Search knows what you are working on
+
+⌘K now weighs which notes are connected to the one you are in. Searching
+"setup" in the middle of a project finds that project's setup rather than the
+other five. A note you linked to and a note that linked to you count the same,
+and the effect fades with distance — but it never beats a better kind of match,
+so a note actually called what you typed still wins.
+
 ### Citations that check themselves
 
 Every other tool stores a page number, and a page number quietly stops being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,32 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Your notebook, on a day you choose
+
+**Show me my notebook as it was on…** in the palette takes the whole notebook
+back to a date: the files that existed that day, and any of them readable as it
+stood. The per-note history answers "how did this page come to be?"; this
+answers "what did I know when I made that decision?", which is a question about
+the shape of the notebook rather than about one file in it.
+
+Read-only, deliberately. Restoring one note is something the history panel does
+well; a button that rolled a whole notebook back to March would be the most
+dangerous control in the app.
+
+Nothing new is stored. Git already holds every version of every file — a tree
+read at an old commit is the same call as a tree read at the newest one.
+
+### What a paragraph used to say
+
+Pointing at a paragraph in the blame view now shows the wording it replaced,
+taken from the revision before the commit that last changed it. A paragraph you
+rewrote in March is one you changed your mind about, and what you changed it
+_from_ is usually the most interesting thing on the page.
+
+Nothing is shown for a paragraph that was added rather than rewritten, or for a
+change older than the history that can be read — those are different facts, and
+inventing a previous wording for them would be a lie.
+
 ### A diagram can be a map of your notebook
 
 Write a `[[wikilink]]` in a box's label — `A["[[Deploy runbook]]"]` — and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,31 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Citations that check themselves
+
+Every other tool stores a page number, and a page number quietly stops being
+true: the author adds a figure to page 4 and every citation after it points one
+page short. Nothing tells you. A ForkLeaf citation records the sentence, so the
+question has an answer — and now there is somewhere to ask it.
+
+- **Check my citations against their documents** in the palette reads every
+  paper you have quoted and reports what it found: quotations that have moved
+  to another page, quotations that matched only loosely, and the ones that are
+  no longer in the document at all
+- A moved quotation can have its page number corrected in place, one press per
+  citation. The words, the context and the path are left exactly as they were —
+  it is the page hint beside them that had gone stale
+- A document that could not be read is reported as unread, never as a document
+  full of broken citations
+
+### ⌘K searches inside your documents
+
+The reader has always extracted every page's text — that is what makes
+find-in-document work through hyphenation and ligatures — and then threw it
+away when the document closed. It is now kept beside the notebook, so ⌘K
+searches the papers as well as the notes and jumps straight to the page. A
+document is indexed the first time it is opened, and by the citation check.
+
 ### A picture too big to send can be resized instead of deleted
 
 When an image cannot be pushed — a screenshot is larger than GitHub will take

--- a/apps/web/src/app/api/gh/at/route.test.ts
+++ b/apps/web/src/app/api/gh/at/route.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const commitAt = vi.fn();
+const listTree = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+  getLiveSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+}));
+
+vi.mock("@forkleaf/github-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@forkleaf/github-client")>("@forkleaf/github-client");
+  return {
+    ...actual,
+    GitHubClient: class {
+      commitAt = commitAt;
+      listTree = listTree;
+    },
+  };
+});
+
+const { GET } = await import("./route");
+
+afterEach(() => vi.clearAllMocks());
+
+const BASE = "http://localhost/api/gh/at?owner=me&repo=notes&branch=main&dir=";
+
+async function get(query: string) {
+  const response = await GET(new Request(`${BASE}${query}`) as never);
+  return { status: response.status, body: await response.json() };
+}
+
+describe("GET /api/gh/at", () => {
+  it("returns the commit that was current, and the tree at it", async () => {
+    commitAt.mockResolvedValue({ sha: "abc123", date: "2026-03-03T18:00:00Z" });
+    listTree.mockResolvedValue([{ kind: "file", name: "a.md", path: "a.md" }]);
+
+    const { status, body } = await get("&until=2026-03-03");
+
+    expect(status).toBe(200);
+    expect(body.commit.sha).toBe("abc123");
+    // The tree has to be read *at that commit*, or the answer is a notebook
+    // that never existed: one day's file list beside another day's date.
+    expect(listTree).toHaveBeenCalledWith(expect.anything(), { ref: "abc123" });
+    expect(body.tree).toHaveLength(1);
+  });
+
+  /**
+   * GitHub's `until` is inclusive and a bare date means midnight, so asking
+   * for "the 3rd" would otherwise answer with the notebook as it stood at the
+   * end of the 2nd — off by a day, silently, which is the worst way for a time
+   * machine to be wrong.
+   */
+  it("means the whole of the day it was given", async () => {
+    commitAt.mockResolvedValue(null);
+    await get("&until=2026-03-03");
+
+    expect(commitAt).toHaveBeenCalledWith(expect.anything(), "2026-03-03T23:59:59Z");
+  });
+
+  it("passes a full timestamp through untouched", async () => {
+    commitAt.mockResolvedValue(null);
+    await get("&until=2026-03-03T09:30:00Z");
+
+    expect(commitAt).toHaveBeenCalledWith(expect.anything(), "2026-03-03T09:30:00Z");
+  });
+
+  it("answers a day before the repository existed with nothing, not an error", async () => {
+    commitAt.mockResolvedValue(null);
+
+    const { status, body } = await get("&until=1999-01-01");
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ commit: null, tree: [] });
+    // Nothing to read a tree at, so nothing is asked for.
+    expect(listTree).not.toHaveBeenCalled();
+  });
+
+  it("refuses anything that is not a date", async () => {
+    // The value is interpolated into the upstream URL, so a date is the only
+    // thing this route has any business asking GitHub about.
+    for (const bad of ["", "yesterday", "2026-03-03&sha=main", "../../etc"]) {
+      const { status } = await get(`&until=${encodeURIComponent(bad)}`);
+      expect(status).toBe(400);
+    }
+
+    expect(commitAt).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/gh/at/route.ts
+++ b/apps/web/src/app/api/gh/at/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest } from "next/server";
+import { handle, requireClient, readRepoRef, ApiError } from "@/lib/api-helpers";
+
+/**
+ * The notebook as it stood on a given day.
+ *
+ * One route rather than two, because the two halves are useless apart: a tree
+ * is read at a commit, and the commit is the thing being asked for. Returning
+ * them together also makes the answer atomic — a tree from one commit beside a
+ * date from another would be a notebook that never existed.
+ *
+ * A repository younger than the date asked for answers `commit: null` with an
+ * empty tree, which is not an error. A notebook has a first day, and "there
+ * was nothing here yet" is the true answer to what it looked like before it.
+ */
+export async function GET(request: NextRequest) {
+  return handle(async () => {
+    const { client } = await requireClient();
+    const params = new URL(request.url).searchParams;
+    const repo = readRepoRef(params);
+
+    const until = params.get("until") ?? "";
+    // Interpolated into the upstream URL, and a date is the only thing this
+    // route has any business asking GitHub about.
+    if (!/^\d{4}-\d{2}-\d{2}(?:T[\d:.]+Z?)?$/.test(until)) {
+      throw new ApiError(400, "validation", "A date is required, as YYYY-MM-DD.");
+    }
+
+    // A bare date means the whole of that day. GitHub's `until` is inclusive
+    // and would otherwise stop at midnight, so asking for "the 3rd" would show
+    // the notebook as it was at the end of the 2nd — off by a day, silently,
+    // which is the worst way for a time machine to be wrong.
+    const moment = until.length === 10 ? `${until}T23:59:59Z` : until;
+
+    const commit = await client.commitAt(repo, moment);
+    if (!commit) return { commit: null, tree: [] };
+
+    return { commit, tree: await client.listTree(repo, { ref: commit.sha }) };
+  });
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -827,6 +827,32 @@ mark.fl-hl-orange {
   outline-color: var(--fl-border);
 }
 
+/*
+ * A box in a diagram that stands for a note.
+ *
+ * Underlined rather than coloured: the diagram already uses colour to mean
+ * something — the author's own something — and repainting a box because it
+ * happens to be a link would be overwriting what they said with what we know.
+ * The dotted underline is the same one a `[[wikilink]]` wears in prose.
+ */
+.fl-diagram-link {
+  cursor: pointer;
+}
+
+.fl-diagram-link .nodeLabel,
+.fl-diagram-link text {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
+}
+
+.fl-diagram-link:hover rect,
+.fl-diagram-link:hover circle,
+.fl-diagram-link:hover polygon,
+.fl-diagram-link:hover path {
+  filter: brightness(1.12);
+}
+
 /* Shown while a diagram is still rendering or its source is mid-edit. */
 .fl-diagram-pending {
   opacity: 0.6;

--- a/apps/web/src/components/BlameView.test.tsx
+++ b/apps/web/src/components/BlameView.test.tsx
@@ -209,3 +209,44 @@ describe("BlameView", () => {
     expect(revisions.prefetch).toHaveBeenCalledWith(["ccc", "bbb", "aaa"]);
   });
 });
+
+/**
+ * "When did I write this?" is the way in. "What did it say before?" is what
+ * somebody re-reading their own notes actually wants — a paragraph you
+ * rewrote is a paragraph you changed your mind about.
+ */
+describe("BlameView — what a paragraph used to say", () => {
+  const REWRITTEN = {
+    aaa: "# Kickoff\n\nSMB signing looks fine everywhere.",
+    bbb: "# Kickoff\n\nSMB signing is off on three hosts.",
+  };
+
+  it("shows the previous wording of a rewritten paragraph", async () => {
+    view({
+      commits: [commit("bbb", 10), commit("aaa", 1)],
+      revisions: cache(REWRITTEN),
+    });
+
+    fireEvent.mouseEnter(
+      paragraphs().find((row) => row.textContent?.includes("off on three hosts"))!,
+    );
+
+    expect(await screen.findByText(/Until .* it said/)).toBeTruthy();
+    expect(screen.getByText("SMB signing looks fine everywhere.")).toBeTruthy();
+  });
+
+  it("says nothing of the kind for a paragraph that was added, not rewritten", () => {
+    view();
+
+    // "You wrote this in March" and "in March you replaced something with
+    // this" are different facts about the same paragraph.
+    fireEvent.mouseEnter(paragraphs().find((row) => row.textContent?.includes("Kerberoasted"))!);
+    expect(screen.queryByText(/it said/)).toBeNull();
+  });
+
+  it("claims nothing about text older than the history it can read", () => {
+    view();
+    fireEvent.mouseEnter(paragraphs()[0]!);
+    expect(screen.queryByText(/it said/)).toBeNull();
+  });
+});

--- a/apps/web/src/components/BlameView.tsx
+++ b/apps/web/src/components/BlameView.tsx
@@ -4,8 +4,10 @@ import { useEffect, useMemo, useState } from "react";
 import {
   buildBlame,
   ageRatio,
+  priorWording,
   type BlameBlock,
   type BlameRevision,
+  type PriorWording,
 } from "@forkleaf/markdown-engine";
 import type { RepoRef } from "@forkleaf/types";
 import type { NoteCommitDto, CommitFileDto } from "@/lib/gateway";
@@ -82,6 +84,23 @@ export function BlameView({ commits, revisions, repo, path }: BlameViewProps) {
     [blame.blocks, active],
   );
 
+  /**
+   * What the paragraph under the cursor said before it was last changed.
+   *
+   * The question people actually ask of their own notes. "When did I write
+   * this?" is the way in; "what did it say before?" is what they wanted, and
+   * a paragraph you rewrote is one you changed your mind about.
+   *
+   * Computed from revisions already fetched for the blame itself, so it costs
+   * nothing extra — and is null, honestly, for a paragraph that was added
+   * rather than rewritten.
+   */
+  const wasSaying = useMemo(() => {
+    const current = input.find((revision) => revision.text !== null)?.text;
+    if (!activeBlock || !current) return null;
+    return priorWording(input, current, activeBlock);
+  }, [input, activeBlock]);
+
   // Nothing has arrived yet — the first frame of a note whose history is still
   // loading. Distinct from a note with no attributable content.
   if (loadedCount === 0 && commits.length > 0) {
@@ -138,7 +157,7 @@ export function BlameView({ commits, revisions, repo, path }: BlameViewProps) {
       </div>
 
       {/* ── The commit behind whatever is under the cursor ───────────────── */}
-      <CommitCard block={activeBlock} repo={repo} notePath={path} />
+      <CommitCard block={activeBlock} was={wasSaying} repo={repo} notePath={path} />
 
       {/* ── The note, with its dates in the margin ──────────────────────── */}
       <div
@@ -265,10 +284,13 @@ function BlockRow({
  */
 function CommitCard({
   block,
+  was,
   repo,
   notePath,
 }: {
   block: BlameBlock | null;
+  /** What this paragraph said before, when it replaced something. */
+  was: PriorWording | null;
   repo: RepoRef;
   notePath: string;
 }) {
@@ -361,6 +383,19 @@ function CommitCard({
           This text was already here in the oldest revision ForkLeaf can read, so it may be older
           than the commit named.
         </p>
+      )}
+
+      {/* Usually the most interesting thing on the page: not that you wrote a
+          paragraph in March, but what it said until you did. */}
+      {was && (
+        <div className="mt-2 border-t border-[var(--fl-border)] pt-2">
+          <p className="text-[11px] text-[var(--fl-muted)]">
+            Until {new Date(was.date).toLocaleDateString()} it said
+          </p>
+          <blockquote className="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap border-l-2 border-[var(--fl-border-strong)] pl-2 text-[12px] leading-relaxed text-[var(--fl-text)]">
+            {was.text}
+          </blockquote>
+        </div>
       )}
 
       {/* The part that turns a date into a memory. */}

--- a/apps/web/src/components/CitationsDialog.test.tsx
+++ b/apps/web/src/components/CitationsDialog.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { PdfPageText } from "@forkleaf/pdf";
+import { CitationsDialog } from "./CitationsDialog";
+
+afterEach(cleanup);
+
+const page = (number: number, text: string): PdfPageText => ({ page: number, text, runs: [] });
+
+/** A note quoting one passage, written the way ForkLeaf writes citations. */
+const note = (quote: string, at: number, path = "reading.md") => ({
+  path,
+  content: [
+    `> ${quote}`,
+    ">",
+    `> — [Paper, p. ${at}](papers/attention.pdf#page=${at}&q=${encodeURIComponent(quote)})`,
+  ].join("\n"),
+});
+
+function open(over: Partial<React.ComponentProps<typeof CitationsDialog>> = {}) {
+  const props = {
+    onClose: vi.fn(),
+    loadNotes: vi.fn(async () => [note("attention is all you need", 2)]),
+    pagesFor: vi.fn(async () => [page(1, "Introduction."), page(2, "attention is all you need")]),
+    onOpenNote: vi.fn(),
+    onOpenDocument: vi.fn(),
+    onFix: vi.fn(async () => {}),
+    ...over,
+  };
+
+  render(<CitationsDialog {...props} />);
+  return props;
+}
+
+/** Presses the button that starts the sweep. */
+const check = () => fireEvent.click(screen.getByRole("button", { name: /Check my citations/ }));
+
+describe("CitationsDialog — checking", () => {
+  it("reads nothing until it is asked to", () => {
+    const props = open();
+    expect(props.pagesFor).not.toHaveBeenCalled();
+  });
+
+  it("says everything is where it should be, without listing all of it", async () => {
+    open();
+    check();
+
+    expect(await screen.findByText(/1 quotation checked/)).toBeTruthy();
+    expect(screen.getByText(/exactly where your notes say/)).toBeTruthy();
+  });
+
+  it("names a quotation that is no longer in the document", async () => {
+    open({ pagesFor: vi.fn(async () => [page(1, "Something else entirely.")]) });
+    check();
+
+    expect(await screen.findByText(/not in the document any more/)).toBeTruthy();
+    expect(screen.getByText(/1 points at text that is no longer there/)).toBeTruthy();
+  });
+});
+
+describe("CitationsDialog — a passage that has moved", () => {
+  const moved = () =>
+    open({
+      pagesFor: vi.fn(async () => [
+        page(1, "Introduction."),
+        page(2, "A figure that was not here before."),
+        page(3, "attention is all you need"),
+      ]),
+    });
+
+  it("says where it is now, and what the note still claims", async () => {
+    moved();
+    check();
+
+    expect(await screen.findByText(/Still there, now on page 3/)).toBeTruthy();
+  });
+
+  it("corrects the page number only when asked, and says it did", async () => {
+    const props = moved();
+    check();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Correct the page number/ }));
+
+    await waitFor(() => expect(props.onFix).toHaveBeenCalled());
+    // The check it was handed is the one that moved, with the new page on it.
+    expect(vi.mocked(props.onFix).mock.calls[0]?.[0]?.page).toBe(3);
+    expect(await screen.findByText(/Page number corrected to 3/)).toBeTruthy();
+    // Offered once. A second press would rewrite a link that is already right.
+    expect(screen.queryByRole("button", { name: /Correct the page number/ })).toBeNull();
+  });
+
+  it("goes to the passage, and to the note that quoted it", async () => {
+    const props = moved();
+    check();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Read page 3/ }));
+    expect(props.onOpenDocument).toHaveBeenCalledWith("papers/attention.pdf", 3);
+
+    fireEvent.click(screen.getByRole("button", { name: /reading\.md, line 3/ }));
+    expect(props.onOpenNote).toHaveBeenCalledWith("reading.md");
+  });
+});
+
+describe("CitationsDialog — when things go wrong", () => {
+  /**
+   * The one message that must never be wrong. A document that could not be
+   * fetched is not a document whose every quotation has been deleted.
+   */
+  it("reports a document it could not read as unread, not as broken", async () => {
+    open({
+      pagesFor: vi.fn(async () => {
+        throw new Error("That PDF could not be read from the repository.");
+      }),
+    });
+    check();
+
+    expect(await screen.findByText(/its citations were not checked/)).toBeTruthy();
+    expect(screen.queryByText(/no longer there/)).toBeNull();
+  });
+
+  it("says so when the notes themselves cannot be read", async () => {
+    open({
+      loadNotes: vi.fn(async () => {
+        throw new Error("The notebook could not be opened.");
+      }),
+    });
+    check();
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByText(/The notebook could not be opened\./)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/CitationsDialog.tsx
+++ b/apps/web/src/components/CitationsDialog.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Dialog } from "@/components/Dialog";
+import type { AuditSummary, CitationCheck, PagesFor } from "@/lib/citation-audit";
+import { auditCitations } from "@/lib/citation-audit";
+import type { MentionSource } from "@/lib/pdf-mentions";
+
+/**
+ * Are these quotations still true?
+ *
+ * The one question a notebook full of citations cannot normally answer. Every
+ * other tool stores a page number, which quietly stops being right the moment
+ * the author adds a figure to page four — the link still opens, it just shows
+ * the wrong paragraph, and nothing tells you. A ForkLeaf citation records the
+ * sentence, so the question has an answer, and this is where it gets asked of
+ * the whole notebook at once.
+ *
+ * A check and then a decision, never one action. What was found is shown, and
+ * correcting a page number is a separate press per citation. Rewriting
+ * somebody's notes on the strength of a text match, without showing them the
+ * match first, is not a thing a notes app should do on one click.
+ */
+
+export interface CitationsDialogProps {
+  onClose: () => void;
+  /** Every note in the notebook, read once when the check starts. */
+  loadNotes: () => Promise<MentionSource[]>;
+  /** Reads a document's text, from the cache or from the repository. */
+  pagesFor: PagesFor;
+  /** Opens a note at the line a citation sits on. */
+  onOpenNote: (path: string) => void;
+  /** Opens the document at the passage, so it can be read in place. */
+  onOpenDocument: (pdfPath: string, page: number) => void;
+  /** Writes a corrected page number into the note holding the citation. */
+  onFix: (check: CitationCheck) => Promise<void>;
+}
+
+type State =
+  | { kind: "idle" }
+  | { kind: "reading"; done: number; total: number; pdfPath: string }
+  | { kind: "done"; summary: AuditSummary }
+  | { kind: "error"; message: string };
+
+export function CitationsDialog({
+  onClose,
+  loadNotes,
+  pagesFor,
+  onOpenNote,
+  onOpenDocument,
+  onFix,
+}: CitationsDialogProps) {
+  const [state, setState] = useState<State>({ kind: "idle" });
+  /** Citations already corrected, so a fixed row stops offering the fix. */
+  const [fixed, setFixed] = useState<Set<string>>(new Set());
+
+  const run = useCallback(async () => {
+    setState({ kind: "reading", done: 0, total: 0, pdfPath: "" });
+    setFixed(new Set());
+
+    try {
+      const notes = await loadNotes();
+      const summary = await auditCitations(notes, pagesFor, {
+        onProgress: (done, total, pdfPath) => setState({ kind: "reading", done, total, pdfPath }),
+      });
+      setState({ kind: "done", summary });
+    } catch (problem: unknown) {
+      setState({
+        kind: "error",
+        message:
+          problem instanceof Error
+            ? problem.message
+            : "Your notes could not be read. Nothing was changed.",
+      });
+    }
+  }, [loadNotes, pagesFor]);
+
+  return (
+    <Dialog
+      title="Citations"
+      subtitle="Every quotation in your notes, checked against the document it came from"
+      onClose={onClose}
+      wide
+    >
+      {state.kind === "idle" && (
+        <div className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+          <p className="max-w-2xl">
+            A ForkLeaf citation records the sentence you quoted, not just the page it was on. So
+            when a paper is revised, the quotation can be looked for again — and this says which of
+            yours have moved, and which are no longer in the document at all.
+          </p>
+          <p className="mt-2 max-w-2xl">
+            Every document you have quoted is read, one at a time. Nothing is changed unless you ask
+            for it, citation by citation.
+          </p>
+          <button type="button" onClick={() => void run()} className="fl-btn fl-btn-primary mt-4">
+            Check my citations
+          </button>
+        </div>
+      )}
+
+      {state.kind === "reading" && (
+        <p role="status" className="text-[13px] text-[var(--fl-muted)]">
+          {state.total > 0
+            ? `Reading ${state.pdfPath} — document ${Math.min(state.done + 1, state.total)} of ${state.total}…`
+            : "Reading your notes…"}
+        </p>
+      )}
+
+      {state.kind === "error" && (
+        <p role="alert" className="text-[13px] text-[var(--fl-danger)]">
+          {state.message}
+        </p>
+      )}
+
+      {state.kind === "done" && (
+        <Report
+          summary={state.summary}
+          fixed={fixed}
+          onOpenNote={onOpenNote}
+          onOpenDocument={onOpenDocument}
+          onFix={async (check) => {
+            await onFix(check);
+            setFixed((current) => new Set(current).add(keyOf(check)));
+          }}
+          onAgain={() => void run()}
+        />
+      )}
+    </Dialog>
+  );
+}
+
+/** Identifies one citation among all of them: which note, which line, which words. */
+function keyOf(check: CitationCheck): string {
+  return `${check.mention.notePath}:${check.mention.line}:${check.mention.citation?.quote ?? ""}`;
+}
+
+function Report({
+  summary,
+  fixed,
+  onOpenNote,
+  onOpenDocument,
+  onFix,
+  onAgain,
+}: {
+  summary: AuditSummary;
+  fixed: ReadonlySet<string>;
+  onOpenNote: (path: string) => void;
+  onOpenDocument: (pdfPath: string, page: number) => void;
+  onFix: (check: CitationCheck) => Promise<void>;
+  onAgain: () => void;
+}) {
+  // Only what is worth reading about. A citation that is exactly where it says
+  // it is needs no row of its own — the count at the top already says how many
+  // of those there are, and a list of two hundred correct things is a list
+  // nobody scrolls to the end of.
+  const documents = summary.documents
+    .map((document) => ({
+      ...document,
+      checks: document.checks.filter((check) => check.quality !== "exact"),
+    }))
+    .filter((document) => document.checks.length > 0 || document.error !== null);
+
+  return (
+    <div className="text-[13px] leading-relaxed">
+      <p className="text-[var(--fl-text)]">
+        {summary.checked === 0
+          ? "No quotations to check yet."
+          : `${summary.checked} ${summary.checked === 1 ? "quotation" : "quotations"} checked.`}{" "}
+        <span className="text-[var(--fl-muted)]">
+          {summary.lost > 0
+            ? `${summary.lost} point${summary.lost === 1 ? "s" : ""} at text that is no longer there. `
+            : ""}
+          {summary.moved > 0 ? `${summary.moved} moved to a different page. ` : ""}
+          {summary.fuzzy > 0 ? `${summary.fuzzy} matched only loosely. ` : ""}
+          {summary.unreadable > 0
+            ? `${summary.unreadable} document${summary.unreadable === 1 ? "" : "s"} could not be read. `
+            : ""}
+          {summary.checked > 0 && documents.length === 0
+            ? "Every one of them is exactly where your notes say it is."
+            : ""}
+        </span>
+      </p>
+
+      <div className="mt-3 space-y-3">
+        {documents.map((document) => (
+          <section key={document.pdfPath}>
+            <h4 className="break-all font-mono text-[11.5px] text-[var(--fl-text)]">
+              {document.pdfPath}
+            </h4>
+
+            {document.error ? (
+              <p className="mt-1 text-[12px] text-[var(--fl-muted)]">
+                Could not be read, so its citations were not checked. {document.error}
+              </p>
+            ) : (
+              <ul className="mt-1.5 space-y-1.5">
+                {document.checks.map((check) => (
+                  <li
+                    key={keyOf(check)}
+                    className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-2"
+                  >
+                    <Verdict check={check} fixed={fixed.has(keyOf(check))} />
+
+                    <blockquote className="mt-1 border-l-2 border-[var(--fl-border)] pl-2 text-[12px] text-[var(--fl-text)]">
+                      {check.mention.citation?.quote}
+                    </blockquote>
+
+                    <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-[var(--fl-muted)]">
+                      <button
+                        type="button"
+                        onClick={() => onOpenNote(check.mention.notePath)}
+                        className="max-w-full truncate underline decoration-dotted underline-offset-2 hover:text-[var(--fl-text)]"
+                      >
+                        {check.mention.notePath}, line {check.mention.line}
+                      </button>
+
+                      {check.page != null && (
+                        <button
+                          type="button"
+                          onClick={() => onOpenDocument(document.pdfPath, check.page!)}
+                          className="underline decoration-dotted underline-offset-2 hover:text-[var(--fl-text)]"
+                        >
+                          Read page {check.page}
+                        </button>
+                      )}
+
+                      {check.stale && !fixed.has(keyOf(check)) && (
+                        <button
+                          type="button"
+                          onClick={() => void onFix(check)}
+                          className="rounded border border-[var(--fl-border)] px-1.5 py-0.5 font-medium text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-surface)]"
+                        >
+                          Correct the page number
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        ))}
+      </div>
+
+      <button type="button" onClick={onAgain} className="fl-btn fl-btn-ghost mt-4 !py-1.5">
+        Check again
+      </button>
+    </div>
+  );
+}
+
+/** One line saying what is actually the matter, in the reader's terms. */
+function Verdict({ check, fixed }: { check: CitationCheck; fixed: boolean }) {
+  if (fixed) {
+    return (
+      <p className="text-[12px] font-medium text-[var(--fl-text)]">
+        Page number corrected to {check.page}.
+      </p>
+    );
+  }
+
+  if (check.quality === "lost") {
+    return (
+      <p className="text-[12px] font-medium text-[var(--fl-danger)]">
+        These words are not in the document any more.
+      </p>
+    );
+  }
+
+  if (check.quality === "moved") {
+    return (
+      <p className="text-[12px] font-medium text-[var(--fl-text)]">
+        Still there, now on page {check.page} — your note says page {check.mention.citation?.page}.
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-[12px] font-medium text-[var(--fl-text)]">
+      Found on page {check.page}, but not word for word. The passage may have been edited.
+    </p>
+  );
+}

--- a/apps/web/src/components/CommandPalette.test.tsx
+++ b/apps/web/src/components/CommandPalette.test.tsx
@@ -99,3 +99,30 @@ describe("CommandPalette — searching inside documents", () => {
     expect(screen.queryByText("Documents")).toBeNull();
   });
 });
+
+describe("CommandPalette — knowing what you are working on", () => {
+  const tree = [
+    { kind: "file" as const, name: "setup.md", path: "projects/website/setup.md" },
+    { kind: "file" as const, name: "setup.md", path: "old/setup.md" },
+  ];
+
+  it("puts the connected note first among equals", () => {
+    open({
+      tree,
+      documents: [],
+      nearby: new Map([["projects/website/setup.md", 1]]),
+    });
+    search("setup");
+
+    const rows = screen.getAllByRole("option");
+    expect(rows[0]?.textContent).toContain("projects/website/setup.md");
+  });
+
+  it("ranks the same way as before when no note is open", () => {
+    open({ tree, documents: [] });
+    search("setup");
+
+    // Nothing to be near, so the usual order stands and nothing is lost.
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+  });
+});

--- a/apps/web/src/components/CommandPalette.test.tsx
+++ b/apps/web/src/components/CommandPalette.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Workspace } from "@forkleaf/types";
+import { CommandPalette } from "./CommandPalette";
+import { entryFrom } from "@/lib/pdf-index";
+
+afterEach(cleanup);
+
+// jsdom has no `scrollIntoView`, and the palette calls it to keep the
+// highlighted row in view. Without this every render throws before anything
+// under test happens.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {};
+});
+
+const WORKSPACE: Workspace = {
+  id: "w",
+  name: "me/notes",
+  repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
+  isDefault: true,
+  isLocal: false,
+  createdAt: "",
+  lastOpenedAt: "",
+};
+
+const DOCUMENTS = [
+  entryFrom("w", "papers/attention.pdf", [
+    { page: 1, text: "We show that attention is all you need." },
+    { page: 2, text: "The rest is engineering." },
+  ]),
+];
+
+function open(over: Partial<React.ComponentProps<typeof CommandPalette>> = {}) {
+  const props = {
+    onClose: vi.fn(),
+    tree: [{ kind: "file" as const, name: "plan.md", path: "plan.md" }],
+    openNotes: [],
+    workspace: WORKSPACE,
+    onOpenNote: vi.fn(),
+    onOpenDocument: vi.fn(),
+    documents: DOCUMENTS,
+    commands: [],
+    ...over,
+  };
+
+  render(<CommandPalette {...props} />);
+  return props;
+}
+
+/** Types into the palette the way somebody looking for something does. */
+function search(text: string) {
+  fireEvent.change(screen.getByRole("combobox"), { target: { value: text } });
+}
+
+describe("CommandPalette — searching inside documents", () => {
+  it("finds a phrase in a paper and says which page it is on", () => {
+    open();
+    search("all you need");
+
+    expect(screen.getByText("Documents")).toBeTruthy();
+    expect(screen.getByText("attention.pdf · p. 1")).toBeTruthy();
+    // The sentence, not the path: the path is on the line above, and the words
+    // are what tell you whether this is the passage you meant.
+    expect(screen.getByText(/attention is all you need/)).toBeTruthy();
+  });
+
+  it("opens the document at the page the phrase is on", () => {
+    const props = open();
+    search("engineering");
+
+    fireEvent.click(screen.getByText("attention.pdf · p. 2"));
+
+    expect(props.onOpenDocument).toHaveBeenCalledWith("papers/attention.pdf", 2);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("lists nothing from the documents until something has been typed", () => {
+    open();
+    expect(screen.queryByText("Documents")).toBeNull();
+  });
+
+  it("says it can search documents, but only when it has some", () => {
+    open();
+    expect(screen.getByRole("combobox").getAttribute("placeholder")).toMatch(/documents/i);
+
+    cleanup();
+    open({ documents: [] });
+    expect(screen.getByRole("combobox").getAttribute("placeholder")).not.toMatch(/documents/i);
+  });
+
+  it("leaves documents out entirely where there is nowhere to open one", () => {
+    // The standalone case: no handler, so a result nobody could act on is
+    // better not offered.
+    open({ onOpenDocument: undefined });
+    search("all you need");
+
+    expect(screen.queryByText("Documents")).toBeNull();
+  });
+});

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -49,6 +49,15 @@ export interface CommandPaletteProps {
   documents?: readonly PdfTextEntry[];
   /** Opens a document at the page a phrase was found on. */
   onOpenDocument?: (pdfPath: string, page: number) => void;
+  /**
+   * The notes around the one being written, by path, with their distance.
+   *
+   * What makes a search know where it is being made from: "setup" typed while
+   * writing about a project finds that project's setup rather than the other
+   * five. Absent when no note is open, which is when there is nowhere to be
+   * near.
+   */
+  nearby?: ReadonlyMap<string, number>;
   commands: Command[];
 }
 
@@ -60,6 +69,7 @@ export function CommandPalette({
   onOpenNote,
   documents = [],
   onOpenDocument,
+  nearby,
   commands,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
@@ -89,8 +99,9 @@ export function CommandPalette({
   }, [tree, openNotes, workspace]);
 
   const noteResults = useMemo(
-    () => queryIndex(noteEntries, { query, sort: "recent" }).slice(0, 8),
-    [noteEntries, query],
+    () =>
+      queryIndex(noteEntries, { query, sort: "recent", ...(nearby ? { nearby } : {}) }).slice(0, 8),
+    [noteEntries, query, nearby],
   );
 
   /**

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import type { Note, TreeNode, Workspace } from "@forkleaf/types";
+import type { Note, PdfTextEntry, TreeNode, Workspace } from "@forkleaf/types";
 import { entryFromNote, entryFromPath, queryIndex } from "@/lib/library";
+import { searchDocuments } from "@/lib/pdf-index";
 
 /**
  * ⌘K — go anywhere, do anything.
@@ -37,6 +38,17 @@ export interface CommandPaletteProps {
   openNotes: Note[];
   workspace: Workspace | null;
   onOpenNote: (path: string) => void;
+  /**
+   * The documents whose text this notebook has kept, for searching inside.
+   *
+   * A PDF's text is extracted the first time it is read and stored beside the
+   * notebook, so ⌘K can look inside the papers as well as at the notes. Empty
+   * until something has been read, which is honest: a document nobody has
+   * opened has not been read by anybody, this app included.
+   */
+  documents?: readonly PdfTextEntry[];
+  /** Opens a document at the page a phrase was found on. */
+  onOpenDocument?: (pdfPath: string, page: number) => void;
   commands: Command[];
 }
 
@@ -46,6 +58,8 @@ export function CommandPalette({
   openNotes,
   workspace,
   onOpenNote,
+  documents = [],
+  onOpenDocument,
   commands,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
@@ -79,6 +93,18 @@ export function CommandPalette({
     [noteEntries, query],
   );
 
+  /**
+   * What the papers say, not only what the notes about them say.
+   *
+   * Only once something has been typed: an empty query would otherwise list
+   * the first few pages of every document that has ever been opened, above the
+   * commands, for no reason.
+   */
+  const documentResults = useMemo(
+    () => (onOpenDocument ? searchDocuments(documents, query) : []),
+    [documents, query, onOpenDocument],
+  );
+
   const commandResults = useMemo(() => {
     const needle = query.trim().toLowerCase();
     if (!needle) return commands;
@@ -92,9 +118,10 @@ export function CommandPalette({
   const rows = useMemo(
     () => [
       ...noteResults.map((entry) => ({ kind: "note" as const, entry })),
+      ...documentResults.map((hit) => ({ kind: "document" as const, hit })),
       ...commandResults.map((command) => ({ kind: "command" as const, command })),
     ],
-    [noteResults, commandResults],
+    [noteResults, documentResults, commandResults],
   );
 
   // Clamped rather than reset: typing narrows the list, and snapping the
@@ -109,11 +136,13 @@ export function CommandPalette({
       onClose();
       if (row.kind === "note") {
         onOpenNote(row.entry.path);
+      } else if (row.kind === "document") {
+        onOpenDocument?.(row.hit.path, row.hit.page);
       } else {
         await row.command.run();
       }
     },
-    [rows, onClose, onOpenNote],
+    [rows, onClose, onOpenNote, onOpenDocument],
   );
 
   // Keep the highlighted row in view when it moves past the fold.
@@ -167,8 +196,12 @@ export function CommandPalette({
           aria-expanded
           aria-controls="command-palette-list"
           aria-activedescendant={rows[selected] ? `palette-row-${selected}` : undefined}
-          placeholder="Search notes, or type a command…"
-          aria-label="Search notes and commands"
+          placeholder={
+            documents.length > 0
+              ? "Search notes and documents, or type a command…"
+              : "Search notes, or type a command…"
+          }
+          aria-label="Search notes, documents and commands"
           className="w-full border-b border-[var(--fl-border)] bg-transparent px-4 py-3.5 text-[15px] text-[var(--fl-text)] outline-none placeholder:text-[var(--fl-muted)]"
         />
 
@@ -187,12 +220,11 @@ export function CommandPalette({
           {rows.map((row, index) => {
             const isActive = index === selected;
             const previous = rows[index - 1];
-            const group = row.kind === "note" ? "Notes" : row.command.group;
-            const previousGroup =
-              previous == null ? null : previous.kind === "note" ? "Notes" : previous.command.group;
+            const group = groupOf(row);
+            const previousGroup = previous == null ? null : groupOf(previous);
 
             return (
-              <li key={row.kind === "note" ? row.entry.id : row.command.id}>
+              <li key={keyOf(row, index)}>
                 {group !== previousGroup && (
                   <p className="px-2.5 pb-1 pt-2.5 text-[10.5px] font-semibold uppercase tracking-[0.13em] text-[var(--fl-muted)]">
                     {group}
@@ -215,10 +247,21 @@ export function CommandPalette({
 
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-[14px] text-[var(--fl-text)]">
-                      {row.kind === "note" ? row.entry.title : row.command.label}
+                      {row.kind === "note"
+                        ? row.entry.title
+                        : row.kind === "document"
+                          ? `${filename(row.hit.path)} · p. ${row.hit.page}`
+                          : row.command.label}
                     </span>
                     <span className="block truncate text-[11.5px] text-[var(--fl-muted)]">
-                      {row.kind === "note" ? row.entry.path : (row.command.hint ?? "")}
+                      {row.kind === "note"
+                        ? row.entry.path
+                        : row.kind === "document"
+                          ? // The sentence it was found in, not the path: the
+                            // path is in the line above and the words are what
+                            // tell you whether this is the passage you meant.
+                            row.hit.snippet
+                          : (row.command.hint ?? "")}
                     </span>
                   </span>
                 </button>
@@ -237,6 +280,25 @@ export function CommandPalette({
   );
 }
 
+type Row =
+  | { kind: "note"; entry: { id: string; path: string; title: string } }
+  | { kind: "document"; hit: { path: string; page: number; snippet: string } }
+  | { kind: "command"; command: Command };
+
+function groupOf(row: Row): string {
+  if (row.kind === "note") return "Notes";
+  if (row.kind === "document") return "Documents";
+  return row.command.group;
+}
+
+function keyOf(row: Row, index: number): string {
+  if (row.kind === "note") return row.entry.id;
+  if (row.kind === "document") return `${row.hit.path}:${row.hit.page}:${index}`;
+  return row.command.id;
+}
+
+const filename = (path: string) => path.split("/").pop() ?? path;
+
 function Key({ children }: { children: ReactNode }) {
   return (
     <span className="inline-flex items-center gap-1">
@@ -247,7 +309,7 @@ function Key({ children }: { children: ReactNode }) {
   );
 }
 
-function Glyph({ kind }: { kind: "note" | "command" }) {
+function Glyph({ kind }: { kind: "note" | "document" | "command" }) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -262,6 +324,13 @@ function Glyph({ kind }: { kind: "note" | "command" }) {
         <>
           <path d="M3.25 2.75h6l3.5 3.5v7a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5Z" />
           <path d="M9 2.75v3.5h3.5" />
+        </>
+      ) : kind === "document" ? (
+        // A page with lines of type on it: a document, as against a note,
+        // which is the same outline with a folded corner.
+        <>
+          <rect x="2.75" y="2.75" width="10.5" height="10.5" rx="1.25" />
+          <path d="M5.25 6h5.5M5.25 8.5h5.5M5.25 11h3" />
         </>
       ) : (
         <path d="M5.5 6 3 8l2.5 2M10.5 6 13 8l-2.5 2M9.25 4l-2.5 8" />

--- a/apps/web/src/components/FreshnessDialog.test.tsx
+++ b/apps/web/src/components/FreshnessDialog.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { FreshnessDialog } from "./FreshnessDialog";
+
+/**
+ * jsdom here has a `localStorage` property with nothing behind it, so
+ * remembering a dismissal — which is half of what this dialog does — could
+ * not otherwise be tested at all. An in-memory Storage is enough: what is
+ * under test is that the dialog writes and reads back, not the browser's.
+ */
+const store = new Map<string, string>();
+
+beforeAll(() => {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, String(value)),
+      removeItem: (key: string) => void store.delete(key),
+      clear: () => store.clear(),
+      key: (index: number) => [...store.keys()][index] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  store.clear();
+});
+
+const YEARS_AGO = "2019-01-01T00:00:00.000Z";
+
+const notes = [
+  {
+    path: "runbook.md",
+    content: "# Deploy runbook\n\n![diagram](assets/gone.png)\n\nNeeds v14.2 as of 2019.",
+    updatedAt: YEARS_AGO,
+  },
+  { path: "fine.md", content: "# Fine\n\nOrdinary prose about how I think.", updatedAt: null },
+];
+
+function open(over: Partial<React.ComponentProps<typeof FreshnessDialog>> = {}) {
+  const props = {
+    onClose: vi.fn(),
+    loadNotes: vi.fn(async () => notes),
+    loadFiles: vi.fn(async () => ["runbook.md", "fine.md"]),
+    onOpenNote: vi.fn(),
+    workspaceId: "w",
+    ...over,
+  };
+
+  render(<FreshnessDialog {...props} />);
+  return props;
+}
+
+const check = () => fireEvent.click(screen.getByRole("button", { name: /Check my notes/ }));
+
+describe("FreshnessDialog — the sweep", () => {
+  it("reads nothing until it is asked to", () => {
+    const props = open();
+    expect(props.loadNotes).not.toHaveBeenCalled();
+  });
+
+  it("names the note, and the file that is not there", async () => {
+    open();
+    check();
+
+    expect(await screen.findByRole("button", { name: "Deploy runbook" })).toBeTruthy();
+    expect(screen.getByText("assets/gone.png")).toBeTruthy();
+    // The note that is fine is not a row. A list of everything is a list
+    // nobody reads.
+    expect(screen.queryByRole("button", { name: "Fine" })).toBeNull();
+  });
+
+  it("says so plainly when there is nothing to report", async () => {
+    open({ loadNotes: vi.fn(async () => [notes[1]!]) });
+    check();
+
+    expect(await screen.findByText(/Nothing looks stale/)).toBeTruthy();
+  });
+
+  it("opens the note a row is about", async () => {
+    const props = open();
+    check();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Deploy runbook" }));
+    expect(props.onOpenNote).toHaveBeenCalledWith("runbook.md");
+  });
+
+  /**
+   * Without the file list every picture in the notebook looks deleted, which
+   * is the most alarming possible thing to be wrong about.
+   */
+  it("checks nothing rather than guessing when the file list will not come", async () => {
+    open({
+      loadFiles: vi.fn(async () => {
+        throw new Error("The repository's file list could not be read.");
+      }),
+    });
+    check();
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.queryByText("assets/gone.png")).toBeNull();
+  });
+});
+
+describe("FreshnessDialog — saying a note is fine", () => {
+  it("takes it off the list and remembers", async () => {
+    open();
+    check();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Dismiss Deploy runbook/ }));
+    expect(screen.queryByRole("button", { name: "Deploy runbook" })).toBeNull();
+
+    // Opened again, the same note stays off the list.
+    cleanup();
+    open();
+    check();
+    expect(await screen.findByText(/dealt with everything/)).toBeTruthy();
+  });
+
+  it("brings it back once the note has been edited again", async () => {
+    open();
+    check();
+    fireEvent.click(await screen.findByRole("button", { name: /Dismiss Deploy runbook/ }));
+
+    cleanup();
+    open({
+      loadNotes: vi.fn(async () => [{ ...notes[0]!, updatedAt: "2026-08-31T00:00:00.000Z" }]),
+    });
+    check();
+
+    // The edit is the only moment its claims could have changed.
+    expect(await screen.findByRole("button", { name: "Deploy runbook" })).toBeTruthy();
+  });
+
+  it("can show what has been dealt with, for anybody who wants to look", async () => {
+    open();
+    check();
+    fireEvent.click(await screen.findByRole("button", { name: /Dismiss Deploy runbook/ }));
+
+    fireEvent.click(screen.getByRole("button", { name: /1 dismissed/ }));
+    expect(screen.getByRole("button", { name: "Deploy runbook" })).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/FreshnessDialog.tsx
+++ b/apps/web/src/components/FreshnessDialog.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Dialog } from "@/components/Dialog";
+import { readDismissals, writeDismissals } from "@/lib/freshness-dismissals";
+import {
+  isDismissed,
+  surveyNotebook,
+  withDismissal,
+  type Dismissals,
+  type StaleNote,
+  type Survey,
+  type SurveySource,
+} from "@/lib/notebook-freshness";
+
+/**
+ * What has gone off, across the whole notebook.
+ *
+ * The freshness panel beside a note answers the question for the note you
+ * happen to have open, which is the wrong way round: nobody opens a note to
+ * find out that it rotted. They find out when they act on it, in front of
+ * somebody. This is the version that comes to you — four notes point at a
+ * file that is not there any more, two make claims about a version that has
+ * moved on — and it is short, because a list of everything is a list nobody
+ * reads.
+ *
+ * Nothing here changes a note. Every row opens the note it is about and gets
+ * out of the way, because what to do about a stale note is a judgement the
+ * app is in no position to make: the version number may be deliberate, the
+ * missing picture may be one you meant to delete.
+ */
+
+export interface FreshnessDialogProps {
+  onClose: () => void;
+  /** Every note in the notebook, read when the sweep starts. */
+  loadNotes: () => Promise<SurveySource[]>;
+  /**
+   * Every path that exists, so a reference to a missing one can be spotted.
+   *
+   * The repository's whole file list, not just its notes — a picture is a file
+   * a note can point at, and one that has been deleted is the clearest signal
+   * on this list.
+   */
+  loadFiles: () => Promise<string[]>;
+  onOpenNote: (path: string) => void;
+  /**
+   * Which notebook this is, for remembering what has been dismissed.
+   *
+   * The dismissals are read here rather than passed in, because this dialog
+   * only exists once somebody has opened it — which is to say on the client,
+   * after a click — and that is the one place `localStorage` can be read
+   * during a render without the server disagreeing about what it said.
+   */
+  workspaceId: string;
+}
+
+type State =
+  | { kind: "idle" }
+  | { kind: "reading" }
+  | { kind: "done"; survey: Survey }
+  | { kind: "error"; message: string };
+
+export function FreshnessDialog({
+  onClose,
+  loadNotes,
+  loadFiles,
+  onOpenNote,
+  workspaceId,
+}: FreshnessDialogProps) {
+  const [state, setState] = useState<State>({ kind: "idle" });
+  const [dismissals, setDismissals] = useState<Dismissals>(() => readDismissals(workspaceId));
+
+  const dismiss = useCallback(
+    (note: StaleNote) => {
+      setDismissals((current) => {
+        const next = withDismissal(current, note);
+        writeDismissals(workspaceId, next);
+        return next;
+      });
+    },
+    [workspaceId],
+  );
+  /** True once the reader asks to see the notes they have already dealt with. */
+  const [showDismissed, setShowDismissed] = useState(false);
+
+  const run = useCallback(async () => {
+    setState({ kind: "reading" });
+
+    try {
+      const [notes, files] = await Promise.all([loadNotes(), loadFiles()]);
+      setState({ kind: "done", survey: surveyNotebook(notes, { files: new Set(files) }) });
+    } catch (problem: unknown) {
+      setState({
+        kind: "error",
+        message:
+          problem instanceof Error
+            ? problem.message
+            : "Your notebook could not be read. Nothing was changed.",
+      });
+    }
+  }, [loadNotes, loadFiles]);
+
+  const survey = state.kind === "done" ? state.survey : null;
+  const shown = (survey?.notes ?? []).filter(
+    (note) => showDismissed || !isDismissed(dismissals, note),
+  );
+  const hidden = (survey?.notes ?? []).length - shown.length;
+
+  return (
+    <Dialog
+      title="What has gone stale"
+      subtitle="Notes pointing at files that have gone, and claims that have aged"
+      onClose={onClose}
+      wide
+    >
+      {state.kind === "idle" && (
+        <div className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+          <p className="max-w-2xl">
+            Reads every note on this device and looks for three things: a link to a file that is not
+            in the repository, a <code>[[link]]</code> matching no note, and datable claims —
+            version numbers, CVEs, &ldquo;currently&rdquo; — in a note nobody has touched for a long
+            time.
+          </p>
+          <p className="mt-2 max-w-2xl">
+            The first two are facts. The third is an inference, and is reported as one. Nothing is
+            changed either way.
+          </p>
+          <button type="button" onClick={() => void run()} className="fl-btn fl-btn-primary mt-4">
+            Check my notes
+          </button>
+        </div>
+      )}
+
+      {state.kind === "reading" && (
+        <p role="status" className="text-[13px] text-[var(--fl-muted)]">
+          Reading your notes…
+        </p>
+      )}
+
+      {state.kind === "error" && (
+        <p role="alert" className="text-[13px] text-[var(--fl-danger)]">
+          {state.message}
+        </p>
+      )}
+
+      {survey && (
+        <div className="text-[13px] leading-relaxed">
+          <p className="text-[var(--fl-text)]">
+            {summary(survey, shown.length)}{" "}
+            {hidden > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowDismissed((current) => !current)}
+                className="text-[var(--fl-muted)] underline decoration-dotted underline-offset-2 hover:text-[var(--fl-text)]"
+              >
+                {showDismissed ? "Hide the ones you have dealt with" : `${hidden} dismissed`}
+              </button>
+            )}
+          </p>
+
+          <ul className="mt-3 space-y-2">
+            {shown.map((note) => (
+              <li
+                key={note.path}
+                className={`rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-2.5 ${
+                  isDismissed(dismissals, note) ? "opacity-60" : ""
+                }`}
+              >
+                <div className="flex items-start gap-2">
+                  <span className="min-w-0 flex-1">
+                    <button
+                      type="button"
+                      onClick={() => onOpenNote(note.path)}
+                      className="block max-w-full truncate text-left text-[13px] font-medium text-[var(--fl-text)] underline decoration-dotted underline-offset-2"
+                    >
+                      {note.title}
+                    </button>
+                    <span className="block truncate font-mono text-[10.5px] text-[var(--fl-muted)]">
+                      {note.path}
+                      {note.ageMonths != null && note.ageMonths > 0
+                        ? ` · untouched for ${note.ageMonths} month${note.ageMonths === 1 ? "" : "s"}`
+                        : ""}
+                    </span>
+                  </span>
+
+                  {!isDismissed(dismissals, note) && (
+                    <button
+                      type="button"
+                      onClick={() => dismiss(note)}
+                      title="Hide this until the note is edited again"
+                      aria-label={`Dismiss ${note.title}`}
+                      className="shrink-0 rounded border border-[var(--fl-border)] px-1.5 py-0.5 text-[10.5px] font-medium text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-surface)] hover:text-[var(--fl-text)]"
+                    >
+                      It is fine
+                    </button>
+                  )}
+                </div>
+
+                <ul className="mt-1.5 space-y-0.5 text-[12px] text-[var(--fl-muted)]">
+                  {note.missingFiles.map((file) => (
+                    <li key={file}>
+                      <span className="text-[var(--fl-danger)]">Links to</span>{" "}
+                      <span className="font-mono text-[11px]">{file}</span>, which is not in the
+                      repository.
+                    </li>
+                  ))}
+                  {note.missingLinks.map((target) => (
+                    <li key={target}>
+                      <span className="text-[var(--fl-danger)]">[[{target}]]</span> matches no note.
+                    </li>
+                  ))}
+                  {/* The inference, and only when it is why the note is on
+                      the list at all. A note listed for a broken link has no
+                      business also being told its prose has no shelf life. */}
+                  {note.missingFiles.length === 0 &&
+                    note.missingLinks.length === 0 &&
+                    note.reasons.map((reason) => <li key={reason}>{reason}</li>)}
+                </ul>
+              </li>
+            ))}
+          </ul>
+
+          <button
+            type="button"
+            onClick={() => void run()}
+            className="fl-btn fl-btn-ghost mt-4 !py-1.5"
+          >
+            Check again
+          </button>
+        </div>
+      )}
+    </Dialog>
+  );
+}
+
+/** The headline: what was read, and what is worth looking at. */
+function summary(survey: Survey, showing: number): string {
+  if (survey.notes.length === 0) {
+    return `${survey.scanned} ${survey.scanned === 1 ? "note" : "notes"} read. Nothing looks stale.`;
+  }
+
+  if (showing === 0) {
+    return `${survey.scanned} notes read. You have dealt with everything on the list.`;
+  }
+
+  const parts: string[] = [];
+  if (survey.counts.missingFiles > 0) {
+    parts.push(
+      `${survey.counts.missingFiles} ${survey.counts.missingFiles === 1 ? "note points" : "notes point"} at a file that has gone`,
+    );
+  }
+  if (survey.counts.missingLinks > 0) {
+    parts.push(
+      `${survey.counts.missingLinks} ${survey.counts.missingLinks === 1 ? "has" : "have"} a link matching no note`,
+    );
+  }
+  if (survey.counts.likelyStale > 0) {
+    parts.push(`${survey.counts.likelyStale} may have aged out`);
+  }
+
+  return `${survey.scanned} notes read. ${parts.join("; ")}.`;
+}

--- a/apps/web/src/components/PdfReader.test.tsx
+++ b/apps/web/src/components/PdfReader.test.tsx
@@ -58,6 +58,8 @@ const NOTES_TAB = "What your notes say about this document";
 
 const mention = (overrides: Partial<PdfMention> = {}): PdfMention => ({
   notePath: "reading/attention.md",
+  pdfPath: "papers/attention.pdf",
+  citation: { quote: "Attention is all you need.", prefix: "", suffix: "", page: 12 },
   line: 6,
   label: "Attention, p. 12",
   page: 12,

--- a/apps/web/src/components/PdfReader.test.tsx
+++ b/apps/web/src/components/PdfReader.test.tsx
@@ -21,6 +21,21 @@ beforeAll(() => {
     },
   );
 
+  // A ready document watches its pages to know which are on screen. jsdom has
+  // no IntersectionObserver either, and the reader wires one up as soon as it
+  // has pages to watch.
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    },
+  );
+
   // Every element in jsdom is nought pixels wide, and the reader reads that as
   // "too narrow to dock anything" — so without a width the docked layout can
   // never be under test. A laptop's worth of room.
@@ -146,5 +161,45 @@ describe("PdfReader — what the notebook says about this document", () => {
     render(<PdfReader reader={loading} layout="document" mentions={null} onClose={null} />);
 
     expect(screen.queryByRole("button", { name: NOTES_TAB })).toBeNull();
+  });
+});
+
+describe("PdfReader — starting a note from the paper", () => {
+  const ready: PdfReaderState = {
+    ...loading,
+    status: "ready",
+    info: {
+      pageCount: 15,
+      metadata: {
+        title: "Attention Is All You Need",
+        author: "Vaswani et al.",
+        subject: null,
+        keywords: [],
+        createdAt: null,
+        modifiedAt: null,
+        producer: null,
+      },
+      // No sizes, so no page is drawn to a canvas jsdom does not have.
+      sizes: [],
+      encrypted: false,
+    },
+  };
+
+  it("offers to write about the paper, and says so in the reader's own words", () => {
+    const onStartNote = vi.fn();
+    render(<PdfReader reader={ready} layout="document" onStartNote={onStartNote} onClose={null} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Start a note about this paper, with its headings/ }),
+    );
+    expect(onStartNote).toHaveBeenCalled();
+  });
+
+  it("offers nothing of the kind while the document is still opening", () => {
+    // The title and the contents are the whole point of the button, and a note
+    // made before they arrive would be called "untitled" and be empty.
+    render(<PdfReader reader={loading} layout="document" onStartNote={vi.fn()} onClose={null} />);
+
+    expect(screen.queryByRole("button", { name: /Start a note about this paper/ })).toBeNull();
   });
 });

--- a/apps/web/src/components/PdfReader.tsx
+++ b/apps/web/src/components/PdfReader.tsx
@@ -72,6 +72,14 @@ export interface PdfReaderProps {
    */
   onOpenInTab?: (() => void) | null;
   /**
+   * Starts a note about this paper, with its headings already in it.
+   *
+   * Absent while the document is still opening: the title and the contents are
+   * the whole point of the button, and a note made before they arrive would be
+   * called "untitled" and be empty.
+   */
+  onStartNote?: (() => void) | null;
+  /**
    * Commits this document into the repository, so it can be linked to.
    *
    * Absent when there is nowhere to put it. `saveHint` explains why, in words,
@@ -154,6 +162,7 @@ export function PdfReader({
   onSave,
   saveHint,
   saving = false,
+  onStartNote = null,
   mentions = null,
   onOpenMention = null,
   titleForNote,
@@ -553,6 +562,15 @@ export function PdfReader({
                   onClick={() => setPanel(panel === "notes" ? null : "notes")}
                 >
                   {`Notes ${mentions.length}`}
+                </ToolButton>
+              ) : null}
+
+              {onStartNote ? (
+                <ToolButton
+                  label="Start a note about this paper, with its headings in it"
+                  onClick={onStartNote}
+                >
+                  Write about this
                 </ToolButton>
               ) : null}
 

--- a/apps/web/src/components/TimeMachineDialog.test.tsx
+++ b/apps/web/src/components/TimeMachineDialog.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { RepoRef } from "@forkleaf/types";
+
+const readNotebookAt = vi.fn();
+const readNoteAtCommit = vi.fn();
+
+vi.mock("@/lib/gateway", () => ({
+  readNotebookAt: (...args: unknown[]) => readNotebookAt(...args),
+  readNoteAtCommit: (...args: unknown[]) => readNoteAtCommit(...args),
+}));
+
+// The preview renders markdown through mermaid and the whole editor package;
+// what is under test here is the time machine around it.
+vi.mock("@forkleaf/editor", () => ({
+  Preview: ({ markdown }: { markdown: string }) => <div data-testid="preview">{markdown}</div>,
+}));
+
+const { TimeMachineDialog } = await import("./TimeMachineDialog");
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const REPO: RepoRef = { owner: "me", repo: "notes", branch: "main", directory: "" };
+
+const TREE = [
+  { kind: "file" as const, name: "kickoff.md", path: "notes/kickoff.md" },
+  { kind: "file" as const, name: "plan.md", path: "plan.md" },
+];
+
+const COMMIT = {
+  sha: "abc1234def",
+  message: "Notes from the third",
+  authorName: "Ada",
+  authorLogin: "ada",
+  avatarUrl: null,
+  date: "2026-03-03T18:00:00.000Z",
+  byForkLeaf: false,
+};
+
+function open() {
+  const onClose = vi.fn();
+  render(<TimeMachineDialog onClose={onClose} repo={REPO} today="2026-08-31" />);
+  return { onClose };
+}
+
+const go = () => fireEvent.click(screen.getByRole("button", { name: /Go there/ }));
+
+const pickDate = (value: string) =>
+  fireEvent.change(screen.getByLabelText(/Show me/), { target: { value } });
+
+describe("TimeMachineDialog — going there", () => {
+  it("reads nothing until it is asked to", () => {
+    open();
+    expect(readNotebookAt).not.toHaveBeenCalled();
+  });
+
+  it("asks for the day that was chosen, and lists what was there", async () => {
+    readNotebookAt.mockResolvedValue({ commit: COMMIT, tree: TREE });
+    open();
+
+    pickDate("2026-03-03");
+    go();
+
+    await waitFor(() => expect(readNotebookAt).toHaveBeenCalledWith(REPO, "2026-03-03"));
+    expect(await screen.findByText("2 files that day")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "notes/kickoff.md" })).toBeTruthy();
+    // Which commit it is showing, so the answer can be checked against the
+    // repository rather than taken on trust.
+    expect(screen.getByText("abc1234")).toBeTruthy();
+  });
+
+  it("cannot be asked for a day that has not happened", () => {
+    open();
+    expect(screen.getByLabelText(/Show me/).getAttribute("max")).toBe("2026-08-31");
+  });
+
+  /**
+   * A notebook has a first day. "There was nothing here yet" is the true
+   * answer to what it looked like before that, and not a failure.
+   */
+  it("says plainly when the repository did not exist yet", async () => {
+    readNotebookAt.mockResolvedValue({ commit: null, tree: [] });
+    open();
+
+    pickDate("1999-01-01");
+    go();
+
+    expect(await screen.findByText(/A notebook has a first day/)).toBeTruthy();
+  });
+
+  it("reports a day it could not read", async () => {
+    readNotebookAt.mockRejectedValue(new Error("Not Found"));
+    open();
+    go();
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+  });
+});
+
+describe("TimeMachineDialog — reading a note as it was", () => {
+  it("reads the note at that commit, not at the newest one", async () => {
+    readNotebookAt.mockResolvedValue({ commit: COMMIT, tree: TREE });
+    readNoteAtCommit.mockResolvedValue("# Kickoff\n\nAs it stood in March.");
+    open();
+    go();
+
+    fireEvent.click(await screen.findByRole("button", { name: "notes/kickoff.md" }));
+
+    await waitFor(() =>
+      expect(readNoteAtCommit).toHaveBeenCalledWith(REPO, "notes/kickoff.md", COMMIT.sha),
+    );
+    expect((await screen.findByTestId("preview")).textContent).toContain("As it stood in March");
+  });
+
+  it("says so in place of the note when one file cannot be read", async () => {
+    readNotebookAt.mockResolvedValue({ commit: COMMIT, tree: TREE });
+    readNoteAtCommit.mockRejectedValue(new Error("gone"));
+    open();
+    go();
+
+    fireEvent.click(await screen.findByRole("button", { name: "plan.md" }));
+
+    // The rest of the day is still readable, so this is not an alarm.
+    expect(await screen.findByText(/plan\.md could not be read at that commit/)).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("offers no way to change anything, which is the point", async () => {
+    readNotebookAt.mockResolvedValue({ commit: COMMIT, tree: TREE });
+    open();
+    go();
+
+    await screen.findByText("2 files that day");
+    expect(screen.queryByRole("button", { name: /restore|revert|roll back/i })).toBeNull();
+  });
+});

--- a/apps/web/src/components/TimeMachineDialog.tsx
+++ b/apps/web/src/components/TimeMachineDialog.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { Preview } from "@forkleaf/editor";
+import type { RepoRef, TreeNode } from "@forkleaf/types";
+import { Dialog } from "@/components/Dialog";
+import { readNotebookAt, readNoteAtCommit, type NoteCommitDto } from "@/lib/gateway";
+import { collectFilePaths } from "@/lib/tree";
+import { relativeTime } from "@/lib/relative-time";
+
+/**
+ * The whole notebook, as it was on a day you choose.
+ *
+ * A note's history answers "how did this page come to be?" one page at a time.
+ * This answers the question people ask when they are trying to remember rather
+ * than to audit: what did I know when I made that decision? Which notes even
+ * existed in March? The per-note history cannot answer either, because both
+ * are about the shape of the notebook rather than about one file in it.
+ *
+ * Nothing here is new machinery. Git already holds every version of every
+ * file; a tree read at an old commit is the same call as a tree read at the
+ * newest one, and the notes come back through the same route the history panel
+ * already uses. All that was missing was somewhere to ask.
+ *
+ * Read-only, deliberately and visibly. Restoring an old version of one note is
+ * a thing the history panel does well and this does not do at all — a button
+ * that rolled a whole notebook back to March would be the single most
+ * dangerous control in the app.
+ */
+
+export interface TimeMachineDialogProps {
+  onClose: () => void;
+  repo: RepoRef;
+  /** Today, so the picker cannot ask for a notebook that has not happened. */
+  today?: string;
+}
+
+type State =
+  | { kind: "idle" }
+  | { kind: "reading" }
+  | { kind: "found"; commit: NoteCommitDto | null; tree: TreeNode[]; date: string }
+  | { kind: "error"; message: string };
+
+export function TimeMachineDialog({ onClose, repo, today }: TimeMachineDialogProps) {
+  const now = today ?? new Date().toISOString().slice(0, 10);
+  const [date, setDate] = useState(now);
+  const [state, setState] = useState<State>({ kind: "idle" });
+
+  /** The note being read, and its text at that commit. */
+  const [open, setOpen] = useState<{ path: string; text: string | null } | null>(null);
+  const [reading, setReading] = useState<string | null>(null);
+
+  const go = useCallback(async () => {
+    setState({ kind: "reading" });
+    setOpen(null);
+
+    try {
+      const { commit, tree } = await readNotebookAt(repo, date);
+      setState({ kind: "found", commit, tree, date });
+    } catch (problem: unknown) {
+      setState({
+        kind: "error",
+        message:
+          problem instanceof Error
+            ? problem.message
+            : "That day could not be read from the repository.",
+      });
+    }
+  }, [repo, date]);
+
+  const paths = useMemo(
+    () => (state.kind === "found" ? collectFilePaths(state.tree).sort() : []),
+    [state],
+  );
+
+  const read = useCallback(
+    async (path: string) => {
+      if (state.kind !== "found" || !state.commit) return;
+
+      setReading(path);
+      setOpen(null);
+      try {
+        const text = await readNoteAtCommit(repo, path, state.commit.sha);
+        setOpen({ path, text });
+      } catch {
+        // Said in place of the note rather than as an alarm: the rest of the
+        // day is still readable, and this is one file in it.
+        setOpen({ path, text: null });
+      } finally {
+        setReading(null);
+      }
+    },
+    [repo, state],
+  );
+
+  return (
+    <Dialog
+      title="Your notebook, on a day you choose"
+      subtitle="Every note as it was — read-only, straight out of the repository's history"
+      onClose={onClose}
+      wide
+      steady
+    >
+      <div className="flex min-h-0 flex-col gap-3 text-[13px]">
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--fl-muted)]">
+              Show me
+            </span>
+            <input
+              type="date"
+              value={date}
+              max={now}
+              onChange={(event) => setDate(event.target.value)}
+              className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2.5 py-1.5 text-[13px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={() => void go()}
+            disabled={state.kind === "reading" || !date}
+            className="fl-btn fl-btn-primary !py-1.5 disabled:opacity-60"
+          >
+            {state.kind === "reading" ? "Reading…" : "Go there"}
+          </button>
+
+          {state.kind === "found" && state.commit && (
+            <p className="text-[11.5px] text-[var(--fl-muted)]">
+              As of{" "}
+              <span className="font-mono text-[11px] text-[var(--fl-text)]">
+                {state.commit.sha.slice(0, 7)}
+              </span>{" "}
+              — {state.commit.message || "(no message)"}, {relativeTime(state.commit.date)}
+            </p>
+          )}
+        </div>
+
+        {state.kind === "error" && (
+          <p role="alert" className="text-[var(--fl-danger)]">
+            {state.message}
+          </p>
+        )}
+
+        {state.kind === "found" && !state.commit && (
+          <p className="text-[var(--fl-muted)]">
+            Nothing had been committed to this repository by {state.date}. A notebook has a first
+            day.
+          </p>
+        )}
+
+        {state.kind === "found" && state.commit && (
+          <div className="grid min-h-0 flex-1 gap-3 md:grid-cols-[minmax(12rem,18rem)_1fr]">
+            <div className="min-h-0 overflow-y-auto rounded-xl border border-[var(--fl-border)] p-1.5">
+              <p className="px-1.5 pb-1 text-[11px] text-[var(--fl-muted)]">
+                {paths.length} {paths.length === 1 ? "file" : "files"} that day
+              </p>
+              <ul>
+                {paths.map((path) => (
+                  <li key={path}>
+                    <button
+                      type="button"
+                      onClick={() => void read(path)}
+                      aria-current={open?.path === path}
+                      className={`block w-full truncate rounded px-1.5 py-1 text-left font-mono text-[11px] transition-colors ${
+                        open?.path === path
+                          ? "bg-[var(--fl-accent-soft)] text-[var(--fl-text)]"
+                          : "text-[var(--fl-muted)] hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
+                      }`}
+                    >
+                      {path}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="min-h-0 overflow-y-auto rounded-xl border border-[var(--fl-border)] p-3">
+              {reading && (
+                <p aria-busy="true" className="text-[var(--fl-muted)]">
+                  Reading {reading}…
+                </p>
+              )}
+
+              {!reading && !open && (
+                <p className="text-[var(--fl-muted)]">
+                  Pick a note to read it as it was. Nothing here can be edited — this is the
+                  repository&rsquo;s own history, not a copy of it.
+                </p>
+              )}
+
+              {!reading && open && open.text === null && (
+                <p className="text-[var(--fl-muted)]">
+                  {open.path} could not be read at that commit.
+                </p>
+              )}
+
+              {!reading && open?.text != null && <Preview markdown={open.text} />}
+            </div>
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -30,7 +30,7 @@ import { useNotebook } from "@/hooks/useNotebook";
 import { usePublishedPages } from "@/hooks/usePublishedPages";
 import { useLinks } from "@/hooks/useLinks";
 import { useLocalFiles } from "@/hooks/useLocalFiles";
-import type { PdfTextEntry } from "@forkleaf/types";
+import type { PdfTextEntry, TreeNode } from "@forkleaf/types";
 import type { LocalFile, LocalPdf } from "@/lib/local-files";
 import { usePdfReader } from "@/hooks/usePdfReader";
 import { PdfReader } from "@/components/PdfReader";
@@ -51,6 +51,7 @@ import { mentionsOfPdf, type PdfMention } from "@/lib/pdf-mentions";
 import { pagesOf, readDocumentText } from "@/lib/pdf-index";
 import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
 import { paperNote } from "@/lib/note-from-paper";
+import { FreshnessDialog } from "@/components/FreshnessDialog";
 import { CitationsDialog } from "@/components/CitationsDialog";
 import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
@@ -83,7 +84,7 @@ import { postHogReset } from "@/lib/posthog";
 import { assetPathFor, relativeSrc, resolveImageSrc } from "@/lib/assets";
 import { revealAsset } from "@/lib/reveal-asset";
 import { imageTypeFor } from "@/lib/media";
-import { collectFolders } from "@/lib/tree";
+import { collectFilePaths, collectFolders } from "@/lib/tree";
 import { hasRelativeImages, repairNoteLinks } from "@/lib/repair-links";
 import { flattenTree, isMarkdown } from "@/lib/library";
 import { track } from "@/lib/firebase/analytics";
@@ -264,6 +265,7 @@ export function EditorWorkspace() {
     | "propose"
     | "publish"
     | "citations"
+    | "freshness"
     | null
   >(null);
   /**
@@ -705,6 +707,43 @@ export function EditorWorkspace() {
     },
     [notebook],
   );
+
+  /**
+   * Every path that exists, so a note pointing at nothing can be spotted.
+   *
+   * The repository's whole file list — pictures and PDFs included, since those
+   * are what notes point at — plus everything written here that has not been
+   * pushed yet, so a picture pasted five minutes ago is not reported as
+   * missing. A notebook with no repository has only the second half, which is
+   * all of it.
+   */
+  const knownFiles = useCallback(async (): Promise<string[]> => {
+    const local = [
+      ...collectFilePaths(notebook.tree),
+      ...notebook.openNotes.map((note) => note.path),
+      ...Object.keys(notebook.assetUrls),
+    ];
+
+    if (!workspace || workspace.isLocal) return local;
+
+    const params = new URLSearchParams({
+      owner: workspace.repo.owner,
+      repo: workspace.repo.repo,
+      branch: workspace.repo.branch,
+      all: "1",
+    });
+    if (workspace.repo.directory) params.set("dir", workspace.repo.directory);
+
+    const response = await fetch(`/api/gh/tree?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error(
+        "The repository's file list could not be read, so nothing was checked. Without it every picture would look deleted.",
+      );
+    }
+
+    const { tree } = (await response.json()) as { tree: TreeNode[] };
+    return [...local, ...collectFilePaths(tree)];
+  }, [workspace, notebook.tree, notebook.openNotes, notebook.assetUrls]);
 
   /**
    * Starts a note about the paper on screen, with its headings already in it.
@@ -1870,6 +1909,18 @@ export function EditorWorkspace() {
       });
     }
 
+    if (workspace) {
+      list.push({
+        id: "freshness",
+        label: "Check which of my notes have gone stale",
+        group: "Notes",
+        hint: "Links pointing at nothing, and claims nobody has looked at in years",
+        keywords:
+          "stale fresh freshness rot decay old outdated broken link missing file check audit sweep review",
+        run: () => setDialog("freshness"),
+      });
+    }
+
     if (workspace && !workspace.isLocal) {
       list.push({
         id: "citations",
@@ -2790,6 +2841,26 @@ export function EditorWorkspace() {
           documents={workspace && !workspace.isLocal ? documentTexts : []}
           onOpenDocument={(path, page) => openRepoPdf(path, `page=${page}`)}
           commands={commands}
+        />
+      )}
+
+      {openDialog === "freshness" && workspace && (
+        <FreshnessDialog
+          onClose={() => setDialog(null)}
+          loadNotes={async () =>
+            (await notebook.allNotes()).map((entry) => ({
+              path: entry.path,
+              content: entry.content,
+              updatedAt: entry.updatedAt,
+              frontmatterTitle: entry.frontmatter.title,
+            }))
+          }
+          loadFiles={knownFiles}
+          onOpenNote={(path) => {
+            setDialog(null);
+            notebook.openNote(path);
+          }}
+          workspaceId={workspace.id}
         />
       )}
 

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -18,6 +18,7 @@ import {
   dirname,
   documentStats,
   joinPath,
+  neighbourhood,
   parseRepoTarget,
   referencedPaths,
   type RepoTarget,
@@ -822,6 +823,17 @@ export function EditorWorkspace() {
     repo: workspace && !workspace.isLocal ? workspace.repo : null,
   });
 
+  /**
+   * The notes around the one being written, for ⌘K to weigh.
+   *
+   * The link graph is built for backlinks and answers this for free: a note
+   * you linked to and a note that linked to you are equally near, because in
+   * both cases somebody decided they belonged together.
+   */
+  const nearbyNotes = useMemo(
+    () => (note && links.ready ? neighbourhood(links.graph, note.path) : null),
+    [note, links.ready, links.graph],
+  );
 
   /**
    * Creates the note a link points at but that nobody has written yet.
@@ -2774,6 +2786,7 @@ export function EditorWorkspace() {
           // A notebook with no repository has no documents to reach: nothing
           // could have been read from one, and a result that opened nothing
           // would be worse than no result.
+          {...(nearbyNotes ? { nearby: nearbyNotes } : {})}
           documents={workspace && !workspace.isLocal ? documentTexts : []}
           onOpenDocument={(path, page) => openRepoPdf(path, `page=${page}`)}
           commands={commands}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -49,6 +49,7 @@ import { insertionFor, quoteMarkdown } from "@/lib/pdf-quote";
 import { mentionsOfPdf, type PdfMention } from "@/lib/pdf-mentions";
 import { pagesOf, readDocumentText } from "@/lib/pdf-index";
 import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
+import { paperNote } from "@/lib/note-from-paper";
 import { CitationsDialog } from "@/components/CitationsDialog";
 import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
@@ -705,6 +706,59 @@ export function EditorWorkspace() {
   );
 
   /**
+   * Starts a note about the paper on screen, with its headings already in it.
+   *
+   * Two writes rather than one, deliberately: the note's links are written
+   * relative to *its own* path, and that path is only decided — slugified from
+   * the title, made unique against everything else — once the note exists. So
+   * it is created, and then filled in now that there is somewhere to write
+   * from. The two land in one commit, since the queue coalesces them.
+   */
+  const startNoteFromPaper = useCallback(async () => {
+    if (!reader.info) return;
+
+    const draft = paperNote({
+      metadata: reader.info.metadata,
+      filename: reader.source?.name ?? "Paper",
+      outline: reader.outline,
+      pageCount: reader.info.pageCount,
+      pdfPath: readerPath,
+      // A placeholder: the real path replaces it below, and the links are
+      // rewritten against it.
+      notePath: "",
+    });
+
+    // Beside the note you were last in, not beside the PDF: `papers/` is where
+    // the files live, and a note about a paper is writing, not a file.
+    const created = await notebook.createNote(
+      draft.title,
+      currentFolder,
+      draft.content,
+      draft.frontmatter,
+    );
+    if (!created) return;
+
+    const filled = paperNote({
+      metadata: reader.info.metadata,
+      filename: reader.source?.name ?? "Paper",
+      outline: reader.outline,
+      pageCount: reader.info.pageCount,
+      pdfPath: readerPath,
+      notePath: created.path,
+    });
+    await notebook.rewriteNote(created.path, () => filled.content);
+
+    // The note it just made is what the reader wants to look at, so the
+    // document steps aside from the middle column and reads beside it.
+    // Moved rather than reopened: the document is already parsed and rendered,
+    // and reopening it would fetch and lay out the whole file again to end up
+    // exactly where it is.
+    if (readerLayout === "document") setReaderLayout("beside");
+
+    setNotice(`Started ${created.path} from this paper`);
+  }, [reader, readerPath, readerLayout, notebook, currentFolder]);
+
+  /**
    * What this notebook has already said about the document being read.
    *
    * Null rather than empty for a document with no repository path: a note
@@ -767,6 +821,7 @@ export function EditorWorkspace() {
     hrefFor: hrefForPath,
     repo: workspace && !workspace.isLocal ? workspace.repo : null,
   });
+
 
   /**
    * Creates the note a link points at but that nobody has written yet.
@@ -2017,6 +2072,7 @@ export function EditorWorkspace() {
       onSave={canSavePdf ? () => void savePdfToNotebook() : null}
       saveHint={pdfSaveHint}
       saving={savingPdf}
+      onStartNote={reader.status === "ready" ? () => void startNoteFromPaper() : null}
       mentions={pdfMentions}
       onOpenMention={(path) => {
         notebook.openNote(path);

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -52,6 +52,7 @@ import { pagesOf, readDocumentText } from "@/lib/pdf-index";
 import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
 import { paperNote } from "@/lib/note-from-paper";
 import { FreshnessDialog } from "@/components/FreshnessDialog";
+import { TimeMachineDialog } from "@/components/TimeMachineDialog";
 import { CitationsDialog } from "@/components/CitationsDialog";
 import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
@@ -266,6 +267,7 @@ export function EditorWorkspace() {
     | "publish"
     | "citations"
     | "freshness"
+    | "time-machine"
     | null
   >(null);
   /**
@@ -1909,6 +1911,18 @@ export function EditorWorkspace() {
       });
     }
 
+    if (workspace && !workspace.isLocal) {
+      list.push({
+        id: "time-machine",
+        label: "Show me my notebook as it was on…",
+        group: "View",
+        hint: "Every note as it stood on a day you choose, read-only",
+        keywords:
+          "time travel machine history date day past was previous version snapshot notebook whole rewind back then",
+        run: () => setDialog("time-machine"),
+      });
+    }
+
     if (workspace) {
       list.push({
         id: "freshness",
@@ -2842,6 +2856,10 @@ export function EditorWorkspace() {
           onOpenDocument={(path, page) => openRepoPdf(path, `page=${page}`)}
           commands={commands}
         />
+      )}
+
+      {openDialog === "time-machine" && workspace && !workspace.isLocal && (
+        <TimeMachineDialog onClose={() => setDialog(null)} repo={workspace.repo} />
       )}
 
       {openDialog === "freshness" && workspace && (

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -29,6 +29,7 @@ import { useNotebook } from "@/hooks/useNotebook";
 import { usePublishedPages } from "@/hooks/usePublishedPages";
 import { useLinks } from "@/hooks/useLinks";
 import { useLocalFiles } from "@/hooks/useLocalFiles";
+import type { PdfTextEntry } from "@forkleaf/types";
 import type { LocalFile, LocalPdf } from "@/lib/local-files";
 import { usePdfReader } from "@/hooks/usePdfReader";
 import { PdfReader } from "@/components/PdfReader";
@@ -46,6 +47,9 @@ import { commitToBranch } from "@/lib/gateway";
 import { readDroppedPdf } from "@/lib/local-files";
 import { insertionFor, quoteMarkdown } from "@/lib/pdf-quote";
 import { mentionsOfPdf, type PdfMention } from "@/lib/pdf-mentions";
+import { pagesOf, readDocumentText } from "@/lib/pdf-index";
+import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
+import { CitationsDialog } from "@/components/CitationsDialog";
 import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
 import { ColumnResizer } from "@/components/ColumnResizer";
@@ -257,6 +261,7 @@ export function EditorWorkspace() {
     | "capture"
     | "propose"
     | "publish"
+    | "citations"
     | null
   >(null);
   /**
@@ -601,6 +606,103 @@ export function EditorWorkspace() {
       live = false;
     };
   }, [reader.status, readerPath, loadAllNotes]);
+
+  /**
+   * The documents whose text this notebook has kept, for ⌘K to search.
+   *
+   * Loaded when the palette opens rather than held all the time: this is every
+   * word of every paper that has been read, which belongs in memory for as
+   * long as somebody is searching it and no longer.
+   */
+  const [documentTexts, setDocumentTexts] = useState<PdfTextEntry[]>([]);
+
+  const loadDocumentText = notebook.allDocumentText;
+
+  useEffect(() => {
+    if (!paletteOpen) return;
+
+    let live = true;
+    void loadDocumentText()
+      .then((entries) => {
+        if (live) setDocumentTexts(entries);
+      })
+      .catch(() => {
+        // Nothing kept is the same as nothing to search: ⌘K still finds notes.
+        if (live) setDocumentTexts([]);
+      });
+
+    return () => {
+      live = false;
+    };
+  }, [paletteOpen, loadDocumentText]);
+
+  /**
+   * Keeps the text of a document the reader has just finished reading.
+   *
+   * The extraction has already happened — it is what makes find-in-document
+   * work — so this only writes down what was going to be thrown away. Once per
+   * document per open, tracked by a ref, since `pages` changes identity on
+   * every render of a document that is still being read.
+   */
+  const savedText = useRef<string | null>(null);
+  const saveDocumentText = notebook.saveDocumentText;
+
+  useEffect(() => {
+    if (reader.status !== "ready" || reader.indexing || !readerPath) return;
+    if (reader.pages.length === 0) return;
+
+    const key = `${workspaceIdForLinks ?? ""}::${readerPath}`;
+    if (savedText.current === key) return;
+    savedText.current = key;
+
+    void saveDocumentText(
+      readerPath,
+      reader.pages.map((page) => ({ page: page.page, text: page.text })),
+    ).catch(() => {
+      // Not worth telling anybody about: the document is open and readable,
+      // and the only thing lost is that ⌘K will not reach inside it yet.
+      savedText.current = null;
+    });
+  }, [
+    reader.status,
+    reader.indexing,
+    reader.pages,
+    readerPath,
+    workspaceIdForLinks,
+    saveDocumentText,
+  ]);
+
+  /**
+   * A document's text for the citation check: from the cache, or read now.
+   *
+   * Reading it here also fills the cache, so checking your citations is also
+   * what makes those papers searchable from ⌘K.
+   */
+  const pagesForDocument = useCallback(
+    async (pdfPath: string) => {
+      if (!workspace || workspace.isLocal) {
+        throw new Error("This notebook has no repository, so its documents cannot be read.");
+      }
+
+      const cached = await notebook.documentText(pdfPath);
+      if (cached && cached.pages.length > 0) return pagesOf(cached);
+
+      const pages = await readDocumentText(workspace, pdfPath);
+      await notebook.saveDocumentText(pdfPath, pages);
+      return pagesOf({ id: "", workspaceId: workspace.id, path: pdfPath, pages, indexedAt: "" });
+    },
+    [workspace, notebook],
+  );
+
+  /** Writes a corrected page number into the note holding the citation. */
+  const correctCitationPage = useCallback(
+    async (check: CitationCheck) => {
+      await notebook.rewriteNote(check.mention.notePath, (content) =>
+        withCorrectedPage(content, check),
+      );
+    },
+    [notebook],
+  );
 
   /**
    * What this notebook has already said about the document being read.
@@ -1701,6 +1803,18 @@ export function EditorWorkspace() {
       });
     }
 
+    if (workspace && !workspace.isLocal) {
+      list.push({
+        id: "citations",
+        label: "Check my citations against their documents",
+        group: "Notes",
+        hint: "Finds quotations that have moved, and ones that are no longer there",
+        keywords:
+          "citation citations quote quotation check verify audit broken stale page pdf paper source reference sweep",
+        run: () => setDialog("citations"),
+      });
+    }
+
     // All three placements, always, with the current one marked — rather than
     // one command whose label is the *other* state. A toggle reads as an
     // instruction ("open PDFs in their own tab") that gives no hint about
@@ -2601,7 +2715,31 @@ export function EditorWorkspace() {
           openNotes={notebook.openNotes}
           workspace={workspace}
           onOpenNote={notebook.openNote}
+          // A notebook with no repository has no documents to reach: nothing
+          // could have been read from one, and a result that opened nothing
+          // would be worse than no result.
+          documents={workspace && !workspace.isLocal ? documentTexts : []}
+          onOpenDocument={(path, page) => openRepoPdf(path, `page=${page}`)}
           commands={commands}
+        />
+      )}
+
+      {openDialog === "citations" && workspace && !workspace.isLocal && (
+        <CitationsDialog
+          onClose={() => setDialog(null)}
+          loadNotes={async () =>
+            (await notebook.allNotes()).map(({ path, content }) => ({ path, content }))
+          }
+          pagesFor={pagesForDocument}
+          onOpenNote={(path) => {
+            setDialog(null);
+            notebook.openNote(path);
+          }}
+          onOpenDocument={(pdfPath, page) => {
+            setDialog(null);
+            openRepoPdf(pdfPath, `page=${page}`);
+          }}
+          onFix={correctCitationPage}
         />
       )}
 

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_SYNC_PREFERENCE,
   type LocalAsset,
   type Note,
+  type NoteFrontmatter,
   type PendingChange,
   type RepoRef,
   type SyncMode,
@@ -945,7 +946,7 @@ export function useNotebook(request: NotebookRequest = {}) {
   );
 
   const createNote = useCallback(
-    async (title: string, folder = "", content?: string) => {
+    async (title: string, folder = "", content?: string, frontmatter?: NoteFrontmatter) => {
       const workspace = state.activeWorkspace;
       const notes = repoRef.current;
       if (!workspace || !notes) return;
@@ -957,8 +958,10 @@ export function useNotebook(request: NotebookRequest = {}) {
         title,
         existingPaths: existing,
         // Given for a note that comes from somewhere else — a file opened from
-        // this machine — rather than one being started from nothing.
+        // this machine, a paper being written about — rather than one being
+        // started from nothing.
         ...(content !== undefined ? { content } : {}),
+        ...(frontmatter !== undefined ? { frontmatter } : {}),
       });
 
       const open = [...state.openNotes, note].slice(-MAX_OPEN_NOTES);

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -41,6 +41,7 @@ import {
 } from "@/lib/workspaces";
 import { forgetLock, isPathLocked, lockedKey, renameLock, toggleLock } from "@/lib/locks";
 import { assetBlob, assetFrom, assetObjectUrl, blobAsBase64, isImagePath } from "@/lib/assets";
+import { entryFrom, pdfTextId } from "@/lib/pdf-index";
 import { shrinkImage, ShrinkError } from "@/lib/shrink-image";
 import {
   DEFAULT_TREE_ORDER,
@@ -1624,6 +1625,34 @@ export function useNotebook(request: NotebookRequest = {}) {
   );
 
   /**
+   * Rewrites any note in this workspace, whether or not it is open.
+   *
+   * `saveNote` writes the note the editor is showing and `replaceNoteContent`
+   * writes one that happens to be in a tab. Repairing a link means writing to
+   * a note nobody has looked at today, which is neither of those — so the note
+   * is read from storage first, and any tab holding it is brought along.
+   */
+  const rewriteNote = useCallback(
+    async (path: string, change: (content: string) => string): Promise<boolean> => {
+      const notes = repoRef.current;
+      const workspace = state.activeWorkspace;
+      if (!notes || !workspace) return false;
+
+      const open = state.openNotes.find((note) => note.path === path);
+      const note = open ?? (await notes.openNote(workspace.id, path));
+      if (!note) return false;
+
+      const next = change(note.content);
+      if (next === note.content) return false;
+
+      await notes.saveNote(note, next);
+      patchOpenNote(path, { content: next, dirty: true });
+      return true;
+    },
+    [state.activeWorkspace, state.openNotes, patchOpenNote],
+  );
+
+  /**
    * Drops one stuck change, so the queue behind it can move.
    *
    * The way out of a change that can never be pushed. Needs a refresh of the
@@ -1840,6 +1869,46 @@ export function useNotebook(request: NotebookRequest = {}) {
     [state.activeWorkspace, state.sync.unpushed, urlForAsset],
   );
 
+  // ── The words documents are made of ─────────────────────────────────────
+
+  /**
+   * Keeps a document's text after it has been read once.
+   *
+   * The reader extracts it anyway — that is what makes find-in-document work —
+   * and used to throw it away when the document closed, so the words were
+   * searchable for exactly as long as somebody was looking at them. Kept, they
+   * are what ⌘K searches and what a citation is checked against.
+   */
+  const saveDocumentText = useCallback(
+    async (path: string, pages: { page: number; text: string }[]) => {
+      const db = dbRef.current;
+      const workspace = state.activeWorkspace;
+      if (!db || !workspace || workspace.isLocal) return;
+
+      await db.putPdfText(entryFrom(workspace.id, path, pages));
+    },
+    [state.activeWorkspace],
+  );
+
+  const documentText = useCallback(
+    async (path: string) => {
+      const db = dbRef.current;
+      const workspace = state.activeWorkspace;
+      if (!db || !workspace) return undefined;
+
+      return db.getPdfText(pdfTextId(workspace.id, path));
+    },
+    [state.activeWorkspace],
+  );
+
+  const allDocumentText = useCallback(async () => {
+    const db = dbRef.current;
+    const workspace = state.activeWorkspace;
+    if (!db || !workspace) return [];
+
+    return db.listPdfText(workspace.id);
+  }, [state.activeWorkspace]);
+
   /** Remembers which folders are open, for the next visit. */
   const setExpandedFolders = useCallback(
     (paths: string[]) => {
@@ -1904,6 +1973,10 @@ export function useNotebook(request: NotebookRequest = {}) {
       discardPending,
       discardChange,
       shrinkChange,
+      rewriteNote,
+      saveDocumentText,
+      documentText,
+      allDocumentText,
       setSyncMode,
       resolveConflict,
       allNotes,
@@ -1962,6 +2035,10 @@ export function useNotebook(request: NotebookRequest = {}) {
       pendingChanges,
       discardPending,
       discardChange,
+      allDocumentText,
+      documentText,
+      saveDocumentText,
+      rewriteNote,
       shrinkChange,
       setSyncMode,
       resolveConflict,

--- a/apps/web/src/lib/citation-audit.test.ts
+++ b/apps/web/src/lib/citation-audit.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PdfPageText } from "@forkleaf/pdf";
+import { auditCitations, checkAgainst, summarise, withCorrectedPage } from "./citation-audit";
+import { allPdfMentions } from "./pdf-mentions";
+
+const page = (number: number, text: string): PdfPageText => ({ page: number, text, runs: [] });
+
+/** A note citing one passage of one paper, the way ForkLeaf writes them. */
+function citing(options: {
+  quote: string;
+  page: number;
+  path?: string;
+  notePath?: string;
+  prefix?: string;
+  suffix?: string;
+}) {
+  const fragment = [
+    `page=${options.page}`,
+    `q=${encodeURIComponent(options.quote)}`,
+    options.prefix ? `pre=${encodeURIComponent(options.prefix)}` : "",
+    options.suffix ? `suf=${encodeURIComponent(options.suffix)}` : "",
+  ]
+    .filter(Boolean)
+    .join("&");
+
+  return {
+    path: options.notePath ?? "reading.md",
+    content: [
+      `> ${options.quote}`,
+      ">",
+      `> — [Paper, p. ${options.page}](${options.path ?? "papers/attention.pdf"}#${fragment})`,
+    ].join("\n"),
+  };
+}
+
+describe("checkAgainst", () => {
+  it("says a quotation is exactly where the note claims", () => {
+    const notes = [citing({ quote: "attention is all you need", page: 2 })];
+    const pages = [page(1, "Introduction."), page(2, "We show that attention is all you need.")];
+
+    const [check] = checkAgainst(pages, allPdfMentions(notes));
+
+    expect(check?.quality).toBe("exact");
+    expect(check?.page).toBe(2);
+    expect(check?.stale).toBe(false);
+  });
+
+  /**
+   * The failure every other tool has silently: the author adds a figure, the
+   * passage moves, and the stored page number is now pointing at the wrong
+   * paragraph. Here the words are the anchor, so it is found and reported.
+   */
+  it("finds a passage that has moved, and says the page number is stale", () => {
+    const notes = [citing({ quote: "attention is all you need", page: 2 })];
+    const pages = [
+      page(1, "Introduction."),
+      page(2, "A figure that was not here before."),
+      page(3, "We show that attention is all you need."),
+    ];
+
+    const [check] = checkAgainst(pages, allPdfMentions(notes));
+
+    expect(check?.quality).toBe("moved");
+    expect(check?.page).toBe(3);
+    expect(check?.stale).toBe(true);
+  });
+
+  it("reports a passage that is not in the document any more", () => {
+    const notes = [citing({ quote: "a sentence since deleted", page: 2 })];
+    const pages = [page(1, "Introduction."), page(2, "Something else entirely.")];
+
+    const [check] = checkAgainst(pages, allPdfMentions(notes));
+
+    expect(check?.quality).toBe("lost");
+    expect(check?.page).toBeNull();
+  });
+
+  it("skips a link that records no words, since there is nothing to check", () => {
+    // `#page=4` is a perfectly good link and makes no claim this could test.
+    const notes = [{ path: "a.md", content: "[the paper](papers/attention.pdf#page=4)" }];
+
+    expect(checkAgainst([page(1, "x")], allPdfMentions(notes))).toEqual([]);
+  });
+});
+
+describe("auditCitations", () => {
+  it("reads each document once, however many notes quote it", async () => {
+    const notes = [
+      citing({ quote: "first passage", page: 1, notePath: "one.md" }),
+      citing({ quote: "second passage", page: 2, notePath: "two.md" }),
+    ];
+
+    const pagesFor = vi.fn(async () => [page(1, "first passage"), page(2, "second passage")]);
+    const summary = await auditCitations(notes, pagesFor);
+
+    expect(pagesFor).toHaveBeenCalledTimes(1);
+    expect(summary.checked).toBe(2);
+    expect(summary.lost).toBe(0);
+  });
+
+  it("counts what is wrong, across every document", async () => {
+    const notes = [
+      citing({ quote: "still here", page: 1 }),
+      citing({ quote: "has moved", page: 1, notePath: "b.md" }),
+      citing({ quote: "gone entirely", page: 1, notePath: "c.md" }),
+    ];
+
+    const summary = await auditCitations(notes, async () => [
+      page(1, "still here"),
+      page(2, "has moved"),
+    ]);
+
+    expect(summary.checked).toBe(3);
+    expect(summary.moved).toBe(1);
+    expect(summary.lost).toBe(1);
+  });
+
+  /**
+   * A document that cannot be read is not a document full of broken
+   * citations. Treating a failed fetch as "no pages" would report every
+   * quotation in it as lost, which is the one message that must never be
+   * wrong.
+   */
+  it("reports a document it could not read as unread, not as broken", async () => {
+    const notes = [citing({ quote: "still here", page: 1 })];
+
+    const summary = await auditCitations(notes, async () => {
+      throw new Error("That PDF could not be read from the repository.");
+    });
+
+    expect(summary.unreadable).toBe(1);
+    expect(summary.lost).toBe(0);
+    expect(summary.checked).toBe(0);
+    expect(summary.documents[0]?.error).toMatch(/could not be read/);
+  });
+
+  it("opens nothing at all for a notebook with no citations in it", async () => {
+    const pagesFor = vi.fn();
+    const summary = await auditCitations([{ path: "a.md", content: "# nothing here" }], pagesFor);
+
+    expect(pagesFor).not.toHaveBeenCalled();
+    expect(summary.documents).toEqual([]);
+  });
+
+  it("says which document it is on, and when it has finished", async () => {
+    const seen: string[] = [];
+    const notes = [
+      citing({ quote: "a", page: 1, path: "papers/one.pdf" }),
+      citing({ quote: "b", page: 1, path: "papers/two.pdf", notePath: "b.md" }),
+    ];
+
+    await auditCitations(notes, async () => [page(1, "a b")], {
+      onProgress: (done, total, pdfPath) => seen.push(`${done}/${total} ${pdfPath}`),
+    });
+
+    expect(seen).toEqual([
+      "0/2 papers/one.pdf",
+      "1/2 papers/one.pdf",
+      "1/2 papers/two.pdf",
+      "2/2 papers/two.pdf",
+    ]);
+  });
+});
+
+describe("withCorrectedPage", () => {
+  it("moves the page number on and leaves the quotation alone", () => {
+    const note = citing({ quote: "attention is all you need", page: 2 });
+    const [check] = checkAgainst(
+      [page(1, "x"), page(2, "y"), page(3, "attention is all you need")],
+      allPdfMentions([note]),
+    );
+
+    const fixed = withCorrectedPage(note.content, check!);
+
+    expect(fixed).toContain("page=3");
+    expect(fixed).toContain(`q=${encodeURIComponent("attention is all you need")}`);
+    // The words of the note are the reader's, not ours to rewrite.
+    expect(fixed).toContain("> attention is all you need");
+  });
+
+  it("rewrites the citation that moved, not its neighbour on the same line", () => {
+    const content = "[A](papers/x.pdf#page=2&q=alpha) and [B](papers/x.pdf#page=9&q=beta)";
+    const [alpha] = checkAgainst(
+      [page(1, "alpha"), page(9, "beta")],
+      allPdfMentions([{ path: "n.md", content }]),
+    );
+
+    const fixed = withCorrectedPage(content, alpha!);
+
+    expect(fixed).toContain("page=1&q=alpha");
+    expect(fixed).toContain("page=9&q=beta");
+  });
+
+  it("changes nothing for a passage that is nowhere to be found", () => {
+    const note = citing({ quote: "gone", page: 2 });
+    const [check] = checkAgainst([page(1, "something else")], allPdfMentions([note]));
+
+    expect(withCorrectedPage(note.content, check!)).toBe(note.content);
+  });
+});
+
+describe("summarise", () => {
+  it("adds nothing up when there is nothing to add up", () => {
+    expect(summarise([])).toEqual({
+      documents: [],
+      checked: 0,
+      lost: 0,
+      moved: 0,
+      fuzzy: 0,
+      unreadable: 0,
+    });
+  });
+});

--- a/apps/web/src/lib/citation-audit.ts
+++ b/apps/web/src/lib/citation-audit.ts
@@ -1,0 +1,194 @@
+"use client";
+
+import { resolveCitation, type PdfMatchQuality } from "@forkleaf/pdf";
+import type { PdfPageText } from "@forkleaf/pdf";
+import { allPdfMentions, type MentionSource, type PdfMention } from "@/lib/pdf-mentions";
+
+/**
+ * Checking that every quotation still says what the note says it says.
+ *
+ * Every other tool stores a page number, and a page number is a claim that
+ * quietly stops being true: the author adds a figure to page 4 and every
+ * citation after it points one page short. Nothing tells you. The link still
+ * opens, it just shows the wrong paragraph — and you find out, if you ever
+ * do, when somebody checks your reference.
+ *
+ * A ForkLeaf citation records the sentence, so the question "is this still
+ * true?" has an answer, and this is the sweep that asks it of the whole
+ * notebook at once. Four outcomes, and they are genuinely different things:
+ *
+ *   - `exact` — the words are there, on the page the note recorded
+ *   - `moved` — the words are there, on a different page. Nothing is wrong
+ *     with the quotation; the link's page number is stale and can be corrected
+ *   - `fuzzy` — the words are there after allowing for hyphenation, ligatures
+ *     and spacing. Worth an eye: it can also mean the passage was edited
+ *   - `lost` — the words are not in the document any more. This is the one
+ *     that matters, and the one no other reader can tell you about
+ *
+ * A pure function over text, with the reading of documents handed in. That is
+ * what makes the interesting half testable without a rendering engine, and it
+ * is why the caller decides whether a document comes from the cache or off
+ * the network.
+ */
+
+export interface CitationCheck {
+  mention: PdfMention;
+  quality: PdfMatchQuality;
+  /** Where the passage is now, or null when it is nowhere. */
+  page: number | null;
+  /** True when the citation's page number no longer matches where it is. */
+  stale: boolean;
+}
+
+export interface DocumentAudit {
+  pdfPath: string;
+  checks: CitationCheck[];
+  /** Why this document could not be checked, when it could not be. */
+  error: string | null;
+}
+
+export interface AuditSummary {
+  documents: DocumentAudit[];
+  /** Citations checked, across every document. */
+  checked: number;
+  lost: number;
+  moved: number;
+  fuzzy: number;
+  /** Documents that could not be read at all. */
+  unreadable: number;
+}
+
+/** Reads a document's text, from wherever the caller keeps it. */
+export type PagesFor = (pdfPath: string) => Promise<PdfPageText[]>;
+
+/**
+ * Checks one document's citations.
+ *
+ * Mentions with no quotation are skipped rather than reported. A link written
+ * as `#page=4` records no words, so there is nothing to look for and nothing
+ * that could have gone wrong with it that this could detect — reporting it as
+ * "fine" would be a claim nobody checked.
+ */
+export function checkAgainst(
+  pages: PdfPageText[],
+  mentions: readonly PdfMention[],
+): CitationCheck[] {
+  const checks: CitationCheck[] = [];
+
+  for (const mention of mentions) {
+    const citation = mention.citation;
+    if (!citation || !citation.quote.trim()) continue;
+
+    const match = resolveCitation(pages, citation);
+    checks.push({
+      mention,
+      quality: match.quality,
+      page: match.page,
+      stale: match.page != null && match.page !== citation.page,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * The whole notebook, document by document.
+ *
+ * Sequential on purpose. Each document means fetching a file and running a
+ * pdf.js worker over every page of it, and doing forty of those at once is how
+ * a browser tab runs out of memory — the reader would rather wait and be told
+ * where it has got to.
+ */
+export async function auditCitations(
+  notes: readonly MentionSource[],
+  pagesFor: PagesFor,
+  options: { onProgress?: (done: number, total: number, pdfPath: string) => void } = {},
+): Promise<AuditSummary> {
+  const mentions = allPdfMentions(notes);
+
+  const byDocument = new Map<string, PdfMention[]>();
+  for (const mention of mentions) {
+    // A mention with no quotation cannot be checked, and a document mentioned
+    // only by such links is a document there is no reason to open.
+    if (!mention.citation?.quote.trim()) continue;
+    byDocument.set(mention.pdfPath, [...(byDocument.get(mention.pdfPath) ?? []), mention]);
+  }
+
+  const paths = [...byDocument.keys()].sort();
+  const documents: DocumentAudit[] = [];
+  let done = 0;
+
+  for (const pdfPath of paths) {
+    options.onProgress?.(done, paths.length, pdfPath);
+
+    try {
+      const pages = await pagesFor(pdfPath);
+      documents.push({
+        pdfPath,
+        checks: checkAgainst(pages, byDocument.get(pdfPath) ?? []),
+        error: null,
+      });
+    } catch (problem: unknown) {
+      // A document that cannot be read is reported as unread, never as a
+      // notebook full of broken citations — which is what treating a failed
+      // fetch as "no pages" would produce.
+      documents.push({
+        pdfPath,
+        checks: [],
+        error: problem instanceof Error ? problem.message : "That document could not be read.",
+      });
+    }
+
+    done += 1;
+    options.onProgress?.(done, paths.length, pdfPath);
+  }
+
+  return summarise(documents);
+}
+
+export function summarise(documents: DocumentAudit[]): AuditSummary {
+  const all = documents.flatMap((document) => document.checks);
+
+  return {
+    documents,
+    checked: all.length,
+    lost: all.filter((check) => check.quality === "lost").length,
+    moved: all.filter((check) => check.quality === "moved").length,
+    fuzzy: all.filter((check) => check.quality === "fuzzy").length,
+    unreadable: documents.filter((document) => document.error !== null).length,
+  };
+}
+
+/**
+ * The note with one citation's page number brought up to date.
+ *
+ * Only the `page=` field, and only on links that resolve to this document at
+ * this passage — the quotation, the context and the path are what identify the
+ * link and are left exactly as they were. A citation whose words have moved is
+ * still a correct citation; it is the page hint beside it that has gone stale,
+ * and rewriting anything else would be editing somebody's note rather than
+ * repairing a link in it.
+ */
+export function withCorrectedPage(content: string, check: CitationCheck): string {
+  const { mention, page } = check;
+  if (page == null) return content;
+
+  const lines = content.split("\n");
+  const index = mention.line - 1;
+  const line = lines[index];
+  if (line === undefined) return content;
+
+  const quote = mention.citation?.quote ?? "";
+  const encoded = encodeURIComponent(quote);
+
+  const repaired = line.replace(/\(([^()\s]*\.pdf#[^()\s]*)\)/gi, (whole, target: string) => {
+    // The right link on a line that may hold several: the one quoting these
+    // words. Comparing the encoded quotation rather than re-parsing keeps
+    // this honest about which link is being rewritten.
+    if (quote && !target.includes(encoded) && !target.includes(quote)) return whole;
+    return `(${target.replace(/(^|[#&])(page|p)=\d+/i, `$1$2=${page}`)})`;
+  });
+
+  lines[index] = repaired;
+  return lines.join("\n");
+}

--- a/apps/web/src/lib/freshness-dismissals.ts
+++ b/apps/web/src/lib/freshness-dismissals.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import type { Dismissals } from "@/lib/notebook-freshness";
+
+/**
+ * The stale notes somebody has already looked at and decided are fine.
+ *
+ * Kept on this device rather than in the repository, and deliberately. "I have
+ * read this and it is still true" is a fact about a person's attention, not
+ * about the notebook — committing it would put a file in everybody's history
+ * every time anyone glanced at a list.
+ *
+ * Keyed per workspace, because a note path means nothing across two of them.
+ */
+const key = (workspaceId: string) => `forkleaf:freshness-dismissed:${workspaceId}`;
+
+export function readDismissals(workspaceId: string): Dismissals {
+  try {
+    const raw = window.localStorage.getItem(key(workspaceId));
+    if (!raw) return {};
+
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+
+    // Anything that is not a path-to-timestamp pair came from a different
+    // version of this, or from somebody editing storage by hand.
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).filter(
+        ([, value]) => typeof value === "string",
+      ),
+    ) as Dismissals;
+  } catch {
+    // Storage can be blocked outright, and the list still works without it.
+    return {};
+  }
+}
+
+export function writeDismissals(workspaceId: string, dismissals: Dismissals): void {
+  try {
+    window.localStorage.setItem(key(workspaceId), JSON.stringify(dismissals));
+  } catch {
+    // Not worth surfacing: the dismissal holds for this session either way.
+  }
+}

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -472,6 +472,22 @@ export async function readNoteAtCommit(
   return content;
 }
 
+/**
+ * The notebook as it stood on a given day.
+ *
+ * The commit that was current at the end of that day, and the file tree at it.
+ * `commit: null` means the repository did not exist yet, which is a true
+ * answer rather than a failure.
+ */
+export async function readNotebookAt(
+  repo: RepoRef,
+  date: string,
+): Promise<{ commit: NoteCommitDto | null; tree: TreeNode[] }> {
+  return await call<{ commit: NoteCommitDto | null; tree: TreeNode[] }>(
+    `/api/gh/at?${repoParams(repo)}&until=${encodeURIComponent(date)}`,
+  );
+}
+
 export async function listRepos(): Promise<RepoSummaryDto[]> {
   const { repos } = await call<{ repos: RepoSummaryDto[] }>("/api/gh/repos");
   return repos;

--- a/apps/web/src/lib/library.test.ts
+++ b/apps/web/src/lib/library.test.ts
@@ -220,6 +220,70 @@ describe("queryIndex", () => {
     ]);
   });
 
+  /**
+   * "Setup" typed in the middle of a project should find that project's setup,
+   * not the other five. The notebook already knows which notes belong
+   * together, because somebody linked them.
+   */
+  describe("knowing what you are working on", () => {
+    const setups = buildIndex(
+      workspace,
+      ["projects/website/setup.md", "projects/api/setup.md", "old/setup.md"],
+      [
+        note("projects/website/setup.md", "# Setup\n\nWebsite.", "2026-01-01T00:00:00.000Z"),
+        note("projects/api/setup.md", "# Setup\n\nApi.", "2026-03-01T00:00:00.000Z"),
+        note("old/setup.md", "# Setup\n\nOld.", "2026-02-01T00:00:00.000Z"),
+      ],
+    );
+
+    it("floats a connected note above one that merely matches as well", () => {
+      const nearby = new Map([["projects/website/setup.md", 1]]);
+
+      const [first] = queryIndex(setups, { query: "setup", nearby });
+      expect(first!.path).toBe("projects/website/setup.md");
+    });
+
+    it("prefers the nearer of two connected notes", () => {
+      const nearby = new Map([
+        ["old/setup.md", 2],
+        ["projects/api/setup.md", 1],
+      ]);
+
+      expect(queryIndex(setups, { query: "setup", nearby }).map((entry) => entry.path)).toEqual([
+        "projects/api/setup.md",
+        "old/setup.md",
+        "projects/website/setup.md",
+      ]);
+    });
+
+    it("never lets nearness beat a better kind of match", () => {
+      const mixed = buildIndex(
+        workspace,
+        ["planning.md", "notes/mentions-planning.md"],
+        [
+          note("planning.md", "# Planning", "2026-01-01T00:00:00.000Z"),
+          note(
+            "notes/mentions-planning.md",
+            "# Elsewhere\n\nAbout planning.",
+            "2026-02-01T00:00:00.000Z",
+          ),
+        ],
+      );
+
+      // The nearby note only mentions the word; the far one is called it.
+      const nearby = new Map([["notes/mentions-planning.md", 1]]);
+      const [first] = queryIndex(mixed, { query: "planning", nearby });
+
+      expect(first!.path).toBe("planning.md");
+    });
+
+    it("changes nothing when there is nowhere to be near", () => {
+      expect(queryIndex(setups, { query: "setup" }).map((entry) => entry.path)).toEqual(
+        queryIndex(setups, { query: "setup", nearby: new Map() }).map((entry) => entry.path),
+      );
+    });
+  });
+
   it("sorts unread notes last rather than treating a missing date as 1970", () => {
     const mixed = buildIndex(
       workspace,

--- a/apps/web/src/lib/library.ts
+++ b/apps/web/src/lib/library.ts
@@ -263,22 +263,41 @@ export function buildIndex(
  * it. The score itself only orders body matches among themselves, capped so a
  * long note repeating a word cannot climb past a title match.
  */
-export function scoreEntry(entry: IndexEntry, needle: string, textScore?: number): number {
+export function scoreEntry(
+  entry: IndexEntry,
+  needle: string,
+  textScore?: number,
+  /**
+   * How many links away this note is from the one being written, if any.
+   *
+   * Searching "setup" while in the middle of a project should find *that*
+   * project's setup, not the other five — and the notebook already knows which
+   * notes belong together, because somebody linked them. The bonus is smaller
+   * than the gap between any two bands below, so a connected note can win a
+   * tie and can rise within its band, but a note whose title matches never
+   * loses to one whose only claim is being nearby.
+   */
+  nearness?: number,
+): number {
   if (!needle) return 1;
 
   const title = entry.title.toLowerCase();
   const path = entry.path.toLowerCase();
+  const near = nearness === undefined ? 0 : Math.max(0, NEAR_BONUS - (nearness - 1) * 4);
 
-  if (title === needle) return 100;
-  if (title.startsWith(needle)) return 80;
-  if (title.includes(needle)) return 60;
-  if (entry.tags.some((tag) => tag.toLowerCase().includes(needle))) return 50;
-  if (textScore !== undefined) return 45 + Math.min(textScore, 9) / 10;
-  if (path.includes(needle)) return 40;
-  if (entry.excerpt.toLowerCase().includes(needle)) return 20;
+  if (title === needle) return 100 + near;
+  if (title.startsWith(needle)) return 80 + near;
+  if (title.includes(needle)) return 60 + near;
+  if (entry.tags.some((tag) => tag.toLowerCase().includes(needle))) return 50 + near;
+  if (textScore !== undefined) return 45 + Math.min(textScore, 9) / 10 + near;
+  if (path.includes(needle)) return 40 + near;
+  if (entry.excerpt.toLowerCase().includes(needle)) return 20 + near;
 
   return 0;
 }
+
+/** What a directly linked note is worth. Two hops away is worth less. */
+const NEAR_BONUS = 8;
 
 export interface QueryOptions {
   query?: string;
@@ -294,11 +313,19 @@ export interface QueryOptions {
    * indexes what the dashboard knows about a note, not what is in it.
    */
   textScores?: Map<string, number>;
+  /**
+   * Notes connected to the one being written, by path, with their distance.
+   *
+   * From the link graph, which is built for backlinks and answers this for
+   * free. Absent everywhere there is no "current note" to be near — the
+   * dashboard is not standing anywhere in particular.
+   */
+  nearby?: ReadonlyMap<string, number>;
 }
 
 export function queryIndex(entries: IndexEntry[], options: QueryOptions = {}): IndexEntry[] {
   const needle = (options.query ?? "").trim().toLowerCase();
-  const { folder, tag, sort = "recent", textScores } = options;
+  const { folder, tag, sort = "recent", textScores, nearby } = options;
 
   const scored = entries
     .filter((entry) => {
@@ -308,7 +335,10 @@ export function queryIndex(entries: IndexEntry[], options: QueryOptions = {}): I
       if (tag && !entry.tags.includes(tag)) return false;
       return true;
     })
-    .map((entry) => ({ entry, score: scoreEntry(entry, needle, textScores?.get(entry.id)) }))
+    .map((entry) => ({
+      entry,
+      score: scoreEntry(entry, needle, textScores?.get(entry.id), nearby?.get(entry.path)),
+    }))
     .filter((candidate) => candidate.score > 0);
 
   // While searching, relevance leads and the chosen sort breaks ties; with no

--- a/apps/web/src/lib/note-from-paper.test.ts
+++ b/apps/web/src/lib/note-from-paper.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { PdfMetadata, PdfOutlineItem } from "@forkleaf/pdf";
+import { paperNote } from "./note-from-paper";
+
+const metadata = (over: Partial<PdfMetadata> = {}): PdfMetadata => ({
+  title: "Attention Is All You Need",
+  author: "Vaswani et al.",
+  subject: null,
+  keywords: [],
+  createdAt: "2017-06-12T00:00:00.000Z",
+  modifiedAt: null,
+  producer: null,
+  ...over,
+});
+
+const heading = (title: string, page: number | null, children: PdfOutlineItem[] = []) =>
+  ({ title, page, children }) as PdfOutlineItem;
+
+const build = (over: Partial<Parameters<typeof paperNote>[0]> = {}) =>
+  paperNote({
+    metadata: metadata(),
+    filename: "attention.pdf",
+    outline: [heading("Introduction", 1), heading("Method", 3), heading("Results", 8)],
+    pageCount: 15,
+    pdfPath: "papers/attention.pdf",
+    notePath: "reading/attention-is-all-you-need.md",
+    ...over,
+  });
+
+describe("paperNote — what it fills in", () => {
+  it("takes the title from the paper, not from the filename", () => {
+    expect(build().title).toBe("Attention Is All You Need");
+    expect(build().frontmatter.title).toBe("Attention Is All You Need");
+  });
+
+  it("falls back to the filename for a paper whose metadata has no title", () => {
+    expect(build({ metadata: metadata({ title: null }) }).title).toBe("attention");
+  });
+
+  it("records the author and the date the paper carries", () => {
+    const { frontmatter } = build();
+
+    expect(frontmatter.author).toBe("Vaswani et al.");
+    // The paper's date, not today's: `created` already records when the note
+    // was started, and the two are different facts.
+    expect(frontmatter.published).toBe("2017-06-12");
+    expect(frontmatter.tags).toEqual(["paper"]);
+  });
+
+  it("leaves out what the paper does not say", () => {
+    const { frontmatter } = build({
+      metadata: metadata({ author: null, createdAt: null }),
+    });
+
+    expect("author" in frontmatter).toBe(false);
+    expect("published" in frontmatter).toBe(false);
+  });
+});
+
+describe("paperNote — the headings", () => {
+  it("turns the paper's contents into headings, each linked to its page", () => {
+    const { content } = build();
+
+    expect(content).toContain("## Introduction");
+    expect(content).toContain("## Method");
+    expect(content).toContain("[p. 3](../papers/attention.pdf#page=3)");
+  });
+
+  it("writes links relative to the note, so they resolve on github.com too", () => {
+    const { content } = build({ notePath: "a/b/c/note.md" });
+    expect(content).toContain("(../../../papers/attention.pdf#page=1)");
+  });
+
+  it("invents no structure for a paper that has no contents list", () => {
+    const { content } = build({ outline: [] });
+
+    expect(content).toContain("## Notes");
+    expect(content).not.toContain("## Introduction");
+  });
+
+  it("goes one level deeper when everything hangs off a single root", () => {
+    const { content } = build({
+      outline: [heading("Contents", null, [heading("One", 1), heading("Two", 4)])],
+    });
+
+    expect(content).toContain("## One");
+    expect(content).toContain("## Two");
+  });
+
+  it("does not open with ninety empty headings", () => {
+    const many = Array.from({ length: 90 }, (_, index) => heading(`Section ${index}`, index + 1));
+    const headings = build({ outline: many }).content.match(/^## /gm) ?? [];
+
+    expect(headings.length).toBeLessThanOrEqual(24);
+  });
+
+  it("names a page it could not link to rather than dropping it", () => {
+    // A heading whose destination the document does not resolve.
+    const { content } = build({ outline: [heading("Preface", null), heading("One", 2)] });
+
+    expect(content).toContain("## Preface");
+    expect(content).not.toContain("#page=null");
+  });
+});
+
+describe("paperNote — a document from a desktop", () => {
+  it("names the paper instead of linking to a file that is not in the notebook", () => {
+    const { content, frontmatter } = build({ pdfPath: null });
+
+    expect(content).not.toContain("](");
+    expect(content).toContain("Attention Is All You Need · Vaswani et al. · 15 pages");
+    expect("source" in frontmatter).toBe(false);
+  });
+});

--- a/apps/web/src/lib/note-from-paper.ts
+++ b/apps/web/src/lib/note-from-paper.ts
@@ -1,0 +1,120 @@
+import { displayTitle, flattenOutline, type PdfMetadata, type PdfOutlineItem } from "@forkleaf/pdf";
+import type { NoteFrontmatter } from "@forkleaf/types";
+import { relativeSrc } from "@/lib/assets";
+
+/**
+ * Starting a note from a paper, rather than from a blank page.
+ *
+ * Everything this fills in is already known: the title and author are in the
+ * file's own metadata, the section headings are its table of contents, and the
+ * page each one begins on is what the outline resolves to. Typing that out by
+ * hand is twenty minutes of transcription before a single thought gets
+ * written down — and it is transcription, so it is also where the page numbers
+ * come out wrong.
+ *
+ * The headings matter more than the metadata. A blank page asks you to have an
+ * opinion about the whole paper at once; a page that already says
+ * "Introduction", "Method", "Results" asks you three smaller questions, each
+ * beside a link to the pages that answer it.
+ *
+ * Nothing is invented. A paper with no table of contents gets no headings —
+ * inventing a structure for it would be worse than the blank page, because it
+ * would be a structure the reader then has to argue with.
+ */
+
+export interface PaperNote {
+  /** What the note is called, which also decides its filename. */
+  title: string;
+  frontmatter: NoteFrontmatter;
+  /** The body, written relative to `notePath`. */
+  content: string;
+}
+
+/**
+ * How deep into the paper's contents to go.
+ *
+ * The top level, which is the sections. Unless the top level is one entry —
+ * some documents wrap everything in a single root — in which case the level
+ * below it is the one that is actually the sections.
+ */
+function sectionsOf(outline: readonly PdfOutlineItem[]) {
+  const rows = flattenOutline(outline);
+  const top = rows.filter((row) => row.depth === 0);
+  return top.length >= 2 ? top : rows.filter((row) => row.depth <= 1);
+}
+
+/**
+ * The most headings worth starting with.
+ *
+ * A paper whose contents list every numbered subsection would otherwise open
+ * as ninety empty headings, which is not a page anybody writes on.
+ */
+const MAX_HEADINGS = 24;
+
+export function paperNote(options: {
+  metadata: PdfMetadata;
+  /** The document's filename, for a paper whose metadata has no title. */
+  filename: string;
+  outline: readonly PdfOutlineItem[];
+  pageCount: number;
+  /**
+   * Where the paper lives in the repository, or null for one opened from a
+   * desktop — which has no path a note could link to, so the note names it
+   * rather than linking to it.
+   */
+  pdfPath: string | null;
+  /** Where the note itself will live, since its links are written relative. */
+  notePath: string;
+}): PaperNote {
+  const title = displayTitle(options.metadata, options.filename);
+  const link = (page?: number) => {
+    if (!options.pdfPath) return null;
+    const target = relativeSrc(options.notePath, options.pdfPath);
+    return page ? `${target}#page=${page}` : target;
+  };
+
+  const frontmatter: NoteFrontmatter = {
+    title,
+    tags: ["paper"],
+    ...(options.metadata.author ? { author: options.metadata.author } : {}),
+    // The date the paper carries, not today's — `created` already records when
+    // the note was started, and the two are different facts.
+    ...(options.metadata.createdAt ? { published: options.metadata.createdAt.slice(0, 10) } : {}),
+    ...(options.pdfPath ? { source: options.pdfPath } : {}),
+  };
+
+  const paperLink = link();
+  const lines: string[] = [
+    `# ${title}`,
+    "",
+    [
+      paperLink ? `[${title}](${paperLink})` : title,
+      options.metadata.author,
+      `${options.pageCount} page${options.pageCount === 1 ? "" : "s"}`,
+    ]
+      .filter(Boolean)
+      .join(" · "),
+    "",
+  ];
+
+  const headings = sectionsOf(options.outline).slice(0, MAX_HEADINGS);
+
+  if (headings.length === 0) {
+    // No contents to work from, so no structure is invented — an empty
+    // heading somebody has to argue with is worse than a blank page.
+    lines.push("## Notes", "", "");
+  } else {
+    for (const heading of headings) {
+      lines.push(`## ${heading.title}`, "");
+
+      const pageLink = heading.page == null ? null : link(heading.page);
+      if (pageLink) lines.push(`[p. ${heading.page}](${pageLink})`, "");
+      else if (heading.page != null) lines.push(`p. ${heading.page}`, "");
+
+      // A blank line under each heading: the place the writing goes.
+      lines.push("");
+    }
+  }
+
+  return { title, frontmatter, content: `${lines.join("\n").trimEnd()}\n` };
+}

--- a/apps/web/src/lib/notebook-freshness.test.ts
+++ b/apps/web/src/lib/notebook-freshness.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import {
+  isDismissed,
+  surveyNotebook,
+  withDismissal,
+  type StaleNote,
+  type SurveySource,
+} from "./notebook-freshness";
+
+const NOW = new Date("2026-08-31T00:00:00.000Z").getTime();
+const YEARS_AGO = "2022-01-01T00:00:00.000Z";
+const YESTERDAY = "2026-08-30T00:00:00.000Z";
+
+const note = (over: Partial<SurveySource> & { path: string }): SurveySource => ({
+  content: "# A note\n\nOrdinary prose.",
+  updatedAt: YESTERDAY,
+  ...over,
+});
+
+const survey = (notes: SurveySource[], files: string[] = []) =>
+  surveyNotebook(notes, { files: new Set([...files, ...notes.map((n) => n.path)]), now: NOW });
+
+describe("surveyNotebook — files that are not there", () => {
+  it("names a picture the note points at and the repository does not have", () => {
+    const result = survey([note({ path: "a.md", content: "# A\n\n![chart](assets/chart.png)" })]);
+
+    expect(result.notes[0]?.missingFiles).toEqual(["assets/chart.png"]);
+    expect(result.counts.missingFiles).toBe(1);
+  });
+
+  it("says nothing about a picture that is right where it should be", () => {
+    const result = survey(
+      [note({ path: "a.md", content: "# A\n\n![chart](assets/chart.png)" })],
+      ["assets/chart.png"],
+    );
+
+    expect(result.notes).toEqual([]);
+  });
+
+  it("resolves what the note points at against the note, not the root", () => {
+    const result = survey(
+      [note({ path: "deep/folder/a.md", content: "# A\n\n![c](../shared/c.png)" })],
+      ["deep/shared/c.png"],
+    );
+
+    expect(result.notes).toEqual([]);
+  });
+
+  /**
+   * The hard evidence outranks every heuristic: a note edited yesterday is
+   * normally left alone, but a note pointing at a file that is gone is wrong
+   * however recently it was written.
+   */
+  it("reports a fresh note whose file has gone, age notwithstanding", () => {
+    const result = survey([
+      note({ path: "a.md", content: "# A\n\n![c](assets/c.png)", updatedAt: YESTERDAY }),
+    ]);
+
+    expect(result.notes[0]?.verdict).toBe("likely-stale");
+    expect(result.notes[0]?.reasons.join(" ")).toMatch(/assets\/c\.png/);
+  });
+});
+
+describe("surveyNotebook — links that match no note", () => {
+  it("names the target as it was typed, which is what has to be fixed", () => {
+    const result = survey([
+      note({ path: "a.md", content: "# A\n\nSee [[Old Roadmap]] for the plan." }),
+    ]);
+
+    expect(result.notes[0]?.missingLinks).toEqual(["Old Roadmap"]);
+  });
+
+  it("leaves a link that resolves alone", () => {
+    const result = survey([
+      note({ path: "a.md", content: "# A\n\nSee [[Roadmap]]." }),
+      note({ path: "roadmap.md", content: "# Roadmap\n\nThe plan." }),
+    ]);
+
+    expect(result.notes).toEqual([]);
+  });
+
+  it("counts one broken target once, however often it is written", () => {
+    const result = survey([note({ path: "a.md", content: "# A\n\n[[Gone]] and [[Gone]] again." })]);
+
+    expect(result.notes[0]?.missingLinks).toEqual(["Gone"]);
+  });
+});
+
+describe("surveyNotebook — claims that have aged", () => {
+  it("flags an old note full of version numbers", () => {
+    const result = survey([
+      note({
+        path: "runbook.md",
+        content: "# Runbook\n\nNeeds v14.2, and Postgres 15.1, as of March 2022. Currently v14.",
+        updatedAt: YEARS_AGO,
+      }),
+    ]);
+
+    expect(result.notes[0]?.verdict).toBe("likely-stale");
+    expect(result.notes[0]?.ageMonths).toBeGreaterThan(50);
+  });
+
+  it("leaves prose alone however old it is, because thinking does not expire", () => {
+    const result = survey([
+      note({
+        path: "essay.md",
+        content: "# On attention\n\nWhat I think about how people read, at length.",
+        updatedAt: YEARS_AGO,
+      }),
+    ]);
+
+    expect(result.notes).toEqual([]);
+  });
+
+  it("leaves a note edited last week alone however many versions it names", () => {
+    const result = survey([
+      note({ path: "a.md", content: "# A\n\nv1.2, v3.4, v5.6 as of now.", updatedAt: YESTERDAY }),
+    ]);
+
+    expect(result.notes).toEqual([]);
+  });
+});
+
+describe("surveyNotebook — the list itself", () => {
+  it("puts facts before inferences", () => {
+    const result = survey([
+      note({
+        path: "old.md",
+        content: "# Old\n\nv1.2 and v3.4 and v5.6 and 2019, currently.",
+        updatedAt: YEARS_AGO,
+      }),
+      note({ path: "broken.md", content: "# Broken\n\n![c](assets/c.png)" }),
+      note({ path: "unlinked.md", content: "# Unlinked\n\n[[Nowhere]]" }),
+    ]);
+
+    expect(result.notes.map((entry) => entry.path)).toEqual(["broken.md", "unlinked.md", "old.md"]);
+  });
+
+  it("reports a clean notebook as clean, and says how much it read", () => {
+    const result = survey([note({ path: "a.md" }), note({ path: "b.md" }), note({ path: "c.md" })]);
+
+    expect(result.notes).toEqual([]);
+    expect(result.scanned).toBe(3);
+  });
+
+  it("names a note by its title, not by its filename", () => {
+    const result = survey([
+      note({ path: "2026-03-14-x.md", content: "# The deploy runbook\n\n![c](c.png)" }),
+    ]);
+
+    expect(result.notes[0]?.title).toBe("The deploy runbook");
+  });
+});
+
+describe("dismissals", () => {
+  const stale: StaleNote = {
+    path: "a.md",
+    title: "A",
+    updatedAt: YESTERDAY,
+    ageMonths: 0,
+    verdict: "likely-stale",
+    reasons: [],
+    missingFiles: [],
+    missingLinks: [],
+  };
+
+  it("stays dismissed while the note is untouched", () => {
+    expect(isDismissed(withDismissal({}, stale), stale)).toBe(true);
+  });
+
+  /**
+   * Editing the note is the only moment its claims could have changed, so it
+   * is the moment the dismissal stops meaning anything.
+   */
+  it("comes back once the note has been edited again", () => {
+    const dismissals = withDismissal({}, stale);
+    expect(isDismissed(dismissals, { ...stale, updatedAt: "2026-08-31T09:00:00.000Z" })).toBe(
+      false,
+    );
+  });
+
+  it("handles a note that has never been edited here", () => {
+    const never = { ...stale, updatedAt: null };
+    expect(isDismissed(withDismissal({}, never), never)).toBe(true);
+  });
+
+  it("says nothing is dismissed when nothing has been", () => {
+    expect(isDismissed({}, stale)).toBe(false);
+  });
+});
+
+describe("surveyNotebook — the counts under the headline", () => {
+  /**
+   * The summary is read as a description of the rows below it. A note counted
+   * as both a broken link and an aged one makes numbers that do not add up to
+   * what is on screen, which reads as the app being confused.
+   */
+  it("counts each note once, under its worst problem", () => {
+    const result = survey([
+      note({
+        path: "both.md",
+        content: "# Both\n\n![c](assets/c.png)\n\nv1.2, v3.4, v5.6, currently, 2019.",
+        updatedAt: YEARS_AGO,
+      }),
+    ]);
+
+    expect(result.counts.missingFiles).toBe(1);
+    expect(result.counts.likelyStale).toBe(0);
+    expect(result.notes).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/notebook-freshness.ts
+++ b/apps/web/src/lib/notebook-freshness.ts
@@ -1,0 +1,187 @@
+import {
+  assessDecay,
+  buildLinkGraph,
+  deriveTitle,
+  referencedPaths,
+  type DecayVerdict,
+} from "@forkleaf/markdown-engine";
+
+/**
+ * Which notes in the whole notebook have gone off.
+ *
+ * The per-note freshness panel answers "is *this* note still true?" for the
+ * note you happen to have open, which is the wrong shape for the question
+ * people actually have. Nobody opens a note to find out that it rotted; they
+ * find out when they act on it. The useful version is a short list that comes
+ * to you: four notes point at a file that is not there any more, two make
+ * claims about a version that has moved on.
+ *
+ * Three signals, in descending order of how much they are worth:
+ *
+ *   1. A note pointing at a file that is not in the repository. A fact, not a
+ *      guess — the file list is right here.
+ *   2. A `[[wikilink]]` matching no note. Also a fact, and usually a rename
+ *      that took the link with it.
+ *   3. Datable claims in a note nobody has touched for a long time. An
+ *      inference, and reported as one.
+ *
+ * Entirely local. Every note is already on this device and the file list is
+ * one request the caller has usually made anyway, so the sweep costs nothing
+ * and can be run as often as somebody likes. Nothing here writes anything.
+ */
+
+export interface StaleNote {
+  path: string;
+  title: string;
+  updatedAt: string | null;
+  /** Whole months since anybody touched it, or null for one never edited. */
+  ageMonths: number | null;
+  verdict: DecayVerdict;
+  /** Why, in sentences somebody can disagree with. */
+  reasons: string[];
+  /** Files it points at that are not in the repository. */
+  missingFiles: string[];
+  /** `[[Wikilinks]]` in it that match no note. */
+  missingLinks: string[];
+}
+
+export interface Survey {
+  /** Only the notes with something to say. A clean note is not a row. */
+  notes: StaleNote[];
+  /** How many notes were read to decide that. */
+  scanned: number;
+  counts: {
+    missingFiles: number;
+    missingLinks: number;
+    likelyStale: number;
+    worthChecking: number;
+  };
+}
+
+export interface SurveySource {
+  path: string;
+  content: string;
+  updatedAt: string | null;
+  /** The note's own title, when it has declared one. */
+  frontmatterTitle?: unknown;
+}
+
+const titleOf = (note: SurveySource) => deriveTitle(note.content, note.frontmatterTitle, note.path);
+
+/** How much a note's worst problem is worth, for ordering the list. */
+function weightOf(note: StaleNote): number {
+  if (note.missingFiles.length > 0) return 3;
+  if (note.missingLinks.length > 0) return 2;
+  if (note.verdict === "likely-stale") return 1;
+  return 0;
+}
+
+export function surveyNotebook(
+  notes: readonly SurveySource[],
+  options: {
+    /**
+     * Every path that exists — the repository's files and anything written
+     * here that has not been pushed yet.
+     *
+     * Passed in rather than derived, because "the files that exist" has three
+     * different answers depending on whether the workspace has a repository,
+     * and getting it wrong means reporting a picture as deleted while the
+     * reader is looking at it.
+     */
+    files: ReadonlySet<string>;
+    now?: number;
+  },
+): Survey {
+  const graph = buildLinkGraph(
+    notes.map((note) => ({
+      path: note.path,
+      title: titleOf(note),
+      content: note.content,
+    })),
+  );
+
+  const found: StaleNote[] = [];
+
+  for (const note of notes) {
+    const missingFiles = referencedPaths(note.path, note.content).filter(
+      // A note is allowed to point at itself, and a folder is not a file.
+      (path) => path !== note.path && !options.files.has(path),
+    );
+
+    const missingLinks = [
+      ...new Set(
+        (graph.outgoing.get(note.path) ?? [])
+          .filter((ref) => ref.to === null)
+          .map((ref) => ref.target),
+      ),
+    ];
+
+    const decay = assessDecay(note.content, {
+      updatedAt: note.updatedAt,
+      ...(options.now !== undefined ? { now: options.now } : {}),
+      // The missing files are told to the decay report as well, so its verdict
+      // is reached knowing the hardest evidence there is rather than in spite
+      // of it.
+      changedFiles: missingFiles,
+    });
+
+    const worthSaying =
+      missingFiles.length > 0 || missingLinks.length > 0 || decay.verdict === "likely-stale";
+    if (!worthSaying) continue;
+
+    found.push({
+      path: note.path,
+      title: titleOf(note),
+      updatedAt: note.updatedAt,
+      ageMonths: decay.ageMonths,
+      verdict: decay.verdict,
+      reasons: decay.reasons,
+      missingFiles,
+      missingLinks,
+    });
+  }
+
+  // Facts before inferences, and the oldest first within each kind — a note
+  // nobody has touched in three years is more likely to be the one that has
+  // actually rotted.
+  found.sort(
+    (a, b) =>
+      weightOf(b) - weightOf(a) ||
+      (b.ageMonths ?? 0) - (a.ageMonths ?? 0) ||
+      a.path.localeCompare(b.path),
+  );
+
+  return {
+    notes: found,
+    scanned: notes.length,
+    counts: {
+      missingFiles: found.filter((note) => note.missingFiles.length > 0).length,
+      missingLinks: found.filter((note) => note.missingLinks.length > 0).length,
+      // Counted only where the age is the *reason* the note is on the list. A
+      // note pointing at a deleted file is reported as "likely stale" too, and
+      // counting it twice makes a summary whose numbers do not add up to the
+      // rows underneath it.
+      likelyStale: found.filter((note) => weightOf(note) === 1).length,
+      worthChecking: found.filter((note) => weightOf(note) === 0).length,
+    },
+  };
+}
+
+/**
+ * Notes the reader has said they are happy with, and when they said it.
+ *
+ * A list that reappears unchanged every time it is opened is a list people
+ * stop opening. Dismissing one is remembered against the note's own
+ * timestamp, so it comes back the moment the note is edited again — which is
+ * the only moment its claims could have changed.
+ */
+export type Dismissals = Record<string, string>;
+
+export function isDismissed(dismissals: Dismissals, note: StaleNote): boolean {
+  const at = dismissals[note.path];
+  return at !== undefined && at === (note.updatedAt ?? "never");
+}
+
+export function withDismissal(dismissals: Dismissals, note: StaleNote): Dismissals {
+  return { ...dismissals, [note.path]: note.updatedAt ?? "never" };
+}

--- a/apps/web/src/lib/pdf-index.test.ts
+++ b/apps/web/src/lib/pdf-index.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { PdfTextEntry } from "@forkleaf/types";
+import { entryFrom, pagesOf, pdfTextId, searchDocuments } from "./pdf-index";
+
+const entry = (path: string, pages: string[]): PdfTextEntry =>
+  entryFrom(
+    "w",
+    path,
+    pages.map((text, index) => ({ page: index + 1, text })),
+  );
+
+describe("entryFrom", () => {
+  it("keys a document by workspace and path, like everything else stored here", () => {
+    expect(entryFrom("w", "papers/x.pdf", []).id).toBe(pdfTextId("w", "papers/x.pdf"));
+  });
+
+  it("records when it was read, so a stale copy can be recognised", () => {
+    const at = new Date("2026-03-14T10:00:00.000Z");
+    expect(entryFrom("w", "papers/x.pdf", [], at).indexedAt).toBe("2026-03-14T10:00:00.000Z");
+  });
+});
+
+describe("pagesOf", () => {
+  it("hands back pages the search and citation code can take", () => {
+    const pages = pagesOf(entry("papers/x.pdf", ["hello"]));
+    expect(pages).toEqual([{ page: 1, text: "hello", runs: [] }]);
+  });
+});
+
+describe("searchDocuments", () => {
+  const shelf = [
+    entry("papers/attention.pdf", ["Attention is all you need.", "A second page of it."]),
+    entry("papers/other.pdf", ["Nothing about attention here — well, one mention."]),
+  ];
+
+  it("finds a phrase inside a document, and says which page", () => {
+    const [hit] = searchDocuments(shelf, "all you need");
+
+    expect(hit?.path).toBe("papers/attention.pdf");
+    expect(hit?.page).toBe(1);
+    expect(hit?.snippet).toContain("all you need");
+  });
+
+  it("reaches every document, not just the first", () => {
+    const paths = searchDocuments(shelf, "attention").map((hit) => hit.path);
+    expect(new Set(paths)).toEqual(new Set(["papers/attention.pdf", "papers/other.pdf"]));
+  });
+
+  /**
+   * A three-hundred-page paper using the word "model" on every page would
+   * otherwise fill the list before the second document was reached — and
+   * somebody searching their notebook is looking for *which* document, not for
+   * four hundred occurrences in one of them.
+   */
+  it("takes only a few hits from any one document", () => {
+    const repetitive = entry(
+      "papers/repeat.pdf",
+      Array.from({ length: 20 }, () => "model model model"),
+    );
+
+    expect(searchDocuments([repetitive], "model", { perDocument: 2 })).toHaveLength(2);
+  });
+
+  it("stops at the overall limit", () => {
+    expect(searchDocuments(shelf, "attention", { limit: 1 })).toHaveLength(1);
+  });
+
+  it("says nothing at all until there is a question", () => {
+    expect(searchDocuments(shelf, "")).toEqual([]);
+    expect(searchDocuments(shelf, " ")).toEqual([]);
+    // One character is still typing, not searching.
+    expect(searchDocuments(shelf, "a")).toEqual([]);
+  });
+
+  it("finds a word the document broke across a line", () => {
+    // The reason searching PDFs is done through the normaliser: a literal
+    // search finds none of these, and the reader concludes the phrase is not
+    // in a document that says it twice.
+    const hyphenated = entry("papers/typeset.pdf", ["the regu-\nlar expression"]);
+
+    expect(searchDocuments([hyphenated], "regular")).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/pdf-index.ts
+++ b/apps/web/src/lib/pdf-index.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import { openPdf, searchPdf, type PdfPageText, type PdfSearchHit } from "@forkleaf/pdf";
+import type { PdfTextEntry, Workspace } from "@forkleaf/types";
+import { fetchRepoPdf } from "@/lib/pdf-source";
+
+/**
+ * Keeping the words a document is made of.
+ *
+ * The reader has always extracted every page's text — that is what makes
+ * find-in-document work through hyphenation and ligatures — and then thrown it
+ * away when the document closed. So the words were searchable for as long as
+ * somebody was looking at them and nowhere else: not from ⌘K, not while
+ * checking whether a citation still points at anything.
+ *
+ * Extracting them again is seconds of work per document. Keeping them is a few
+ * hundred kilobytes. This is the small module that turns the second into the
+ * first: read once, stored beside the notebook, and used by everything that
+ * has a question about what a document says.
+ *
+ * Only the text is kept. The positioned runs behind it are for drawing a
+ * highlight on a page and are far larger; anything that needs them has the
+ * document open in front of it.
+ */
+
+/** Where pdf.js finds its standard fonts and character maps. */
+export const PDFJS_ASSETS = "/pdfjs";
+
+export const pdfTextId = (workspaceId: string, path: string) => `${workspaceId}::${path}`;
+
+/**
+ * Stored pages as the search and citation code want them.
+ *
+ * Both take `PdfPageText`, whose `runs` they never read — the runs exist to
+ * turn a character range into rectangles on a canvas, which is a question only
+ * an open document can answer.
+ */
+export function pagesOf(entry: PdfTextEntry): PdfPageText[] {
+  return entry.pages.map((page) => ({ page: page.page, text: page.text, runs: [] }));
+}
+
+/** The text of a repository document, read out of the file itself. */
+export async function readDocumentText(
+  workspace: Workspace,
+  path: string,
+  onProgress?: (done: number, total: number) => void,
+): Promise<{ page: number; text: string }[]> {
+  const bytes = await fetchRepoPdf(workspace, path);
+  const session = await openPdf(bytes, { assetsUrl: PDFJS_ASSETS });
+
+  try {
+    const pages = await (onProgress ? session.allText({ onProgress }) : session.allText());
+    return pages.map((page) => ({ page: page.page, text: page.text }));
+  } finally {
+    // A worker per document, held open for as long as this takes and not one
+    // moment longer. Indexing a shelf of papers otherwise ends with a dozen
+    // pdf.js workers alive at once.
+    await session.destroy().catch(() => {});
+  }
+}
+
+export function entryFrom(
+  workspaceId: string,
+  path: string,
+  pages: { page: number; text: string }[],
+  now = new Date(),
+): PdfTextEntry {
+  return {
+    id: pdfTextId(workspaceId, path),
+    workspaceId,
+    path,
+    pages,
+    indexedAt: now.toISOString(),
+  };
+}
+
+/** One occurrence of a phrase, in one document. */
+export interface DocumentHit {
+  path: string;
+  page: number;
+  /** A line of the page around the match, for the result list. */
+  snippet: string;
+  /** Where the match sits inside `snippet`. */
+  snippetRange: [start: number, end: number];
+}
+
+/**
+ * Every occurrence of a phrase across the documents whose text is kept.
+ *
+ * Capped per document as well as overall, deliberately. A three-hundred-page
+ * paper that uses the word "model" on every page would otherwise fill the
+ * whole result list before the second document was reached, which is the
+ * opposite of what somebody searching their notebook wants — they are looking
+ * for *which* document, not for all four hundred occurrences in one of them.
+ */
+export function searchDocuments(
+  entries: readonly PdfTextEntry[],
+  query: string,
+  options: { perDocument?: number; limit?: number } = {},
+): DocumentHit[] {
+  const needle = query.trim();
+  // Two characters is where "find as you type" stops being a search of every
+  // word in every document and starts being a question.
+  if (needle.length < 2) return [];
+
+  const perDocument = options.perDocument ?? 3;
+  const limit = options.limit ?? 12;
+  const found: DocumentHit[] = [];
+
+  for (const entry of entries) {
+    const hits: PdfSearchHit[] = searchPdf(pagesOf(entry), needle, { limit: perDocument });
+
+    for (const hit of hits) {
+      found.push({
+        path: entry.path,
+        page: hit.page,
+        snippet: hit.snippet,
+        snippetRange: hit.snippetRange,
+      });
+      if (found.length >= limit) return found;
+    }
+  }
+
+  return found;
+}

--- a/apps/web/src/lib/pdf-mentions.ts
+++ b/apps/web/src/lib/pdf-mentions.ts
@@ -1,4 +1,4 @@
-import { parseCitation } from "@forkleaf/pdf";
+import { parseCitation, type PdfCitation } from "@forkleaf/pdf";
 import { pdfLinkTarget } from "@/lib/pdf-source";
 
 /**
@@ -22,6 +22,17 @@ import { pdfLinkTarget } from "@/lib/pdf-source";
 export interface PdfMention {
   /** The note the mention was found in. */
   notePath: string;
+  /** The document it points at, repository-relative. */
+  pdfPath: string;
+  /**
+   * The passage this points at, as the link records it.
+   *
+   * Null for a link with no fragment at all — "the paper", rather than a
+   * particular sentence in it. Kept whole rather than reduced to a page
+   * number, because checking whether a citation still holds means matching the
+   * words, and the page is only ever a hint about where to start looking.
+   */
+  citation: PdfCitation | null;
   /** 1-based, so it can be reported and jumped to. */
   line: number;
   /** The link's own text — usually "Title, p. 12". */
@@ -57,6 +68,21 @@ export interface MentionSource {
 }
 
 export function mentionsOfPdf(notes: readonly MentionSource[], pdfPath: string): PdfMention[] {
+  return scan(notes, (path) => path === pdfPath);
+}
+
+/**
+ * Every mention of every document, across the whole notebook.
+ *
+ * The same scan without the filter, for the sweep that checks all of them at
+ * once. One pass over the notes rather than one pass per document: a notebook
+ * with forty papers in it would otherwise be read forty times.
+ */
+export function allPdfMentions(notes: readonly MentionSource[]): PdfMention[] {
+  return scan(notes, () => true);
+}
+
+function scan(notes: readonly MentionSource[], wanted: (pdfPath: string) => boolean): PdfMention[] {
   const found: PdfMention[] = [];
 
   for (const note of notes) {
@@ -71,12 +97,14 @@ export function mentionsOfPdf(notes: readonly MentionSource[], pdfPath: string):
       for (const match of line.matchAll(LINK)) {
         const [, rawLabel = "", href = ""] = match;
         const target = pdfLinkTarget(note.path, href);
-        if (!target || target.path !== pdfPath) continue;
+        if (!target || !wanted(target.path)) continue;
 
         const citation = target.fragment ? parseCitation(target.fragment) : null;
 
         found.push({
           notePath: note.path,
+          pdfPath: target.path,
+          citation,
           line: index + 1,
           label: unescapeLinkText(rawLabel),
           page: citation?.page ?? pageFromFragment(target.fragment),
@@ -92,6 +120,7 @@ export function mentionsOfPdf(notes: readonly MentionSource[], pdfPath: string):
   // the passage is, so reading down the list is reading through the paper —
   // mentions with no page at all go last rather than pretending to be page 0.
   return found.sort((a, b) => {
+    if (a.pdfPath !== b.pdfPath) return a.pdfPath.localeCompare(b.pdfPath);
     if (a.page !== b.page) return (a.page ?? Infinity) - (b.page ?? Infinity);
     if (a.notePath !== b.notePath) return a.notePath.localeCompare(b.notePath);
     return a.line - b.line;

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -28,17 +28,18 @@ Ticked entries link to nothing; the git history is the record.
       published page fixes a mistake and you get a suggestion to accept or
       decline, without either of you touching GitHub. This is the single most
       distinctive thing ForkLeaf could ship
-- [ ] **Notes that tell you when they have gone stale** — Medium. A list that
-      comes to you, across the notebook: four notes link to a file that has
-      been deleted, two mention a version that has moved on. The per-note
-      freshness check already exists; this is the notebook-wide roll-up
+- [x] **Notes that tell you when they have gone stale** — Medium. A list that
+      comes to you, across the notebook: notes pointing at files that have
+      gone, links matching no note, and claims that have aged
 - [ ] **Borrow somebody else's notebook** — Big. Link into their notes, pinned
       to a version, rather than copying and going stale
 - [x] **Search that knows what you are working on** — Small. Notes linked to
       the one you are in float to the top of ⌘K, by however many hops away
       they are
-- [ ] **Diagrams you can click through** — Medium. A box in a diagram can be a
-      note, so a diagram becomes a map of the notebook
+- [x] **Diagrams you can click through** — Medium. A `[[wikilink]]` in a box's
+      label makes the box a way to the note. Clickable wherever a diagram is
+      read; in the rich editor a click still opens the diagram for editing,
+      which is what a click there has always meant
 
 ## PDFs
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -44,14 +44,13 @@ Ticked entries link to nothing; the git history is the record.
 
 - [x] **Save this PDF into my notebook** — shipped before this list existed
 - [x] **Open a PDF and see everything you have written about it** — Small
-- [ ] **Search inside your PDFs from ⌘K** — Small. The text is already
-      extracted for find-in-document; it just is not kept
+- [x] **Search inside your PDFs from ⌘K** — Small. The text is kept the first
+      time a document is read, so ⌘K reaches inside the papers as well
 - [ ] **Scroll one pane, the other follows** — Small. Scroll the note and the
       document moves to the page you are writing about, and back again
-- [ ] **A list of citations that have broken** — Medium. Check every quotation
-      in the notebook against the document as it stands now. The hard part —
-      finding the sentence again — already works and is already tested. If one
-      thing on this list gets built, it should be this one
+- [x] **A list of citations that have broken** — Medium. Every quotation in the
+      notebook, checked against the document as it stands now: what has moved,
+      what is gone, and a one-press fix for a stale page number
 - [ ] **See what changed between two versions of a PDF** — Medium. The file is
       in a repository, so old versions are kept: show page 12 then and now, and
       say whether the page you quoted is one of the ones that changed

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -18,12 +18,12 @@ Ticked entries link to nothing; the git history is the record.
       button gives you a second copy of a note to experiment on, compared side
       by side; keep it or throw it away. It is a git branch, which ForkLeaf
       already has for free
-- [ ] **Read your notebook as it was on any date** — Small. A date picker that
-      takes the _whole notebook_ back, not one note at a time. The per-note
-      time-travel panel already exists; this is the same idea one level up
-- [ ] **Ask a sentence where it came from** — Medium. Click a sentence: "you
-      wrote this on 12 January, changed it twice, it used to say the
-      opposite." The blame view exists but reads like a developer tool
+- [x] **Read your notebook as it was on any date** — Small. A date picker that
+      takes the _whole notebook_ back: the files that existed that day, and
+      each one readable as it stood. Read-only
+- [x] **Ask a sentence where it came from** — Medium. Pointing at a paragraph
+      now says what it used to say, taken from the revision before the change
+      that produced it
 - [ ] **Suggest a change to someone else's notes** — Big. A reader of a
       published page fixes a mistake and you get a suggestion to accept or
       decline, without either of you touching GitHub. This is the single most

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -34,9 +34,9 @@ Ticked entries link to nothing; the git history is the record.
       freshness check already exists; this is the notebook-wide roll-up
 - [ ] **Borrow somebody else's notebook** — Big. Link into their notes, pinned
       to a version, rather than copying and going stale
-- [ ] **Search that knows what you are working on** — Small. Notes connected to
-      the one you are in float to the top. The link graph is already built for
-      backlinks; this uses it for ranking
+- [x] **Search that knows what you are working on** — Small. Notes linked to
+      the one you are in float to the top of ⌘K, by however many hops away
+      they are
 - [ ] **Diagrams you can click through** — Medium. A box in a diagram can be a
       note, so a diagram becomes a map of the notebook
 
@@ -56,8 +56,9 @@ Ticked entries link to nothing; the git history is the record.
       say whether the page you quoted is one of the ones that changed
 - [ ] **Highlights that are just text files** — Medium. A highlight is an
       ordinary file beside the PDF, drawn over the page when you read
-- [ ] **Start a note from a paper** — Small. Title, author and date fill
-      themselves in; the paper's headings become the note's headings
+- [x] **Start a note from a paper** — Small. Title, author and date fill
+      themselves in; the paper's headings become the note's headings, each
+      linked to the page it starts on
 - [ ] **Read scanned documents** — Big. Recognise the text once and keep it
       beside the file, so the work is shared with every device
 - [ ] **Publish your reading, not just your notes** — Big. A public page of

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -148,3 +148,12 @@ export {
   type DiagramImport,
   type ImportKind,
 } from "./import";
+
+export {
+  extractDiagramLinks,
+  hasDiagramLinks,
+  markLinkedNodes,
+  normalizeLabel,
+  type DiagramLink,
+  type LinkedDiagram,
+} from "./links";

--- a/packages/diagrams/src/links.test.ts
+++ b/packages/diagrams/src/links.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { extractDiagramLinks, hasDiagramLinks, markLinkedNodes, normalizeLabel } from "./links";
+
+describe("extractDiagramLinks", () => {
+  it("leaves the words on the box and takes the link out", () => {
+    const { code, links } = extractDiagramLinks('flowchart TD\n  A["[[Deploy runbook]]"] --> B');
+
+    // Mermaid never sees the brackets: it would render them, or read them as
+    // one of its own shapes.
+    expect(code).toBe('flowchart TD\n  A["Deploy runbook"] --> B');
+    expect(links).toEqual([{ label: "Deploy runbook", target: "Deploy runbook", anchor: null }]);
+  });
+
+  it("uses the alias as the label and the target as the destination", () => {
+    const { code, links } = extractDiagramLinks(
+      'flowchart TD\n  A["[[deploy/runbook|The runbook]]"]',
+    );
+
+    expect(code).toContain('"The runbook"');
+    expect(links[0]).toEqual({
+      label: "The runbook",
+      target: "deploy/runbook",
+      anchor: null,
+    });
+  });
+
+  it("carries an anchor through to the click", () => {
+    const { links } = extractDiagramLinks('flowchart TD\n  A["[[Runbook#Rollback]]"]');
+    expect(links[0]?.anchor).toBe("Rollback");
+  });
+
+  it("finds every link in the diagram", () => {
+    const { links } = extractDiagramLinks(
+      'flowchart TD\n  A["[[One]]"] --> B["[[Two]]"] --> C[Plain]',
+    );
+
+    expect(links.map((link) => link.target)).toEqual(["One", "Two"]);
+  });
+
+  it("leaves an ordinary diagram exactly as it was", () => {
+    const code = "flowchart TD\n  A[Start] --> B[End]";
+    expect(extractDiagramLinks(code)).toEqual({ code, links: [] });
+  });
+
+  it("ignores an empty link, which is a typo rather than a destination", () => {
+    const code = 'flowchart TD\n  A["[[ ]]"]';
+    expect(extractDiagramLinks(code).links).toEqual([]);
+  });
+});
+
+describe("hasDiagramLinks", () => {
+  it("answers without doing the work, and does not get stuck on its own state", () => {
+    const code = 'flowchart TD\n  A["[[One]]"]';
+
+    // A global regex remembers where it got to; asking twice must not answer
+    // differently the second time.
+    expect(hasDiagramLinks(code)).toBe(true);
+    expect(hasDiagramLinks(code)).toBe(true);
+    expect(hasDiagramLinks("flowchart TD\n  A[One]")).toBe(false);
+  });
+});
+
+describe("normalizeLabel", () => {
+  it("collapses the whitespace mermaid adds when it lays a label out", () => {
+    expect(normalizeLabel("Deploy\n  runbook ")).toBe("Deploy runbook");
+  });
+});
+
+describe("markLinkedNodes", () => {
+  /** A rendered flowchart, in the shape mermaid produces. */
+  function drawn(labels: string[]): HTMLElement {
+    const root = document.createElement("figure");
+    root.innerHTML = `<svg>${labels
+      .map(
+        (label, index) =>
+          `<g class="node" id="flowchart-${index}"><rect></rect><g class="label"><span class="nodeLabel">${label}</span></g></g>`,
+      )
+      .join("")}</svg>`;
+    return root;
+  }
+
+  it("marks the box whose words match, and only that one", () => {
+    const root = drawn(["Deploy runbook", "Something else"]);
+
+    const marked = markLinkedNodes(root, [
+      { label: "Deploy runbook", target: "deploy/runbook.md", anchor: null },
+    ]);
+
+    expect(marked).toBe(1);
+    const linked = root.querySelectorAll("[data-fl-note]");
+    expect(linked).toHaveLength(1);
+    expect(linked[0]?.getAttribute("data-fl-note")).toBe("deploy/runbook.md");
+    expect(linked[0]?.classList.contains("fl-diagram-link")).toBe(true);
+  });
+
+  it("matches through the whitespace mermaid puts in a wrapped label", () => {
+    const root = drawn(["Deploy\n   runbook"]);
+
+    expect(markLinkedNodes(root, [{ label: "Deploy runbook", target: "x.md", anchor: null }])).toBe(
+      1,
+    );
+  });
+
+  it("keeps the anchor, so a click can land on the right heading", () => {
+    const root = drawn(["Runbook"]);
+    markLinkedNodes(root, [{ label: "Runbook", target: "runbook", anchor: "Rollback" }]);
+
+    expect(root.querySelector("[data-fl-note]")?.getAttribute("data-fl-anchor")).toBe("Rollback");
+  });
+
+  it("marks two boxes that say the same thing, because they mean the same thing", () => {
+    const root = drawn(["Runbook", "Runbook"]);
+    expect(markLinkedNodes(root, [{ label: "Runbook", target: "x", anchor: null }])).toBe(2);
+  });
+
+  it("reports nothing marked when mermaid drew something it does not recognise", () => {
+    const root = document.createElement("figure");
+    root.innerHTML = "<svg><g class='mystery'>Runbook</g></svg>";
+
+    // Worth distinguishing from "no links": it means the shape of the output
+    // has moved, and pretending otherwise would hide that.
+    expect(markLinkedNodes(root, [{ label: "Runbook", target: "x", anchor: null }])).toBe(0);
+  });
+
+  it("does nothing at all for a diagram with no links in it", () => {
+    const root = drawn(["Start", "End"]);
+    expect(markLinkedNodes(root, [])).toBe(0);
+    expect(root.querySelector("[data-fl-note]")).toBeNull();
+  });
+});

--- a/packages/diagrams/src/links.ts
+++ b/packages/diagrams/src/links.ts
@@ -1,0 +1,118 @@
+/**
+ * Diagram boxes that are notes.
+ *
+ * A diagram in a notebook is drawn to say how things relate — and then it is a
+ * picture, so a box labelled "Deploy runbook" is a box, and the note called
+ * Deploy runbook is somewhere else entirely. Writing a `[[wikilink]]` in the
+ * label closes that gap: the box keeps its label and becomes the way to the
+ * note, which turns the diagram editor from a drawing tool into a map of the
+ * notebook that you can draw by hand.
+ *
+ * It stays plain text in the file. `A["[[Deploy runbook]]"]` is an ordinary
+ * mermaid label, so the diagram still renders on github.com and in every other
+ * mermaid tool — showing the brackets, exactly as a `[[wikilink]]` in prose
+ * does there. Nothing bespoke is stored and nothing else has to understand it.
+ *
+ * Two halves, both pure. Before rendering, the links come out of the source
+ * and the labels are left as the words somebody wrote; after rendering, the
+ * nodes carrying those words are found in the SVG so a click can be caught.
+ * The second half is DOM work and belongs to whoever has the document.
+ */
+
+/** The same dialect as a wikilink in prose: `target#anchor|alias`. */
+const WIKILINK_RE = /\[\[([^[\]|#\n]+)(?:#([^[\]|\n]*))?(?:\|([^[\]\n]*))?\]\]/g;
+
+export interface DiagramLink {
+  /** The text left in the diagram, which is what the box now reads. */
+  label: string;
+  target: string;
+  anchor: string | null;
+}
+
+export interface LinkedDiagram {
+  /** The source with each wikilink replaced by the words it displays. */
+  code: string;
+  links: DiagramLink[];
+}
+
+/**
+ * Takes the wikilinks out of a diagram's source, leaving the labels behind.
+ *
+ * Mermaid has no idea what `[[…]]` means and would either render the brackets
+ * or — inside an unquoted label — read them as one of its own shapes. So the
+ * link is resolved away before mermaid ever sees the source, and what is left
+ * is the text a reader wanted on the box.
+ */
+export function extractDiagramLinks(code: string): LinkedDiagram {
+  const links: DiagramLink[] = [];
+
+  const rewritten = code.replace(
+    WIKILINK_RE,
+    (whole, rawTarget: string, rawAnchor?: string, rawAlias?: string) => {
+      const target = rawTarget.trim();
+      if (!target) return whole;
+
+      const anchor = rawAnchor?.trim() || null;
+      const label = (rawAlias?.trim() || target).trim();
+      if (!label) return whole;
+
+      links.push({ label, target, anchor });
+      return label;
+    },
+  );
+
+  return { code: rewritten, links };
+}
+
+/** True when this diagram has nothing to link to, which is most of them. */
+export function hasDiagramLinks(code: string): boolean {
+  WIKILINK_RE.lastIndex = 0;
+  return WIKILINK_RE.test(code);
+}
+
+/**
+ * The words a rendered node is showing, normalised for comparison.
+ *
+ * Mermaid lays a long label out across several `<tspan>`s and may add its own
+ * whitespace, so the text read back off the SVG is rarely the string that went
+ * in character for character. Collapsing runs of whitespace is enough to match
+ * them without pretending two different labels are the same.
+ */
+export function normalizeLabel(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Marks the nodes of a rendered diagram that stand for notes.
+ *
+ * Matched on the label rather than on mermaid's element ids, deliberately.
+ * The ids are an implementation detail that differs between diagram types and
+ * changes between releases; the label is the thing the author wrote and the
+ * thing the reader is looking at. Two boxes with the same words are the same
+ * link, which is what anybody would expect them to be.
+ *
+ * Returns how many were marked, so a caller can tell "no links" from "links
+ * that could not be found" — the second means mermaid drew something this does
+ * not understand, and is worth not pretending about.
+ */
+export function markLinkedNodes(root: ParentNode, links: readonly DiagramLink[]): number {
+  if (links.length === 0) return 0;
+
+  const wanted = new Map(links.map((link) => [normalizeLabel(link.label), link]));
+  let marked = 0;
+
+  for (const node of root.querySelectorAll<SVGElement>("g.node, g.nodes > g, .nodeLabel")) {
+    const element = node.closest<SVGElement>("g.node") ?? node;
+    if (element.hasAttribute("data-fl-note")) continue;
+
+    const link = wanted.get(normalizeLabel(element.textContent ?? ""));
+    if (!link) continue;
+
+    element.setAttribute("data-fl-note", link.target);
+    if (link.anchor) element.setAttribute("data-fl-anchor", link.anchor);
+    element.classList.add("fl-diagram-link");
+    marked += 1;
+  }
+
+  return marked;
+}

--- a/packages/editor/src/Preview.tsx
+++ b/packages/editor/src/Preview.tsx
@@ -2,7 +2,14 @@
 
 import { useEffect, useMemo, useState, useRef } from "react";
 import { markdownToHtml, extractMermaidBlocks } from "@forkleaf/markdown-engine";
-import { renderDiagram, LIGHT_THEME, DARK_THEME } from "@forkleaf/diagrams";
+import {
+  renderDiagram,
+  extractDiagramLinks,
+  markLinkedNodes,
+  LIGHT_THEME,
+  DARK_THEME,
+  type DiagramLink,
+} from "@forkleaf/diagrams";
 import { useDocumentTheme } from "./useDocumentTheme";
 import { handleLinkClick, type LinkBridge } from "./links";
 
@@ -59,6 +66,14 @@ export function Preview({
   const documentTheme = useDocumentTheme();
   const resolved = theme ?? documentTheme;
   const [diagrams, setDiagrams] = useState<Map<number, string>>(new Map());
+  /**
+   * The notes each diagram's boxes stand for, by block.
+   *
+   * Held beside the rendered SVG rather than inside it: the marking is done
+   * against the live DOM once the SVG is on the page, because matching on
+   * mermaid's own element ids would be matching on an implementation detail.
+   */
+  const [diagramLinks, setDiagramLinks] = useState<Map<number, DiagramLink[]>>(new Map());
   const containerRef = useRef<HTMLDivElement>(null);
 
   const blocks = useMemo(() => extractMermaidBlocks(markdown), [markdown]);
@@ -105,13 +120,24 @@ export function Preview({
       const palette = resolved === "dark" ? DARK_THEME : LIGHT_THEME;
       const rendered = new Map<number, string>();
 
+      const links = new Map<number, DiagramLink[]>();
+
       for (const [index, block] of blocks.entries()) {
-        const { svg } = await renderDiagram(block.code, palette);
+        // The wikilinks come out before mermaid sees the source: it has no
+        // idea what `[[…]]` means and would render the brackets, or read them
+        // as one of its own shapes.
+        const linked = extractDiagramLinks(block.code);
+        if (linked.links.length > 0) links.set(index, linked.links);
+
+        const { svg } = await renderDiagram(linked.code, palette);
         if (cancelled) return;
         if (svg) rendered.set(index, svg);
       }
 
-      if (!cancelled) setDiagrams(rendered);
+      if (!cancelled) {
+        setDiagrams(rendered);
+        setDiagramLinks(links);
+      }
     };
 
     void run();
@@ -142,6 +168,24 @@ export function Preview({
     });
   }, [html, diagrams, blocks]);
 
+  /**
+   * Finds the boxes that stand for notes, once they are drawn.
+   *
+   * After the paint rather than during it, because the SVG arrives through
+   * `dangerouslySetInnerHTML` and there is no React element to hang this on.
+   * Runs whenever the drawn diagrams change, which is also when a label could
+   * have changed under a mark.
+   */
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || diagramLinks.size === 0) return;
+
+    for (const [index, links] of diagramLinks) {
+      const figure = container.querySelector(`[data-diagram-index="${index}"]`);
+      if (figure) markLinkedNodes(figure, links);
+    }
+  }, [finalHtml, diagramLinks]);
+
   // Diagram and wikilink clicks are both delegated from the container: the
   // HTML is injected raw, so there is no React element to attach a handler to.
   useEffect(() => {
@@ -150,6 +194,17 @@ export function Preview({
 
     const handler = (event: MouseEvent) => {
       if (handleLinkClick(event, links)) return;
+
+      // A box that stands for a note goes to the note, and does not also open
+      // the diagram editor underneath it.
+      const box = (event.target as HTMLElement).closest?.("[data-fl-note]");
+      if (box && links) {
+        event.preventDefault();
+        event.stopPropagation();
+        links.open(box.getAttribute("data-fl-note") ?? "", box.getAttribute("data-fl-anchor"));
+        return;
+      }
+
       if (!onDiagramClick) return;
 
       const figure = (event.target as HTMLElement).closest<HTMLElement>("[data-diagram-index]");

--- a/packages/editor/src/mermaid/useDiagramSvg.ts
+++ b/packages/editor/src/mermaid/useDiagramSvg.ts
@@ -1,7 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { renderDiagram, LIGHT_THEME, DARK_THEME, type DiagramError } from "@forkleaf/diagrams";
+import {
+  renderDiagram,
+  extractDiagramLinks,
+  LIGHT_THEME,
+  DARK_THEME,
+  type DiagramError,
+} from "@forkleaf/diagrams";
 import { useDocumentTheme } from "../useDocumentTheme";
 
 /**
@@ -34,7 +40,13 @@ export function useDiagramSvg(
     setPending(true);
 
     const timer = setTimeout(async () => {
-      const result = await renderDiagram(code, resolved === "dark" ? DARK_THEME : LIGHT_THEME);
+      // A `[[wikilink]]` in a label is a link to a note, and mermaid has
+      // never heard of one: left in, it draws the brackets. Taken out here as
+      // well as in the preview so a box reads the same wherever it is drawn,
+      // whether or not this particular surface can be clicked through.
+      const { code: source } = extractDiagramLinks(code);
+
+      const result = await renderDiagram(source, resolved === "dark" ? DARK_THEME : LIGHT_THEME);
       if (cancelled) return;
 
       setError(result.error);

--- a/packages/exporter/src/html.ts
+++ b/packages/exporter/src/html.ts
@@ -1,5 +1,5 @@
 import { markdownToHtml, extractMermaidBlocks, serializeDocument } from "@forkleaf/markdown-engine";
-import { renderDiagram, LIGHT_THEME, DARK_THEME } from "@forkleaf/diagrams";
+import { renderDiagram, extractDiagramLinks, LIGHT_THEME, DARK_THEME } from "@forkleaf/diagrams";
 import type { ExportOptions } from "@forkleaf/types";
 
 /**
@@ -76,7 +76,12 @@ async function inlineDiagrams(markdown: string, theme: "light" | "dark"): Promis
   for (const block of blocks) {
     result += markdown.slice(cursor, block.start);
 
-    const { svg } = await renderDiagram(block.code, palette);
+    // A `[[wikilink]]` in a label is a link to a note. Exported, there is no
+    // notebook to click through to — but the box should still read as the
+    // words somebody wrote rather than showing the brackets.
+    const { code } = extractDiagramLinks(block.code);
+
+    const { svg } = await renderDiagram(code, palette);
     result += svg
       ? // Blank lines keep the raw HTML as its own markdown block.
         `\n\n<div class="diagram">${svg}</div>\n\n`

--- a/packages/exporter/src/index.ts
+++ b/packages/exporter/src/index.ts
@@ -1,6 +1,12 @@
 import type { ExportFormat, ExportOptions, Note } from "@forkleaf/types";
 import { serializeDocument, documentStats } from "@forkleaf/markdown-engine";
-import { renderDiagram, toStandaloneSvg, LIGHT_THEME, DARK_THEME } from "@forkleaf/diagrams";
+import {
+  renderDiagram,
+  extractDiagramLinks,
+  toStandaloneSvg,
+  LIGHT_THEME,
+  DARK_THEME,
+} from "@forkleaf/diagrams";
 import { toHtml, type ImageResolver } from "./html";
 import { toDocx } from "./docx";
 
@@ -273,7 +279,9 @@ export async function exportDiagram(
   options: { theme?: "light" | "dark"; scale?: number; filename?: string } = {},
 ): Promise<ExportResult> {
   const palette = options.theme === "dark" ? DARK_THEME : LIGHT_THEME;
-  const { svg, error } = await renderDiagram(code, palette);
+  // The picture leaves the notebook, so its links cannot come with it; the
+  // labels do, as the words they read.
+  const { svg, error } = await renderDiagram(extractDiagramLinks(code).code, palette);
 
   if (!svg) throw new Error(error?.message ?? "This diagram could not be rendered");
 

--- a/packages/github-client/src/client.test.ts
+++ b/packages/github-client/src/client.test.ts
@@ -895,3 +895,86 @@ describe("listDirectory", () => {
     expect(await client.listDirectory("octo", "notes", "main", "docs")).toEqual([]);
   });
 });
+
+/**
+ * The notebook as it was on a day, which is the whole of "time travel": one
+ * commit, and every tree and file read after it hangs off that object name.
+ */
+describe("commitAt", () => {
+  const listing = [
+    {
+      sha: "old-sha",
+      commit: {
+        message: "Notes from the third\n\nwith a body nobody needs",
+        author: { name: "Ada", date: "2026-03-03T18:00:00Z" },
+      },
+      author: { login: "ada", avatar_url: null },
+    },
+  ];
+
+  it("asks for the newest commit at or before the moment, on this branch", async () => {
+    const { calls, fetchImpl } = fakeGitHub({
+      "GET /repos/octo/notes/commits?sha=main&until=2026-03-03T23%3A59%3A59Z&per_page=1": listing,
+    });
+
+    const commit = await new GitHubClient({ token: "t", fetch: fetchImpl }).commitAt(
+      repo,
+      "2026-03-03T23:59:59Z",
+    );
+
+    expect(commit?.sha).toBe("old-sha");
+    // The subject only: a commit body is not a thing this list has room for.
+    expect(commit?.message).toBe("Notes from the third");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("answers a date before the repository existed with nothing", async () => {
+    const { fetchImpl } = fakeGitHub({
+      "GET /repos/octo/notes/commits?sha=main&until=1999-01-01T00%3A00%3A00Z&per_page=1": [],
+    });
+
+    const commit = await new GitHubClient({ token: "t", fetch: fetchImpl }).commitAt(
+      repo,
+      "1999-01-01T00:00:00Z",
+    );
+
+    // Not an error: a notebook has a first day.
+    expect(commit).toBeNull();
+  });
+});
+
+describe("listTree at a ref", () => {
+  const tree = {
+    sha: "old-tree",
+    truncated: false,
+    tree: [
+      { path: "a.md", type: "blob", sha: "b1", size: 10 },
+      { path: "assets/x.png", type: "blob", sha: "b2", size: 20 },
+    ],
+  };
+
+  it("reads the tree at the commit it is given, without asking what HEAD is", async () => {
+    const { calls, fetchImpl } = fakeGitHub({
+      "GET /repos/octo/notes/git/trees/old-sha?recursive=1": tree,
+    });
+
+    const nodes = await new GitHubClient({ token: "t", fetch: fetchImpl }).listTree(repo, {
+      ref: "old-sha",
+    });
+
+    expect(nodes.map((node) => node.path)).toEqual(["a.md"]);
+    // A commit that has already happened cannot move, so there is no reason to
+    // look up where the branch points now.
+    expect(calls.some((call) => call.url.includes("git/ref/heads"))).toBe(false);
+  });
+
+  it("still follows the branch when no ref is given", async () => {
+    const { calls, fetchImpl } = fakeGitHub({
+      "GET /repos/octo/notes/git/trees/head-sha?recursive=1": tree,
+    });
+
+    await new GitHubClient({ token: "t", fetch: fetchImpl }).listTree(repo);
+
+    expect(calls.some((call) => call.url.includes("git/ref/heads/main"))).toBe(true);
+  });
+});

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -873,8 +873,16 @@ export class GitHubClient {
    *   - `"all"` is every blob, which the link repair needs: it can only find
    *     the image a broken note meant if it can see the images.
    */
-  async listTree(repo: RepoRef, options: { include?: "notes" | "all" } = {}): Promise<TreeNode[]> {
-    const head = await this.getBranchHead(repo);
+  async listTree(
+    repo: RepoRef,
+    options: { include?: "notes" | "all"; ref?: string } = {},
+  ): Promise<TreeNode[]> {
+    // `ref` is the notebook as it stood at some commit rather than as it
+    // stands now. Everything below is identical either way: a tree is a tree,
+    // and the ETag cache is keyed by the object name, so an old one is cached
+    // as happily as the current one — and never invalidated, because a commit
+    // that has already happened does not change.
+    const head = options.ref ?? (await this.getBranchHead(repo));
     const path = `/repos/${repo.owner}/${repo.repo}/git/trees/${head}?recursive=1`;
 
     const cached = this.etags.get(path);
@@ -1058,6 +1066,40 @@ export class GitHubClient {
       // autosave from an edit someone made elsewhere.
       byForkLeaf: (entry.commit.message ?? "").startsWith(COMMIT_MARKER),
     }));
+  }
+
+  /**
+   * The last commit on this branch at or before a moment.
+   *
+   * The whole of "what did my notebook look like on the third of March": one
+   * commit, and every tree and file read after it hangs off that object name.
+   * Null when the repository did not exist yet, which is a real answer and not
+   * an error — a notebook has a first day.
+   *
+   * `until` is GitHub's own parameter and is inclusive, so a date with no time
+   * on it means "up to the start of that day". The caller decides whether it
+   * meant the end of it.
+   */
+  async commitAt(repo: RepoRef, until: string): Promise<NoteCommit | null> {
+    const url =
+      `/repos/${repo.owner}/${repo.repo}/commits` +
+      `?sha=${encodeURIComponent(repo.branch)}` +
+      `&until=${encodeURIComponent(until)}` +
+      `&per_page=1`;
+
+    const { data } = await this.transport.request<ApiCommitListEntry[]>(url);
+    const entry = data?.[0];
+    if (!entry) return null;
+
+    return {
+      sha: entry.sha,
+      message: (entry.commit.message ?? "").split("\n")[0] ?? "",
+      authorName: entry.commit.author?.name ?? entry.author?.login ?? "Unknown",
+      authorLogin: entry.author?.login ?? null,
+      avatarUrl: entry.author?.avatar_url ?? null,
+      date: entry.commit.author?.date ?? entry.commit.committer?.date ?? "",
+      byForkLeaf: (entry.commit.message ?? "").startsWith(COMMIT_MARKER),
+    };
   }
 
   /**

--- a/packages/markdown-engine/src/blame.test.ts
+++ b/packages/markdown-engine/src/blame.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { buildBlame, toBlocks, ageRatio, type BlameRevision } from "./blame";
+import {
+  buildBlame,
+  priorWording,
+  replacedWithin,
+  toBlocks,
+  ageRatio,
+  type BlameRevision,
+} from "./blame";
 
 const at = (day: number) => `2026-03-${String(day).padStart(2, "0")}T10:00:00.000Z`;
 
@@ -284,5 +291,93 @@ describe("ageRatio", () => {
 
   it("does not produce NaN for an unparseable date", () => {
     expect(Number.isFinite(ageRatio("nonsense", OLD, NEW))).toBe(true);
+  });
+});
+
+/**
+ * The question after "when did I write this?", and the more interesting one:
+ * what did it say before? A paragraph rewritten in March is one you changed
+ * your mind about, and what you changed it *from* is usually the point.
+ */
+describe("priorWording", () => {
+  const revisions = (texts: [sha: string, date: string, text: string | null][]): BlameRevision[] =>
+    texts.map(([sha, date, text]) => ({ sha, date, text }));
+
+  it("shows what a rewritten paragraph used to say", () => {
+    const before = "# Title\n\nThe answer is obviously yes.\n";
+    const after = "# Title\n\nThe answer is obviously no.\n";
+
+    const input = revisions([
+      ["a", "2026-01-01T00:00:00Z", before],
+      ["b", "2026-03-01T00:00:00Z", after],
+    ]);
+    const blame = buildBlame(input);
+    const block = blame.blocks.find((candidate) => candidate.text.includes("obviously no"))!;
+
+    const prior = priorWording(input, after, block);
+
+    expect(prior?.text).toBe("The answer is obviously yes.");
+    expect(prior?.sha).toBe("a");
+  });
+
+  it("says nothing for a paragraph that was added rather than rewritten", () => {
+    const before = "# Title\n\nOne.\n";
+    const after = "# Title\n\nOne.\n\nTwo, which is new.\n";
+
+    const input = revisions([
+      ["a", "2026-01-01T00:00:00Z", before],
+      ["b", "2026-03-01T00:00:00Z", after],
+    ]);
+    const blame = buildBlame(input);
+    const block = blame.blocks.find((candidate) => candidate.text.includes("Two"))!;
+
+    // "You wrote this in March" and "in March you replaced something with
+    // this" are different facts, and inventing the second would be a lie.
+    expect(priorWording(input, after, block)).toBeNull();
+  });
+
+  it("says nothing when the change is older than the history we can see", () => {
+    const text = "# Title\n\nAs it has always been.\n";
+    const input = revisions([["a", "2026-01-01T00:00:00Z", text]]);
+    const blame = buildBlame(input);
+
+    expect(priorWording(input, text, blame.blocks[0]!)).toBeNull();
+  });
+
+  it("skips a revision that could not be read rather than diffing against nothing", () => {
+    const first = "# Title\n\nOriginal wording.\n";
+    const second = "# Title\n\nReplaced wording.\n";
+
+    const input = revisions([
+      ["a", "2026-01-01T00:00:00Z", first],
+      ["b", "2026-02-01T00:00:00Z", null],
+      ["c", "2026-03-01T00:00:00Z", second],
+    ]);
+    const blame = buildBlame(input);
+    const block = blame.blocks.find((candidate) => candidate.text.includes("Replaced"))!;
+
+    expect(priorWording(input, second, block)?.text).toBe("Original wording.");
+  });
+});
+
+describe("replacedWithin", () => {
+  it("takes only the lines this paragraph replaced, not the note's others", () => {
+    const before = ["First para, old.", "", "Second para, old."].join("\n");
+    const after = ["First para, new.", "", "Second para, new."].join("\n");
+
+    expect(replacedWithin(before, after, { start: 1, end: 1 })).toBe("First para, old.");
+    expect(replacedWithin(before, after, { start: 3, end: 3 })).toBe("Second para, old.");
+  });
+
+  it("joins the lines of a paragraph that was several", () => {
+    const before = "One.\nTwo.\nThree.";
+    const after = "Rewritten.";
+
+    expect(replacedWithin(before, after, { start: 1, end: 1 })).toBe("One.\nTwo.\nThree.");
+  });
+
+  it("returns nothing when the two revisions are the same", () => {
+    const text = "Unchanged.";
+    expect(replacedWithin(text, text, { start: 1, end: 1 })).toBeNull();
   });
 });

--- a/packages/markdown-engine/src/blame.ts
+++ b/packages/markdown-engine/src/blame.ts
@@ -282,3 +282,79 @@ export function ageRatio(date: string, oldest: string, newest: string): number {
   if (to <= from) return 1;
   return Math.min(1, Math.max(0, (timeOf(date) - from) / (to - from)));
 }
+
+/**
+ * What a paragraph said before the change that produced it.
+ *
+ * Blame answers "when did I write this?". The more interesting question, and
+ * the one people actually ask of their own notes, is the one after it: what
+ * did it say before? A paragraph you rewrote in March is a paragraph you
+ * changed your mind about, and seeing what you changed your mind *from* is
+ * usually the most interesting thing on the page.
+ *
+ * Null when this block was added rather than rewritten. That is a real
+ * distinction and worth keeping: "you wrote this in March" and "in March you
+ * replaced something else with this" are different facts about the same
+ * paragraph, and inventing a previous wording for the first would be a lie.
+ */
+export interface PriorWording {
+  text: string;
+  /** The revision it said that in. */
+  sha: string;
+  date: string;
+}
+
+export function priorWording(
+  input: readonly BlameRevision[],
+  currentText: string,
+  block: Pick<BlameBlock, "start" | "end" | "newest">,
+): PriorWording | null {
+  const revisions = [...input]
+    .filter((revision) => revision.text !== null)
+    .sort((a, b) => timeOf(a.date) - timeOf(b.date));
+
+  const changed = revisions.findIndex((revision) => revision.sha === block.newest.sha);
+  // Either the commit that wrote this block is outside the window of history
+  // we can see, or it is the oldest thing in it — in both cases there is no
+  // "before" to show, and guessing at one is exactly the wrong move.
+  if (changed <= 0) return null;
+
+  const previous = revisions[changed - 1];
+  if (!previous?.text) return null;
+
+  const replaced = replacedWithin(previous.text, currentText, block);
+  return replaced === null ? null : { text: replaced, sha: previous.sha, date: previous.date };
+}
+
+/**
+ * The lines the block replaced, from a diff of the two revisions.
+ *
+ * A deletion belongs to the block when it sits inside the block's span in the
+ * *new* text — tracked by the last new line number the walk has passed, since
+ * a deleted line has no new number of its own. Anything deleted elsewhere in
+ * the note is somebody else's paragraph and none of this block's business.
+ */
+export function replacedWithin(
+  previousText: string,
+  currentText: string,
+  block: { start: number; end: number },
+): string | null {
+  const removed: string[] = [];
+  // Deletions before the first new line still belong to a block that starts at
+  // line 1, so the walk begins just above it rather than at it.
+  let at = 0;
+
+  for (const line of diffLines(previousText, currentText)) {
+    if (line.newNumber !== null) {
+      at = line.newNumber;
+      continue;
+    }
+
+    // A deletion sitting at the top edge of the block counts: the lines it
+    // replaced were above the first line the block now occupies.
+    if (at >= block.start - 1 && at <= block.end) removed.push(line.text);
+  }
+
+  const text = removed.join("\n").trim();
+  return text === "" ? null : text;
+}

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -92,12 +92,15 @@ export {
 
 export {
   buildBlame,
+  priorWording,
+  replacedWithin,
   toBlocks,
   ageRatio,
   type Blame,
   type BlameBlock,
   type BlameLine,
   type BlameRevision,
+  type PriorWording,
 } from "./blame";
 
 export {

--- a/packages/markdown-engine/src/index.ts
+++ b/packages/markdown-engine/src/index.ts
@@ -42,6 +42,7 @@ export {
   resolveWikilink,
   wikilinkToPath,
   buildLinkGraph,
+  neighbourhood,
   remarkWikilink,
   type WikiLink,
   type LinkCandidate,

--- a/packages/markdown-engine/src/wikilinks.test.ts
+++ b/packages/markdown-engine/src/wikilinks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildLinkGraph,
+  neighbourhood,
   extractWikilinks,
   resolveWikilink,
   wikilinkTargets,
@@ -148,5 +149,63 @@ describe("rendering", () => {
       resolveWikilink: () => ({ href: "javascript:alert(1)", exists: true }),
     });
     expect(html).not.toContain("javascript:");
+  });
+});
+
+/**
+ * The graph exists for backlinks and answers a second question for free:
+ * which notes are about the same thing as this one?
+ */
+describe("neighbourhood", () => {
+  const graph = () =>
+    buildLinkGraph([
+      { path: "project.md", title: "Project", content: "See [[Setup]] and [[Deploy]]." },
+      { path: "setup.md", title: "Setup", content: "Uses [[Postgres]]." },
+      { path: "deploy.md", title: "Deploy", content: "Nothing yet." },
+      { path: "postgres.md", title: "Postgres", content: "A database." },
+      { path: "mentions.md", title: "Mentions", content: "About [[Project]]." },
+      { path: "elsewhere.md", title: "Elsewhere", content: "Unrelated." },
+    ]);
+
+  it("counts a note you linked to as one hop away", () => {
+    expect(neighbourhood(graph(), "project.md").get("setup.md")).toBe(1);
+  });
+
+  it("counts a note that linked to you as just as near", () => {
+    // Both directions mean the same thing: somebody decided these belonged
+    // together.
+    expect(neighbourhood(graph(), "project.md").get("mentions.md")).toBe(1);
+  });
+
+  it("reaches the second ring, and knows it is further away", () => {
+    expect(neighbourhood(graph(), "project.md").get("postgres.md")).toBe(2);
+  });
+
+  it("stops where it is told to", () => {
+    expect(neighbourhood(graph(), "project.md", 1).has("postgres.md")).toBe(false);
+  });
+
+  it("leaves out a note nothing connects to", () => {
+    expect(neighbourhood(graph(), "project.md").has("elsewhere.md")).toBe(false);
+  });
+
+  it("does not report the note as near itself", () => {
+    expect(neighbourhood(graph(), "project.md").has("project.md")).toBe(false);
+  });
+
+  it("takes the shortest way round, not the first one found", () => {
+    // `c` is reachable in two hops through `b` and in one directly; the
+    // shorter distance is the true one.
+    const small = buildLinkGraph([
+      { path: "a.md", title: "A", content: "[[B]] and [[C]]." },
+      { path: "b.md", title: "B", content: "[[C]]." },
+      { path: "c.md", title: "C", content: "." },
+    ]);
+
+    expect(neighbourhood(small, "a.md").get("c.md")).toBe(1);
+  });
+
+  it("says nothing about a note with no links at all", () => {
+    expect(neighbourhood(graph(), "elsewhere.md").size).toBe(0);
   });
 });

--- a/packages/markdown-engine/src/wikilinks.ts
+++ b/packages/markdown-engine/src/wikilinks.ts
@@ -362,3 +362,47 @@ function lineAt(content: string, offset: number): string {
   const end = content.indexOf("\n", offset);
   return content.slice(start, end === -1 ? content.length : end).trim();
 }
+
+/**
+ * The notes around one note, and how far away each of them is.
+ *
+ * A link graph is built for backlinks — "what points at this?" — and answers a
+ * second question for free that nothing was asking it: which notes are *about
+ * the same thing* as the one somebody is looking at. Links run both ways here,
+ * because a note you linked to and a note that linked to you are equally near
+ * in the only sense that matters: you decided they belonged together.
+ *
+ * Breadth-first, so the first distance found for a note is its shortest, and
+ * bounded by `hops` because the third ring out of a well-linked notebook is
+ * most of the notebook — at which point "nearby" has stopped meaning anything.
+ *
+ * The starting note is not in the result. It is not near itself; it is itself,
+ * and every caller has it already.
+ */
+export function neighbourhood(graph: LinkGraph, from: string, hops = 2): Map<string, number> {
+  const distances = new Map<string, number>();
+  let frontier = [from];
+
+  for (let distance = 1; distance <= hops && frontier.length > 0; distance += 1) {
+    const next: string[] = [];
+
+    for (const path of frontier) {
+      const linked = [
+        ...(graph.outgoing.get(path) ?? []).map((ref) => ref.to),
+        ...(graph.backlinks.get(path) ?? []).map((ref) => ref.from),
+      ];
+
+      for (const neighbour of linked) {
+        // An unresolved link points at nothing, and a cycle back to the start
+        // is not a discovery about the neighbourhood.
+        if (!neighbour || neighbour === from || distances.has(neighbour)) continue;
+        distances.set(neighbour, distance);
+        next.push(neighbour);
+      }
+    }
+
+    frontier = next;
+  }
+
+  return distances;
+}

--- a/packages/store/src/idb-db.test.ts
+++ b/packages/store/src/idb-db.test.ts
@@ -134,7 +134,7 @@ describe("openLocalDatabase", () => {
       const request = indexedDB.open(DB_NAME, 99);
       request.onupgradeneeded = () => {
         const db = request.result;
-        for (const name of ["notes", "queue", "assets"]) {
+        for (const name of ["notes", "queue", "assets", "pdftext"]) {
           db.createObjectStore(name, { keyPath: "id" }).createIndex("by-workspace", "workspaceId");
         }
         db.createObjectStore("workspaces", { keyPath: "id" });

--- a/packages/store/src/idb-db.ts
+++ b/packages/store/src/idb-db.ts
@@ -1,5 +1,12 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
-import type { LocalAsset, Note, PendingChange, TreeNode, Workspace } from "@forkleaf/types";
+import type {
+  LocalAsset,
+  Note,
+  PdfTextEntry,
+  PendingChange,
+  TreeNode,
+  Workspace,
+} from "@forkleaf/types";
 import type { LocalDatabase } from "./ports";
 import { tabChannel, type TabChannel } from "./tab-channel";
 
@@ -38,11 +45,16 @@ interface ForkLeafSchema extends DBSchema {
     key: string;
     value: { key: string; value: unknown };
   };
+  pdftext: {
+    key: string;
+    value: PdfTextEntry;
+    indexes: { "by-workspace": string };
+  };
 }
 
 const DB_NAME = "forkleaf";
 /**
- * Bumped to 2 for the `assets` store.
+ * Bumped to 3 for the `pdftext` store, and to 2 before that for `assets`.
  *
  * Every store is created behind a `contains` check rather than in a
  * version-numbered branch, so an existing database gains the new store and
@@ -53,7 +65,7 @@ const DB_NAME = "forkleaf";
  * make a second tab briefly unable to open it. Only bump it when a new store
  * actually requires it.
  */
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 /**
  * How long to wait for the database to open before giving up on it.
@@ -72,7 +84,15 @@ const OPEN_TIMEOUT_MS = 8_000;
 const RELEASE_TIMEOUT_MS = 1_500;
 
 /** Every store the code below reads from. Checked when no upgrade can run. */
-const REQUIRED_STORES = ["notes", "workspaces", "queue", "trees", "assets", "meta"] as const;
+const REQUIRED_STORES = [
+  "notes",
+  "workspaces",
+  "queue",
+  "trees",
+  "assets",
+  "meta",
+  "pdftext",
+] as const;
 
 export class IndexedDbDatabase implements LocalDatabase {
   readonly persistent = true;
@@ -187,7 +207,7 @@ export class IndexedDbDatabase implements LocalDatabase {
          */
         upgrade(db, _oldVersion, _newVersion, tx) {
           const store = <
-            Name extends "notes" | "queue" | "assets" | "workspaces" | "trees" | "meta",
+            Name extends "notes" | "queue" | "assets" | "workspaces" | "trees" | "meta" | "pdftext",
           >(
             name: Name,
             keyPath: string,
@@ -196,7 +216,7 @@ export class IndexedDbDatabase implements LocalDatabase {
               ? tx.objectStore(name)
               : db.createObjectStore(name, { keyPath });
 
-          for (const name of ["notes", "queue", "assets"] as const) {
+          for (const name of ["notes", "queue", "assets", "pdftext"] as const) {
             const created = store(name, "id");
             if (!created.indexNames.contains("by-workspace")) {
               created.createIndex("by-workspace", "workspaceId");
@@ -393,6 +413,22 @@ export class IndexedDbDatabase implements LocalDatabase {
 
   async listAssets(workspaceId: string): Promise<LocalAsset[]> {
     return (await this.db).getAllFromIndex("assets", "by-workspace", workspaceId);
+  }
+
+  async getPdfText(id: string): Promise<PdfTextEntry | undefined> {
+    return (await this.db).get("pdftext", id);
+  }
+
+  async putPdfText(entry: PdfTextEntry): Promise<void> {
+    await (await this.db).put("pdftext", entry);
+  }
+
+  async deletePdfText(id: string): Promise<void> {
+    await (await this.db).delete("pdftext", id);
+  }
+
+  async listPdfText(workspaceId: string): Promise<PdfTextEntry[]> {
+    return (await this.db).getAllFromIndex("pdftext", "by-workspace", workspaceId);
   }
 
   async getMeta<T>(key: string): Promise<T | undefined> {

--- a/packages/store/src/memory-db.ts
+++ b/packages/store/src/memory-db.ts
@@ -1,4 +1,11 @@
-import type { LocalAsset, Note, PendingChange, TreeNode, Workspace } from "@forkleaf/types";
+import type {
+  LocalAsset,
+  Note,
+  PdfTextEntry,
+  PendingChange,
+  TreeNode,
+  Workspace,
+} from "@forkleaf/types";
 import type { LocalDatabase } from "./ports";
 
 /**
@@ -17,6 +24,7 @@ export class MemoryDatabase implements LocalDatabase {
   private queue = new Map<string, PendingChange>();
   private trees = new Map<string, TreeNode[]>();
   private assets = new Map<string, LocalAsset>();
+  private pdfText = new Map<string, PdfTextEntry>();
   private meta = new Map<string, unknown>();
 
   async getNote(id: string): Promise<Note | undefined> {
@@ -95,6 +103,22 @@ export class MemoryDatabase implements LocalDatabase {
 
   async listAssets(workspaceId: string): Promise<LocalAsset[]> {
     return [...this.assets.values()].filter((asset) => asset.workspaceId === workspaceId);
+  }
+
+  async getPdfText(id: string): Promise<PdfTextEntry | undefined> {
+    return clone(this.pdfText.get(id));
+  }
+
+  async putPdfText(entry: PdfTextEntry): Promise<void> {
+    this.pdfText.set(entry.id, clone(entry)!);
+  }
+
+  async deletePdfText(id: string): Promise<void> {
+    this.pdfText.delete(id);
+  }
+
+  async listPdfText(workspaceId: string): Promise<PdfTextEntry[]> {
+    return [...this.pdfText.values()].filter((entry) => entry.workspaceId === workspaceId);
   }
 
   async getMeta<T>(key: string): Promise<T | undefined> {

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -297,6 +297,14 @@ export class NoteRepository {
     folder: string;
     title: string;
     content?: string;
+    /**
+     * Fields to record beside the ones every note gets.
+     *
+     * For a note that is *about* something — a paper's author and the date it
+     * was published — where the facts are known at the moment of creation and
+     * would otherwise have to be typed in again by hand.
+     */
+    frontmatter?: NoteFrontmatter;
     existingPaths: string[];
   }): Promise<Note> {
     const filename = `${slugifyFilename(options.title)}.md`;
@@ -308,6 +316,10 @@ export class NoteRepository {
     const frontmatter: NoteFrontmatter = this.stamp({
       title: options.title,
       created: timestamp,
+      // Merged over the defaults rather than under them, so a caller that
+      // knows the note's real title — a paper's, rather than the filename it
+      // was created from — is the one that wins.
+      ...options.frontmatter,
     });
     const content = options.content ?? `# ${options.title}\n\n`;
 

--- a/packages/store/src/ports.ts
+++ b/packages/store/src/ports.ts
@@ -1,4 +1,11 @@
-import type { LocalAsset, Note, PendingChange, TreeNode, Workspace } from "@forkleaf/types";
+import type {
+  LocalAsset,
+  Note,
+  PdfTextEntry,
+  PendingChange,
+  TreeNode,
+  Workspace,
+} from "@forkleaf/types";
 
 /**
  * Ports the sync engine depends on.
@@ -40,6 +47,11 @@ export interface LocalDatabase {
   putAsset(asset: LocalAsset): Promise<void>;
   deleteAsset(id: string): Promise<void>;
   listAssets(workspaceId: string): Promise<LocalAsset[]>;
+
+  getPdfText(id: string): Promise<PdfTextEntry | undefined>;
+  putPdfText(entry: PdfTextEntry): Promise<void>;
+  deletePdfText(id: string): Promise<void>;
+  listPdfText(workspaceId: string): Promise<PdfTextEntry[]>;
 
   getMeta<T>(key: string): Promise<T | undefined>;
   putMeta<T>(key: string, value: T): Promise<void>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -385,6 +385,33 @@ export interface LocalAsset {
   pushed: boolean;
 }
 
+// ─── Documents ──────────────────────────────────────────────────────────────
+
+/**
+ * The text of a PDF, kept after it has been read once.
+ *
+ * Extracting the text of a three-hundred-page paper takes seconds, and it was
+ * being done on every open and thrown away on every close — so the words were
+ * searchable inside the reader, for as long as the reader was looking at them,
+ * and nowhere else. Keeping them is what lets the notebook's own search reach
+ * inside documents, and what lets a citation be checked without opening the
+ * paper it points at.
+ *
+ * The positioned runs are deliberately not kept. They exist to draw a
+ * highlight on a page and are far larger than the text; anything that needs
+ * them has the document open in front of it.
+ */
+export interface PdfTextEntry {
+  /** `${workspaceId}::${path}`, like every other stored thing here. */
+  id: string;
+  workspaceId: string;
+  /** Repository-relative path of the document the text came out of. */
+  path: string;
+  pages: { page: number; text: string }[];
+  /** When it was read, so a stale copy can be recognised as one. */
+  indexedAt: string;
+}
+
 // ─── Export ─────────────────────────────────────────────────────────────────
 
 export type ExportFormat = "md" | "html" | "pdf" | "docx" | "txt" | "json";


### PR DESCRIPTION
One branch off `main`, replacing the stack that was #62 → #63 → #64. #61 is already merged, so its work (the reader layout, resizable columns, and the image resize/remove fixes) is not repeated here.

Ten features from [docs/ideas.md](docs/ideas.md), which they tick off, plus the thing that makes them findable. **2084 tests passing** — lint, typecheck and build clean.

---

## First: people have to know these exist

Ten features went in and the help dialog had not heard of any of them. The only way to discover one was to type the right word into ⌘K and be lucky.

Help now covers every one, in a shape that repeats: **what it is** in one line, **Do** — the exact words to press — and **You get** — what happens. The exactness is the point: "there is a way to do that" is not something anybody can act on; "⌘K → Check my citations against their documents" is. Two new topics, **Papers & PDFs** and **Checks & history**, and the existing ones gained what they were missing.

## Reading

- **Citations that check themselves** — every quotation checked against the document as it stands now: what moved (with a one-press page fix), what matched only loosely, what is gone. A document that could not be read is reported as unread, never as one full of broken citations.
- **⌘K searches inside your documents** — page text is kept the first time a paper is read.
- **Start a note from a paper** — title, author and date in the frontmatter; the paper's sections as headings, linked to their pages.
- **The paper and the note stay on the same page** — move the cursor past a citation and the document turns to that page; turn to a page and the note scrolls to what you wrote about it. The note's own citations are the map, so nothing is guessed.
- **The citation format, written down** — [/docs/citation-links](apps/web/src/app/docs/content/citation-links.tsx), field by field, plus **Copy link** to put one on the clipboard. Being the format everyone adopts beats being the app everyone copies, and neither happens without the page.

## Finding

- **⌘K knows which note you are in** — linked notes float up, without ever beating a better kind of match.
- **What has gone stale, notebook-wide** — links pointing at nothing, and claims nobody has looked at in years. Facts are labelled as facts; the age heuristic is labelled as an inference.

## Remembering

- **Your notebook, on a day you choose** — the files that existed that day, each readable as it stood. Read-only.
- **What a paragraph used to say** — the wording it replaced. Nothing claimed for a paragraph that was added rather than rewritten.
- **A diagram can be a map of your notebook** — a `[[wikilink]]` in a box's label makes the box the way to that note, while staying an ordinary Mermaid label.

## Under it

A fourth IndexedDB store, `pdftext`, holding page text only — database version 3, verified in a real browser that a v2 database upgrades in place. `revealLine` on the source editor scrolls without moving the caret.

## What I could and could not exercise

Verified in a browser against real data: ⌘K finding a phrase inside a document; the stale sweep over a seeded notebook and its dismissal persisting; real Mermaid output marked and clicked through to a note; **Write about this** producing a note with the paper's own headings and publication date; the v2 → v3 upgrade; the new help topics; the citation-format page.

Not exercised live, because they need a connected GitHub repository: the citation sweep against real papers, the notebook time machine, the previous-wording line in blame, and follow-along (which needs a repository PDF to have citations at all). Each is covered by tests at every layer it owns — route tests for `/api/gh/at`, client tests for `commitAt` and `listTree` at a ref, pure tests for the follow-along mapping — but a real repository is the one thing I could not stand in for.

Four bugs found by looking rather than by the tests, all fixed: the stale summary double-counted a note that was both broken and aged; a note listed for a broken link was also told its prose had no shelf life; after **Write about this** the reader stayed full-width and hid the note it had just made; and the two follow-along directions would have chased each other until suppressed.