### PR TITLE
The rest of the ideas list, a help dialog that knows about it, and the folder-rename bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,24 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Publish your reading, not just your notes
+
+A note written from a paper is commentary with the passages set into it, each
+linked back to the page it came from. That is the thing worth sharing — not
+&ldquo;here is a PDF&rdquo; and not &ldquo;here is an opinion&rdquo;, but the
+argument with its receipts.
+
+It did not survive publishing. A citation is written relative to the note,
+which is right in the repository and reaches nothing from a page served out of
+`docs/` — so every quotation on a published reading page was a dead link,
+silently, which is worse than no link at all because it looks like there is a
+source behind it.
+
+Citations are now rewritten on the way out, to the document in your repository,
+fragment and all. Only the published copy changes: the note keeps its relative
+links, because that is what makes it readable on github.com and in any other
+editor.
+
 ### Highlights that are just text files
 
 Everybody else locks a highlight inside the PDF — a binary annotation only a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,23 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Highlights that are just text files
+
+Everybody else locks a highlight inside the PDF — a binary annotation only a
+PDF reader can see — or inside their own app, where you can never get it out.
+Both mean the marks you made on a paper are worth nothing away from the tool
+you made them in, which is a strange fate for the part that is actually yours.
+
+Select a passage and press **Highlight**. It becomes a line in
+`attention.highlights.md`, committed beside the document, and is drawn in green
+over the page when you read it. The file renders on github.com, opens in
+Notepad, greps and diffs.
+
+The PDF is never touched. And because each line records the words rather than a
+page number, a highlight made against last year's version of a paper is still
+drawn in the right place after the author adds a figure to page 4 — one that has
+genuinely gone is simply not drawn, rather than drawn somewhere wrong.
+
 ### Try a rewrite without losing what you had
 
 Rewriting a note you care about is a small act of courage: the old version goes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,33 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Fixed — renaming a folder duplicated it, and broke every picture in it
+
+Three faults in one action, which together made renaming a folder unsafe.
+
+**The links to the pictures were repointed at the old folder.** A note's links
+are relative to where the note sits, so moving one is normally accompanied by
+rewriting them — but when the whole folder moves, the pictures move with it,
+and `assets/chart.png` was being rewritten to `../../old-folder/assets/chart.png`,
+which no longer exists. Every image in a renamed folder broke immediately, and
+the note looked fine until somebody opened it. Links that point _out_ of the
+folder are still rewritten, because those files did not move.
+
+**The old folder stayed on screen beside the new one.** The sidebar corrects
+the repository's file list with whatever has not been pushed yet, and it knew
+about renames and deletions but not about _moves_ — which is how everything
+that is not a note travels, a PDF included. So a folder holding a paper
+appeared twice.
+
+**An open tab kept pointing at the old path.** The next keystroke in it saved
+the note back to where it used to be, recreating the folder that had just been
+renamed with one note inside it. Tabs now follow the rename, and so do the
+locks on the notes in them.
+
+Between them these explain the duplicate folder people were left deleting — and
+why deleting it took real files with it: the duplicate was not a copy, it was
+the original.
+
 ### Borrow a note from somebody else's notebook
 
 When a friend writes a good note, what people do is copy and paste it. Now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,23 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Try a rewrite without losing what you had
+
+Rewriting a note you care about is a small act of courage: the old version goes
+into the history, where you have to know it exists and how to get it back. In
+practice people either do not try, or paste the original into a second note
+called `runbook-old.md`.
+
+⌘K → **Try a rewrite of this note** gives you a copy of the notebook to
+experiment in, and a bar at the top that says so and never goes away. **Keep
+it** puts the rewrite back onto the branch it came from as one change; **Throw
+it away** deletes the experiment and leaves the original exactly as it was.
+
+It is a git branch — named `try/<branch>/<what>`, so the name itself says what
+it is and where it has to land, and a second device picks the experiment up
+knowing both. Nothing is written down anywhere else, because anything written
+down anywhere else is the thing that gets lost.
+
 ### Readers can suggest a change to your notes
 
 Programmers have had &ldquo;here is a fix for what you wrote&rdquo; for twenty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,25 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Readers can suggest a change to your notes
+
+Programmers have had &ldquo;here is a fix for what you wrote&rdquo; for twenty
+years and call it a pull request. Nobody has ever offered it to people writing
+notes: a published page is something you read, and that is where it ends.
+
+- Every page you publish now carries **Suggest an edit**. A reader who spots a
+  mistake follows it, fixes the note in GitHub's own editor, and their change
+  becomes a suggestion — GitHub does the forking and the pull request, and
+  neither of you has to say those words
+- ⌘K → **See what other people have suggested** lists what has come in: who,
+  what, and when. **Read what changed** opens the diff and the conversation on
+  GitHub, which is a thing GitHub does very well; **Accept** merges it into your
+  notes from here, and the next sync brings it down to this device
+
+The link points at the note in the repository it came from, never at the
+published copy — a suggestion against a copy is one you could not accept
+without hand-copying it back.
+
 ### The paper and the note stay on the same page
 
 Read a document beside a note and the two follow each other: move the cursor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,19 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### The paper and the note stay on the same page
+
+Read a document beside a note and the two follow each other: move the cursor
+past a citation and the document turns to that page; turn to a page and the
+note scrolls to what you wrote about it. This is what people open two windows
+to fake.
+
+Nothing is guessed. Every citation already records the page it came from, so
+the mapping is the notebook's own. Above the first citation nothing follows —
+a cursor in a heading is not a statement about any page. ⌘K → **Stop the
+document following the note** switches it off; it works in Split and Source
+view, where there is a cursor to follow.
+
 ### The citation format, written down
 
 A ForkLeaf citation was always an ordinary Markdown link — a relative path plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,21 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### Borrow a note from somebody else's notebook
+
+When a friend writes a good note, what people do is copy and paste it. Now
+there are two copies, one is already out of date, and neither of you can tell
+which. Installing a library solved this for code thirty years ago and nobody
+has solved it for the things people know.
+
+⌘K → **Borrow a note from another notebook** takes a repository as
+`owner/name`, lists the notes in it, and writes a link into yours —
+`[[repo:ada/notes:runbook.md@a1b2c3d]]` — pinned to the revision you read.
+Theirs stays theirs, nothing is copied here, and the link keeps working after
+they change it, because it names the version you actually read rather than
+&ldquo;whatever is there now&rdquo;. Unpin it if following along is what you
+wanted.
+
 ### See what changed between two versions of a document
 
 A paper in your repository has every version of itself kept beside it, which no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,27 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### The citation format, written down
+
+A ForkLeaf citation was always an ordinary Markdown link — a relative path plus
+the `#page=` fragment every PDF reader has understood for twenty years, with the
+W3C Web Annotation text selector spelled into a query string. That is only
+useful to anybody else if it is written down, so it now is:
+[the citation link format](/docs/citation-links), field by field, with what a
+tool has to do to read one.
+
+**Copy link** on a selected passage puts exactly that form on the clipboard, for
+pasting into anything that is not ForkLeaf.
+
+### Help knows about all of it
+
+Ten features have gone in lately and the help dialog had not heard of any of
+them. It now covers every one, in the same three beats: what it is in one line,
+the exact words to press, and what happens when you do. Two new topics —
+**Papers & PDFs** and **Checks & history** — and the existing ones gained the
+resizable columns, the search that weighs what you are working on, diagram boxes
+that are notes, and what to do about an image too big to send.
+
 ### Your notebook, on a day you choose
 
 **Show me my notebook as it was on…** in the palette takes the whole notebook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,34 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### A document's text, kept beside it
+
+Two problems with one answer.
+
+A scan is a photograph of a page. There is no text in it, so there is nothing
+to search, nothing to quote and nothing to check a citation against — the
+reader said so honestly and then there was nowhere to go. And a paper that
+_does_ carry its text still had it extracted from scratch on every device,
+every time, and thrown away at the end.
+
+The reader now looks for `<name>.text.md` beside a document and uses it when
+the document has nothing of its own. Recognise a scan's words once — with
+`ocrmypdf`, `tesseract`, or anything else — commit the file, and search,
+quotations, highlights and the citation check all start working on it, on every
+device. For a paper that already has text, ⌘K → **Keep this document's text
+beside it** writes the same file from what has already been read.
+
+Markdown with a `## Page 1` heading per page, deliberately: somebody will make
+these by hand and will want to correct a mangled line when they find one, which
+means the format has to be something a person can open and read. Correcting a
+line there corrects it everywhere.
+
+A document's own text always wins. A file beside a paper never silently
+replaces what the paper actually says.
+
+**Recognising the words inside ForkLeaf is still not possible**, and that is a
+decision rather than an omission — see `docs/ideas.md`.
+
 ### Fixed — renaming a folder duplicated it, and broke every picture in it
 
 Three faults in one action, which together made renaming a folder unsafe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,22 @@ ForkLeaf opens PDFs, beside the note you are writing from them.
   all three with the current one marked, so it answers "where do they open
   now?" as well as changing it
 
+### See what changed between two versions of a document
+
+A paper in your repository has every version of itself kept beside it, which no
+other reading app can say. ⌘K → **See what changed in this document** picks an
+earlier version and reports which pages changed — and whether one of them is a
+page you quoted.
+
+Compared as text, not as bytes: a paper re-exported from the same source
+differs in every byte while saying exactly the same thing, and a comparison
+that reported four hundred changed pages every time somebody re-saved it would
+be one nobody reads twice. Hyphenation across a line break, ligatures and runs
+of spaces are not edits.
+
+Whether the words you quoted survived is a different question, and one **Check
+my citations against their documents** already answers.
+
 ### Publish your reading, not just your notes
 
 A note written from a paper is commentary with the passages set into it, each

--- a/apps/web/src/app/api/gh/branches/route.test.ts
+++ b/apps/web/src/app/api/gh/branches/route.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const listBranchSummaries = vi.fn();
+const createBranch = vi.fn();
+const deleteBranch = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+  getLiveSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+}));
+
+vi.mock("@forkleaf/github-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@forkleaf/github-client")>("@forkleaf/github-client");
+  return {
+    ...actual,
+    GitHubClient: class {
+      listBranchSummaries = listBranchSummaries;
+      createBranch = createBranch;
+      deleteBranch = deleteBranch;
+    },
+  };
+});
+
+const { DELETE } = await import("./route");
+
+afterEach(() => vi.clearAllMocks());
+
+async function remove(body: unknown) {
+  const response = await DELETE(
+    new Request("http://localhost/api/gh/branches", {
+      method: "DELETE",
+      body: JSON.stringify(body),
+    }) as never,
+  );
+  return { status: response.status, body: await response.json() };
+}
+
+describe("DELETE /api/gh/branches", () => {
+  it("throws an experiment away", async () => {
+    const { status } = await remove({ owner: "me", repo: "notes", name: "try/main/rewrite" });
+
+    expect(status).toBe(200);
+    expect(deleteBranch).toHaveBeenCalledWith("me", "notes", "try/main/rewrite");
+  });
+
+  /**
+   * The narrowness is the point. Nothing in this app needs to delete an
+   * ordinary branch, and a route that could is a route that can lose work.
+   */
+  it("refuses to delete anything that is not an experiment", async () => {
+    for (const name of ["main", "release/2026", "feature/search", ""]) {
+      expect((await remove({ owner: "me", repo: "notes", name })).status).toBe(400);
+    }
+
+    expect(deleteBranch).not.toHaveBeenCalled();
+  });
+
+  it("refuses a request with no repository named", async () => {
+    expect((await remove({ name: "try/main/x" })).status).toBe(400);
+    expect(deleteBranch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/gh/branches/route.ts
+++ b/apps/web/src/app/api/gh/branches/route.ts
@@ -47,3 +47,35 @@ export async function POST(request: NextRequest) {
     };
   });
 }
+
+/**
+ * Deletes a branch.
+ *
+ * Only ever asked for by the experiment flow, which is why it is willing to
+ * delete at all: a branch called `try/…` that somebody has decided against is
+ * theirs, and leaving it behind would be a strange kind of throwing away.
+ */
+export async function DELETE(request: NextRequest) {
+  return handle(async () => {
+    const { client } = await requireClient();
+
+    const body = (await request.json().catch(() => ({}))) as {
+      owner?: string;
+      repo?: string;
+      name?: string;
+    };
+
+    const { owner, repo } = readOwnerRepo(body);
+    const name = sanitizeBranchName(body.name ?? "");
+    if (!name) throw new ApiError(400, "validation", "A branch name is required.");
+
+    // Deliberately narrow. Nothing in this app needs to delete an ordinary
+    // branch, and a route that could would be a route that can lose work.
+    if (!name.startsWith("try/")) {
+      throw new ApiError(400, "validation", "Only an experiment branch can be deleted here.");
+    }
+
+    await client.deleteBranch(owner, repo, name);
+    return { deleted: name };
+  });
+}

--- a/apps/web/src/app/api/gh/repos/route.ts
+++ b/apps/web/src/app/api/gh/repos/route.ts
@@ -1,9 +1,38 @@
-import { handle, requireClient } from "@/lib/api-helpers";
+import { type NextRequest } from "next/server";
+import { ApiError, assertName, handle, requireClient } from "@/lib/api-helpers";
 
-/** Lists the repositories the signed-in user can write to. */
-export async function GET() {
+/**
+ * Lists the repositories the signed-in user can write to — or describes one
+ * named repository, whoever it belongs to.
+ *
+ * The second is for borrowing: reading somebody else's notebook needs to know
+ * which branch it keeps its notes on, and that is a fact about their
+ * repository rather than about this user's own list. Only what a public
+ * repository already tells anybody who visits it; a private one they cannot
+ * see answers exactly as GitHub does, which is "not found".
+ */
+export async function GET(request: NextRequest) {
   return handle(async () => {
     const { client } = await requireClient();
+    const params = new URL(request.url).searchParams;
+
+    const owner = params.get("owner");
+    const name = params.get("repo");
+
+    if (owner || name) {
+      if (!owner || !name) {
+        throw new ApiError(400, "validation", "Both an owner and a repository are required.");
+      }
+
+      const found = await client.getRepo(
+        assertName(owner, "repository owner"),
+        assertName(name, "repository name"),
+      );
+      if (!found) throw new ApiError(404, "not-found", `${owner}/${name} could not be found.`);
+
+      return { repo: found };
+    }
+
     return { repos: await client.listRepos() };
   });
 }

--- a/apps/web/src/app/api/gh/suggestions/route.test.ts
+++ b/apps/web/src/app/api/gh/suggestions/route.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const listOpenPullRequests = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+  getLiveSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+}));
+
+vi.mock("@forkleaf/github-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@forkleaf/github-client")>("@forkleaf/github-client");
+  return {
+    ...actual,
+    GitHubClient: class {
+      listOpenPullRequests = listOpenPullRequests;
+    },
+  };
+});
+
+const { GET } = await import("./route");
+
+afterEach(() => vi.clearAllMocks());
+
+async function get(query: string) {
+  const response = await GET(new Request(`http://localhost/api/gh/suggestions${query}`) as never);
+  return { status: response.status, body: await response.json() };
+}
+
+describe("GET /api/gh/suggestions", () => {
+  it("lists what is open on the notebook", async () => {
+    listOpenPullRequests.mockResolvedValue([{ number: 7, title: "Fix a typo" }]);
+
+    const { status, body } = await get("?owner=me&repo=notes");
+
+    expect(status).toBe(200);
+    expect(body.pulls).toHaveLength(1);
+    expect(listOpenPullRequests).toHaveBeenCalledWith("me", "notes");
+  });
+
+  it("refuses a request with no repository named", async () => {
+    // Both halves are interpolated into the upstream URL.
+    expect((await get("?owner=me")).status).toBe(400);
+    expect((await get("?repo=notes")).status).toBe(400);
+    expect(listOpenPullRequests).not.toHaveBeenCalled();
+  });
+
+  it("refuses a name that is not one", async () => {
+    expect((await get("?owner=me&repo=notes/../../etc")).status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/gh/suggestions/route.ts
+++ b/apps/web/src/app/api/gh/suggestions/route.ts
@@ -1,0 +1,25 @@
+import { type NextRequest } from "next/server";
+import { assertName, handle, requireClient } from "@/lib/api-helpers";
+
+/**
+ * The suggestions open on a notebook.
+ *
+ * Every open pull request on the repository, which for a notebook is what a
+ * suggestion *is*: somebody read a published page, spotted a mistake, and sent
+ * the fix back. Until now the only place to find out was github.com, which is
+ * the one place the author of a notes app should not have to go.
+ *
+ * A list, not a review. What each one changes and what was said about it are
+ * separate requests, made only for the one somebody opens.
+ */
+export async function GET(request: NextRequest) {
+  return handle(async () => {
+    const { client } = await requireClient();
+    const params = new URL(request.url).searchParams;
+
+    const owner = assertName(params.get("owner") ?? "", "owner");
+    const repo = assertName(params.get("repo") ?? "", "repository");
+
+    return { pulls: await client.listOpenPullRequests(owner, repo) };
+  });
+}

--- a/apps/web/src/app/docs/content/citation-links.tsx
+++ b/apps/web/src/app/docs/content/citation-links.tsx
@@ -1,0 +1,154 @@
+import { A, Code, H2, H3, Lead, LI, Note, P, Pre, Table, UL } from "@/components/prose";
+
+/**
+ * The link format, written down so other tools can read it.
+ *
+ * ForkLeaf's citations are the one thing here that could outlive ForkLeaf. The
+ * format is not an invention — it is a relative path, the `#page=` fragment
+ * every PDF reader has understood for twenty years, and the W3C Web Annotation
+ * text selector spelled into a query string. Nothing about it needs this app.
+ *
+ * That is only true if it is written down. A format that lives in one
+ * codebase's head is a private format however standard its parts are, so this
+ * page is the specification: what the fields mean, how they resolve, and what
+ * another tool has to do to support them.
+ */
+export function CitationLinks() {
+  return (
+    <>
+      <Lead>
+        A ForkLeaf citation is an ordinary Markdown link. Nothing about it is proprietary and
+        nothing about it needs this app: a relative path, plus a fragment made of the{" "}
+        <Code>#page=</Code> convention every PDF reader has understood for twenty years and the W3C
+        Web Annotation text selector. This page writes it down so that anything else — an Obsidian
+        plugin, Zotero, a static site, a script — can read and write the same links.
+      </Lead>
+
+      <H2 id="shape">The shape of one</H2>
+      <P>This is a whole citation, as it lands in a note:</P>
+
+      <Pre label="A cited passage in a note">{`> Attention is all you need, and the rest is engineering.
+>
+> — [On Attention, p. 12](../papers/attention.pdf#page=12&q=Attention%20is%20all&pre=We%20show%20that&suf=%2C%20and%20the%20rest)`}</Pre>
+
+      <P>
+        The blockquote is the passage as it was read. The line under it is a Markdown link whose
+        destination has two halves: a path, relative to the note holding it, and a fragment.
+      </P>
+
+      <Note>
+        Because it is a relative path, the link resolves on github.com, in any Markdown editor, and
+        on a static site built from the repository. Nothing has to understand the fragment for the
+        link to open the right file — understanding the fragment only makes it open at the right
+        place.
+      </Note>
+
+      <H2 id="fields">The fragment</H2>
+      <P>
+        Fields are <Code>key=value</Code> pairs joined by <Code>&amp;</Code>, percent-encoded, in
+        any order. An unknown key is ignored rather than treated as an error.
+      </P>
+
+      <Table
+        head={["Field", "Means", "Required"]}
+        rows={[
+          [
+            <Code key="page">page</Code>,
+            "The 1-based page the passage was on when the link was written. A hint, never the authority.",
+            "One of page or q",
+          ],
+          [
+            <Code key="q">q</Code>,
+            "The quoted text itself, as it appeared on the page. Up to 512 characters.",
+            "One of page or q",
+          ],
+          [
+            <Code key="pre">pre</Code>,
+            "Up to 48 characters immediately before the quotation, for telling two occurrences apart.",
+            "No",
+          ],
+          [
+            <Code key="suf">suf</Code>,
+            "Up to 48 characters immediately after it, for the same reason.",
+            "No",
+          ],
+        ]}
+      />
+
+      <P>
+        <Code>p</Code> is accepted as a synonym for <Code>page</Code>, and <Code>quote</Code> for{" "}
+        <Code>q</Code>. A bare <Code>#12</Code> means page 12, because that is what people type.
+      </P>
+
+      <H2 id="why">Why the quotation and not just the page</H2>
+      <P>
+        A page number is a claim that quietly stops being true. The author adds a figure to page 4
+        and every citation after it points one page short — the link still opens, it just shows the
+        wrong paragraph, and nothing tells you. Storing the sentence makes the link checkable:
+        search the document as it stands now for those words, and use the page only as a hint about
+        where to start looking.
+      </P>
+
+      <H3>How ForkLeaf resolves one</H3>
+      <UL>
+        <LI>
+          Normalise the document&rsquo;s text and the quotation the same way — ligatures folded (
+          <Code>ﬁ</Code> to <Code>fi</Code>), hyphenation across line breaks joined, runs of
+          whitespace collapsed. This is what makes a search for &ldquo;find&rdquo; match a page that
+          really contains <Code>ﬁnd</Code>.
+        </LI>
+        <LI>
+          Look for the quotation, preferring the recorded page, then the pages around it, then the
+          whole document.
+        </LI>
+        <LI>
+          Where several occurrences match, <Code>pre</Code> and <Code>suf</Code> choose between
+          them. That is what context is for: in a paper that says &ldquo;as discussed above&rdquo;
+          forty times, the quotation alone identifies nothing.
+        </LI>
+        <LI>
+          Report the outcome honestly — found where it said, found on another page, found only after
+          normalising, or not found at all. A resolver that silently falls back to &ldquo;whatever
+          is on page 12 now&rdquo; is the behaviour this format exists to avoid.
+        </LI>
+      </UL>
+
+      <H2 id="writing">Writing one</H2>
+      <P>
+        Select a passage in ForkLeaf&rsquo;s reader and press <strong>Copy link</strong> to put
+        exactly this form on the clipboard. To generate one elsewhere: take the selected text, the
+        48 characters either side of it, and the page it is on; percent-encode each; and join them
+        onto the file&rsquo;s path.
+      </P>
+
+      <Pre label="The minimum a tool has to produce">{`papers/attention.pdf#page=12&q=Attention%20is%20all%20you%20need`}</Pre>
+
+      <H2 id="support">Supporting it in another tool</H2>
+      <P>
+        Reading these links is worth more than writing them, and it is the smaller job. A tool that
+        already opens PDFs at a page needs only to notice <Code>q</Code>, search for it, and prefer
+        what it finds over the page number.
+      </P>
+      <UL>
+        <LI>
+          <strong>Ignore what you do not use.</strong> A reader that only understands{" "}
+          <Code>#page=</Code> behaves exactly as it does today; the extra fields cost it nothing.
+        </LI>
+        <LI>
+          <strong>Do not require the fields to be in order.</strong> They are a query string, not a
+          format.
+        </LI>
+        <LI>
+          <strong>Treat the page as a hint.</strong> If the quotation is elsewhere in the document,
+          the quotation is right and the page is stale.
+        </LI>
+      </UL>
+
+      <P>
+        If you are building something that reads or writes these, we would like to hear about it —{" "}
+        <A href="/support">tell us</A>, and if the format is missing something you need, say so
+        while it is still small enough to change.
+      </P>
+    </>
+  );
+}

--- a/apps/web/src/app/docs/content/index.tsx
+++ b/apps/web/src/app/docs/content/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { GettingStarted, HowItWorks } from "./start";
 import { Editor, Diagrams, Properties, Export, Shortcuts } from "./writing";
 import { Reading } from "./reading";
+import { CitationLinks } from "./citation-links";
 import { Features } from "./features";
 import { SigningIn, Repositories, Sync, Conflicts } from "./github";
 import { Plans, PrivacyAndData, Security } from "./account";
@@ -23,6 +24,7 @@ export const DOC_CONTENT: Record<string, () => React.JSX.Element> = {
   properties: Properties,
   export: Export,
   reading: Reading,
+  "citation-links": CitationLinks,
   shortcuts: Shortcuts,
   features: Features,
   "signing-in": SigningIn,

--- a/apps/web/src/app/docs/nav.ts
+++ b/apps/web/src/app/docs/nav.ts
@@ -61,6 +61,12 @@ export const DOC_SECTIONS: DocSection[] = [
           "Following links, the hover card that says where they go, reading a linked file, reading and citing a PDF, and locking a note so reading it cannot change it.",
       },
       {
+        slug: "citation-links",
+        title: "The citation link format",
+        summary:
+          "How a quotation from a PDF is written into a note, field by field — a relative path plus a standard fragment, so other tools can read and write the same links.",
+      },
+      {
         slug: "export",
         title: "Exporting",
         summary: "Markdown, PDF, HTML, Word, plain text and JSON — all produced in your browser.",

--- a/apps/web/src/components/BorrowDialog.test.tsx
+++ b/apps/web/src/components/BorrowDialog.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const describeRepo = vi.fn();
+const listBranches = vi.fn();
+
+vi.mock("@/lib/gateway", () => ({
+  describeRepo: (...args: unknown[]) => describeRepo(...args),
+  listBranches: (...args: unknown[]) => listBranches(...args),
+}));
+
+const { BorrowDialog } = await import("./BorrowDialog");
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const TREE = [
+  { kind: "file" as const, name: "runbook.md", path: "notes/runbook.md" },
+  { kind: "file" as const, name: "chart.png", path: "assets/chart.png" },
+];
+
+function open(over: Partial<React.ComponentProps<typeof BorrowDialog>> = {}) {
+  const props = {
+    onClose: vi.fn(),
+    loadTree: vi.fn(async () => TREE),
+    onBorrow: vi.fn(),
+    ...over,
+  };
+
+  render(<BorrowDialog {...props} />);
+  return props;
+}
+
+/** Types a name and presses the button, the way somebody would. */
+async function look(name = "ada/notes") {
+  fireEvent.change(screen.getByLabelText(/Whose notebook/), { target: { value: name } });
+  fireEvent.click(screen.getByRole("button", { name: /Look inside/ }));
+}
+
+const found = {
+  owner: "ada",
+  name: "notes",
+  fullName: "ada/notes",
+  private: false,
+  defaultBranch: "main",
+  description: null,
+  updatedAt: "",
+};
+
+describe("BorrowDialog — finding a notebook", () => {
+  it("reads their notes, and leaves everything that is not one out", async () => {
+    describeRepo.mockResolvedValue(found);
+    listBranches.mockResolvedValue([{ name: "main", sha: "a1b2c3d4e5", isDefault: true }]);
+    open();
+    await look();
+
+    expect(await screen.findByRole("button", { name: "notes/runbook.md" })).toBeTruthy();
+    // A picture is not a note somebody can borrow.
+    expect(screen.queryByRole("button", { name: "assets/chart.png" })).toBeNull();
+  });
+
+  it("asks for the branch the notebook actually keeps its notes on", async () => {
+    describeRepo.mockResolvedValue({ ...found, defaultBranch: "trunk" });
+    listBranches.mockResolvedValue([]);
+    const props = open();
+    await look();
+
+    await waitFor(() => expect(props.loadTree).toHaveBeenCalledWith("ada", "notes", "trunk"));
+  });
+
+  it("says what it needs when given something that is not a repository", async () => {
+    open();
+    await look("just-a-name");
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(describeRepo).not.toHaveBeenCalled();
+  });
+
+  it("says so when the notebook cannot be read", async () => {
+    describeRepo.mockRejectedValue(new Error("ada/notes could not be found."));
+    open();
+    await look();
+
+    expect(await screen.findByText(/could not be found/)).toBeTruthy();
+  });
+});
+
+describe("BorrowDialog — the link it writes", () => {
+  /**
+   * The pin is the whole idea. An unpinned link says "whatever they have now",
+   * and a note that changes under a claim you made about it is exactly what
+   * borrowing is supposed to prevent.
+   */
+  it("pins to the revision that was read", async () => {
+    describeRepo.mockResolvedValue(found);
+    listBranches.mockResolvedValue([{ name: "main", sha: "a1b2c3d4e5f6", isDefault: true }]);
+    const props = open();
+    await look();
+
+    fireEvent.click(await screen.findByRole("button", { name: "notes/runbook.md" }));
+
+    expect(props.onBorrow).toHaveBeenCalledWith("[[repo:ada/notes:notes/runbook.md@a1b2c3d]]");
+  });
+
+  it("can follow along instead, for somebody who wants the newest", async () => {
+    describeRepo.mockResolvedValue(found);
+    listBranches.mockResolvedValue([{ name: "main", sha: "a1b2c3d4e5f6", isDefault: true }]);
+    const props = open();
+    await look();
+
+    fireEvent.click(await screen.findByLabelText(/Pin to the version I read/));
+    fireEvent.click(screen.getByRole("button", { name: "notes/runbook.md" }));
+
+    expect(props.onBorrow).toHaveBeenCalledWith("[[repo:ada/notes:notes/runbook.md]]");
+  });
+
+  it("says plainly when there is no revision to pin to", async () => {
+    describeRepo.mockResolvedValue(found);
+    listBranches.mockResolvedValue([]);
+    const props = open();
+    await look();
+
+    expect(await screen.findByText(/cannot be pinned/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "notes/runbook.md" }));
+    expect(props.onBorrow).toHaveBeenCalledWith("[[repo:ada/notes:notes/runbook.md]]");
+  });
+});

--- a/apps/web/src/components/BorrowDialog.tsx
+++ b/apps/web/src/components/BorrowDialog.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { TreeNode } from "@forkleaf/types";
+import { Dialog } from "@/components/Dialog";
+import { describeRepo, listBranches } from "@/lib/gateway";
+import { collectFilePaths } from "@/lib/tree";
+
+/**
+ * Borrowing a note from somebody else's notebook.
+ *
+ * When a friend writes a good note, what people do is copy and paste it. Now
+ * there are two copies, one of them is already out of date, and neither of you
+ * can tell which. It is the problem installing a library solves for code, and
+ * nobody has solved it for the things people know.
+ *
+ * A borrowed note is a link into their repository, pinned to the revision you
+ * read: `[[repo:them/notes:runbook.md@a1b2c3d]]`. Their note stays theirs and
+ * yours stays yours; the link keeps working after they edit it, because it
+ * names the version you actually read rather than "whatever is there now".
+ * Unpinning is a character you delete, if following along is what you wanted.
+ *
+ * Nothing is copied and nothing is stored. This dialog only helps find the
+ * path, because the link itself has always worked and nobody could be expected
+ * to type a repository path from memory.
+ */
+
+export interface BorrowDialogProps {
+  onClose: () => void;
+  /** Reads the file list of any repository the reader can see. */
+  loadTree: (owner: string, repo: string, branch: string) => Promise<TreeNode[]>;
+  /** Writes the link into the note being read from. */
+  onBorrow: (link: string) => void;
+}
+
+type State =
+  | { kind: "idle" }
+  | { kind: "looking" }
+  | {
+      kind: "found";
+      owner: string;
+      repo: string;
+      branch: string;
+      /** The revision that branch is on right now, which is what gets pinned. */
+      sha: string | null;
+      paths: string[];
+    }
+  | { kind: "error"; message: string };
+
+export function BorrowDialog({ onClose, loadTree, onBorrow }: BorrowDialogProps) {
+  const [name, setName] = useState("");
+  const [filter, setFilter] = useState("");
+  const [state, setState] = useState<State>({ kind: "idle" });
+  /**
+   * Whether the link names the revision read.
+   *
+   * On by default, which is the whole idea: an unpinned link says "whatever
+   * they have now", and a note that changes under a claim you made about it is
+   * the thing borrowing is supposed to prevent. Off is a real choice for
+   * somebody following a document they expect to keep changing.
+   */
+  const [pin, setPin] = useState(true);
+
+  const look = useCallback(async () => {
+    const [owner, repo] = name
+      .trim()
+      .replace(/^https:\/\/github\.com\//, "")
+      .split("/");
+    if (!owner || !repo) {
+      setState({ kind: "error", message: "Give it as owner/repository — for example ada/notes." });
+      return;
+    }
+
+    setState({ kind: "looking" });
+
+    try {
+      const found = await describeRepo(owner, repo.replace(/\.git$/, ""));
+
+      const [tree, branches] = await Promise.all([
+        loadTree(found.owner, found.name, found.defaultBranch),
+        // The revision to pin to. A branch name would be no pin at all: it is
+        // a name for "whatever is there now", which is the thing borrowing is
+        // meant to protect a note from.
+        listBranches(found.owner, found.name).catch(() => []),
+      ]);
+
+      setState({
+        kind: "found",
+        owner: found.owner,
+        repo: found.name,
+        branch: found.defaultBranch,
+        sha: branches.find((branch) => branch.name === found.defaultBranch)?.sha ?? null,
+        paths: collectFilePaths(tree).filter((path) => /\.mdx?$/i.test(path)),
+      });
+    } catch (problem: unknown) {
+      setState({
+        kind: "error",
+        message:
+          problem instanceof Error
+            ? problem.message
+            : "That notebook could not be read. It may be private, or not exist.",
+      });
+    }
+  }, [name, loadTree]);
+
+  const paths =
+    state.kind === "found"
+      ? state.paths.filter((path) => path.toLowerCase().includes(filter.trim().toLowerCase()))
+      : [];
+
+  return (
+    <Dialog
+      title="Borrow a note"
+      subtitle="Link into somebody else's notebook instead of copying out of it"
+      onClose={onClose}
+      wide
+    >
+      <div className="text-[13px]">
+        <p className="max-w-2xl leading-relaxed text-[var(--fl-muted)]">
+          Copying a note makes a second copy that is already going out of date. A borrowed note is a
+          link into their repository, pinned to the version you read — theirs stays theirs, and your
+          link keeps working after they change it.
+        </p>
+
+        <div className="mt-3 flex flex-wrap items-end gap-2">
+          <label className="flex min-w-[16rem] flex-1 flex-col gap-1">
+            <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--fl-muted)]">
+              Whose notebook
+            </span>
+            <input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void look();
+              }}
+              placeholder="ada/notes"
+              autoFocus
+              className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2.5 py-1.5 text-[13px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={() => void look()}
+            disabled={state.kind === "looking"}
+            className="fl-btn fl-btn-primary !py-1.5 disabled:opacity-60"
+          >
+            {state.kind === "looking" ? "Looking…" : "Look inside"}
+          </button>
+        </div>
+
+        {state.kind === "error" && (
+          <p role="alert" className="mt-3 text-[var(--fl-danger)]">
+            {state.message}
+          </p>
+        )}
+
+        {state.kind === "found" && (
+          <div className="mt-4">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+              <p className="text-[var(--fl-muted)]">
+                {state.paths.length} {state.paths.length === 1 ? "note" : "notes"} in{" "}
+                <span className="font-mono text-[12px] text-[var(--fl-text)]">
+                  {state.owner}/{state.repo}
+                </span>{" "}
+                on <span className="font-mono text-[12px]">{state.branch}</span>
+              </p>
+
+              <label className="ml-auto flex items-center gap-1.5 text-[12px] text-[var(--fl-muted)]">
+                <input
+                  type="checkbox"
+                  checked={pin && state.sha !== null}
+                  disabled={state.sha === null}
+                  onChange={(event) => setPin(event.target.checked)}
+                />
+                {state.sha === null
+                  ? "That revision could not be read, so this cannot be pinned"
+                  : "Pin to the version I read"}
+              </label>
+            </div>
+
+            {state.paths.length > 8 && (
+              <input
+                value={filter}
+                onChange={(event) => setFilter(event.target.value)}
+                placeholder="Filter by name…"
+                className="mt-2 w-full rounded-lg border border-[var(--fl-border)] bg-[var(--fl-surface)] px-2.5 py-1.5 text-[12.5px] text-[var(--fl-text)] outline-none focus:border-[var(--fl-accent)]"
+              />
+            )}
+
+            <ul className="mt-2 max-h-[38vh] overflow-y-auto rounded-xl border border-[var(--fl-border)] p-1.5">
+              {paths.length === 0 && (
+                <li className="px-1.5 py-2 text-[12.5px] text-[var(--fl-muted)]">
+                  {state.paths.length === 0
+                    ? "There are no markdown notes in that repository."
+                    : "Nothing matches that."}
+                </li>
+              )}
+
+              {paths.map((path) => (
+                <li key={path}>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onBorrow(
+                        `[[repo:${state.owner}/${state.repo}:${path}` +
+                          `${pin && state.sha ? `@${state.sha.slice(0, 7)}` : ""}]]`,
+                      )
+                    }
+                    className="block w-full truncate rounded px-1.5 py-1 text-left font-mono text-[11.5px] text-[var(--fl-muted)] transition-colors hover:bg-[var(--fl-elevated)] hover:text-[var(--fl-text)]"
+                  >
+                    {path}
+                  </button>
+                </li>
+              ))}
+            </ul>
+
+            <p className="mt-2 text-[11.5px] leading-relaxed text-[var(--fl-muted)]">
+              Choosing one writes a link into your note. Nothing is copied, and nothing of theirs is
+              stored here — the note is read from their repository when you open it.
+            </p>
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/DocumentVersionsDialog.test.tsx
+++ b/apps/web/src/components/DocumentVersionsDialog.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Workspace } from "@forkleaf/types";
+
+const listNoteHistory = vi.fn();
+const readDocumentText = vi.fn();
+
+vi.mock("@/lib/gateway", () => ({
+  listNoteHistory: (...args: unknown[]) => listNoteHistory(...args),
+}));
+
+vi.mock("@/lib/pdf-index", () => ({
+  readDocumentText: (...args: unknown[]) => readDocumentText(...args),
+}));
+
+const { DocumentVersionsDialog } = await import("./DocumentVersionsDialog");
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const WORKSPACE: Workspace = {
+  id: "w",
+  name: "me/notes",
+  repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
+  isDefault: true,
+  isLocal: false,
+  createdAt: "",
+  lastOpenedAt: "",
+};
+
+const commit = (sha: string, message: string) => ({
+  sha,
+  message,
+  authorName: "Ada",
+  authorLogin: "ada",
+  avatarUrl: null,
+  date: "2026-03-01T10:00:00.000Z",
+  byForkLeaf: false,
+});
+
+const pages = (...texts: string[]) => texts.map((text, index) => ({ page: index + 1, text }));
+
+function open(over: Partial<React.ComponentProps<typeof DocumentVersionsDialog>> = {}) {
+  const props = {
+    onClose: vi.fn(),
+    workspace: WORKSPACE,
+    path: "papers/attention.pdf",
+    cited: [] as number[],
+    onGoToPage: vi.fn(),
+    ...over,
+  };
+
+  render(<DocumentVersionsDialog {...props} />);
+  return props;
+}
+
+describe("DocumentVersionsDialog — choosing a version", () => {
+  it("reads nothing until a version is picked", async () => {
+    listNoteHistory.mockResolvedValue([commit("new", "v3"), commit("old", "v2")]);
+    open();
+
+    expect(await screen.findByText("v2")).toBeTruthy();
+    // Reading two whole documents is seconds of work.
+    expect(readDocumentText).not.toHaveBeenCalled();
+  });
+
+  it("does not offer the version you are already reading", async () => {
+    listNoteHistory.mockResolvedValue([commit("new", "v3"), commit("old", "v2")]);
+    open();
+
+    await screen.findByText("v2");
+    // Comparing a thing with itself is not a question.
+    expect(screen.queryByText("v3")).toBeNull();
+  });
+
+  it("says so when there is only one version", async () => {
+    listNoteHistory.mockResolvedValue([commit("only", "first commit")]);
+    open();
+
+    expect(await screen.findByText(/only ever been committed once/)).toBeTruthy();
+  });
+});
+
+describe("DocumentVersionsDialog — the comparison", () => {
+  // Set before the dialog renders: it asks for the history on mount, and a
+  // mock installed afterwards would arrive too late — for the first test in
+  // the file only, which is the most confusing kind of order dependence.
+  beforeEach(() => {
+    listNoteHistory.mockResolvedValue([commit("new", "v3"), commit("old", "v2")]);
+  });
+
+  const compare = async () =>
+    fireEvent.click(await screen.findByRole("button", { name: "Compare" }));
+
+  it("names the pages whose words changed", async () => {
+    readDocumentText
+      .mockResolvedValueOnce(pages("one", "two", "three"))
+      .mockResolvedValueOnce(pages("one", "two, revised", "three"));
+    open();
+    await compare();
+
+    expect(await screen.findByText(/1 of 3 pages changed/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "p. 2" })).toBeTruthy();
+  });
+
+  it("reads the old version at its commit, and the new one at the branch", async () => {
+    readDocumentText.mockResolvedValue(pages("same"));
+    open();
+    await compare();
+
+    await waitFor(() => expect(readDocumentText).toHaveBeenCalledTimes(2));
+    expect(readDocumentText.mock.calls[0]?.[0]?.repo?.branch).toBe("old");
+    expect(readDocumentText.mock.calls[1]?.[0]?.repo?.branch).toBe("main");
+  });
+
+  /** The sentence no other reading app can print. */
+  it("says when a page you quoted is one of the ones that changed", async () => {
+    readDocumentText
+      .mockResolvedValueOnce(pages("one", "two"))
+      .mockResolvedValueOnce(pages("one", "rewritten"));
+    open({ cited: [2] });
+    await compare();
+
+    expect(await screen.findByText(/is one you quoted/)).toBeTruthy();
+  });
+
+  it("says plainly when none of your pages are affected", async () => {
+    readDocumentText
+      .mockResolvedValueOnce(pages("one", "two"))
+      .mockResolvedValueOnce(pages("one", "rewritten"));
+    open({ cited: [1] });
+    await compare();
+
+    expect(await screen.findByText(/None of the pages you quoted/)).toBeTruthy();
+  });
+
+  it("takes you to a changed page in the document you are reading", async () => {
+    readDocumentText
+      .mockResolvedValueOnce(pages("one", "two"))
+      .mockResolvedValueOnce(pages("one", "rewritten"));
+    const props = open();
+    await compare();
+
+    fireEvent.click(await screen.findByRole("button", { name: "p. 2" }));
+    expect(props.onGoToPage).toHaveBeenCalledWith(2);
+  });
+
+  it("reports two versions that cannot both be read", async () => {
+    readDocumentText.mockRejectedValue(new Error("That PDF could not be read."));
+    open();
+    await compare();
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/DocumentVersionsDialog.tsx
+++ b/apps/web/src/components/DocumentVersionsDialog.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { Workspace } from "@forkleaf/types";
+import { Dialog } from "@/components/Dialog";
+import { listNoteHistory, type NoteCommitDto } from "@/lib/gateway";
+import { readDocumentText } from "@/lib/pdf-index";
+import { affected, comparePages, listPages, type VersionComparison } from "@/lib/pdf-versions";
+import { relativeTime } from "@/lib/relative-time";
+
+/**
+ * What changed between two versions of a document.
+ *
+ * The file sits in a repository, so every version of it is kept — which no
+ * other reading app can say — and that makes one sentence possible that none
+ * of them can print: *the page you quoted is one of the ones that changed*.
+ *
+ * Compared as text rather than as bytes. A paper re-exported from the same
+ * source differs in every byte while saying exactly the same thing, and a
+ * comparison that reported four hundred changed pages every time somebody
+ * re-saved it would be one nobody reads twice.
+ *
+ * Reading two whole documents is seconds of work, so nothing happens until a
+ * version is chosen. The list of versions is cheap and comes first.
+ */
+
+export interface DocumentVersionsDialogProps {
+  onClose: () => void;
+  workspace: Workspace;
+  /** The document being read, repository-relative. */
+  path: string;
+  /** Pages this notebook quotes or has marked, for the sentence at the end. */
+  cited: readonly number[];
+  /** Turns the open reader to a page, so a change can be looked at. */
+  onGoToPage?: ((page: number) => void) | null;
+}
+
+type State =
+  | { kind: "listing" }
+  | { kind: "ready"; commits: NoteCommitDto[] }
+  | { kind: "error"; message: string };
+
+export function DocumentVersionsDialog({
+  onClose,
+  workspace,
+  path,
+  cited,
+  onGoToPage,
+}: DocumentVersionsDialogProps) {
+  const [state, setState] = useState<State>({ kind: "listing" });
+  const [reading, setReading] = useState<string | null>(null);
+  const [result, setResult] = useState<{
+    sha: string;
+    comparison: VersionComparison;
+  } | null>(null);
+  const [problem, setProblem] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+
+    void listNoteHistory(workspace.repo, path, 30)
+      .then((commits) => {
+        if (live) setState({ kind: "ready", commits });
+      })
+      .catch((error: unknown) => {
+        if (!live) return;
+        setState({
+          kind: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "This document's history could not be read from GitHub.",
+        });
+      });
+
+    return () => {
+      live = false;
+    };
+  }, [workspace.repo, path]);
+
+  const compare = useCallback(
+    async (sha: string) => {
+      setReading(sha);
+      setProblem(null);
+      setResult(null);
+
+      try {
+        // The same route the reader uses, asked for a commit instead of a
+        // branch: GitHub's contents API takes either.
+        const [before, after] = await Promise.all([
+          readDocumentText({ ...workspace, repo: { ...workspace.repo, branch: sha } }, path),
+          readDocumentText(workspace, path),
+        ]);
+
+        setResult({ sha, comparison: comparePages(before, after) });
+      } catch (error: unknown) {
+        setProblem(
+          error instanceof Error ? error.message : "Those two versions could not both be read.",
+        );
+      } finally {
+        setReading(null);
+      }
+    },
+    [workspace, path],
+  );
+
+  return (
+    <Dialog title="What changed in this document" subtitle={path} onClose={onClose} wide steady>
+      {state.kind === "listing" && (
+        <p aria-busy="true" className="text-[13px] text-[var(--fl-muted)]">
+          Reading this document&rsquo;s history…
+        </p>
+      )}
+
+      {state.kind === "error" && (
+        <p role="alert" className="text-[13px] text-[var(--fl-danger)]">
+          {state.message}
+        </p>
+      )}
+
+      {state.kind === "ready" && state.commits.length <= 1 && (
+        <p className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+          This document has only ever been committed once, so there is no earlier version to compare
+          it with.
+        </p>
+      )}
+
+      {state.kind === "ready" && state.commits.length > 1 && (
+        <div className="text-[13px]">
+          <p className="text-[var(--fl-muted)]">
+            Pick a version to compare with the one you are reading. Both are read in full, which
+            takes a moment on a long paper.
+          </p>
+
+          <ul className="mt-3 space-y-1.5">
+            {/* The newest commit is the version being read, so it is not on
+                offer: comparing a thing with itself is not a question. */}
+            {state.commits.slice(1).map((commit) => (
+              <li
+                key={commit.sha}
+                className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-[var(--fl-border)] px-2.5 py-2"
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[13px] text-[var(--fl-text)]">
+                    {commit.message || "(no message)"}
+                  </span>
+                  <span className="block text-[11px] text-[var(--fl-muted)]">
+                    <span className="font-mono">{commit.sha.slice(0, 7)}</span> ·{" "}
+                    {commit.authorName} · {relativeTime(commit.date)}
+                  </span>
+                </span>
+
+                <button
+                  type="button"
+                  disabled={reading !== null}
+                  onClick={() => void compare(commit.sha)}
+                  className="shrink-0 rounded border border-[var(--fl-border)] px-2 py-1 text-[11.5px] font-medium text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)] disabled:opacity-50"
+                >
+                  {reading === commit.sha ? "Reading both…" : "Compare"}
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          {problem && (
+            <p role="alert" className="mt-3 text-[12.5px] text-[var(--fl-danger)]">
+              {problem}
+            </p>
+          )}
+
+          {result && (
+            <Report
+              comparison={result.comparison}
+              cited={cited}
+              {...(onGoToPage ? { onGoToPage } : {})}
+            />
+          )}
+        </div>
+      )}
+    </Dialog>
+  );
+}
+
+function Report({
+  comparison,
+  cited,
+  onGoToPage,
+}: {
+  comparison: VersionComparison;
+  cited: readonly number[];
+  onGoToPage?: (page: number) => void;
+}) {
+  const yours = affected(comparison, cited);
+
+  return (
+    <div className="mt-4 border-t border-[var(--fl-border)] pt-3">
+      <p className="text-[13px] text-[var(--fl-text)]">
+        {comparison.changes.length === 0
+          ? "Nothing changed. The two versions say the same thing on every page."
+          : `${comparison.changes.length} of ${comparison.pages} ${
+              comparison.pages === 1 ? "page" : "pages"
+            } changed.`}
+      </p>
+
+      {comparison.changes.length > 0 && (
+        <ul className="mt-2 flex flex-wrap gap-1.5">
+          {comparison.changes.map((change) => (
+            <li key={`${change.page}-${change.kind}`}>
+              <button
+                type="button"
+                disabled={!onGoToPage || change.kind === "removed"}
+                onClick={() => onGoToPage?.(change.page)}
+                title={
+                  change.kind === "removed"
+                    ? "This page is not in the version you are reading"
+                    : `Go to page ${change.page}`
+                }
+                className="rounded border border-[var(--fl-border)] px-1.5 py-0.5 text-[11.5px] text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-elevated)] disabled:cursor-default disabled:opacity-60"
+              >
+                p. {change.page}
+                {change.kind === "changed" ? "" : ` (${change.kind})`}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* The sentence this whole comparison exists to be able to say. */}
+      {yours.length > 0 && (
+        <p className="mt-3 text-[12.5px] leading-relaxed text-[var(--fl-text)]">
+          <strong>
+            {listPages(yours.map((change) => change.page))
+              .replace(/^p/, "P")
+              .replace(/^pages/, "Pages")}
+          </strong>{" "}
+          {yours.length === 1 ? "is one you quoted" : "are ones you quoted"}, and{" "}
+          {yours.length === 1 ? "it has" : "they have"} changed. Whether the words you quoted are
+          still there is what <strong>Check my citations against their documents</strong> answers.
+        </p>
+      )}
+
+      {yours.length === 0 && cited.length > 0 && comparison.changes.length > 0 && (
+        <p className="mt-3 text-[12.5px] text-[var(--fl-muted)]">
+          None of the pages you quoted are among them.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/HelpDialog.test.tsx
+++ b/apps/web/src/components/HelpDialog.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import type { Workspace } from "@forkleaf/types";
+import { HelpDialog } from "./HelpDialog";
+
+afterEach(cleanup);
+
+const WORKSPACE: Workspace = {
+  id: "w",
+  name: "me/notes",
+  repo: { owner: "me", repo: "notes", branch: "main", directory: "" },
+  isDefault: true,
+  isLocal: false,
+  createdAt: "",
+  lastOpenedAt: "",
+};
+
+function open(over: Partial<React.ComponentProps<typeof HelpDialog>> = {}) {
+  render(
+    <HelpDialog
+      onClose={vi.fn()}
+      user={{ login: "me", name: "Me", avatarUrl: null } as never}
+      workspace={WORKSPACE}
+      githubAvailable
+      onSignIn={vi.fn()}
+      onConnectRepo={vi.fn()}
+      {...over}
+    />,
+  );
+}
+
+const tab = (name: RegExp) => fireEvent.click(screen.getByRole("tab", { name }));
+
+/**
+ * A feature nobody can find is a feature nobody has. These assert that each
+ * one is named here under the words somebody would actually go looking for —
+ * and, more importantly, that the exact command is written down, since "there
+ * is a way to do that" is not an answer anybody can act on.
+ */
+describe("HelpDialog — every feature is findable", () => {
+  it("offers a topic for each part of the app", () => {
+    open();
+
+    for (const name of [
+      /Getting started/,
+      /Writing/,
+      /Papers & PDFs/,
+      /Diagrams/,
+      /Checks & history/,
+      /GitHub & sync/,
+      /Shortcuts/,
+    ]) {
+      expect(screen.getByRole("tab", { name })).toBeTruthy();
+    }
+  });
+
+  it("names the papers features, and what to press for each", () => {
+    open();
+    tab(/Papers & PDFs/);
+
+    expect(screen.getByText(/Read a paper in the notebook it belongs to/)).toBeTruthy();
+    expect(screen.getByText("Quote into note")).toBeTruthy();
+    expect(screen.getByText("Write about this")).toBeTruthy();
+    expect(screen.getByText("Save to notebook")).toBeTruthy();
+  });
+
+  it("names the checks, each with its palette command", () => {
+    open();
+    tab(/Checks & history/);
+
+    expect(screen.getByText("Check my citations against their documents")).toBeTruthy();
+    expect(screen.getByText("Check which of my notes have gone stale")).toBeTruthy();
+    expect(screen.getByText("Show me my notebook as it was on…")).toBeTruthy();
+  });
+
+  it("says how to make a diagram box into a note", () => {
+    open();
+    tab(/Diagrams/);
+
+    expect(screen.getByText(/A box can be a note/)).toBeTruthy();
+    expect(screen.getByText(/\[\[Deploy runbook\]\]/)).toBeTruthy();
+  });
+
+  it("says what to do about an image that will not send", () => {
+    open();
+    tab(/GitHub & sync/);
+
+    expect(screen.getByText(/When an image is too big to send/)).toBeTruthy();
+    expect(screen.getByText("Resize")).toBeTruthy();
+  });
+
+  it("tells every feature in the same three beats", () => {
+    open();
+    tab(/Papers & PDFs/);
+
+    // What it is, what to press, what happens. A paragraph of prose about a
+    // feature is a paragraph people skim and still do not know what to press.
+    const entry = screen.getByText(/Start a note from a paper/).closest("div")!;
+    expect(within(entry).getByText("Do")).toBeTruthy();
+    expect(within(entry).getByText("You get")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -143,6 +143,23 @@ export function HelpDialog({
             then="The widths are remembered on this device, and bounded so nothing can be dragged into uselessness."
           />
           <Feature
+            title="Try a rewrite without losing what you had"
+            what="Rewriting a note you care about is a small act of courage. It should not be."
+            doThis={
+              <>
+                <Mono>⌘K</Mono> → <strong>Try a rewrite of this note</strong>
+              </>
+            }
+            then={
+              <>
+                You get a copy of the whole notebook to experiment in, and a bar at the top saying
+                so. <strong>Keep it</strong> puts the rewrite back as one change;{" "}
+                <strong>Throw it away</strong> leaves the original exactly as it was. It is a git
+                branch, which is why nothing can be lost either way.
+              </>
+            }
+          />
+          <Feature
             title="Search that knows what you are working on"
             what="Typing “setup” in the middle of a project should find that project's setup."
             doThis={

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -217,6 +217,23 @@ export function HelpDialog({
             }
           />
           <Feature
+            title="Highlight a passage, and keep it as a text file"
+            what="Everybody else locks a highlight inside the PDF, or inside their own app, where you can never get it out."
+            doThis={
+              <>
+                Select text in the document, then <strong>Highlight</strong>. Selecting it again
+                offers <strong>Unhighlight</strong>.
+              </>
+            }
+            then={
+              <>
+                A line in <Mono>attention.highlights.md</Mono>, committed beside the document, drawn
+                in green over the page when you read it. The PDF itself is never touched, and the
+                marks open in Notepad.
+              </>
+            }
+          />
+          <Feature
             title="See everything you have written about a paper"
             what="Months later this list is the useful thing, not the paper."
             doThis={

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -340,6 +340,18 @@ export function HelpDialog({
             }
           />
           <Feature
+            title="Let readers send corrections back"
+            what="Programmers have had “here is a fix for what you wrote” for twenty years. Nobody has offered it to people writing notes."
+            doThis={
+              <>
+                Publish a note. Every published page carries <strong>Suggest an edit</strong>; to
+                see what has come in, <Mono>⌘K</Mono> →{" "}
+                <strong>See what other people have suggested</strong>.
+              </>
+            }
+            then="The reader fixes the note in GitHub's editor and their change arrives in your list. Read what changed on GitHub, and accept it here — the next sync brings it down to this device."
+          />
+          <Feature
             title="What did my notebook look like in March?"
             what="Not one note's history — the whole notebook, on a day you choose."
             doThis={

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -226,6 +226,23 @@ export function HelpDialog({
             then="Matches from every document you have opened, under Documents, with the sentence they were found in. Opening one goes straight to the page."
           />
           <Feature
+            title="Send a passage to something that is not ForkLeaf"
+            what="The citation format is a relative path plus a standard fragment, so other tools can follow it."
+            doThis={
+              <>
+                Select a passage, then <strong>Copy link</strong>.
+              </>
+            }
+            then={
+              <>
+                <Mono>papers/attention.pdf#page=12&amp;q=…</Mono> on the clipboard. Any PDF reader
+                opens the right page; one that reads the quotation finds the right sentence even
+                after the paper is revised.{" "}
+                <DocLink href="/docs/citation-links">The format, written down</DocLink>.
+              </>
+            }
+          />
+          <Feature
             title="Keep a PDF from your desktop"
             what="A dropped file has no path in the repository, so nothing can link to it."
             doThis={<strong>Save to notebook</strong>}

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -272,6 +272,17 @@ export function HelpDialog({
             then="Moving the cursor past a citation turns the document to that page; turning to a page scrolls the note to what you wrote about it. Your citations are the map, so nothing is guessed."
           />
           <Feature
+            title="Publish your reading, not just your notes"
+            what="A note written from a paper is commentary with the passages set into it — the argument, with the receipts."
+            doThis={
+              <>
+                Publish the note as you would any other, from <strong>Publish as a web page</strong>{" "}
+                in the properties panel.
+              </>
+            }
+            then="Every quotation on the page links back to the document in your repository, at the page it came from. The note itself keeps its ordinary relative links, so it still reads correctly on github.com."
+          />
+          <Feature
             title="Send a passage to something that is not ForkLeaf"
             what="The citation format is a relative path plus a standard fragment, so other tools can follow it."
             doThis={

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -143,6 +143,23 @@ export function HelpDialog({
             then="The widths are remembered on this device, and bounded so nothing can be dragged into uselessness."
           />
           <Feature
+            title="Borrow a note instead of copying it"
+            what="Copying a friend's note makes a second copy that is already going out of date, and neither of you can tell which is which."
+            doThis={
+              <>
+                <Mono>⌘K</Mono> → <strong>Borrow a note from another notebook</strong>, then give
+                their repository as <Mono>owner/name</Mono>.
+              </>
+            }
+            then={
+              <>
+                A link written into your note — <Mono>[[repo:ada/notes:runbook.md@a1b2c3d]]</Mono> —
+                pinned to the version you read. Theirs stays theirs, nothing is copied, and the link
+                keeps working after they change it.
+              </>
+            }
+          />
+          <Feature
             title="Try a rewrite without losing what you had"
             what="Rewriting a note you care about is a small act of courage. It should not be."
             doThis={

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -226,6 +226,18 @@ export function HelpDialog({
             then="Matches from every document you have opened, under Documents, with the sentence they were found in. Opening one goes straight to the page."
           />
           <Feature
+            title="Keep the paper and the note on the same page"
+            what="What people open two windows to fake: write about page 12, scroll the document to page 12, over and over."
+            doThis={
+              <>
+                Read the document <strong>beside the note</strong>, in Split or Source view, with at
+                least one passage already quoted. <Mono>⌘K</Mono> →{" "}
+                <strong>Stop the document following the note</strong> switches it off.
+              </>
+            }
+            then="Moving the cursor past a citation turns the document to that page; turning to a page scrolls the note to what you wrote about it. Your citations are the map, so nothing is guessed."
+          />
+          <Feature
             title="Send a passage to something that is not ForkLeaf"
             what="The citation format is a relative path plus a standard fragment, so other tools can follow it."
             doThis={

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -15,12 +15,14 @@ export interface HelpDialogProps {
   onConnectRepo: () => void;
 }
 
-type Tab = "start" | "writing" | "diagrams" | "sync" | "keys";
+type Tab = "start" | "writing" | "papers" | "diagrams" | "checks" | "sync" | "keys";
 
 const TABS: { id: Tab; label: string }[] = [
   { id: "start", label: "Getting started" },
   { id: "writing", label: "Writing" },
+  { id: "papers", label: "Papers & PDFs" },
   { id: "diagrams", label: "Diagrams" },
+  { id: "checks", label: "Checks & history" },
   { id: "sync", label: "GitHub & sync" },
   { id: "keys", label: "Shortcuts" },
 ];
@@ -134,11 +136,106 @@ export function HelpDialog({
             block at the top. That is why notes written here open correctly in Obsidian, Jekyll and
             Hugo.
           </Item>
+          <Feature
+            title="Make the columns the width you want"
+            what="Every panel here can be resized, including the reader."
+            doThis="Drag the seam between two panels. Double-click it to put it back; arrow keys move it too."
+            then="The widths are remembered on this device, and bounded so nothing can be dragged into uselessness."
+          />
+          <Feature
+            title="Search that knows what you are working on"
+            what="Typing “setup” in the middle of a project should find that project's setup."
+            doThis={
+              <>
+                <Mono>⌘K</Mono> with a note open.
+              </>
+            }
+            then="Notes linked to the one you are in float to the top — both the ones you linked to and the ones that linked to you. A note actually called what you typed still wins."
+          />
           <Item title="Export">
             <Mono>Export</Mono> in the header produces Markdown, PDF, HTML, Word or plain text.
             Everything is generated in your browser — the note is never uploaded anywhere to become
             a file.
           </Item>
+        </Section>
+      )}
+
+      {tab === "papers" && (
+        <Section>
+          <Feature
+            title="Read a paper in the notebook it belongs to"
+            what="A PDF in your repository is part of the notebook, not an attachment to it."
+            doThis={
+              <>
+                Click a <Mono>.pdf</Mono> in the sidebar, or drop one onto the window.
+              </>
+            }
+            then="It opens in the middle column, with its own table of contents beside it. Drag the seam between them to give either more room."
+          />
+          <Feature
+            title="Choose where PDFs open"
+            what="Three different things people do with a document, so three answers."
+            doThis={
+              <>
+                <Mono>⌘K</Mono> → <strong>Open PDFs in this window</strong>,{" "}
+                <strong>beside the note</strong>, or <strong>in their own browser tab</strong>.
+              </>
+            }
+            then="The one you pick is marked, and remembered on this device."
+          />
+          <Feature
+            title="Quote a passage into a note"
+            what="A citation that records the sentence, not just the page it was on."
+            doThis={
+              <>
+                Select text in the document, then <strong>Quote into note</strong>.
+              </>
+            }
+            then={
+              <>
+                A blockquote and an ordinary Markdown link —{" "}
+                <Mono>[On Attention, p. 12](paper.pdf#page=12…)</Mono> — that renders on github.com
+                and still finds the passage after the paper is revised.
+              </>
+            }
+          />
+          <Feature
+            title="See everything you have written about a paper"
+            what="Months later this list is the useful thing, not the paper."
+            doThis={
+              <>
+                Open the document and choose the <strong>Notes</strong> tab beside it.
+              </>
+            }
+            then="Every note quoting it, each with the passage it took and the page, in the document's own order. Click a passage to go to that page, or the note to open it."
+          />
+          <Feature
+            title="Start a note from a paper"
+            what="A page that already has the paper's shape, instead of a blank one."
+            doThis={<strong>Write about this</strong>}
+            then="A new note with the title, author and publication date filled in, and the paper's sections as headings — each linked to the page it starts on. The document moves aside and sits beside it."
+          />
+          <Feature
+            title="Search inside your documents"
+            what="The words in your papers, not only the words in your notes."
+            doThis={
+              <>
+                <Mono>⌘K</Mono> and type a phrase.
+              </>
+            }
+            then="Matches from every document you have opened, under Documents, with the sentence they were found in. Opening one goes straight to the page."
+          />
+          <Feature
+            title="Keep a PDF from your desktop"
+            what="A dropped file has no path in the repository, so nothing can link to it."
+            doThis={<strong>Save to notebook</strong>}
+            then={
+              <>
+                It is committed to a <Mono>papers/</Mono> folder beside your note, and its citations
+                become real links.
+              </>
+            }
+          />
         </Section>
       )}
 
@@ -161,10 +258,79 @@ export function HelpDialog({
             messages that point at the offending line, and a <strong>Syntax help</strong> panel you
             can click snippets out of. Both write the same code, and the preview updates as you go.
           </Item>
+          <Feature
+            title="A box can be a note"
+            what="Which turns a diagram into a map of the notebook rather than a picture of one."
+            doThis={
+              <>
+                Put a wikilink in the label: <Mono>A[&quot;[[Deploy runbook]]&quot;]</Mono>. An
+                alias works too — <Mono>[[deploy/runbook|The runbook]]</Mono>.
+              </>
+            }
+            then={
+              <>
+                The box reads <strong>Deploy runbook</strong> and opens that note when clicked in
+                the preview. It is still an ordinary Mermaid label, so the diagram renders on
+                github.com exactly as before.
+              </>
+            }
+          />
           <Item title="They are not locked in">
             A diagram is stored as an ordinary <Mono>```mermaid</Mono> code fence, so GitHub renders
             it natively when you view the file there, and so does anything else that speaks Mermaid.
           </Item>
+        </Section>
+      )}
+
+      {tab === "checks" && (
+        <Section>
+          <Feature
+            title="Are my quotations still true?"
+            what="Every other tool stores a page number, which quietly stops being right when a paper is revised."
+            doThis={
+              <>
+                <Mono>⌘K</Mono> → <strong>Check my citations against their documents</strong>
+              </>
+            }
+            then="Which quotations moved to another page, which matched only loosely, and which are no longer in the document at all. A moved one can have its page number corrected in place, one press per citation."
+          />
+          <Feature
+            title="What has gone stale?"
+            what="Notes rot quietly. Nobody opens a note to find out that it did."
+            doThis={
+              <>
+                <Mono>⌘K</Mono> → <strong>Check which of my notes have gone stale</strong>
+              </>
+            }
+            then={
+              <>
+                Notes pointing at a file that is not in the repository, <Mono>[[links]]</Mono>{" "}
+                matching no note, and datable claims nobody has looked at in years. Nothing is
+                changed — <strong>It is fine</strong> hides one until the note is edited again.
+              </>
+            }
+          />
+          <Feature
+            title="What did my notebook look like in March?"
+            what="Not one note's history — the whole notebook, on a day you choose."
+            doThis={
+              <>
+                <Mono>⌘K</Mono> → <strong>Show me my notebook as it was on…</strong>
+              </>
+            }
+            then="The files that existed that day, and any of them readable as it stood. Read-only: nothing here can change what you have now."
+          />
+          <Feature
+            title="Where did this paragraph come from?"
+            what="When you wrote it, and — more usefully — what it said before."
+            doThis={
+              <>
+                Properties panel → <strong>When each paragraph was written</strong>, then point at a
+                paragraph.
+              </>
+            }
+            then="The date it last changed, the commit and what else that commit touched, and the wording it replaced. Nothing is claimed for a paragraph that was added rather than rewritten."
+          />
         </Section>
       )}
 
@@ -234,6 +400,23 @@ export function HelpDialog({
               </>
             )}
           </Item>
+          <Feature
+            title="When an image is too big to send"
+            what="GitHub will not take more than about 3 MB in one request. The picture is fine; there is just more of it than the wire will carry."
+            doThis={
+              <>
+                Click the sync status in the bar at the bottom, then <strong>Resize</strong> beside
+                the file — as large as will still send, 1 MB, or 500 KB.
+              </>
+            }
+            then={
+              <>
+                It is re-encoded in the same format, replaces the copy on this device, and is pushed
+                again. <strong>Remove</strong> is still there, and now also takes the image out of
+                the notes that showed it, so nothing is left pointing at a file that has gone.
+              </>
+            }
+          />
           <Item title="Working across devices">
             Sign in with the same GitHub account on another machine and ForkLeaf pulls the
             repository down. Both devices commit to the same branch.
@@ -321,6 +504,47 @@ function Step({ n, title, children }: { n: number; title: string; children: Reac
         <h3 className="mb-1 text-[14px] font-semibold text-[var(--fl-text)]">{title}</h3>
         <div className="text-[13.5px] leading-relaxed text-[var(--fl-muted)]">{children}</div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * One feature, in three beats: what it is, what to do, what happens.
+ *
+ * The shape exists because a paragraph of prose about a feature is a paragraph
+ * people skim and then still do not know which button to press. Somebody
+ * opening help has one question — "how do I do the thing?" — and the answer is
+ * a command name and a sentence about the result. Anything longer belongs in
+ * the documentation, which is linked at the bottom of every tab.
+ */
+function Feature({
+  title,
+  what,
+  doThis,
+  then,
+}: {
+  title: string;
+  what: React.ReactNode;
+  /** The exact words on the button or in the palette, so it can be found. */
+  doThis: React.ReactNode;
+  then: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--fl-border)] px-3 py-2.5">
+      <h3 className="text-[14px] font-semibold text-[var(--fl-text)]">{title}</h3>
+      <p className="mt-0.5 text-[13px] leading-relaxed text-[var(--fl-muted)]">{what}</p>
+
+      <dl className="mt-2 grid grid-cols-[3.75rem_1fr] gap-x-3 gap-y-1">
+        <dt className="pt-[3px] text-[10.5px] font-semibold uppercase tracking-[0.1em] text-[var(--fl-muted)]">
+          Do
+        </dt>
+        <dd className="text-[13px] leading-relaxed text-[var(--fl-text)]">{doThis}</dd>
+
+        <dt className="pt-[3px] text-[10.5px] font-semibold uppercase tracking-[0.1em] text-[var(--fl-muted)]">
+          You get
+        </dt>
+        <dd className="text-[13px] leading-relaxed text-[var(--fl-muted)]">{then}</dd>
+      </dl>
     </div>
   );
 }

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -234,6 +234,19 @@ export function HelpDialog({
             }
           />
           <Feature
+            title="A scan, or a paper every device re-reads"
+            what="A scan is a photograph of a page: nothing in it can be searched, quoted or checked. And a paper that does carry its text has it read again on every device, every time."
+            doThis={
+              <>
+                Recognise a scan&rsquo;s words once with a tool like <Mono>ocrmypdf</Mono> and
+                commit the result beside it as <Mono>&lt;name&gt;.text.md</Mono>, a{" "}
+                <Mono>## Page 1</Mono> heading per page. For a paper that already has text,{" "}
+                <Mono>⌘K</Mono> → <strong>Keep this document&rsquo;s text beside it</strong>.
+              </>
+            }
+            then="The reader uses that file when the document has nothing of its own, so search, quotations and the citation check start working on a scan — and no other device has to read the document again. Correcting a mangled line in the file corrects it everywhere."
+          />
+          <Feature
             title="Highlight a passage, and keep it as a text file"
             what="Everybody else locks a highlight inside the PDF, or inside their own app, where you can never get it out."
             doThis={

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -397,6 +397,17 @@ export function HelpDialog({
             then="The reader fixes the note in GitHub's editor and their change arrives in your list. Read what changed on GitHub, and accept it here — the next sync brings it down to this device."
           />
           <Feature
+            title="What changed in this paper since I read it?"
+            what="The document is in a repository, so every version of it is kept — which no other reading app can say."
+            doThis={
+              <>
+                Open the document, then <Mono>⌘K</Mono> →{" "}
+                <strong>See what changed in this document</strong> and pick an earlier version.
+              </>
+            }
+            then="Which pages changed, comparing the words rather than the bytes — and, if one of them is a page you quoted, it says so. Whether your quotation itself survived is what the citation check answers."
+          />
+          <Feature
             title="What did my notebook look like in March?"
             what="Not one note's history — the whole notebook, on a day you choose."
             doThis={

--- a/apps/web/src/components/PdfPage.tsx
+++ b/apps/web/src/components/PdfPage.tsx
@@ -27,8 +27,11 @@ import { rectsForRange, type PdfPageText, type PdfSession } from "@forkleaf/pdf"
 export interface PdfHighlight {
   /** Character range in this page's text. */
   range: [number, number];
-  /** `citation` is the passage a link points at; `search` is a find result. */
-  kind: "citation" | "search";
+  /**
+   * `citation` is the passage a link points at, `search` a find result, and
+   * `highlight` something the reader marked and kept.
+   */
+  kind: "citation" | "search" | "highlight";
   /** The one the reader is currently on, drawn more strongly. */
   current?: boolean;
 }
@@ -120,9 +123,11 @@ export function PdfPage({
                     background:
                       highlight.kind === "citation"
                         ? "var(--fl-hl-yellow)"
-                        : highlight.current
-                          ? "var(--fl-hl-pink)"
-                          : "var(--fl-hl-blue)",
+                        : highlight.kind === "highlight"
+                          ? "var(--fl-hl-green)"
+                          : highlight.current
+                            ? "var(--fl-hl-pink)"
+                            : "var(--fl-hl-blue)",
                   }}
                 />
               ))

--- a/apps/web/src/components/PdfReader.test.tsx
+++ b/apps/web/src/components/PdfReader.test.tsx
@@ -61,6 +61,9 @@ const loading: PdfReaderState = {
   outline: [],
   pages: [],
   indexing: false,
+  scanned: false,
+  textSupplied: false,
+  supplyText: () => {},
   error: null,
   open: () => {},
   close: () => {},
@@ -291,5 +294,58 @@ describe("PdfReader — marking a passage", () => {
     );
 
     expect(document.querySelectorAll("[data-pdf-page]")).toHaveLength(0);
+  });
+});
+
+/**
+ * A scan is a photograph of a page. Saying so, and saying what would fix it,
+ * beats letting somebody search it and find nothing.
+ */
+describe("PdfReader — a document with no text of its own", () => {
+  const scan: PdfReaderState = { ...loading, status: "ready", scanned: true };
+
+  it("says it is a scan, and names the file that would fix it", () => {
+    render(<PdfReader reader={scan} layout="document" path="papers/minutes.pdf" onClose={null} />);
+
+    expect(screen.getByText(/photographs of pages/)).toBeTruthy();
+    expect(screen.getByText("minutes.text.md")).toBeTruthy();
+  });
+
+  it("suggests no file for a document that is not in the notebook", () => {
+    // Nowhere to commit one, so naming a path would be advice nobody can take.
+    render(<PdfReader reader={scan} layout="document" path={null} onClose={null} />);
+
+    expect(screen.getByText(/photographs of pages/)).toBeTruthy();
+    expect(screen.queryByText(/\.text\.md/)).toBeNull();
+  });
+
+  it("says where the words came from once they have been supplied", () => {
+    render(
+      <PdfReader
+        reader={{ ...scan, scanned: false, textSupplied: true }}
+        layout="document"
+        path="papers/minutes.pdf"
+        onClose={null}
+      />,
+    );
+
+    expect(screen.getByText(/text from the file beside it/)).toBeTruthy();
+    expect(screen.queryByText(/photographs of pages/)).toBeNull();
+  });
+
+  it("says nothing of the kind while the document is still being read", () => {
+    // "No text yet" and "no text at all" look identical until the reading
+    // finishes, and calling a paper a photograph while it loads would be wrong
+    // about half the documents that ever open.
+    render(
+      <PdfReader
+        reader={{ ...loading, status: "ready", indexing: true }}
+        layout="document"
+        path="papers/minutes.pdf"
+        onClose={null}
+      />,
+    );
+
+    expect(screen.queryByText(/photographs of pages/)).toBeNull();
   });
 });

--- a/apps/web/src/components/PdfReader.test.tsx
+++ b/apps/web/src/components/PdfReader.test.tsx
@@ -266,3 +266,30 @@ describe("PdfReader — following the note", () => {
     expect(onPageChange).toHaveBeenCalledWith(1);
   });
 });
+
+/**
+ * Everybody else locks a highlight inside the PDF or inside their own app.
+ * Here it is a line in a text file, and the page draws what the file says.
+ */
+describe("PdfReader — marking a passage", () => {
+  it("offers no marking for a document the notebook cannot keep marks beside", () => {
+    // From a desktop: there is nowhere to write the file.
+    render(<PdfReader reader={loading} layout="document" onHighlight={null} onClose={null} />);
+    expect(screen.queryByRole("button", { name: /Highlight/ })).toBeNull();
+  });
+
+  it("draws nothing for a document whose text has not been read yet", () => {
+    // The words cannot be looked for until the pages have been extracted, and
+    // a highlight is found by its words rather than trusted to a page number.
+    render(
+      <PdfReader
+        reader={loading}
+        layout="document"
+        highlights={[{ page: 1, quote: "a passage", prefix: "", suffix: "" }]}
+        onClose={null}
+      />,
+    );
+
+    expect(document.querySelectorAll("[data-pdf-page]")).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/PdfReader.test.tsx
+++ b/apps/web/src/components/PdfReader.test.tsx
@@ -241,3 +241,28 @@ describe("PdfReader — a link anything can follow", () => {
     expect(screen.queryByRole("button", { name: /Copy link/ })).toBeNull();
   });
 });
+
+describe("PdfReader — following the note", () => {
+  it("turns to a page it is asked for, and only when the request changes", () => {
+    const { rerender } = render(
+      <PdfReader reader={loading} layout="document" showPage={null} onClose={null} />,
+    );
+
+    // jsdom has no layout, so what is under test is the decision to scroll,
+    // not the scrolling: the page is recorded as current either way.
+    rerender(<PdfReader reader={loading} layout="document" showPage={4} onClose={null} />);
+    rerender(<PdfReader reader={loading} layout="document" showPage={4} onClose={null} />);
+
+    // No throw, no loop: asking twice for the same page is not two requests.
+    expect(screen.getByLabelText("Contents and search")).toBeTruthy();
+  });
+
+  it("reports the page it is on, so the note can follow it back", () => {
+    const onPageChange = vi.fn();
+    render(
+      <PdfReader reader={loading} layout="document" onPageChange={onPageChange} onClose={null} />,
+    );
+
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/web/src/components/PdfReader.test.tsx
+++ b/apps/web/src/components/PdfReader.test.tsx
@@ -203,3 +203,41 @@ describe("PdfReader — starting a note from the paper", () => {
     expect(screen.queryByRole("button", { name: /Start a note about this paper/ })).toBeNull();
   });
 });
+
+/**
+ * The one thing here that could outlive ForkLeaf: a citation is a relative
+ * path plus a standard fragment, and anything can follow it.
+ */
+describe("PdfReader — a link anything can follow", () => {
+  const withText: PdfReaderState = {
+    ...loading,
+    status: "ready",
+    pages: [
+      {
+        page: 1,
+        text: "We show that attention is all you need, and the rest is engineering.",
+        runs: [],
+      },
+    ],
+    info: {
+      pageCount: 1,
+      metadata: {
+        title: null,
+        author: null,
+        subject: null,
+        keywords: [],
+        createdAt: null,
+        modifiedAt: null,
+        producer: null,
+      },
+      sizes: [],
+      encrypted: false,
+    },
+  };
+
+  it("offers no link for a document that has no path to link to", () => {
+    // A PDF from a desktop: a link naming a file nobody else has is not a link.
+    render(<PdfReader reader={withText} layout="document" path={null} onClose={null} />);
+    expect(screen.queryByRole("button", { name: /Copy link/ })).toBeNull();
+  });
+});

--- a/apps/web/src/components/PdfReader.tsx
+++ b/apps/web/src/components/PdfReader.tsx
@@ -93,6 +93,16 @@ export interface PdfReaderProps {
   /** Reports the page now on screen, so the note can follow it back. */
   onPageChange?: ((page: number) => void) | null;
   /**
+   * A one-off request to turn to a page, from somewhere outside the reader.
+   *
+   * Separate from `showPage`, which is a value derived from where the note's
+   * cursor is and may therefore be the same number twice in a row without
+   * meaning "go there again". This carries an id so that asking for the same
+   * page a second time is a second request — which is what a reader pressing
+   * "p. 12" twice plainly means.
+   */
+  jumpTo?: { page: number; id: number } | null;
+  /**
    * Where this document lives, so a link to a passage can name it.
    *
    * Null for one opened from a desktop: there is no path for a link to point
@@ -194,6 +204,7 @@ export function PdfReader({
   onHighlight = null,
   showPage = null,
   onPageChange = null,
+  jumpTo = null,
   path = null,
   onStartNote = null,
   mentions = null,
@@ -369,6 +380,15 @@ export function PdfReader({
   useEffect(() => {
     onPageChange?.(current);
   }, [current, onPageChange]);
+
+  /** The last one-off request acted on, so it is acted on exactly once. */
+  const jumpedTo = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!jumpTo || jumpedTo.current === jumpTo.id) return;
+    jumpedTo.current = jumpTo.id;
+    goToPage(jumpTo.page);
+  }, [jumpTo, goToPage]);
 
   // ─── Search ───────────────────────────────────────────────────────────────
 

--- a/apps/web/src/components/PdfReader.tsx
+++ b/apps/web/src/components/PdfReader.tsx
@@ -73,6 +73,16 @@ export interface PdfReaderProps {
    */
   onOpenInTab?: (() => void) | null;
   /**
+   * A page to turn to, when the note beside the document moves to it.
+   *
+   * Watched rather than called, so the caller can say "page 12" as often as it
+   * likes without the reader jumping every time a render happens: the page is
+   * only turned when the number actually changes.
+   */
+  showPage?: number | null;
+  /** Reports the page now on screen, so the note can follow it back. */
+  onPageChange?: ((page: number) => void) | null;
+  /**
    * Where this document lives, so a link to a passage can name it.
    *
    * Null for one opened from a desktop: there is no path for a link to point
@@ -170,6 +180,8 @@ export function PdfReader({
   onSave,
   saveHint,
   saving = false,
+  showPage = null,
+  onPageChange = null,
   path = null,
   onStartNote = null,
   mentions = null,
@@ -326,6 +338,25 @@ export function PdfReader({
     container.scrollTo({ top: target.offsetTop - 16, behavior: "smooth" });
     setCurrent(page);
   }, []);
+
+  /**
+   * Follows the note beside the document.
+   *
+   * Only on a change of the *asked-for* page, never on a change of the page
+   * showing: scrolling the document sets `current`, which would otherwise be
+   * read back as an instruction and scroll it again.
+   */
+  const asked = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (showPage == null || asked.current === showPage) return;
+    asked.current = showPage;
+    goToPage(showPage);
+  }, [showPage, goToPage]);
+
+  useEffect(() => {
+    onPageChange?.(current);
+  }, [current, onPageChange]);
 
   // ─── Search ───────────────────────────────────────────────────────────────
 

--- a/apps/web/src/components/PdfReader.tsx
+++ b/apps/web/src/components/PdfReader.tsx
@@ -213,6 +213,7 @@ export function PdfReader({
   layout = "panel",
 }: PdfReaderProps) {
   const { status, info, source, session, outline, pages, indexing, error } = reader;
+  const { scanned, textSupplied } = reader;
 
   const frameRef = useRef<HTMLElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -635,6 +636,11 @@ export function PdfReader({
             {info ? `${info.pageCount} page${info.pageCount === 1 ? "" : "s"}` : "Opening…"}
             {section ? ` · ${section.title}` : ""}
             {indexing ? " · reading text…" : ""}
+            {/* Where the words came from, when they did not come from the
+                document. Somebody searching a scan should know that what they
+                are searching is a file somebody else made. */}
+            {textSupplied ? " · text from the file beside it" : ""}
+            {scanned && !textSupplied ? " · a scan: no text to search or quote" : ""}
           </p>
         </div>
 
@@ -768,6 +774,23 @@ export function PdfReader({
           ) : null}
           {status === "error" ? <Notice tone="danger">{error}</Notice> : null}
 
+          {/* Said once, where the pages are, rather than left for somebody to
+              discover by searching and finding nothing. */}
+          {scanned && !textSupplied ? (
+            <Notice tone="warn">
+              This document is a scan — photographs of pages, with no text in it. Nothing here can
+              be searched, quoted or checked until its words are recognised.
+              {path ? (
+                <>
+                  {" "}
+                  Recognise them once with a tool like <code>ocrmypdf</code> and commit the result
+                  beside it as <code>{textFileName(path)}</code>; every device then reads it from
+                  there.
+                </>
+              ) : null}
+            </Notice>
+          ) : null}
+
           {status === "ready" && info && session ? (
             <div className="flex flex-col items-center gap-4">
               {info.sizes.map((size, index) => {
@@ -884,6 +907,12 @@ export function PdfReader({
 }
 
 /** The highlights a page should show, from the citation and the search. */
+/** `papers/attention.pdf` → `attention.text.md`, for saying it in a sentence. */
+function textFileName(pdfPath: string): string {
+  const name = pdfPath.split("/").pop() ?? pdfPath;
+  return `${name.replace(/\.pdf$/i, "")}.text.md`;
+}
+
 function highlightsFor(
   page: number,
   located: { page: number; range: [number, number] } | null,

--- a/apps/web/src/components/PdfReader.tsx
+++ b/apps/web/src/components/PdfReader.tsx
@@ -73,6 +73,16 @@ export interface PdfReaderProps {
    */
   onOpenInTab?: (() => void) | null;
   /**
+   * The passages this reader has marked and kept, drawn over the page.
+   *
+   * Resolved against the document as it is now rather than trusted: a
+   * highlight records the words, so one made against last year's version of a
+   * paper is still drawn in the right place after the author adds a figure.
+   */
+  highlights?: readonly PdfCitation[];
+  /** Marks the selected passage, or unmarks it if it is already marked. */
+  onHighlight?: ((citation: PdfCitation, marked: boolean) => void) | null;
+  /**
    * A page to turn to, when the note beside the document moves to it.
    *
    * Watched rather than called, so the caller can say "page 12" as often as it
@@ -180,6 +190,8 @@ export function PdfReader({
   onSave,
   saveHint,
   saving = false,
+  highlights = [],
+  onHighlight = null,
   showPage = null,
   onPageChange = null,
   path = null,
@@ -514,6 +526,40 @@ export function PdfReader({
     });
   }, []);
 
+  /**
+   * Every kept highlight, located in the document on screen.
+   *
+   * Recomputed when the text arrives rather than when the file is read: the
+   * words cannot be looked for until the pages have been extracted, and a
+   * highlight that could not be found is simply not drawn — the file still
+   * has it, and saying "this passage has gone" is the citation check's job.
+   */
+  const marked = useMemo(() => {
+    if (highlights.length === 0 || pages.length === 0) return [];
+
+    const found: { page: number; range: [number, number] }[] = [];
+
+    for (const citation of highlights) {
+      const match = reader.locate(citation);
+      // A passage no longer in the document is simply not drawn. The file
+      // still holds it, and saying "this has gone" is the citation check's
+      // job rather than the page's.
+      if (match?.page != null && match.range != null) {
+        found.push({ page: match.page, range: match.range });
+      }
+    }
+
+    return found;
+  }, [highlights, pages, reader]);
+
+  /** Whether the passage selected right now is one already kept. */
+  const selectionMarked = useMemo(() => {
+    const citation = citationFor();
+    if (!citation) return false;
+    const wanted = citation.quote.replace(/\s+/g, " ").trim();
+    return highlights.some((held) => held.quote.replace(/\s+/g, " ").trim() === wanted);
+  }, [citationFor, highlights]);
+
   const section = useMemo(
     () => (outline.length > 0 ? outlineEntryForPage(outline, current) : null),
     [outline, current],
@@ -715,7 +761,7 @@ export function PdfReader({
                     scale={scale}
                     text={pageText(page)}
                     visible={visible.has(page)}
-                    highlights={highlightsFor(page, located, hits, hitIndex)}
+                    highlights={highlightsFor(page, located, hits, hitIndex, marked)}
                     onSelect={onSelect}
                   />
                 );
@@ -730,6 +776,18 @@ export function PdfReader({
               reason={noCiteReason}
               copied={copied}
               onCite={cite}
+              onHighlight={
+                onHighlight
+                  ? () => {
+                      const citation = citationFor();
+                      if (!citation) return;
+                      onHighlight(citation, !selectionMarked);
+                      setSelection(null);
+                      window.getSelection()?.removeAllRanges();
+                    }
+                  : null
+              }
+              highlightLabel={selectionMarked ? "Unhighlight" : "Highlight"}
               onCopyLink={path ? () => void copyLink() : null}
               onCopy={async () => {
                 const text = pageText(selection.page)?.text.slice(selection.start, selection.end);
@@ -811,8 +869,13 @@ function highlightsFor(
   located: { page: number; range: [number, number] } | null,
   hits: readonly PdfSearchHit[],
   hitIndex: number,
+  marked: readonly { page: number; range: [number, number] }[] = [],
 ): PdfHighlight[] {
   const highlights: PdfHighlight[] = [];
+
+  for (const held of marked) {
+    if (held.page === page) highlights.push({ range: held.range, kind: "highlight" });
+  }
 
   if (located?.page === page) {
     highlights.push({ range: located.range, kind: "citation" });
@@ -843,6 +906,8 @@ function CiteBar({
   reason,
   copied,
   onCite,
+  onHighlight,
+  highlightLabel,
   onCopyLink,
   onCopy,
   onDismiss,
@@ -852,6 +917,9 @@ function CiteBar({
   reason: string | null;
   copied: boolean;
   onCite: (withQuote: boolean) => void;
+  /** Marks the passage, in a text file beside the document. */
+  onHighlight: (() => void) | null;
+  highlightLabel: string;
   /** Puts a plain web link to this passage on the clipboard. */
   onCopyLink: (() => void) | null;
   onCopy: () => void | Promise<void>;
@@ -867,6 +935,14 @@ function CiteBar({
           </>
         ) : reason ? (
           <span className="px-2 text-xs text-[var(--fl-muted)]">{reason}</span>
+        ) : null}
+        {onHighlight ? (
+          <BarButton
+            onClick={onHighlight}
+            title="Keeps this passage in a text file beside the document"
+          >
+            {highlightLabel}
+          </BarButton>
         ) : null}
         {onCopyLink ? (
           <BarButton

--- a/apps/web/src/components/PdfReader.tsx
+++ b/apps/web/src/components/PdfReader.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  citationLink,
   createCitation,
   displayTitle,
   serializeCitation,
@@ -71,6 +72,13 @@ export interface PdfReaderProps {
    * window's memory.
    */
   onOpenInTab?: (() => void) | null;
+  /**
+   * Where this document lives, so a link to a passage can name it.
+   *
+   * Null for one opened from a desktop: there is no path for a link to point
+   * at, and a link naming a file nobody else has is not a link.
+   */
+  path?: string | null;
   /**
    * Starts a note about this paper, with its headings already in it.
    *
@@ -162,6 +170,7 @@ export function PdfReader({
   onSave,
   saveHint,
   saving = false,
+  path = null,
   onStartNote = null,
   mentions = null,
   onOpenMention = null,
@@ -406,6 +415,26 @@ export function PdfReader({
     },
     [citationFor, onCite],
   );
+
+  /**
+   * The passage as a link anything can follow.
+   *
+   * Not a ForkLeaf address: `papers/x.pdf#page=12&q=…` is a relative path plus
+   * a fragment, which is a plain web link. Every PDF reader has understood
+   * `#page=` for twenty years, and the rest is the W3C Web Annotation text
+   * selector spelled into a query string — so a tool that has never heard of
+   * this app can still open the right page, and one that reads the quotation
+   * can find the right sentence. See /docs/citation-links.
+   */
+  const copyLink = useCallback(async () => {
+    const citation = citationFor();
+    if (!citation || !path) return;
+
+    await navigator.clipboard.writeText(citationLink(path, citation));
+    setCopied(true);
+    setSelection(null);
+    window.getSelection()?.removeAllRanges();
+  }, [citationFor, path]);
 
   // ─── Keyboard ─────────────────────────────────────────────────────────────
 
@@ -670,6 +699,7 @@ export function PdfReader({
               reason={noCiteReason}
               copied={copied}
               onCite={cite}
+              onCopyLink={path ? () => void copyLink() : null}
               onCopy={async () => {
                 const text = pageText(selection.page)?.text.slice(selection.start, selection.end);
                 if (!text) return;
@@ -782,6 +812,7 @@ function CiteBar({
   reason,
   copied,
   onCite,
+  onCopyLink,
   onCopy,
   onDismiss,
 }: {
@@ -790,6 +821,8 @@ function CiteBar({
   reason: string | null;
   copied: boolean;
   onCite: (withQuote: boolean) => void;
+  /** Puts a plain web link to this passage on the clipboard. */
+  onCopyLink: (() => void) | null;
   onCopy: () => void | Promise<void>;
   onDismiss: () => void;
 }) {
@@ -803,6 +836,14 @@ function CiteBar({
           </>
         ) : reason ? (
           <span className="px-2 text-xs text-[var(--fl-muted)]">{reason}</span>
+        ) : null}
+        {onCopyLink ? (
+          <BarButton
+            onClick={onCopyLink}
+            title="A plain link to this passage, for anything outside ForkLeaf"
+          >
+            Copy link
+          </BarButton>
         ) : null}
         <BarButton onClick={() => void onCopy()}>{copied ? "Copied" : "Copy"}</BarButton>
         <BarButton onClick={onDismiss} aria-label="Dismiss">

--- a/apps/web/src/components/PublishDialog.tsx
+++ b/apps/web/src/components/PublishDialog.tsx
@@ -6,6 +6,7 @@ import { deriveTitle, slugifyFilename, stripExtension } from "@forkleaf/markdown
 import { toHtml } from "@forkleaf/exporter";
 import { ApiGatewayError, publishNote, unpublishNote } from "@/lib/gateway";
 import { Dialog } from "./Dialog";
+import { linkDocuments } from "@/lib/publish-citations";
 import {
   describeTarget,
   isSplitPublishing,
@@ -115,7 +116,17 @@ export function PublishDialog({
 
       try {
         setStep("Rendering the page…");
-        const html = await toHtml(note.content, note.frontmatter, {
+
+        // Citations are written relative to the note, which is right in the
+        // repository and reaches nothing from a page served out of `docs/`.
+        // Only the published copy is rewritten; the note keeps its relative
+        // links, because that is what makes it readable everywhere else.
+        const body = linkDocuments(note.content, {
+          notePath: note.path,
+          repo: workspace.repo,
+        });
+
+        const html = await toHtml(body, note.frontmatter, {
           format: "html",
           title,
           includeFrontmatter: false,

--- a/apps/web/src/components/PublishDialog.tsx
+++ b/apps/web/src/components/PublishDialog.tsx
@@ -11,6 +11,7 @@ import {
   isSplitPublishing,
   parseTarget,
   publishTargetOf,
+  suggestEditUrl,
   targetWarning,
 } from "@/lib/publish-target";
 
@@ -120,6 +121,9 @@ export function PublishDialog({
           includeFrontmatter: false,
           renderDiagrams: true,
           theme: "light",
+          // The reader's way to send a correction back. Points at the note in
+          // the repository it came from, never at the published copy.
+          suggestUrl: suggestEditUrl(workspace.repo, note.path),
         });
 
         setStep("Committing it to your repository…");
@@ -133,7 +137,7 @@ export function PublishDialog({
         setStage("idle");
       }
     },
-    [note, title, slug, onChanged],
+    [note, title, slug, onChanged, workspace.repo],
   );
 
   const publish = useCallback(() => publishTo(target), [publishTo, target]);

--- a/apps/web/src/components/ReaderWindow.tsx
+++ b/apps/web/src/components/ReaderWindow.tsx
@@ -122,6 +122,7 @@ export function ReaderWindow() {
         // rather than behind a button.
         layout="document"
         reader={reader}
+        path={target?.path ?? null}
         initialCitation={citation}
         onCite={copyCitation}
         citeLabels={{

--- a/apps/web/src/components/SuggestionsDialog.test.tsx
+++ b/apps/web/src/components/SuggestionsDialog.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { RepoRef } from "@forkleaf/types";
+
+const listSuggestions = vi.fn();
+const acceptSuggestion = vi.fn();
+
+vi.mock("@/lib/gateway", () => ({
+  listSuggestions: (...args: unknown[]) => listSuggestions(...args),
+  acceptSuggestion: (...args: unknown[]) => acceptSuggestion(...args),
+}));
+
+const { SuggestionsDialog } = await import("./SuggestionsDialog");
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const REPO: RepoRef = { owner: "me", repo: "notes", branch: "main", directory: "" };
+
+const suggestion = (over: Record<string, unknown> = {}) => ({
+  number: 7,
+  url: "https://github.com/me/notes/pull/7",
+  state: "open",
+  title: "Fix the version in the deploy runbook",
+  draft: false,
+  head: "reader:patch-1",
+  base: "main",
+  author: "a-reader",
+  updatedAt: new Date().toISOString(),
+  ...over,
+});
+
+function open(over: Partial<React.ComponentProps<typeof SuggestionsDialog>> = {}) {
+  const props = { onClose: vi.fn(), repo: REPO, onAccepted: vi.fn(), ...over };
+  render(<SuggestionsDialog {...props} />);
+  return props;
+}
+
+describe("SuggestionsDialog — the list", () => {
+  it("names who suggested what, and where it would land", async () => {
+    listSuggestions.mockResolvedValue([suggestion()]);
+    open();
+
+    expect(await screen.findByText("Fix the version in the deploy runbook")).toBeTruthy();
+    expect(screen.getByText(/by a-reader/)).toBeTruthy();
+    expect(screen.getByText(/reader:patch-1 → main/)).toBeTruthy();
+  });
+
+  /**
+   * The empty state has work to do: somebody who has never been sent a
+   * suggestion does not know the feature exists, and this is the one place
+   * they will read about it.
+   */
+  it("explains how one would arrive when there are none", async () => {
+    listSuggestions.mockResolvedValue([]);
+    open();
+
+    expect(await screen.findByText(/Nothing has been suggested yet/)).toBeTruthy();
+    expect(screen.getByText("Suggest an edit")).toBeTruthy();
+  });
+
+  it("says so when GitHub cannot be read", async () => {
+    listSuggestions.mockRejectedValue(new Error("Bad credentials"));
+    open();
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+  });
+});
+
+describe("SuggestionsDialog — accepting one", () => {
+  it("merges it, and tells the notebook to catch up", async () => {
+    listSuggestions.mockResolvedValue([suggestion()]);
+    acceptSuggestion.mockResolvedValue({ merged: true, sha: "abc" });
+    const props = open();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Accept" }));
+
+    await waitFor(() =>
+      expect(acceptSuggestion).toHaveBeenCalledWith({
+        owner: "me",
+        repo: "notes",
+        number: 7,
+        title: "Fix the version in the deploy runbook",
+      }),
+    );
+    expect(await screen.findByText(/It is in your notes now/)).toBeTruthy();
+    // Merged on GitHub is not the same as present on this device.
+    expect(props.onAccepted).toHaveBeenCalled();
+  });
+
+  it("passes GitHub's own words on when it refuses", async () => {
+    listSuggestions.mockResolvedValue([suggestion()]);
+    acceptSuggestion.mockRejectedValue(
+      new Error("this branch has conflicts that must be resolved"),
+    );
+    open();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Accept" }));
+
+    // Better than ours: it says exactly what to do next, on a page that can
+    // do it.
+    expect(await screen.findByText(/conflicts that must be resolved/)).toBeTruthy();
+  });
+
+  it("will not accept a draft, which is not finished being written", async () => {
+    listSuggestions.mockResolvedValue([suggestion({ draft: true })]);
+    open();
+
+    expect((await screen.findByRole("button", { name: "Accept" })).hasAttribute("disabled")).toBe(
+      true,
+    );
+  });
+
+  it("sends reading a suggestion to GitHub, where the diff is", async () => {
+    listSuggestions.mockResolvedValue([suggestion()]);
+    open();
+
+    const link = await screen.findByRole("link", { name: /Read what changed/ });
+    expect(link.getAttribute("href")).toBe("https://github.com/me/notes/pull/7");
+  });
+});

--- a/apps/web/src/components/SuggestionsDialog.tsx
+++ b/apps/web/src/components/SuggestionsDialog.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { RepoRef } from "@forkleaf/types";
+import { Dialog } from "@/components/Dialog";
+import { acceptSuggestion, listSuggestions, type SuggestionDto } from "@/lib/gateway";
+import { relativeTime } from "@/lib/relative-time";
+
+/**
+ * What other people have suggested you change.
+ *
+ * Programmers have had "here is a fix for what you wrote" for twenty years and
+ * call it a pull request. Nobody has ever offered it to people writing notes: a
+ * published page is something you read, and that is where it ends — a reader
+ * who spots a mistake can email you about it, and usually does not.
+ *
+ * A published ForkLeaf page now carries **Suggest an edit**, which takes the
+ * reader to the note in GitHub's own editor, where their change becomes a pull
+ * request without anybody having to know that word. This is the other end of
+ * it: the author's list, in the app they write in, with the one action that
+ * matters on each.
+ *
+ * Reading a suggestion still happens on GitHub. That is deliberate rather than
+ * unfinished — a diff with a conversation attached is a thing GitHub is
+ * extremely good at, and a worse copy of it here would be a worse copy of it
+ * here. Accepting one, which is the part that belongs to the person whose
+ * notebook it is, happens here.
+ */
+
+export interface SuggestionsDialogProps {
+  onClose: () => void;
+  repo: RepoRef;
+  /** Re-reads the notebook after one is accepted, so the notes catch up. */
+  onAccepted?: () => void | Promise<void>;
+}
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ready"; pulls: SuggestionDto[] }
+  | { kind: "error"; message: string };
+
+export function SuggestionsDialog({ onClose, repo, onAccepted }: SuggestionsDialogProps) {
+  const [state, setState] = useState<State>({ kind: "loading" });
+  /** The suggestion being merged, so its row can say so. */
+  const [accepting, setAccepting] = useState<number | null>(null);
+  const [accepted, setAccepted] = useState<Set<number>>(new Set());
+  const [problem, setProblem] = useState<string | null>(null);
+
+  /**
+   * Reads the list, once, when the dialog opens.
+   *
+   * The state moves in the promise's callbacks rather than in the effect
+   * body: the dialog already opens in "loading", so writing it again on the
+   * way in would be a render spent saying what the previous render said.
+   */
+  useEffect(() => {
+    let live = true;
+
+    void listSuggestions(repo.owner, repo.repo)
+      .then((pulls) => {
+        if (live) setState({ kind: "ready", pulls });
+      })
+      .catch((error: unknown) => {
+        if (!live) return;
+        setState({
+          kind: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "The suggestions could not be read from GitHub.",
+        });
+      });
+
+    return () => {
+      live = false;
+    };
+  }, [repo.owner, repo.repo]);
+
+  const accept = useCallback(
+    async (pull: SuggestionDto) => {
+      setAccepting(pull.number);
+      setProblem(null);
+
+      try {
+        await acceptSuggestion({
+          owner: repo.owner,
+          repo: repo.repo,
+          number: pull.number,
+          title: pull.title,
+        });
+        setAccepted((current) => new Set(current).add(pull.number));
+        await onAccepted?.();
+      } catch (error: unknown) {
+        // Usually a conflict, and GitHub's own words are better than ours:
+        // "this branch has conflicts that must be resolved" says exactly what
+        // to do next, on a page that can do it.
+        setProblem(
+          error instanceof Error ? error.message : "GitHub would not accept that suggestion.",
+        );
+      } finally {
+        setAccepting(null);
+      }
+    },
+    [repo.owner, repo.repo, onAccepted],
+  );
+
+  return (
+    <Dialog
+      title="Suggestions"
+      subtitle="Changes other people have proposed to this notebook"
+      onClose={onClose}
+      wide
+    >
+      {state.kind === "loading" && (
+        <p aria-busy="true" className="text-[13px] text-[var(--fl-muted)]">
+          Reading what is open on {repo.owner}/{repo.repo}…
+        </p>
+      )}
+
+      {state.kind === "error" && (
+        <p role="alert" className="text-[13px] text-[var(--fl-danger)]">
+          {state.message}
+        </p>
+      )}
+
+      {state.kind === "ready" && state.pulls.length === 0 && (
+        <div className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+          <p className="max-w-2xl">Nothing has been suggested yet.</p>
+          <p className="mt-2 max-w-2xl">
+            Every page you publish carries a <strong>Suggest an edit</strong> link. A reader who
+            spots a mistake follows it, fixes the note in GitHub&rsquo;s editor, and their change
+            arrives here for you to accept or decline — without either of you having to say the
+            words &ldquo;pull request&rdquo;.
+          </p>
+        </div>
+      )}
+
+      {state.kind === "ready" && state.pulls.length > 0 && (
+        <div className="text-[13px]">
+          {problem && (
+            <p role="alert" className="mb-2 text-[12.5px] text-[var(--fl-danger)]">
+              {problem}
+            </p>
+          )}
+
+          <ul className="space-y-2">
+            {state.pulls.map((pull) => (
+              <li
+                key={pull.number}
+                className="rounded-lg border border-[var(--fl-border)] bg-[var(--fl-elevated)] p-2.5"
+              >
+                <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                  <span className="text-[13.5px] font-medium text-[var(--fl-text)]">
+                    {pull.title}
+                  </span>
+                  {pull.draft && (
+                    <span className="rounded bg-[var(--fl-surface)] px-1.5 py-px text-[10.5px] uppercase tracking-wide text-[var(--fl-muted)]">
+                      draft
+                    </span>
+                  )}
+                </div>
+
+                <p className="mt-0.5 text-[11.5px] text-[var(--fl-muted)]">
+                  #{pull.number} · {pull.author ? `by ${pull.author}` : "by somebody"}
+                  {pull.updatedAt ? ` · ${relativeTime(pull.updatedAt)}` : ""} ·{" "}
+                  <span className="font-mono text-[11px]">
+                    {pull.head} → {pull.base}
+                  </span>
+                </p>
+
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <a
+                    href={pull.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="rounded border border-[var(--fl-border)] px-2 py-1 text-[11.5px] font-medium text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-surface)]"
+                  >
+                    Read what changed
+                  </a>
+
+                  {accepted.has(pull.number) ? (
+                    <span className="text-[11.5px] text-[var(--fl-muted)]">
+                      Accepted. It is in your notes now.
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled={accepting !== null || pull.draft}
+                      onClick={() => void accept(pull)}
+                      title={
+                        pull.draft
+                          ? "A draft is not finished being written"
+                          : "Squash-merges it into your notes"
+                      }
+                      className="rounded border border-[var(--fl-border)] px-2 py-1 text-[11.5px] font-medium text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-surface)] disabled:opacity-50"
+                    >
+                      {accepting === pull.number ? "Accepting…" : "Accept"}
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          {/* Said once, at the bottom, rather than on every row: reading a diff
+              with a conversation on it is a thing GitHub does very well, and a
+              worse copy of it here would help nobody. */}
+          <p className="mt-3 text-[11.5px] leading-relaxed text-[var(--fl-muted)]">
+            <strong>Read what changed</strong> opens the suggestion on GitHub, where the diff and
+            the conversation are. <strong>Accept</strong> merges it into your notes here, and the
+            next sync brings the change down to this device.
+          </p>
+        </div>
+      )}
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -2149,6 +2149,7 @@ export function EditorWorkspace() {
       onSave={canSavePdf ? () => void savePdfToNotebook() : null}
       saveHint={pdfSaveHint}
       saving={savingPdf}
+      path={readerPath}
       onStartNote={reader.status === "ready" ? () => void startNoteFromPaper() : null}
       mentions={pdfMentions}
       onOpenMention={(path) => {

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -44,7 +44,13 @@ import {
   whyCannotSave,
   type PdfSource,
 } from "@/lib/pdf-source";
-import { commitToBranch } from "@/lib/gateway";
+import {
+  commitToBranch,
+  createBranch,
+  deleteBranch,
+  openPullRequest,
+  acceptSuggestion,
+} from "@/lib/gateway";
 import { readDroppedPdf } from "@/lib/local-files";
 import { insertionFor, quoteMarkdown } from "@/lib/pdf-quote";
 import { mentionsOfPdf, type PdfMention } from "@/lib/pdf-mentions";
@@ -52,6 +58,7 @@ import { pagesOf, readDocumentText } from "@/lib/pdf-index";
 import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
 import { paperNote } from "@/lib/note-from-paper";
 import { anchorsFor, lineForPage, pageForLine } from "@/lib/pdf-follow";
+import { describeTry, parseTryBranch, tryBranchFor } from "@/lib/try-branch";
 import { FreshnessDialog } from "@/components/FreshnessDialog";
 import { TimeMachineDialog } from "@/components/TimeMachineDialog";
 import { SuggestionsDialog } from "@/components/SuggestionsDialog";
@@ -784,6 +791,123 @@ export function EditorWorkspace() {
     const { tree } = (await response.json()) as { tree: TreeNode[] };
     return [...local, ...collectFilePaths(tree)];
   }, [workspace, notebook.tree, notebook.openNotes, notebook.assetUrls]);
+
+  // ── Trying a rewrite ────────────────────────────────────────────────────
+  //
+  // Work on a copy, keep it or throw it away, and the original is never in any
+  // danger. That is a branch, which this app has for free; all that was
+  // missing was a name that says what it is and two buttons that do not say
+  // "git".
+
+  /** The experiment this workspace is on, if it is on one. */
+  const experiment = useMemo(
+    () => (workspace && !workspace.isLocal ? parseTryBranch(workspace.repo.branch) : null),
+    [workspace],
+  );
+  const [experimentBusy, setExperimentBusy] = useState<"keeping" | "discarding" | null>(null);
+
+  const startExperiment = useCallback(async () => {
+    if (!workspace || workspace.isLocal || !note) return;
+
+    const name = tryBranchFor(workspace.repo.branch, title);
+    setExperimentBusy("keeping");
+
+    try {
+      await createBranch({
+        owner: workspace.repo.owner,
+        repo: workspace.repo.repo,
+        name,
+        from: workspace.repo.branch,
+      });
+      await notebook.switchBranch(name);
+      setNotice(
+        `Trying a rewrite of ${title}. Nothing you do here touches ${workspace.repo.branch}.`,
+      );
+    } catch (problem: unknown) {
+      notebook.reportError(
+        problem instanceof Error ? problem.message : "That experiment could not be started.",
+      );
+    } finally {
+      setExperimentBusy(null);
+    }
+  }, [workspace, note, title, notebook]);
+
+  /**
+   * Keeps the rewrite: onto the branch it came from, as one change.
+   *
+   * A pull request opened and immediately merged, rather than a direct commit,
+   * because that is what leaves a record of the experiment having happened —
+   * and because merging is the one operation that knows what to do when the
+   * base branch has moved on underneath.
+   */
+  const keepExperiment = useCallback(async () => {
+    if (!workspace || workspace.isLocal || !experiment) return;
+
+    setExperimentBusy("keeping");
+    const branch = workspace.repo.branch;
+
+    try {
+      const { pull } = await openPullRequest({
+        owner: workspace.repo.owner,
+        repo: workspace.repo.repo,
+        base: experiment.base,
+        head: branch,
+        title: `Rewrite of ${describeTry(experiment.slug)}`,
+      });
+
+      await acceptSuggestion({
+        owner: workspace.repo.owner,
+        repo: workspace.repo.repo,
+        number: pull.number,
+        title: `Rewrite of ${describeTry(experiment.slug)}`,
+      });
+
+      await notebook.switchBranch(experiment.base);
+      await deleteBranch({
+        owner: workspace.repo.owner,
+        repo: workspace.repo.repo,
+        name: branch,
+      }).catch(() => {
+        // The work is already on the base branch. A leftover branch is untidy
+        // and is not worth reporting as a failure of the thing that worked.
+      });
+
+      setNotice(`Kept. The rewrite is on ${experiment.base}.`);
+    } catch (problem: unknown) {
+      notebook.reportError(
+        problem instanceof Error ? problem.message : "That rewrite could not be kept.",
+      );
+    } finally {
+      setExperimentBusy(null);
+    }
+  }, [workspace, experiment, notebook]);
+
+  /** Throws the rewrite away, and the branch with it. */
+  const discardExperiment = useCallback(async () => {
+    if (!workspace || workspace.isLocal || !experiment) return;
+
+    setExperimentBusy("discarding");
+    const branch = workspace.repo.branch;
+
+    try {
+      // Back to the original *first*: deleting the branch a workspace is
+      // sitting on would leave the editor pointed at something that no longer
+      // exists.
+      await notebook.switchBranch(experiment.base);
+      await deleteBranch({
+        owner: workspace.repo.owner,
+        repo: workspace.repo.repo,
+        name: branch,
+      });
+      setNotice(`Thrown away. ${experiment.base} is exactly as you left it.`);
+    } catch (problem: unknown) {
+      notebook.reportError(
+        problem instanceof Error ? problem.message : "That experiment could not be thrown away.",
+      );
+    } finally {
+      setExperimentBusy(null);
+    }
+  }, [workspace, experiment, notebook]);
 
   /**
    * Starts a note about the paper on screen, with its headings already in it.
@@ -1990,6 +2114,18 @@ export function EditorWorkspace() {
       });
     }
 
+    if (note && workspace && !workspace.isLocal && !experiment) {
+      list.push({
+        id: "try-rewrite",
+        label: "Try a rewrite of this note",
+        group: "Notes",
+        hint: "Work on a copy. Keep it or throw it away; the original is never at risk",
+        keywords:
+          "try rewrite experiment branch draft copy alternative version safe discard revert what if",
+        run: () => void startExperiment(),
+      });
+    }
+
     if (workspace && !workspace.isLocal) {
       list.push({
         id: "suggestions",
@@ -2118,6 +2254,8 @@ export function EditorWorkspace() {
     reader,
     pdfPlacement,
     following,
+    experiment,
+    startExperiment,
     canSavePdf,
     savePdfToNotebook,
   ]);
@@ -2619,6 +2757,50 @@ export function EditorWorkspace() {
                 >
                   Sign in again
                 </button>
+              </div>
+            )}
+
+            {/* An experiment says so, permanently, wherever you are in it.
+                A branch you have forgotten you are on is how work ends up
+                somewhere nobody looks — and the two ways out belong beside
+                the sentence that explains why they are there. */}
+            {experiment && (
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-[var(--fl-border)] bg-[var(--fl-accent-soft)] px-3 py-2">
+                <p className="min-w-0 flex-1 text-[12.5px] leading-relaxed text-[var(--fl-text)]">
+                  <strong>Trying a rewrite</strong> of {describeTry(experiment.slug)}. Nothing here
+                  touches <span className="font-mono text-[11.5px]">{experiment.base}</span> until
+                  you keep it.
+                </p>
+
+                <span className="flex shrink-0 items-center gap-1.5">
+                  <button
+                    type="button"
+                    disabled={experimentBusy !== null}
+                    onClick={() => void keepExperiment()}
+                    className="rounded-lg bg-[var(--fl-accent)] px-2.5 py-1 text-[12px] font-semibold text-[var(--fl-accent-contrast)] transition-colors hover:bg-[var(--fl-accent-hover)] disabled:opacity-60"
+                  >
+                    {experimentBusy === "keeping" ? "Keeping…" : "Keep it"}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={experimentBusy !== null}
+                    onClick={() =>
+                      setPrompt({
+                        title: "Throw this rewrite away?",
+                        label: "",
+                        initialValue: "",
+                        confirmLabel: "Throw it away",
+                        body: `Everything written on this branch goes, and ${experiment.base} stays exactly as you left it. This cannot be undone.`,
+                        onConfirm: async () => {
+                          await discardExperiment();
+                        },
+                      })
+                    }
+                    className="rounded-lg border border-[var(--fl-border)] px-2.5 py-1 text-[12px] font-medium text-[var(--fl-text)] transition-colors hover:bg-[var(--fl-surface)] disabled:opacity-60"
+                  >
+                    {experimentBusy === "discarding" ? "Throwing away…" : "Throw it away"}
+                  </button>
+                </span>
               </div>
             )}
 

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -51,6 +51,7 @@ import { mentionsOfPdf, type PdfMention } from "@/lib/pdf-mentions";
 import { pagesOf, readDocumentText } from "@/lib/pdf-index";
 import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
 import { paperNote } from "@/lib/note-from-paper";
+import { anchorsFor, lineForPage, pageForLine } from "@/lib/pdf-follow";
 import { FreshnessDialog } from "@/components/FreshnessDialog";
 import { TimeMachineDialog } from "@/components/TimeMachineDialog";
 import { CitationsDialog } from "@/components/CitationsDialog";
@@ -157,6 +158,41 @@ function writePdfPlacement(value: PdfPlacement): void {
 function subscribeToPdfPlacement(onChange: () => void): () => void {
   const handle = (event: StorageEvent) => {
     if (event.key === null || event.key === PDF_PLACEMENT_KEY) onChange();
+  };
+  window.addEventListener("storage", handle);
+  return () => window.removeEventListener("storage", handle);
+}
+
+/**
+ * Whether the document follows the note, and the note the document.
+ *
+ * On by default. The mapping is not a guess — every citation in the note
+ * records the page it came from — so following is right far more often than it
+ * is wrong, and the one case it is wrong in (you are reading ahead of what you
+ * have written) is one keystroke from being switched off.
+ */
+const FOLLOW_KEY = "forkleaf:pdf-follow";
+
+function readFollow(): boolean {
+  try {
+    return window.localStorage.getItem(FOLLOW_KEY) !== "0";
+  } catch {
+    return true;
+  }
+}
+
+function writeFollow(value: boolean): void {
+  try {
+    window.localStorage.setItem(FOLLOW_KEY, value ? "1" : "0");
+  } catch {
+    // The setting still holds for this session.
+  }
+  window.dispatchEvent(new StorageEvent("storage", { key: FOLLOW_KEY }));
+}
+
+function subscribeToFollow(onChange: () => void): () => void {
+  const handle = (event: StorageEvent) => {
+    if (event.key === null || event.key === FOLLOW_KEY) onChange();
   };
   window.addEventListener("storage", handle);
   return () => window.removeEventListener("storage", handle);
@@ -821,6 +857,47 @@ export function EditorWorkspace() {
 
     return mentionsOfPdf(merged, readerPath);
   }, [readerPath, storedNotes, notebook.openNotes]);
+
+  // ── Following along ─────────────────────────────────────────────────────
+  //
+  // The document and the note kept on the same page: write about page twelve
+  // and the paper turns to page twelve, read page twelve and the note scrolls
+  // to what you said about it. This is what people open two windows to fake.
+
+  const following = useSyncExternalStore(subscribeToFollow, readFollow, () => true);
+  /** The page the reader is showing, so the note can follow it back. */
+  const [readerPage, setReaderPage] = useState(1);
+
+  /** This note's citations of the document being read, in note order. */
+  const followAnchors = useMemo(
+    () => (note && pdfMentions ? anchorsFor(pdfMentions, note.path) : []),
+    [note, pdfMentions],
+  );
+
+  /**
+   * Only beside the note, and only when the mapping exists.
+   *
+   * A document filling the middle column has no note next to it to follow, and
+   * a note with no citations of it has nothing to say about where it is.
+   */
+  const canFollow = following && readerLayout === "beside" && followAnchors.length > 0;
+
+  const followPage = useMemo(
+    () => (canFollow && cursor ? pageForLine(followAnchors, cursor.line) : null),
+    [canFollow, cursor, followAnchors],
+  );
+
+  /**
+   * The line to scroll the note to, for the page now on screen.
+   *
+   * Suppressed while the caret is what moved: the two directions would
+   * otherwise take turns nudging each other, and a reader who put their cursor
+   * somewhere would watch it scroll away from them.
+   */
+  const followLine = useMemo(
+    () => (canFollow && followPage === null ? lineForPage(followAnchors, readerPage) : null),
+    [canFollow, followPage, followAnchors, readerPage],
+  );
 
   /**
    * Writes a cited passage into the note being read alongside.
@@ -1947,6 +2024,21 @@ export function EditorWorkspace() {
       });
     }
 
+    if (reader.status !== "idle") {
+      list.push({
+        id: "pdf-follow",
+        label: following
+          ? "Stop the document following the note"
+          : "Let the document follow the note",
+        group: "View",
+        hint: following
+          ? "The paper and the note stop moving with each other"
+          : "Write about page 12 and the paper turns to page 12, and back again",
+        keywords: "follow sync scroll page together beside link caret cursor track document paper",
+        run: () => writeFollow(!following),
+      });
+    }
+
     // All three placements, always, with the current one marked — rather than
     // one command whose label is the *other* state. A toggle reads as an
     // instruction ("open PDFs in their own tab") that gives no hint about
@@ -2011,6 +2103,7 @@ export function EditorWorkspace() {
     localFiles,
     reader,
     pdfPlacement,
+    following,
     canSavePdf,
     savePdfToNotebook,
   ]);
@@ -2150,6 +2243,8 @@ export function EditorWorkspace() {
       saveHint={pdfSaveHint}
       saving={savingPdf}
       path={readerPath}
+      showPage={followPage}
+      onPageChange={setReaderPage}
       onStartNote={reader.status === "ready" ? () => void startNoteFromPaper() : null}
       mentions={pdfMentions}
       onOpenMention={(path) => {
@@ -2537,6 +2632,7 @@ export function EditorWorkspace() {
                   mode={mode}
                   theme={theme}
                   onCursorChange={setCursor}
+                  revealLine={followLine}
                   images={images}
                   links={linkBridge}
                   imageDestination={

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -59,6 +59,7 @@ import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
 import { paperNote } from "@/lib/note-from-paper";
 import { anchorsFor, lineForPage, pageForLine } from "@/lib/pdf-follow";
 import { describeTry, parseTryBranch, tryBranchFor } from "@/lib/try-branch";
+import { formatPageText, parsePageText, textPathFor } from "@/lib/pdf-text-file";
 import {
   highlightsPathFor,
   parseHighlights,
@@ -1074,6 +1075,58 @@ export function EditorWorkspace() {
     },
     [highlightPath, readerPath, reader, notebook],
   );
+
+  // ── A document's text, kept beside it ───────────────────────────────────
+  //
+  // A scan has no text at all, so nothing in it can be searched, quoted or
+  // checked. A paper that does have text has it extracted again on every
+  // device, every time, and thrown away at the end. One file beside the
+  // document answers both: read once, committed, and read from there after.
+
+  const textPath = useMemo(() => (readerPath ? textPathFor(readerPath) : null), [readerPath]);
+  const supplyText = reader.supplyText;
+
+  useEffect(() => {
+    if (!textPath) return;
+
+    let live = true;
+    void readNote(textPath)
+      .then((content) => {
+        if (live && content) supplyText(parsePageText(content));
+      })
+      .catch(() => {
+        // No such file, which is the ordinary case. A document with its own
+        // text does not need one, and a scan without one says so.
+      });
+
+    return () => {
+      live = false;
+    };
+  }, [textPath, readNote, supplyText]);
+
+  /**
+   * Writes what has been read out of this document into a file beside it.
+   *
+   * Offered for a document that has its own text — the work is done, and this
+   * is what stops every other device redoing it. A scan has nothing to write,
+   * and the reader says what to do about that instead.
+   */
+  const keepDocumentText = useCallback(async () => {
+    if (!textPath || !readerPath || reader.pages.length === 0) return;
+
+    const title = reader.info
+      ? displayTitle(reader.info.metadata, reader.source?.name ?? "")
+      : (reader.source?.name ?? "document");
+
+    await notebook.upsertNote(textPath, () =>
+      formatPageText(
+        title,
+        reader.pages.map((page) => ({ page: page.page, text: page.text })),
+      ),
+    );
+
+    setNotice(`Kept the text of this document in ${textPath}`);
+  }, [textPath, readerPath, reader, notebook]);
 
   // ── Following along ─────────────────────────────────────────────────────
   //
@@ -2277,6 +2330,20 @@ export function EditorWorkspace() {
       });
     }
 
+    if (readerPath && workspace && !workspace.isLocal && reader.pages.length > 0) {
+      list.push({
+        id: "keep-document-text",
+        label: reader.textSupplied
+          ? "Rewrite this document's text file"
+          : "Keep this document's text beside it",
+        group: "Notes",
+        hint: "So no other device has to read the whole document again",
+        keywords:
+          "text ocr scan recognise extract keep save beside sidecar words searchable index share devices",
+        run: () => void keepDocumentText(),
+      });
+    }
+
     if (readerPath && workspace && !workspace.isLocal) {
       list.push({
         id: "document-versions",
@@ -2369,6 +2436,7 @@ export function EditorWorkspace() {
     reader,
     pdfPlacement,
     readerPath,
+    keepDocumentText,
     following,
     experiment,
     startExperiment,

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -54,6 +54,7 @@ import { paperNote } from "@/lib/note-from-paper";
 import { anchorsFor, lineForPage, pageForLine } from "@/lib/pdf-follow";
 import { FreshnessDialog } from "@/components/FreshnessDialog";
 import { TimeMachineDialog } from "@/components/TimeMachineDialog";
+import { SuggestionsDialog } from "@/components/SuggestionsDialog";
 import { CitationsDialog } from "@/components/CitationsDialog";
 import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
@@ -304,6 +305,7 @@ export function EditorWorkspace() {
     | "citations"
     | "freshness"
     | "time-machine"
+    | "suggestions"
     | null
   >(null);
   /**
@@ -1990,6 +1992,18 @@ export function EditorWorkspace() {
 
     if (workspace && !workspace.isLocal) {
       list.push({
+        id: "suggestions",
+        label: "See what other people have suggested",
+        group: "Notes",
+        hint: "Corrections readers have sent back from your published pages",
+        keywords:
+          "suggestion suggestions pull request pr incoming reader correction fix accept merge contribute proposed change",
+        run: () => setDialog("suggestions"),
+      });
+    }
+
+    if (workspace && !workspace.isLocal) {
+      list.push({
         id: "time-machine",
         label: "Show me my notebook as it was on…",
         group: "View",
@@ -2952,6 +2966,14 @@ export function EditorWorkspace() {
           documents={workspace && !workspace.isLocal ? documentTexts : []}
           onOpenDocument={(path, page) => openRepoPdf(path, `page=${page}`)}
           commands={commands}
+        />
+      )}
+
+      {openDialog === "suggestions" && workspace && !workspace.isLocal && (
+        <SuggestionsDialog
+          onClose={() => setDialog(null)}
+          repo={workspace.repo}
+          onAccepted={() => void notebook.pullRemote()}
         />
       )}
 

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -69,6 +69,7 @@ import { FreshnessDialog } from "@/components/FreshnessDialog";
 import { TimeMachineDialog } from "@/components/TimeMachineDialog";
 import { SuggestionsDialog } from "@/components/SuggestionsDialog";
 import { DocumentVersionsDialog } from "@/components/DocumentVersionsDialog";
+import { BorrowDialog } from "@/components/BorrowDialog";
 import { CitationsDialog } from "@/components/CitationsDialog";
 import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
@@ -321,6 +322,7 @@ export function EditorWorkspace() {
     | "time-machine"
     | "suggestions"
     | "document-versions"
+    | "borrow"
     | null
   >(null);
   /**
@@ -2203,6 +2205,18 @@ export function EditorWorkspace() {
       });
     }
 
+    if (note && workspace && !workspace.isLocal) {
+      list.push({
+        id: "borrow",
+        label: "Borrow a note from another notebook",
+        group: "Notes",
+        hint: "Link into somebody else's, pinned to the version you read",
+        keywords:
+          "borrow link somebody else other notebook repository shared reuse reference pin theirs copy",
+        run: () => setDialog("borrow"),
+      });
+    }
+
     if (note && workspace && !workspace.isLocal && !experiment) {
       list.push({
         id: "try-rewrite",
@@ -3253,6 +3267,30 @@ export function EditorWorkspace() {
           documents={workspace && !workspace.isLocal ? documentTexts : []}
           onOpenDocument={(path, page) => openRepoPdf(path, `page=${page}`)}
           commands={commands}
+        />
+      )}
+
+      {openDialog === "borrow" && note && workspace && !workspace.isLocal && (
+        <BorrowDialog
+          onClose={() => setDialog(null)}
+          loadTree={async (owner, repo, branch) => {
+            const params = new URLSearchParams({ owner, repo, branch });
+            const response = await fetch(`/api/gh/tree?${params.toString()}`);
+            if (!response.ok) {
+              throw new Error("That notebook could not be read. It may be private, or not exist.");
+            }
+            const { tree } = (await response.json()) as { tree: TreeNode[] };
+            return tree;
+          }}
+          onBorrow={(link) => {
+            setDialog(null);
+            // At the end of the note, like a cited passage: the caret has not
+            // been in the editor since the dialog opened, so its last recorded
+            // position is wherever it was several minutes ago.
+            const { text } = insertionFor(note.content, note.content.length, link);
+            void notebook.saveNote(text);
+            setNotice("Borrowed. The link reads their note from their repository.");
+          }}
         />
       )}
 

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -68,6 +68,7 @@ import {
 import { FreshnessDialog } from "@/components/FreshnessDialog";
 import { TimeMachineDialog } from "@/components/TimeMachineDialog";
 import { SuggestionsDialog } from "@/components/SuggestionsDialog";
+import { DocumentVersionsDialog } from "@/components/DocumentVersionsDialog";
 import { CitationsDialog } from "@/components/CitationsDialog";
 import { isPdfPath } from "@/lib/media";
 import { useTheme } from "@/hooks/useTheme";
@@ -319,6 +320,7 @@ export function EditorWorkspace() {
     | "freshness"
     | "time-machine"
     | "suggestions"
+    | "document-versions"
     | null
   >(null);
   /**
@@ -1005,6 +1007,19 @@ export function EditorWorkspace() {
    * another's pages. Reading it back through the current path gives the same
    * "nothing yet" with neither problem.
    */
+  /**
+   * A page something outside the reader has asked it to turn to.
+   *
+   * Carries an id rather than being a bare number, so asking for the same page
+   * twice is two requests — pressing "p. 12" again plainly means "take me back
+   * there".
+   */
+  const [pageRequest, setPageRequest] = useState<{ page: number; id: number } | null>(null);
+  const requestPage = useCallback(
+    (page: number) => setPageRequest((last) => ({ page, id: (last?.id ?? 0) + 1 })),
+    [],
+  );
+
   const [highlightFile, setHighlightFile] = useState<{ path: string; content: string } | null>(
     null,
   );
@@ -2248,6 +2263,18 @@ export function EditorWorkspace() {
       });
     }
 
+    if (readerPath && workspace && !workspace.isLocal) {
+      list.push({
+        id: "document-versions",
+        label: "See what changed in this document",
+        group: "View",
+        hint: "Compares it with an earlier version, and says whether a page you quoted moved",
+        keywords:
+          "version versions changed diff compare document pdf revision earlier older history updated paper",
+        run: () => setDialog("document-versions"),
+      });
+    }
+
     if (reader.status !== "idle") {
       list.push({
         id: "pdf-follow",
@@ -2327,6 +2354,7 @@ export function EditorWorkspace() {
     localFiles,
     reader,
     pdfPlacement,
+    readerPath,
     following,
     experiment,
     startExperiment,
@@ -2472,6 +2500,7 @@ export function EditorWorkspace() {
       highlights={highlights}
       onHighlight={readerPath ? (citation, marked) => void toggleHighlight(citation, marked) : null}
       showPage={followPage}
+      jumpTo={pageRequest}
       onPageChange={setReaderPage}
       onStartNote={reader.status === "ready" ? () => void startNoteFromPaper() : null}
       mentions={pdfMentions}
@@ -3224,6 +3253,26 @@ export function EditorWorkspace() {
           documents={workspace && !workspace.isLocal ? documentTexts : []}
           onOpenDocument={(path, page) => openRepoPdf(path, `page=${page}`)}
           commands={commands}
+        />
+      )}
+
+      {openDialog === "document-versions" && workspace && !workspace.isLocal && readerPath && (
+        <DocumentVersionsDialog
+          onClose={() => setDialog(null)}
+          workspace={workspace}
+          path={readerPath}
+          // The pages this notebook has an opinion about: what it quotes, and
+          // what it has marked.
+          cited={[
+            ...new Set([
+              ...(pdfMentions ?? []).flatMap((mention) => (mention.page ? [mention.page] : [])),
+              ...highlights.map((held) => held.page),
+            ]),
+          ]}
+          onGoToPage={(page) => {
+            setDialog(null);
+            requestPage(page);
+          }}
         />
       )}
 

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -59,6 +59,12 @@ import { withCorrectedPage, type CitationCheck } from "@/lib/citation-audit";
 import { paperNote } from "@/lib/note-from-paper";
 import { anchorsFor, lineForPage, pageForLine } from "@/lib/pdf-follow";
 import { describeTry, parseTryBranch, tryBranchFor } from "@/lib/try-branch";
+import {
+  highlightsPathFor,
+  parseHighlights,
+  withHighlight,
+  withoutHighlight,
+} from "@/lib/pdf-highlights";
 import { FreshnessDialog } from "@/components/FreshnessDialog";
 import { TimeMachineDialog } from "@/components/TimeMachineDialog";
 import { SuggestionsDialog } from "@/components/SuggestionsDialog";
@@ -983,6 +989,74 @@ export function EditorWorkspace() {
 
     return mentionsOfPdf(merged, readerPath);
   }, [readerPath, storedNotes, notebook.openNotes]);
+
+  // ── Highlights ──────────────────────────────────────────────────────────
+  //
+  // Kept in a markdown file beside the document rather than written into the
+  // PDF. The file in the repository stays exactly as it was committed, and the
+  // marks — the part that is actually yours — stay readable without this app.
+
+  /**
+   * The highlights file, tagged with the document it belongs to.
+   *
+   * Tagged rather than cleared when the document changes: clearing means
+   * writing state from inside an effect, which is a render spent undoing the
+   * last one — and leaves a window in which one paper's marks are drawn over
+   * another's pages. Reading it back through the current path gives the same
+   * "nothing yet" with neither problem.
+   */
+  const [highlightFile, setHighlightFile] = useState<{ path: string; content: string } | null>(
+    null,
+  );
+  const highlightPath = useMemo(
+    () => (readerPath ? highlightsPathFor(readerPath) : null),
+    [readerPath],
+  );
+
+  const readNote = notebook.readNote;
+
+  useEffect(() => {
+    if (!highlightPath) return;
+
+    let live = true;
+    void readNote(highlightPath)
+      .then((content) => {
+        if (live) setHighlightFile({ path: highlightPath, content: content ?? "" });
+      })
+      .catch(() => {
+        // No highlights file yet, or it could not be read. Either way there is
+        // nothing to draw, and the next highlight makes one.
+        if (live) setHighlightFile({ path: highlightPath, content: "" });
+      });
+
+    return () => {
+      live = false;
+    };
+  }, [highlightPath, readNote]);
+
+  const highlights = useMemo(() => {
+    const content = highlightFile?.path === highlightPath ? highlightFile.content : "";
+    return parseHighlights(content).map((held) => held.citation);
+  }, [highlightFile, highlightPath]);
+
+  const toggleHighlight = useCallback(
+    async (citation: PdfCitation, marked: boolean) => {
+      if (!highlightPath || !readerPath) return;
+
+      const title = reader.info
+        ? displayTitle(reader.info.metadata, reader.source?.name ?? "")
+        : (reader.source?.name ?? "document");
+
+      const next = await notebook.upsertNote(highlightPath, (content) =>
+        marked
+          ? withHighlight(content, { pdfPath: readerPath, title, citation })
+          : withoutHighlight(content, { pdfPath: readerPath, title, quote: citation.quote }),
+      );
+
+      if (next !== null) setHighlightFile({ path: highlightPath, content: next });
+    },
+    [highlightPath, readerPath, reader, notebook],
+  );
 
   // ── Following along ─────────────────────────────────────────────────────
   //
@@ -2395,6 +2469,8 @@ export function EditorWorkspace() {
       saveHint={pdfSaveHint}
       saving={savingPdf}
       path={readerPath}
+      highlights={highlights}
+      onHighlight={readerPath ? (citation, marked) => void toggleHighlight(citation, marked) : null}
       showPage={followPage}
       onPageChange={setReaderPage}
       onStartNote={reader.status === "ready" ? () => void startNoteFromPaper() : null}

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -1281,6 +1281,46 @@ export function useNotebook(request: NotebookRequest = {}) {
         putCreated(withCreatedRenamed(state.createdAt, source, target));
         putTreeOrder(withPathRenamed(state.treeOrder, source, target));
 
+        /**
+         * The notes open in tabs move too.
+         *
+         * Without this a tab left pointing at the old path, and the next
+         * keystroke in it saved the note *back* to where it used to be —
+         * recreating the folder that had just been renamed, with one note in
+         * it, on GitHub. That is the duplicate folder people were left
+         * deleting, and deleting it took the real files with it.
+         *
+         * Re-read rather than repathed, because the move rewrote the links in
+         * notes that pointed out of the folder: keeping the copy in the tab
+         * would show text that is no longer what the file says.
+         */
+        const inside = (path: string) => path === source || path.startsWith(`${source}/`);
+        const moved = (path: string) =>
+          inside(path) ? `${target}${path.slice(source.length)}` : path;
+
+        if (state.openNotes.some((note) => inside(note.path))) {
+          const reopened = await Promise.all(
+            state.openNotes.map(async (note) =>
+              inside(note.path)
+                ? await notes.openNote(workspace.id, moved(note.path)).catch(() => null)
+                : note,
+            ),
+          );
+
+          const open = reopened.filter((note): note is Note => note !== null);
+          const activePath = state.activePath ? moved(state.activePath) : null;
+
+          // Renaming a folder is not unlocking the notes inside it.
+          let locks = state.lockedPaths;
+          for (const note of state.openNotes) {
+            if (inside(note.path)) locks = renameLock(locks, note.path, moved(note.path));
+          }
+          if (locks !== state.lockedPaths) putLocked(locks);
+
+          patch({ openNotes: open, activePath });
+          rememberTabs(workspace.id, open, activePath);
+        }
+
         await refreshTree();
       } finally {
         patch({ busy: null });
@@ -1295,9 +1335,14 @@ export function useNotebook(request: NotebookRequest = {}) {
       state.emptyFolders,
       state.createdAt,
       state.treeOrder,
+      state.openNotes,
+      state.activePath,
+      state.lockedPaths,
       putEmptyFolders,
       putCreated,
       putTreeOrder,
+      putLocked,
+      rememberTabs,
       refreshTree,
       patch,
     ],

--- a/apps/web/src/hooks/useNotebook.ts
+++ b/apps/web/src/hooks/useNotebook.ts
@@ -1656,6 +1656,63 @@ export function useNotebook(request: NotebookRequest = {}) {
   );
 
   /**
+   * Writes a file in the notebook whether or not it exists yet.
+   *
+   * `rewriteNote` needs a note to already be there. This is for the files the
+   * app makes on somebody's behalf — a document's highlights, kept beside it —
+   * where "there is not one yet" is the ordinary first case rather than an
+   * error. It goes through the note repository like everything else, so the
+   * file gets the same offline queue, the same commit and the same history as
+   * anything typed by hand.
+   */
+  const upsertNote = useCallback(
+    async (path: string, change: (content: string) => string): Promise<string | null> => {
+      const notes = repoRef.current;
+      const workspace = state.activeWorkspace;
+      if (!notes || !workspace) return null;
+
+      const existing = await notes.openNote(workspace.id, path).catch(() => null);
+      const note: Note = existing ?? {
+        id: `${workspace.id}::${path}`,
+        workspaceId: workspace.id,
+        path,
+        content: "",
+        frontmatter: {},
+        baseSha: null,
+        updatedAt: null,
+        dirty: true,
+      };
+
+      const next = change(note.content);
+      if (next === note.content) return note.content;
+
+      await notes.saveNote(note, next);
+      patchOpenNote(path, { content: next, dirty: true });
+
+      // A file made this way is a file in the notebook, so the sidebar has to
+      // know about it — otherwise it appears at the next refresh from GitHub
+      // and looks like something somebody else committed.
+      if (!existing) patch({ tree: insertIntoTree(state.tree, path) });
+
+      return next;
+    },
+    [state.activeWorkspace, state.tree, patch, patchOpenNote],
+  );
+
+  /** Reads a file in the notebook, or null when there is not one. */
+  const readNote = useCallback(
+    async (path: string): Promise<string | null> => {
+      const notes = repoRef.current;
+      const workspace = state.activeWorkspace;
+      if (!notes || !workspace) return null;
+
+      const note = await notes.openNote(workspace.id, path).catch(() => null);
+      return note?.content ?? null;
+    },
+    [state.activeWorkspace],
+  );
+
+  /**
    * Drops one stuck change, so the queue behind it can move.
    *
    * The way out of a change that can never be pushed. Needs a refresh of the
@@ -1977,6 +2034,8 @@ export function useNotebook(request: NotebookRequest = {}) {
       discardChange,
       shrinkChange,
       rewriteNote,
+      upsertNote,
+      readNote,
       saveDocumentText,
       documentText,
       allDocumentText,
@@ -2042,6 +2101,8 @@ export function useNotebook(request: NotebookRequest = {}) {
       documentText,
       saveDocumentText,
       rewriteNote,
+      upsertNote,
+      readNote,
       shrinkChange,
       setSyncMode,
       resolveConflict,

--- a/apps/web/src/hooks/usePdfReader.ts
+++ b/apps/web/src/hooks/usePdfReader.ts
@@ -45,6 +45,25 @@ export interface PdfReaderState {
   outline: PdfOutlineItem[];
   /** Page text, filled in behind the first render. Empty until extraction runs. */
   pages: PdfPageText[];
+  /**
+   * True when a document carries no text of its own — a scan.
+   *
+   * Only meaningful once the reading has finished: until then "no text yet"
+   * and "no text at all" look identical, and telling somebody their paper is a
+   * photograph while it is still being read would be wrong about half the
+   * documents that ever open.
+   */
+  scanned: boolean;
+  /** True when the words on screen came from a file rather than the document. */
+  textSupplied: boolean;
+  /**
+   * Hands the reader the words of a document that has none.
+   *
+   * For a scan whose text has been recognised elsewhere and committed beside
+   * it. Ignored when the document has its own text: a file beside a paper must
+   * never quietly replace what the paper actually says.
+   */
+  supplyText: (pages: readonly { page: number; text: string }[]) => void;
   /** True while text extraction is still running. */
   indexing: boolean;
   error: string | null;
@@ -66,7 +85,8 @@ export function usePdfReader(workspace: Workspace | null): PdfReaderState {
   const [session, setSession] = useState<PdfSession | null>(null);
   const [info, setInfo] = useState<PdfDocumentInfo | null>(null);
   const [outline, setOutline] = useState<PdfOutlineItem[]>([]);
-  const [pages, setPages] = useState<PdfPageText[]>([]);
+  const [extracted, setExtracted] = useState<PdfPageText[]>([]);
+  const [supplied, setSupplied] = useState<PdfPageText[]>([]);
   const [indexing, setIndexing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -109,7 +129,8 @@ export function usePdfReader(workspace: Workspace | null): PdfReaderState {
       setError(null);
       setInfo(null);
       setOutline([]);
-      setPages([]);
+      setExtracted([]);
+      setSupplied([]);
 
       void (async () => {
         try {
@@ -167,8 +188,8 @@ export function usePdfReader(workspace: Workspace | null): PdfReaderState {
 
         void opened
           .allText({ signal: controller.signal })
-          .then((extracted) => {
-            if (ticket === request.current) setPages(extracted);
+          .then((read) => {
+            if (ticket === request.current) setExtracted(read);
           })
           .catch(() => {
             // Aborted, or a document whose text cannot be read — a pure scan
@@ -192,7 +213,8 @@ export function usePdfReader(workspace: Workspace | null): PdfReaderState {
     setSource(null);
     setInfo(null);
     setOutline([]);
-    setPages([]);
+    setExtracted([]);
+    setSupplied([]);
     setIndexing(false);
     setError(null);
     setStatus("idle");
@@ -200,6 +222,24 @@ export function usePdfReader(workspace: Workspace | null): PdfReaderState {
 
   // The worker outlives React unless something stops it.
   useEffect(() => teardown, [teardown]);
+
+  /**
+   * What the reader has to work with: the document's own words, or the ones
+   * supplied for it.
+   *
+   * The document always wins. A supplied file is for a document that has
+   * nothing to say for itself, and letting it override a paper that does would
+   * make searching and citation quietly answer from the wrong text.
+   */
+  const pages = extracted.length > 0 ? extracted : supplied;
+
+  const supplyText = useCallback((given: readonly { page: number; text: string }[]) => {
+    setSupplied(
+      given
+        .filter((page) => page.text.trim() !== "")
+        .map((page) => ({ page: page.page, text: page.text, runs: [] })),
+    );
+  }, []);
 
   const search = useCallback(
     (query: string) => (pages.length === 0 ? [] : searchPdf(pages, query)),
@@ -218,6 +258,11 @@ export function usePdfReader(workspace: Workspace | null): PdfReaderState {
     info,
     outline,
     pages,
+    // A document that has been read and had nothing to give is a photograph
+    // of a page. Before the reading finishes, nobody can say that.
+    scanned: status === "ready" && !indexing && extracted.length === 0,
+    textSupplied: extracted.length === 0 && supplied.length > 0,
+    supplyText,
     indexing,
     error,
     open,

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -488,6 +488,19 @@ export async function readNotebookAt(
   );
 }
 
+/**
+ * One repository, whoever it belongs to.
+ *
+ * For borrowing: reading somebody else's notebook needs to know which branch
+ * they keep it on, which is a fact about their repository and not about yours.
+ */
+export async function describeRepo(owner: string, repo: string): Promise<RepoSummaryDto> {
+  const { repo: found } = await call<{ repo: RepoSummaryDto }>(
+    `/api/gh/repos?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`,
+  );
+  return found;
+}
+
 export async function listRepos(): Promise<RepoSummaryDto[]> {
   const { repos } = await call<{ repos: RepoSummaryDto[] }>("/api/gh/repos");
   return repos;

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -525,6 +525,38 @@ export interface PullRequestDto {
   base: string;
 }
 
+export interface SuggestionDto extends PullRequestDto {
+  author: string | null;
+  /** ISO 8601 — when it was last touched, which is how they are ordered. */
+  updatedAt: string;
+}
+
+/**
+ * The suggestions open on this notebook.
+ *
+ * Open pull requests, which for a notebook is what a suggestion is: somebody
+ * read a page and sent a correction back.
+ */
+export async function listSuggestions(owner: string, repo: string): Promise<SuggestionDto[]> {
+  const { pulls } = await call<{ pulls: SuggestionDto[] }>(
+    `/api/gh/suggestions?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`,
+  );
+  return pulls;
+}
+
+/** Accepts a suggestion, squashed, the way every other merge here is done. */
+export async function acceptSuggestion(options: {
+  owner: string;
+  repo: string;
+  number: number;
+  title?: string;
+}): Promise<{ merged: boolean; sha: string | null }> {
+  return call("/api/gh/review", {
+    method: "POST",
+    body: JSON.stringify({ ...options, action: "merge", method: "squash" }),
+  });
+}
+
 export async function listBranches(owner: string, repo: string): Promise<BranchSummaryDto[]> {
   const { branches } = await call<{ branches: BranchSummaryDto[] }>(
     `/api/gh/branches?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`,

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -577,6 +577,15 @@ export async function createBranch(options: {
   return branch;
 }
 
+/** Throws away an experiment branch, and whatever was tried on it. */
+export async function deleteBranch(options: {
+  owner: string;
+  repo: string;
+  name: string;
+}): Promise<void> {
+  await call("/api/gh/branches", { method: "DELETE", body: JSON.stringify(options) });
+}
+
 /** Forks a repository so the user can write to a project they cannot push to. */
 export async function forkRepo(
   owner: string,

--- a/apps/web/src/lib/pdf-follow.test.ts
+++ b/apps/web/src/lib/pdf-follow.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { anchorsFor, lineForPage, pageForLine, type Anchor } from "./pdf-follow";
+import type { PdfMention } from "./pdf-mentions";
+
+const mention = (over: Partial<PdfMention>): PdfMention => ({
+  notePath: "reading.md",
+  pdfPath: "papers/x.pdf",
+  citation: null,
+  line: 1,
+  label: "x",
+  page: 1,
+  quote: null,
+  context: "",
+  ...over,
+});
+
+const anchors: Anchor[] = [
+  { line: 5, page: 2 },
+  { line: 20, page: 7 },
+  { line: 40, page: 12 },
+];
+
+describe("anchorsFor", () => {
+  it("takes this note's citations, in the order they are written", () => {
+    const found = anchorsFor(
+      [
+        mention({ line: 20, page: 7 }),
+        mention({ line: 5, page: 2 }),
+        mention({ notePath: "elsewhere.md", line: 1, page: 99 }),
+      ],
+      "reading.md",
+    );
+
+    expect(found).toEqual([
+      { line: 5, page: 2 },
+      { line: 20, page: 7 },
+    ]);
+  });
+
+  it("ignores a link that names no page, since it points at no part of it", () => {
+    expect(anchorsFor([mention({ page: null })], "reading.md")).toEqual([]);
+  });
+});
+
+describe("pageForLine", () => {
+  it("follows the nearest citation above the caret", () => {
+    expect(pageForLine(anchors, 25)).toBe(7);
+    expect(pageForLine(anchors, 40)).toBe(12);
+    expect(pageForLine(anchors, 1000)).toBe(12);
+  });
+
+  it("takes the citation the caret is on, not the one before it", () => {
+    expect(pageForLine(anchors, 20)).toBe(7);
+  });
+
+  /**
+   * A caret in the note's introduction is not a statement about any page.
+   * Turning the document because somebody clicked in a heading is the kind of
+   * helpfulness people switch off.
+   */
+  it("follows nothing above the first citation", () => {
+    expect(pageForLine(anchors, 1)).toBeNull();
+    expect(pageForLine([], 10)).toBeNull();
+  });
+});
+
+describe("lineForPage", () => {
+  it("finds the paragraph written about the part now on screen", () => {
+    expect(lineForPage(anchors, 7)).toBe(20);
+    expect(lineForPage(anchors, 9)).toBe(20);
+    expect(lineForPage(anchors, 400)).toBe(40);
+  });
+
+  it("follows nothing before the first cited page", () => {
+    expect(lineForPage(anchors, 1)).toBeNull();
+  });
+
+  it("orders by page, not by where the citations happen to sit in the note", () => {
+    // A note that quotes page 12 before page 2 is a note somebody wrote out of
+    // order, which is normal and must not confuse the mapping.
+    const jumbled: Anchor[] = [
+      { line: 5, page: 12 },
+      { line: 30, page: 2 },
+    ];
+
+    expect(lineForPage(jumbled, 3)).toBe(30);
+    expect(lineForPage(jumbled, 12)).toBe(5);
+  });
+});

--- a/apps/web/src/lib/pdf-follow.ts
+++ b/apps/web/src/lib/pdf-follow.ts
@@ -1,0 +1,65 @@
+import type { PdfMention } from "@/lib/pdf-mentions";
+
+/**
+ * Keeping a note and the paper it is about on the same page.
+ *
+ * This is what people open two windows to fake: write a paragraph about page
+ * twelve, and scroll the document to page twelve by hand, over and over, all
+ * afternoon. The notebook already knows the mapping — every citation in the
+ * note records the page it came from — so nothing has to be inferred and no
+ * scroll positions have to be guessed at.
+ *
+ * Both directions are the same idea from either end: the nearest citation at
+ * or above the place you are is the one you are working from. Above every
+ * citation there is nothing to follow, and saying so is better than jumping to
+ * the first page of a document nobody has cited yet.
+ *
+ * Pure, and deliberately unaware of scroll containers, editors and readers.
+ * What "where you are" means differs by view; what to do about it does not.
+ */
+
+/** Citations in one note, ordered by where they sit in it. */
+export function anchorsFor(mentions: readonly PdfMention[], notePath: string) {
+  return mentions
+    .filter((mention) => mention.notePath === notePath && mention.page != null)
+    .map((mention) => ({ line: mention.line, page: mention.page as number }))
+    .sort((a, b) => a.line - b.line);
+}
+
+export interface Anchor {
+  line: number;
+  page: number;
+}
+
+/**
+ * The page to show for a caret on `line`.
+ *
+ * The nearest citation at or above it. Null above the first one: a caret in
+ * the note's introduction is not a statement about any page, and turning the
+ * document to page one because somebody put their cursor in a heading is the
+ * kind of helpfulness people switch off.
+ */
+export function pageForLine(anchors: readonly Anchor[], line: number): number | null {
+  let found: number | null = null;
+  for (const anchor of anchors) {
+    if (anchor.line > line) break;
+    found = anchor.page;
+  }
+  return found;
+}
+
+/**
+ * The line to show for a document open at `page`.
+ *
+ * The last citation at or before that page, which is the paragraph written
+ * about the part of the paper now on screen. Null before the first citation,
+ * for the same reason as above.
+ */
+export function lineForPage(anchors: readonly Anchor[], page: number): number | null {
+  let found: number | null = null;
+  for (const anchor of [...anchors].sort((a, b) => a.page - b.page || a.line - b.line)) {
+    if (anchor.page > page) break;
+    found = anchor.line;
+  }
+  return found;
+}

--- a/apps/web/src/lib/pdf-highlights.test.ts
+++ b/apps/web/src/lib/pdf-highlights.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { PdfCitation } from "@forkleaf/pdf";
+import {
+  highlightsPathFor,
+  parseHighlights,
+  withHighlight,
+  withoutHighlight,
+} from "./pdf-highlights";
+
+const cite = (page: number, quote: string): PdfCitation => ({
+  page,
+  quote,
+  prefix: "",
+  suffix: "",
+});
+
+const options = { pdfPath: "papers/attention.pdf", title: "attention" };
+
+describe("highlightsPathFor", () => {
+  it("puts the file beside the document it belongs to", () => {
+    expect(highlightsPathFor("papers/attention.pdf")).toBe("papers/attention.highlights.md");
+  });
+
+  it("works for a document at the top of the repository", () => {
+    expect(highlightsPathFor("attention.pdf")).toBe("attention.highlights.md");
+  });
+});
+
+describe("withHighlight", () => {
+  it("writes a line anybody could read without this app", () => {
+    const file = withHighlight("", { ...options, citation: cite(12, "attention is all you need") });
+
+    expect(file).toContain("# Highlights — attention");
+    // The document's own name: the file sits beside it, so the link resolves
+    // on github.com too.
+    expect(file).toContain("- [p. 12](attention.pdf#page=12");
+    expect(file).toContain("— attention is all you need");
+  });
+
+  it("keeps them in page order, however they were made", () => {
+    let file = withHighlight("", { ...options, citation: cite(12, "later") });
+    file = withHighlight(file, { ...options, citation: cite(3, "earlier") });
+
+    expect(file.indexOf("earlier")).toBeLessThan(file.indexOf("later"));
+  });
+
+  it("does not mark the same passage twice", () => {
+    const once = withHighlight("", { ...options, citation: cite(4, "the same words") });
+    const twice = withHighlight(once, { ...options, citation: cite(4, "the  same words ") });
+
+    // Highlighting a sentence again is somebody checking it is there.
+    expect(twice).toBe(once);
+  });
+
+  it("keeps what was already in the file", () => {
+    const first = withHighlight("", { ...options, citation: cite(1, "one") });
+    const second = withHighlight(first, { ...options, citation: cite(2, "two") });
+
+    expect(parseHighlights(second).map((held) => held.text)).toEqual(["one", "two"]);
+  });
+});
+
+describe("parseHighlights", () => {
+  it("reads back what it wrote, citation and all", () => {
+    const file = withHighlight("", {
+      ...options,
+      citation: { page: 12, quote: "attention is all", prefix: "We show that", suffix: ", and" },
+    });
+
+    const [held] = parseHighlights(file);
+
+    expect(held?.citation.page).toBe(12);
+    expect(held?.citation.quote).toBe("attention is all");
+    // The context is what tells two occurrences of a phrase apart, so it has
+    // to survive the round trip.
+    expect(held?.citation.prefix).toBe("We show that");
+  });
+
+  it("ignores prose somebody has added around the list", () => {
+    const file = [
+      "# Highlights — attention",
+      "",
+      "Some notes I typed in here by hand.",
+      "",
+      "- [p. 2](attention.pdf#page=2&q=a%20passage) — a passage",
+    ].join("\n");
+
+    expect(parseHighlights(file)).toHaveLength(1);
+  });
+
+  it("finds nothing in a file that has none", () => {
+    expect(parseHighlights("# Just a note\n\nNothing marked.")).toEqual([]);
+  });
+});
+
+describe("withoutHighlight", () => {
+  it("takes one out and leaves the rest", () => {
+    let file = withHighlight("", { ...options, citation: cite(1, "keep me") });
+    file = withHighlight(file, { ...options, citation: cite(2, "remove me") });
+
+    const after = withoutHighlight(file, { ...options, quote: "remove me" });
+
+    expect(parseHighlights(after).map((held) => held.text)).toEqual(["keep me"]);
+  });
+
+  it("leaves a file that still says what it is when the last one goes", () => {
+    const file = withHighlight("", { ...options, citation: cite(1, "only one") });
+    const after = withoutHighlight(file, { ...options, quote: "only one" });
+
+    // Not an empty file: a heading says what the file is for, and the next
+    // highlight has somewhere to go.
+    expect(after.trim()).toBe("# Highlights — attention");
+  });
+});

--- a/apps/web/src/lib/pdf-highlights.ts
+++ b/apps/web/src/lib/pdf-highlights.ts
@@ -1,0 +1,121 @@
+import { citationLink, parseCitation, type PdfCitation } from "@forkleaf/pdf";
+import { basename, dirname, joinPath, stripExtension } from "@forkleaf/markdown-engine";
+
+/**
+ * Highlights that are just a text file.
+ *
+ * Everybody else locks a highlight inside the PDF — where it is a binary
+ * annotation you can only read with a PDF reader — or inside their own app,
+ * where you can never get it out at all. Both mean the marks you made on a
+ * paper are worth nothing away from the tool you made them in, which is a
+ * strange fate for the part that is actually yours.
+ *
+ * A ForkLeaf highlight is a line in an ordinary markdown file, committed beside
+ * the document: `attention.pdf` gets `attention.highlights.md`. It renders on
+ * github.com, opens in Notepad, greps, diffs, and comes back years later
+ * without this app. The PDF itself is never touched — the file in the
+ * repository stays exactly as it was committed, which is the promise the
+ * reader has always made.
+ *
+ * Each line carries the same citation as a quotation in a note, so a highlight
+ * is found again by its words rather than by a page number that goes stale.
+ */
+
+/** `papers/attention.pdf` → `papers/attention.highlights.md`. */
+export function highlightsPathFor(pdfPath: string): string {
+  const folder = dirname(pdfPath);
+  const name = stripExtension(basename(pdfPath));
+  return joinPath(folder, `${name}.highlights.md`);
+}
+
+export interface Highlight {
+  citation: PdfCitation;
+  /** The passage as it reads, which is what the line is mostly made of. */
+  text: string;
+}
+
+/**
+ * A line, as it is written into the file.
+ *
+ * A list item rather than a blockquote: a page of blockquotes is a page that
+ * reads as though somebody wrote it, and this is a list of things somebody
+ * marked. The link is relative to the file, which sits beside the document, so
+ * it is just the document's name.
+ */
+const LINE = /^\s*[-*]\s+\[p\.\s*(\d+)\]\(([^()\s]+)\)\s*(?:—|--)?\s*(.*)$/;
+
+export function parseHighlights(markdown: string): Highlight[] {
+  const found: Highlight[] = [];
+
+  for (const line of markdown.split("\n")) {
+    const match = LINE.exec(line);
+    if (!match) continue;
+
+    const fragment = match[2]?.split("#")[1] ?? "";
+    const citation = parseCitation(fragment);
+    if (!citation) continue;
+
+    found.push({ citation, text: (match[3] ?? "").trim() });
+  }
+
+  return found;
+}
+
+/**
+ * The file with one more highlight in it.
+ *
+ * Kept in page order, because the file is read by people as well as by this
+ * app and a list of a paper's passages out of order is a list nobody can use.
+ * A passage already marked is not marked twice: highlighting the same sentence
+ * again is somebody checking it is there, not asking for a duplicate.
+ */
+export function withHighlight(
+  markdown: string,
+  options: { pdfPath: string; title: string; citation: PdfCitation },
+): string {
+  const quote = tidy(options.citation.quote);
+  const existing = parseHighlights(markdown);
+
+  if (existing.some((held) => tidy(held.citation.quote) === quote)) return markdown;
+
+  const all = [...existing, { citation: options.citation, text: quote }].sort(
+    (a, b) => a.citation.page - b.citation.page,
+  );
+
+  return render(options.title, options.pdfPath, all);
+}
+
+/** Removes one highlight, leaving the rest of the file as it was. */
+export function withoutHighlight(
+  markdown: string,
+  options: { pdfPath: string; title: string; quote: string },
+): string {
+  const wanted = tidy(options.quote);
+  const kept = parseHighlights(markdown).filter((held) => tidy(held.citation.quote) !== wanted);
+
+  return render(options.title, options.pdfPath, kept);
+}
+
+/** The whole file: a heading, and one line per highlight in page order. */
+function render(title: string, pdfPath: string, highlights: readonly Highlight[]): string {
+  if (highlights.length === 0) return `${header(title)}\n`;
+
+  const lines = highlights.map((held) => lineFor(pdfPath, held.citation, held.text));
+  return `${header(title)}\n\n${lines.join("\n")}\n`;
+}
+
+function header(title: string): string {
+  return `# Highlights — ${title}`;
+}
+
+function lineFor(pdfPath: string, citation: PdfCitation, text: string): string {
+  // Relative to the highlights file, which sits beside the document — so the
+  // link is the document's own name and resolves on github.com too.
+  const target = basename(pdfPath);
+  return `- [p. ${citation.page}](${citationLink(target, citation)}) — ${text}`;
+}
+
+/** Whitespace is not what makes two passages different. */
+function tidy(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}

--- a/apps/web/src/lib/pdf-mentions.test.ts
+++ b/apps/web/src/lib/pdf-mentions.test.ts
@@ -117,3 +117,16 @@ describe("mentionsOfPdf — labels", () => {
     expect(mentionsOfPdf(notes, "papers/x.pdf")[0]?.label).toBe("Results [draft], p. 3");
   });
 });
+
+describe("mentionsOfPdf — a document's own highlights", () => {
+  it("leaves the highlights file out, since the page already shows it", () => {
+    const notes = [
+      {
+        path: "papers/attention.highlights.md",
+        content: "- [p. 12](attention.pdf#page=12&q=marked) — marked",
+      },
+    ];
+
+    expect(mentionsOfPdf(notes, "papers/attention.pdf")).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/pdf-mentions.ts
+++ b/apps/web/src/lib/pdf-mentions.ts
@@ -91,6 +91,11 @@ function scan(notes: readonly MentionSource[], wanted: (pdfPath: string) => bool
     // notebook of a few thousand notes.
     if (!note.content.toLowerCase().includes(".pdf")) continue;
 
+    // A document's own highlights file is not a note about the document: the
+    // passages in it are already drawn on the page, and listing them here as
+    // well would say the same thing twice.
+    if (note.path.endsWith(".highlights.md")) continue;
+
     const lines = note.content.split("\n");
 
     lines.forEach((line, index) => {

--- a/apps/web/src/lib/pdf-text-file.test.ts
+++ b/apps/web/src/lib/pdf-text-file.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { formatPageText, parsePageText, textPathFor } from "./pdf-text-file";
+
+describe("textPathFor", () => {
+  it("puts the file beside the document it belongs to", () => {
+    expect(textPathFor("papers/attention.pdf")).toBe("papers/attention.text.md");
+  });
+
+  it("works for a document at the top of the repository", () => {
+    expect(textPathFor("scan.pdf")).toBe("scan.text.md");
+  });
+});
+
+describe("parsePageText", () => {
+  it("reads a page per heading", () => {
+    const file = [
+      "# Text of scan",
+      "",
+      "## Page 1",
+      "",
+      "The first page.",
+      "",
+      "## Page 2",
+      "",
+      "The second.",
+    ].join("\n");
+
+    expect(parsePageText(file)).toEqual([
+      { page: 1, text: "The first page." },
+      { page: 2, text: "The second." },
+    ]);
+  });
+
+  it("keeps every line of a page, blank lines and all", () => {
+    const file = "## Page 1\n\nOne.\n\nTwo.\n";
+    expect(parsePageText(file)[0]?.text).toBe("One.\n\nTwo.");
+  });
+
+  /**
+   * Somebody will make these with `ocrmypdf` or by hand and will annotate
+   * them. Refusing to read a file over a note somebody left themselves would
+   * be the wrong way round.
+   */
+  it("tolerates a heading that says more than the page number", () => {
+    expect(parsePageText("## Page 12 (the fold-out)\n\nWords.")).toEqual([
+      { page: 12, text: "Words." },
+    ]);
+  });
+
+  it("ignores whatever comes before the first page", () => {
+    const file = "# Text of scan\n\nMade with ocrmypdf.\n\n## Page 1\n\nWords.";
+    expect(parsePageText(file)).toEqual([{ page: 1, text: "Words." }]);
+  });
+
+  it("drops a page with nothing on it, which a blank scan really has", () => {
+    expect(parsePageText("## Page 1\n\n## Page 2\n\nWords.")).toEqual([
+      { page: 2, text: "Words." },
+    ]);
+  });
+
+  it("finds nothing in a file that is not one of these", () => {
+    expect(parsePageText("# A note\n\nAbout something else.")).toEqual([]);
+  });
+});
+
+describe("formatPageText", () => {
+  it("writes a file the parser reads back exactly", () => {
+    const pages = [
+      { page: 2, text: "The second." },
+      { page: 1, text: "The first." },
+    ];
+
+    const file = formatPageText("attention", pages);
+
+    // In page order, whatever order they arrived in: the file is read by
+    // people as well as by this app.
+    expect(parsePageText(file)).toEqual([
+      { page: 1, text: "The first." },
+      { page: 2, text: "The second." },
+    ]);
+    expect(file).toContain("# Text of attention");
+  });
+});

--- a/apps/web/src/lib/pdf-text-file.ts
+++ b/apps/web/src/lib/pdf-text-file.ts
@@ -1,0 +1,90 @@
+import { basename, dirname, joinPath, stripExtension } from "@forkleaf/markdown-engine";
+import type { PdfPageText } from "@forkleaf/pdf";
+
+/**
+ * A document's text, kept beside it as a file.
+ *
+ * Two problems, one answer.
+ *
+ * A scan is a photograph of a page. There is no text in it, so there is
+ * nothing to search, nothing to quote and nothing to check a citation
+ * against — the reader says so honestly today and then there is nowhere to go.
+ * The words have to be recognised by something, once, and the result has to
+ * live somewhere every device can see. A file beside the document is that
+ * somewhere.
+ *
+ * And a paper that *does* carry its text still has it extracted from scratch
+ * on every device, every time — seconds of work per document, repeated
+ * forever, thrown away at the end. The same file fixes that too: read once,
+ * committed, and every other machine simply reads it.
+ *
+ * Deliberately markdown with a heading per page, not JSON. Somebody will
+ * produce these with `ocrmypdf`, `tesseract` or by hand, and will want to fix
+ * a mangled line when they find one — which means the format has to be
+ * something a person can open, read and correct without a tool. It renders on
+ * github.com, greps, and diffs a page at a time.
+ */
+
+/** `papers/attention.pdf` → `papers/attention.text.md`. */
+export function textPathFor(pdfPath: string): string {
+  const folder = dirname(pdfPath);
+  const name = stripExtension(basename(pdfPath));
+  return joinPath(folder, `${name}.text.md`);
+}
+
+/**
+ * `## Page 12`, at the start of a line.
+ *
+ * Tolerant about the rest of the heading — `## Page 12 (front matter)` is
+ * still page 12 — because a person writing one of these by hand will annotate
+ * it, and refusing to read a file over a note somebody left themselves would
+ * be the wrong way round.
+ */
+const PAGE_HEADING = /^\s{0,3}#{1,6}\s+page\s+(\d+)\b.*$/i;
+
+export function parsePageText(markdown: string): { page: number; text: string }[] {
+  const pages: { page: number; lines: string[] }[] = [];
+
+  for (const line of markdown.split("\n")) {
+    const heading = PAGE_HEADING.exec(line);
+    if (heading?.[1]) {
+      pages.push({ page: Number.parseInt(heading[1], 10), lines: [] });
+      continue;
+    }
+
+    // Anything before the first page heading is the file's own title and
+    // whatever the person who made it wanted to say about it.
+    pages[pages.length - 1]?.lines.push(line);
+  }
+
+  return pages
+    .map((page) => ({ page: page.page, text: page.lines.join("\n").trim() }))
+    .filter((page) => Number.isFinite(page.page) && page.page > 0 && page.text !== "");
+}
+
+/** The file, as this app writes one. */
+export function formatPageText(
+  title: string,
+  pages: readonly { page: number; text: string }[],
+): string {
+  const body = [...pages]
+    .sort((a, b) => a.page - b.page)
+    .map((page) => `## Page ${page.page}\n\n${page.text.trim()}`)
+    .join("\n\n");
+
+  return [
+    `# Text of ${title}`,
+    "",
+    "The words of the document beside this file, one section per page — so they",
+    "can be searched, quoted and checked without every device reading the whole",
+    "document again. Correcting a line here corrects it everywhere.",
+    "",
+    body,
+    "",
+  ].join("\n");
+}
+
+/** Stored pages as the search and citation code want them. */
+export function asPageText(pages: readonly { page: number; text: string }[]): PdfPageText[] {
+  return pages.map((page) => ({ page: page.page, text: page.text, runs: [] }));
+}

--- a/apps/web/src/lib/pdf-text-file.ts
+++ b/apps/web/src/lib/pdf-text-file.ts
@@ -1,5 +1,4 @@
 import { basename, dirname, joinPath, stripExtension } from "@forkleaf/markdown-engine";
-import type { PdfPageText } from "@forkleaf/pdf";
 
 /**
  * A document's text, kept beside it as a file.
@@ -82,9 +81,4 @@ export function formatPageText(
     body,
     "",
   ].join("\n");
-}
-
-/** Stored pages as the search and citation code want them. */
-export function asPageText(pages: readonly { page: number; text: string }[]): PdfPageText[] {
-  return pages.map((page) => ({ page: page.page, text: page.text, runs: [] }));
 }

--- a/apps/web/src/lib/pdf-versions.test.ts
+++ b/apps/web/src/lib/pdf-versions.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { affected, comparePages, listPages } from "./pdf-versions";
+
+const pages = (...texts: string[]) => texts.map((text, index) => ({ page: index + 1, text }));
+
+describe("comparePages", () => {
+  it("names the pages whose words changed", () => {
+    const before = pages("One.", "Two.", "Three.");
+    const after = pages("One.", "Two, revised.", "Three.");
+
+    const result = comparePages(before, after);
+
+    expect(result.changes).toEqual([{ page: 2, kind: "changed" }]);
+    expect(result.unchanged).toBe(2);
+  });
+
+  /**
+   * A PDF re-exported from the same source differs in every byte — timestamps,
+   * object order, a new producer string — while saying exactly the same thing.
+   * A diff that reported four hundred changed pages every time somebody
+   * re-saved a paper is a diff nobody reads twice.
+   */
+  it("is not fooled by typesetting that says the same thing", () => {
+    const before = pages("the regu-\nlar expression, ﬁnally");
+    const after = pages("the  regular expression,   finally");
+
+    expect(comparePages(before, after).changes).toEqual([]);
+  });
+
+  it("notices a page that was inserted", () => {
+    const before = pages("One.", "Two.");
+    const after = pages("One.", "A new figure.", "Two.");
+
+    // Everything after the insertion reads as changed, which is exactly what
+    // has happened to it: page 2 is not what page 2 was.
+    expect(comparePages(before, after).changes).toEqual([
+      { page: 2, kind: "changed" },
+      { page: 3, kind: "added" },
+    ]);
+  });
+
+  it("notices pages that have gone", () => {
+    const before = pages("One.", "Two.", "Three.");
+    const after = pages("One.", "Two.");
+
+    // A citation pointing at page 3 is pointing at nothing.
+    expect(comparePages(before, after).changes).toEqual([{ page: 3, kind: "removed" }]);
+  });
+
+  it("says nothing at all about two versions that match", () => {
+    const same = pages("One.", "Two.");
+    expect(comparePages(same, same)).toEqual({ changes: [], unchanged: 2, pages: 2 });
+  });
+});
+
+describe("affected", () => {
+  it("picks out the pages you actually quoted", () => {
+    const comparison = comparePages(pages("a", "b", "c"), pages("a", "B!", "C!"));
+
+    // The sentence no other reading app can print.
+    expect(affected(comparison, [3])).toEqual([{ page: 3, kind: "changed" }]);
+    expect(affected(comparison, [1])).toEqual([]);
+  });
+});
+
+describe("listPages", () => {
+  it("says it the way somebody would say it out loud", () => {
+    expect(listPages([])).toBe("");
+    expect(listPages([4])).toBe("page 4");
+    expect(listPages([4, 7])).toBe("pages 4 and 7");
+    expect(listPages([4, 7, 12])).toBe("pages 4, 7 and 12");
+  });
+});

--- a/apps/web/src/lib/pdf-versions.ts
+++ b/apps/web/src/lib/pdf-versions.ts
@@ -1,0 +1,95 @@
+import { normalizeForMatch } from "@forkleaf/pdf";
+
+/**
+ * What changed between two versions of a document.
+ *
+ * The file sits in a repository, so every version of it is kept — which no
+ * other reading app can say. What follows from that is the sentence none of
+ * them can print: *the page you quoted is one of the ones that changed*. Every
+ * other tool stores a page number, cannot see the old file, and so cannot
+ * notice; here the old file is one request away.
+ *
+ * Compared as text, page by page. Not as bytes: a PDF re-exported from the
+ * same source differs in every byte — timestamps, object order, a new
+ * producer string — while saying exactly the same thing, and a diff that
+ * reported "all 400 pages changed" every time somebody re-saved a paper would
+ * be a diff nobody reads twice.
+ *
+ * Normalised the same way citations and search are, so hyphenation across a
+ * line break, a ligature and a run of spaces are not treated as edits. What is
+ * left is a change in the words.
+ */
+
+export type PageChangeKind = "changed" | "added" | "removed";
+
+export interface PageChange {
+  page: number;
+  kind: PageChangeKind;
+}
+
+export interface VersionComparison {
+  changes: PageChange[];
+  /** Pages present in both versions saying the same thing. */
+  unchanged: number;
+  /** How many pages the newer version has. */
+  pages: number;
+}
+
+export interface PageText {
+  page: number;
+  text: string;
+}
+
+export function comparePages(
+  before: readonly PageText[],
+  after: readonly PageText[],
+): VersionComparison {
+  const older = new Map(before.map((page) => [page.page, normalise(page.text)]));
+  const newer = new Map(after.map((page) => [page.page, normalise(page.text)]));
+
+  const changes: PageChange[] = [];
+  let unchanged = 0;
+
+  for (const [page, text] of newer) {
+    const was = older.get(page);
+    if (was === undefined) changes.push({ page, kind: "added" });
+    else if (was !== text) changes.push({ page, kind: "changed" });
+    else unchanged += 1;
+  }
+
+  // A shorter document has lost pages off the end, which is a change worth
+  // naming: a citation pointing at one of them is pointing at nothing.
+  for (const page of older.keys()) {
+    if (!newer.has(page)) changes.push({ page, kind: "removed" });
+  }
+
+  changes.sort((a, b) => a.page - b.page);
+  return { changes, unchanged, pages: after.length };
+}
+
+/**
+ * The pages somebody has quoted or marked that are among the changes.
+ *
+ * The sentence this whole comparison exists to be able to say. A page that
+ * changed under a citation is not necessarily a citation that has broken —
+ * the words may still be there, further down — which is what the citation
+ * check answers. This says where to look.
+ */
+export function affected(comparison: VersionComparison, cited: readonly number[]): PageChange[] {
+  const wanted = new Set(cited);
+  return comparison.changes.filter((change) => wanted.has(change.page));
+}
+
+/** "pages 4, 7 and 12" — the way somebody would say it out loud. */
+export function listPages(pages: readonly number[]): string {
+  if (pages.length === 0) return "";
+  if (pages.length === 1) return `page ${pages[0]}`;
+
+  const all = [...pages];
+  const last = all.pop();
+  return `pages ${all.join(", ")} and ${last}`;
+}
+
+function normalise(text: string): string {
+  return normalizeForMatch(text).text.trim();
+}

--- a/apps/web/src/lib/publish-citations.test.ts
+++ b/apps/web/src/lib/publish-citations.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { RepoRef } from "@forkleaf/types";
+import { documentUrl, linkDocuments } from "./publish-citations";
+
+const repo: RepoRef = { owner: "me", repo: "notes", branch: "main", directory: "" };
+const options = { notePath: "reading/attention.md", repo };
+
+describe("linkDocuments", () => {
+  it("points a citation at a document a reader can actually reach", () => {
+    const markdown =
+      "> A passage.\n>\n> — [Paper, p. 12](../papers/attention.pdf#page=12&q=A%20passage)";
+
+    expect(linkDocuments(markdown, options)).toContain(
+      "https://github.com/me/notes/blob/main/papers/attention.pdf#page=12&q=A%20passage",
+    );
+  });
+
+  it("keeps the fragment exactly as it was", () => {
+    // It is the standard `#page=` plus the quotation, and it is what makes the
+    // link open the right page in anything.
+    const markdown = "[p. 3](../papers/x.pdf#page=3&q=words&pre=before&suf=after)";
+
+    expect(linkDocuments(markdown, options)).toContain("#page=3&q=words&pre=before&suf=after");
+  });
+
+  it("resolves against the note, not the repository root", () => {
+    const deep = { notePath: "a/b/c/note.md", repo };
+    expect(linkDocuments("[x](../../papers/y.pdf#page=1)", deep)).toContain(
+      "/blob/main/a/papers/y.pdf",
+    );
+  });
+
+  it("leaves everything that is not a document alone", () => {
+    const markdown = [
+      "[a note](../other.md)",
+      "[a site](https://example.com/x.pdf#page=2)",
+      "![a picture](assets/chart.png)",
+      "[an anchor](#heading)",
+    ].join("\n\n");
+
+    expect(linkDocuments(markdown, options)).toBe(markdown);
+  });
+
+  it("leaves an image of a document alone, which is not a citation", () => {
+    const markdown = "![figure](../papers/x.pdf)";
+    expect(linkDocuments(markdown, options)).toBe(markdown);
+  });
+
+  it("keeps the words of the link", () => {
+    const markdown = "[On Attention, p. 12](../papers/attention.pdf#page=12)";
+    expect(linkDocuments(markdown, options)).toContain("[On Attention, p. 12](");
+  });
+});
+
+describe("documentUrl", () => {
+  it("includes the workspace's folder, since that is where the file is", () => {
+    expect(documentUrl({ ...repo, directory: "wiki" }, "papers/x.pdf")).toBe(
+      "https://github.com/me/notes/blob/main/wiki/papers/x.pdf",
+    );
+  });
+
+  it("encodes each segment without encoding the slashes between them", () => {
+    expect(documentUrl(repo, "SOC 101/week one.pdf")).toBe(
+      "https://github.com/me/notes/blob/main/SOC%20101/week%20one.pdf",
+    );
+  });
+});

--- a/apps/web/src/lib/publish-citations.ts
+++ b/apps/web/src/lib/publish-citations.ts
@@ -1,0 +1,74 @@
+import type { RepoRef } from "@forkleaf/types";
+import { resolveAgainstNote } from "@/lib/assets";
+import { isPdfPath } from "@/lib/media";
+
+/**
+ * Publishing your reading, not just your notes.
+ *
+ * A note written from a paper is commentary with the passages set into it, each
+ * one linked back to the page it came from — which is the thing actually worth
+ * sharing. Not "here is a PDF", and not "here is an opinion", but the argument
+ * with its receipts attached.
+ *
+ * It did not survive publishing. A citation is written relative to the note —
+ * `../papers/attention.pdf#page=12` — which is right in the repository and
+ * wrong on a published page: GitHub Pages serves the `docs/` folder, so a link
+ * pointing above it reaches nothing at all. Every quotation on a published
+ * reading page was a dead link, silently, which is worse than no link because
+ * it looks like there is a source behind it.
+ *
+ * So the links are rewritten on the way out, to the document where a reader
+ * can actually reach it. The fragment goes with them untouched: it is the
+ * standard `#page=` every reader has understood for twenty years plus the
+ * quotation, so it still opens the right page, and anything that knows the
+ * format can still find the right sentence.
+ *
+ * Only the published copy is rewritten. The note in the repository keeps its
+ * relative links, because that is what makes it readable on github.com, in
+ * another editor, and by this app.
+ */
+
+/** Markdown inline links, minus images: `![alt](x.pdf)` is not a citation. */
+const LINK = /(?<!!)\[((?:[^[\]\\]|\\.)*)\]\(([^()\s]+)\)/g;
+
+export function linkDocuments(
+  markdown: string,
+  options: { notePath: string; repo: RepoRef },
+): string {
+  return markdown.replace(LINK, (whole, label: string, href: string) => {
+    const [path, fragment = ""] = splitFragment(href);
+    if (!path || !isRelative(path) || !isPdfPath(path)) return whole;
+
+    const inRepo = resolveAgainstNote(options.notePath, path);
+    return `[${label}](${documentUrl(options.repo, inRepo)}${fragment ? `#${fragment}` : ""})`;
+  });
+}
+
+/**
+ * Where a reader can see the document itself.
+ *
+ * github.com rather than `raw.githubusercontent.com`: raw serves a PDF as
+ * something to download, and a reader who followed a citation wanted to *read*
+ * the page, not to end up with a file in their downloads folder. The blob page
+ * shows it in a viewer, and for a private repository it at least says plainly
+ * that this is a document they cannot see — which a 404 from raw does not.
+ */
+export function documentUrl(repo: RepoRef, path: string): string {
+  const full = repo.directory ? `${repo.directory}/${path}` : path;
+  const encoded = full
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  return `https://github.com/${repo.owner}/${repo.repo}/blob/${encodeURIComponent(repo.branch)}/${encoded}`;
+}
+
+/** True when a note is naming a file of its own rather than somewhere else. */
+function isRelative(path: string): boolean {
+  return !/^[a-z][a-z0-9+.-]*:/i.test(path) && !path.startsWith("//") && !path.startsWith("/");
+}
+
+function splitFragment(href: string): [path: string, fragment: string] {
+  const hash = href.indexOf("#");
+  return hash === -1 ? [href, ""] : [href.slice(0, hash), href.slice(hash + 1)];
+}

--- a/apps/web/src/lib/publish-target.test.ts
+++ b/apps/web/src/lib/publish-target.test.ts
@@ -4,6 +4,7 @@ import {
   describeTarget,
   idIsStableAcross,
   isSplitPublishing,
+  suggestEditUrl,
   parseTarget,
   publishTargetOf,
   targetWarning,
@@ -155,5 +156,40 @@ describe("withPublishTarget", () => {
 describe("describeTarget", () => {
   it("reads as owner/name", () => {
     expect(describeTarget(PUBLIC)).toBe("me/site");
+  });
+});
+
+/**
+ * The reader's way to send a correction back. GitHub's own editor forks,
+ * commits and opens the pull request; none of that has to be built here.
+ */
+describe("suggestEditUrl", () => {
+  const repo: RepoRef = { owner: "me", repo: "notes", branch: "main", directory: "" };
+
+  it("points at the note's own file, on its own branch", () => {
+    expect(suggestEditUrl(repo, "notes/runbook.md")).toBe(
+      "https://github.com/me/notes/edit/main/notes/runbook.md",
+    );
+  });
+
+  it("includes the workspace's folder, since that is where the file is", () => {
+    expect(suggestEditUrl({ ...repo, directory: "wiki" }, "a.md")).toBe(
+      "https://github.com/me/notes/edit/main/wiki/a.md",
+    );
+  });
+
+  it("encodes each segment without encoding the slashes between them", () => {
+    // A path is a path: percent-encoding its separators makes GitHub look for
+    // one file with slashes in its name.
+    expect(suggestEditUrl(repo, "SOC 101/week one.md")).toBe(
+      "https://github.com/me/notes/edit/main/SOC%20101/week%20one.md",
+    );
+  });
+
+  it("points at the source repository, whatever the page was published to", () => {
+    // A page published into a separate public site is a copy. A suggestion
+    // against the copy is one the author cannot accept without hand-copying it
+    // back.
+    expect(suggestEditUrl(repo, "a.md")).toContain("/me/notes/");
   });
 });

--- a/apps/web/src/lib/publish-target.ts
+++ b/apps/web/src/lib/publish-target.ts
@@ -118,3 +118,26 @@ export function withPublishTarget(workspace: Workspace, target: RepoRef | null):
 export function idIsStableAcross(workspace: Workspace): boolean {
   return workspace.id === workspaceId(workspace.repo);
 }
+
+/**
+ * Where a reader who spots a mistake in a published page should go.
+ *
+ * GitHub's own editor for the note's file. Following it forks the repository,
+ * commits the change to the fork and opens a pull request — three things the
+ * reader never has to know the names of, and none of which this app has to
+ * build, host or hold a token for.
+ *
+ * Deliberately the *source* repository, not wherever the page was published
+ * to. A page published into a separate public site is a copy; suggesting a
+ * change to the copy would produce a suggestion the author cannot accept
+ * without hand-copying it back.
+ */
+export function suggestEditUrl(repo: RepoRef, notePath: string): string {
+  const path = repo.directory ? `${repo.directory}/${notePath}` : notePath;
+  const encoded = path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  return `https://github.com/${repo.owner}/${repo.repo}/edit/${encodeURIComponent(repo.branch)}/${encoded}`;
+}

--- a/apps/web/src/lib/try-branch.test.ts
+++ b/apps/web/src/lib/try-branch.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { describeTry, parseTryBranch, tryBranchFor } from "./try-branch";
+
+describe("tryBranchFor", () => {
+  it("says what it is, where it came from, and what it is about", () => {
+    expect(tryBranchFor("main", "The deploy runbook")).toBe("try/main/the-deploy-runbook");
+  });
+
+  it("keeps a base branch that has slashes in it", () => {
+    expect(tryBranchFor("release/2026", "Notes")).toBe("try/release/2026/notes");
+  });
+
+  it("takes the slashes out of the subject, which is the last segment", () => {
+    // Otherwise a note called "SOC 101/week one" would be read back as a
+    // branch that came from `main/soc-101`.
+    expect(tryBranchFor("main", "SOC 101/week one")).toBe("try/main/soc-101-week-one");
+  });
+
+  it("names an untitled experiment something rather than nothing", () => {
+    expect(tryBranchFor("main", "!!!")).toBe("try/main/rewrite");
+  });
+});
+
+describe("parseTryBranch", () => {
+  it("reads back what the name says", () => {
+    expect(parseTryBranch("try/main/the-deploy-runbook")).toEqual({
+      base: "main",
+      slug: "the-deploy-runbook",
+    });
+  });
+
+  it("gives a base branch its slashes back", () => {
+    expect(parseTryBranch("try/release/2026/notes")).toEqual({
+      base: "release/2026",
+      slug: "notes",
+    });
+  });
+
+  it("says nothing about an ordinary branch", () => {
+    // Being wrong here would offer to merge somebody's feature branch into a
+    // branch this invented.
+    expect(parseTryBranch("main")).toBeNull();
+    expect(parseTryBranch("feature/search")).toBeNull();
+    expect(parseTryBranch("try/")).toBeNull();
+    expect(parseTryBranch("try/main")).toBeNull();
+  });
+
+  it("round-trips whatever it made", () => {
+    const branch = tryBranchFor("release/2026", "The deploy runbook");
+    expect(parseTryBranch(branch)).toEqual({ base: "release/2026", slug: "the-deploy-runbook" });
+  });
+});
+
+describe("describeTry", () => {
+  it("turns a slug back into words", () => {
+    expect(describeTry("the-deploy-runbook")).toBe("the deploy runbook");
+  });
+});

--- a/apps/web/src/lib/try-branch.ts
+++ b/apps/web/src/lib/try-branch.ts
@@ -1,0 +1,65 @@
+import { sanitizeBranchName } from "@/lib/branch-name";
+
+/**
+ * Trying a rewrite without losing what you had.
+ *
+ * Rewriting a note you care about is a small act of courage: the old version
+ * goes into the history, where you have to know it exists and how to get it
+ * back, so in practice people either do not try or paste the original into a
+ * second note called `runbook-old.md`. Both are worse than the thing every
+ * programmer has had for twenty years — work on a copy, keep it or throw it
+ * away, and the original is never in any danger.
+ *
+ * That is a branch, which this app already has for free. All that was missing
+ * was a name for it that says what it is, and somewhere to say "keep this" or
+ * "that did not work" without either of those meaning `git`.
+ *
+ * The branch name carries everything needed to offer both: `try/<base>/<slug>`
+ * says it is an experiment, which branch it came from and what it is about, so
+ * a second device — or the same one next week — can pick the experiment up
+ * knowing where it has to land. Nothing is written down anywhere else, because
+ * anything written down anywhere else would be the thing that gets lost.
+ */
+
+export const TRY_PREFIX = "try/";
+
+export interface TryBranch {
+  /** The branch this experiment must land back on, when it is kept. */
+  base: string;
+  /** What it is about, for saying so on screen. */
+  slug: string;
+}
+
+/** `main` + "The deploy runbook" → `try/main/the-deploy-runbook`. */
+export function tryBranchFor(base: string, subject: string): string {
+  // Slashes out of the subject, not out of the base: the last segment is the
+  // subject and everything between the prefix and it is the base, so a subject
+  // with a slash in it would be read back as part of the branch it came from.
+  const slug =
+    sanitizeBranchName(subject.toLowerCase().replace(/\//g, "-")).slice(0, 40) || "rewrite";
+
+  return `${TRY_PREFIX}${sanitizeBranchName(base)}/${slug}`;
+}
+
+/**
+ * Reads a branch name back, or null for a branch that is not an experiment.
+ *
+ * A base branch with slashes in it — `release/2026` — survives, because the
+ * subject is the last segment and the base is everything before it.
+ */
+export function parseTryBranch(branch: string): TryBranch | null {
+  if (!branch.startsWith(TRY_PREFIX)) return null;
+
+  const rest = branch.slice(TRY_PREFIX.length);
+  const cut = rest.lastIndexOf("/");
+  if (cut <= 0) return null;
+
+  const base = rest.slice(0, cut);
+  const slug = rest.slice(cut + 1);
+  return base && slug ? { base, slug } : null;
+}
+
+/** "the-deploy-runbook" → "the deploy runbook", for saying it out loud. */
+export function describeTry(slug: string): string {
+  return slug.replace(/-+/g, " ").trim();
+}

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -47,8 +47,9 @@ Ticked entries link to nothing; the git history is the record.
 - [x] **Open a PDF and see everything you have written about it** — Small
 - [x] **Search inside your PDFs from ⌘K** — Small. The text is kept the first
       time a document is read, so ⌘K reaches inside the papers as well
-- [ ] **Scroll one pane, the other follows** — Small. Scroll the note and the
-      document moves to the page you are writing about, and back again
+- [x] **Scroll one pane, the other follows** — Small. The cursor and the page
+      follow each other, mapped by the note's own citations. Split and Source
+      view, where there is a cursor to follow
 - [x] **A list of citations that have broken** — Medium. Every quotation in the
       notebook, checked against the document as it stands now: what has moved,
       what is gone, and a one-press fix for a stale page number

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -24,10 +24,10 @@ Ticked entries link to nothing; the git history is the record.
 - [x] **Ask a sentence where it came from** — Medium. Pointing at a paragraph
       now says what it used to say, taken from the revision before the change
       that produced it
-- [ ] **Suggest a change to someone else's notes** — Big. A reader of a
-      published page fixes a mistake and you get a suggestion to accept or
-      decline, without either of you touching GitHub. This is the single most
-      distinctive thing ForkLeaf could ship
+- [x] **Suggest a change to someone else's notes** — Big. Published pages carry
+      **Suggest an edit**; suggestions arrive in a list you can accept from.
+      Reading the diff still happens on GitHub, and the reader still needs a
+      GitHub account — the half that would remove that is still to do
 - [x] **Notes that tell you when they have gone stale** — Medium. A list that
       comes to you, across the notebook: notes pointing at files that have
       gone, links matching no note, and claims that have aged

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -55,8 +55,9 @@ Ticked entries link to nothing; the git history is the record.
 - [ ] **See what changed between two versions of a PDF** — Medium. The file is
       in a repository, so old versions are kept: show page 12 then and now, and
       say whether the page you quoted is one of the ones that changed
-- [ ] **Highlights that are just text files** — Medium. A highlight is an
-      ordinary file beside the PDF, drawn over the page when you read
+- [x] **Highlights that are just text files** — Medium. A line in
+      `<document>.highlights.md` beside the PDF, drawn over the page when you
+      read, found again by its words rather than by a page number
 - [x] **Start a note from a paper** — Small. Title, author and date fill
       themselves in; the paper's headings become the note's headings, each
       linked to the page it starts on

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -62,17 +62,19 @@ Ticked entries link to nothing; the git history is the record.
 - [x] **Start a note from a paper** — Small. Title, author and date fill
       themselves in; the paper's headings become the note's headings, each
       linked to the page it starts on
-- [ ] **Read scanned documents** — Big, and blocked rather than unstarted.
-      Every browser OCR engine needs WebAssembly, and this app deliberately
-      refuses `wasm-unsafe-eval` in the CSP that guards the route rendering
-      markdown from repositories you do not control (see `packages/pdf`'s
-      `document.ts`). Recognising the text on a server instead would mean
-      sending somebody's documents to us, which is the other thing this app
-      is built not to do. It needs a decision about one of those two, not more
-      code
-- [x] **Publish your reading, not just your notes** — Big. Publishing a note
-      now rewrites its citations to the document in your repository, so the
-      quotations on the page link back to the pages they came from
-- [x] **Let other apps understand ForkLeaf's links** — Big. The format is
-      written down at `/docs/citation-links`, and **Copy link** puts one on the
-      clipboard. Inviting the plugin authors is the half that is still to do
+- [~] **Read scanned documents** — Big. Half done, and the other half is a
+  decision rather than code.
+
+      **Done:** a document's words can live in `<name>.text.md` beside it. The
+      reader uses that file when the document has none of its own, so a scan
+      becomes searchable, quotable and checkable — and the work is done once
+      and shared with every device instead of redone on each one.
+
+      **Not done:** recognising the words inside ForkLeaf. Every browser OCR
+      engine needs WebAssembly, and this app deliberately refuses
+      `wasm-unsafe-eval` in the CSP that guards the route rendering markdown
+      from repositories you do not control. Recognising them on a server
+      instead would mean sending somebody's documents to us, which is the other
+      thing this app is built not to do. Either the policy changes or the
+      privacy promise does; until somebody decides which, the file beside the
+      document is the honest answer, and any tool can write it.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -14,10 +14,9 @@ Ticked entries link to nothing; the git history is the record.
 
 ## The whole app
 
-- [ ] **Try a rewrite without losing the original** — Medium. A "Try this"
-      button gives you a second copy of a note to experiment on, compared side
-      by side; keep it or throw it away. It is a git branch, which ForkLeaf
-      already has for free
+- [x] **Try a rewrite without losing the original** — Medium. An experiment
+      branch with a bar that says so, and two buttons: keep it, or throw it
+      away. Comparing the two side by side is still to do
 - [x] **Read your notebook as it was on any date** — Small. A date picker that
       takes the _whole notebook_ back: the files that existed that day, and
       each one readable as it stood. Read-only

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -30,8 +30,9 @@ Ticked entries link to nothing; the git history is the record.
 - [x] **Notes that tell you when they have gone stale** — Medium. A list that
       comes to you, across the notebook: notes pointing at files that have
       gone, links matching no note, and claims that have aged
-- [ ] **Borrow somebody else's notebook** — Big. Link into their notes, pinned
-      to a version, rather than copying and going stale
+- [x] **Borrow somebody else's notebook** — Big. Browse another repository's
+      notes and write a pinned link into yours. Reading one still opens it in a
+      dialog rather than as a note of your own, which is the honest shape
 - [x] **Search that knows what you are working on** — Small. Notes linked to
       the one you are in float to the top of ⌘K, by however many hops away
       they are
@@ -61,8 +62,14 @@ Ticked entries link to nothing; the git history is the record.
 - [x] **Start a note from a paper** — Small. Title, author and date fill
       themselves in; the paper's headings become the note's headings, each
       linked to the page it starts on
-- [ ] **Read scanned documents** — Big. Recognise the text once and keep it
-      beside the file, so the work is shared with every device
+- [ ] **Read scanned documents** — Big, and blocked rather than unstarted.
+      Every browser OCR engine needs WebAssembly, and this app deliberately
+      refuses `wasm-unsafe-eval` in the CSP that guards the route rendering
+      markdown from repositories you do not control (see `packages/pdf`'s
+      `document.ts`). Recognising the text on a server instead would mean
+      sending somebody's documents to us, which is the other thing this app
+      is built not to do. It needs a decision about one of those two, not more
+      code
 - [x] **Publish your reading, not just your notes** — Big. Publishing a note
       now rewrites its citations to the document in your repository, so the
       quotations on the page link back to the pages they came from

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -65,6 +65,6 @@ Ticked entries link to nothing; the git history is the record.
 - [ ] **Publish your reading, not just your notes** — Big. A public page of
       your commentary with the quoted passages set into it, each linking back
       to the exact page
-- [ ] **Let other apps understand ForkLeaf's links** — Big. The link format is
-      a web standard plus the `#page=` every reader has understood for twenty
-      years. Write it up and invite Obsidian and Zotero plugins to use it
+- [x] **Let other apps understand ForkLeaf's links** — Big. The format is
+      written down at `/docs/citation-links`, and **Copy link** puts one on the
+      clipboard. Inviting the plugin authors is the half that is still to do

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -52,9 +52,9 @@ Ticked entries link to nothing; the git history is the record.
 - [x] **A list of citations that have broken** — Medium. Every quotation in the
       notebook, checked against the document as it stands now: what has moved,
       what is gone, and a one-press fix for a stale page number
-- [ ] **See what changed between two versions of a PDF** — Medium. The file is
-      in a repository, so old versions are kept: show page 12 then and now, and
-      say whether the page you quoted is one of the ones that changed
+- [x] **See what changed between two versions of a PDF** — Medium. Which pages
+      changed, compared as text rather than bytes, and whether one of them is a
+      page you quoted. Rendering the two pages side by side is still to do
 - [x] **Highlights that are just text files** — Medium. A line in
       `<document>.highlights.md` beside the PDF, drawn over the page when you
       read, found again by its words rather than by a page number

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -63,9 +63,9 @@ Ticked entries link to nothing; the git history is the record.
       linked to the page it starts on
 - [ ] **Read scanned documents** — Big. Recognise the text once and keep it
       beside the file, so the work is shared with every device
-- [ ] **Publish your reading, not just your notes** — Big. A public page of
-      your commentary with the quoted passages set into it, each linking back
-      to the exact page
+- [x] **Publish your reading, not just your notes** — Big. Publishing a note
+      now rewrites its citations to the document in your repository, so the
+      quotations on the page link back to the pages they came from
 - [x] **Let other apps understand ForkLeaf's links** — Big. The format is
       written down at `/docs/citation-links`, and **Copy link** puts one on the
       clipboard. Inviting the plugin authors is the half that is still to do

--- a/packages/editor/src/MarkdownEditor.tsx
+++ b/packages/editor/src/MarkdownEditor.tsx
@@ -52,6 +52,14 @@ export interface MarkdownEditorProps {
    * so this stays silent in wysiwyg mode rather than inventing a number.
    */
   onCursorChange?: (position: CursorPosition | null) => void;
+  /**
+   * A 1-based line to bring into view, in the source and split views.
+   *
+   * For following something outside the editor. Rich text has no lines to
+   * scroll to — the same note is a tree of nodes there — so it is ignored, and
+   * the feature that uses this says so rather than pretending otherwise.
+   */
+  revealLine?: number | null;
   /** Where images pasted, dropped or picked in this note are stored. */
   images?: ImageBridge;
   /** Shown under "Add an image" — usually where the file will be committed. */
@@ -100,6 +108,7 @@ export function MarkdownEditor({
   hideModeSwitcher = false,
   hideToolbar = false,
   onCursorChange,
+  revealLine = null,
   images,
   imageDestination,
   links,
@@ -427,6 +436,7 @@ export function MarkdownEditor({
             readOnly={readOnly}
             handleRef={sourceHandle}
             onCursorChange={handleCursor}
+            revealLine={revealLine}
             slashActions={actionContext}
             {...(canUpload && !readOnly ? { onImageFiles: handleSourceImages } : {})}
             {...(placeholder ? { placeholder } : {})}
@@ -448,6 +458,7 @@ export function MarkdownEditor({
               readOnly={readOnly}
               handleRef={sourceHandle}
               onCursorChange={handleCursor}
+              revealLine={revealLine}
               slashActions={actionContext}
               {...(canUpload && !readOnly ? { onImageFiles: handleSourceImages } : {})}
               {...(placeholder ? { placeholder } : {})}

--- a/packages/editor/src/SourceEditor.tsx
+++ b/packages/editor/src/SourceEditor.tsx
@@ -56,6 +56,14 @@ export interface SourceEditorProps {
   /** Reports where the caret is, for a status bar. Both numbers are 1-based. */
   onCursorChange?: (position: CursorPosition) => void;
   /**
+   * A 1-based line to bring into view.
+   *
+   * For following something outside the editor — a document being read beside
+   * the note. Only ever scrolls: the caret is not moved, because the reader is
+   * looking at a page, not asking to type somewhere.
+   */
+  revealLine?: number | null;
+  /**
    * Handles images pasted or dropped into the raw markdown.
    *
    * Raw markdown is still markdown: dropping a screenshot into it should write
@@ -151,6 +159,7 @@ export function SourceEditor({
   ariaLabel = "Markdown source",
   handleRef,
   onCursorChange,
+  revealLine,
   onImageFiles,
   slashActions,
   readOnly = false,
@@ -350,6 +359,23 @@ export function SourceEditor({
     // The history above describes a document that no longer exists.
     emitted.current = [];
   }, [value]);
+
+  /**
+   * Brings a line into view without touching what is selected.
+   *
+   * `scrollIntoView` on a position rather than a selection change: moving the
+   * caret would take focus and the note's own selection away from somebody who
+   * is reading, which is the opposite of following along quietly.
+   */
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || revealLine == null) return;
+
+    const line = Math.min(Math.max(revealLine, 1), view.state.doc.lines);
+    view.dispatch({
+      effects: EditorView.scrollIntoView(view.state.doc.line(line).from, { y: "center" }),
+    });
+  }, [revealLine]);
 
   /**
    * The live view, but only when it may be written to.

--- a/packages/exporter/src/html.ts
+++ b/packages/exporter/src/html.ts
@@ -136,6 +136,7 @@ export async function toHtml(
     options.title,
     forPrinting(withoutRepeatedTitle(body, options.title)),
     options.theme,
+    options.suggestUrl ?? null,
   );
 }
 
@@ -159,6 +160,28 @@ function withoutRepeatedTitle(html: string, title: string): string {
   return html.replace(/^\s*<h1\b[^>]*>([\s\S]*?)<\/h1>/i, (whole, inner: string) =>
     normaliseHeading(stripTags(inner)) === wanted ? "" : whole,
   );
+}
+
+/**
+ * The invitation at the foot of a published page.
+ *
+ * Programmers have had "suggest a change to what I wrote" for twenty years and
+ * call it a pull request. Nobody has ever offered it to people writing notes —
+ * a published page is something you read, and that is where it ends.
+ *
+ * The link goes to the note's own file in the repository it came from, where
+ * GitHub's editor forks, commits and opens the request without the reader
+ * having to understand that any of that is happening. Said plainly underneath,
+ * because "suggest an edit" should not be a euphemism for "you are about to
+ * need a GitHub account".
+ */
+function suggestion(url: string | null): string {
+  if (!url) return "";
+
+  return `<aside class="doc-suggest">
+  <a class="doc-suggest-link" href="${escapeHtml(url)}" rel="noopener">Suggest an edit</a>
+  <span class="doc-suggest-note">Opens this note on GitHub. Your change is sent to the author as a suggestion — nothing here changes until they accept it.</span>
+</aside>`;
 }
 
 function stripTags(html: string): string {
@@ -204,7 +227,12 @@ function forPrinting(html: string): string {
  */
 const BRAND_MARK = `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21v-7"/><path d="M12 14 6.5 8.5A4 4 0 0 1 5.4 5.7L5 3l2.7.4a4 4 0 0 1 2.8 1.1L12 6"/><path d="m12 14 5.5-5.5a4 4 0 0 0 1.1-2.8L19 3l-2.7.4a4 4 0 0 0-2.8 1.1L12 6"/></svg>`;
 
-function document(title: string, body: string, theme: "light" | "dark"): string {
+function document(
+  title: string,
+  body: string,
+  theme: "light" | "dark",
+  suggestUrl: string | null,
+): string {
   const dark = theme === "dark";
   const colors = dark
     ? {
@@ -302,6 +330,29 @@ function document(title: string, body: string, theme: "light" | "dark"): string 
   /* The body's own leading H1 would repeat the title block. */
   .doc-head + h1:first-of-type { margin-top: 0; }
 
+  /* ── The invitation to suggest a change ───────────────────────────────
+     Set apart from the note and quiet about it: a reader has come to read,
+     and this is an offer, not a call to action. Never printed — a sheet of
+     paper is not a thing anybody can suggest an edit to. */
+  .doc-suggest {
+    margin-top: 4rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--rule);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+  }
+  .doc-suggest-link {
+    color: var(--accent);
+    font-weight: 600;
+    text-decoration: none;
+    border-bottom: 1px solid currentColor;
+  }
+  .doc-suggest-note { color: var(--muted); }
+  @media print { .doc-suggest { display: none; } }
+
   /* ── The footer ──────────────────────────────────────────────────────
      Hidden on screen, where the app's own chrome is already saying all of
      this, and shown on paper where nothing else is. */
@@ -371,6 +422,7 @@ function document(title: string, body: string, theme: "light" | "dark"): string 
   <p class="doc-meta">${escapeHtml(printedOn())}</p>
 </header>
 ${body}
+${suggestion(suggestUrl)}
 </main>
 <footer class="doc-foot" aria-hidden="true">
   <span class="doc-foot-title">${escapeHtml(title)}</span>

--- a/packages/exporter/src/index.test.ts
+++ b/packages/exporter/src/index.test.ts
@@ -281,3 +281,43 @@ describe("the document's title block", () => {
     expect(html).toContain(">Introduction</h1>");
   });
 });
+
+/**
+ * The other half of "suggest a change to someone else's notes": the page that
+ * invites it. Programmers have had this for twenty years; nobody has offered
+ * it to people writing notes.
+ */
+describe("toHtml — inviting a correction", () => {
+  const url = "https://github.com/me/notes/edit/main/notes/runbook.md";
+
+  it("offers the reader a way to send a fix back", async () => {
+    const html = await toHtml("# Runbook\n\nNeeds v14.", {}, { ...options(), suggestUrl: url });
+
+    expect(html).toContain(url);
+    expect(html).toContain("Suggest an edit");
+    // Said plainly, because "suggest an edit" should not be a euphemism for
+    // "you are about to need a GitHub account".
+    expect(html).toContain("Opens this note on GitHub");
+  });
+
+  it("says nothing of the kind in an ordinary export", async () => {
+    // A PDF in somebody's inbox has no author to reach and no repository
+    // behind it.
+    const html = await toHtml("# Runbook", {}, options());
+
+    expect(html).not.toContain("Suggest an edit");
+    // The rules for it stay in the stylesheet either way; what must not be
+    // there is the block itself.
+    expect(html).not.toContain('<aside class="doc-suggest"');
+  });
+
+  it("escapes the address rather than injecting it", async () => {
+    const html = await toHtml(
+      "# x",
+      {},
+      { ...options(), suggestUrl: '"><script>alert(1)</script>' },
+    );
+
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+});

--- a/packages/github-client/src/client.test.ts
+++ b/packages/github-client/src/client.test.ts
@@ -1037,3 +1037,33 @@ describe("listOpenPullRequests", () => {
     expect(pulls).toHaveLength(3);
   });
 });
+
+/**
+ * The way out of an experiment somebody has decided against. A "throw it
+ * away" that left the branch behind would be a strange kind of throwing away.
+ */
+describe("deleteBranch", () => {
+  it("deletes the ref", async () => {
+    const { calls, fetchImpl } = fakeGitHub({
+      "DELETE /repos/octo/notes/git/refs/heads/try%2Fmain%2Fnotes": {},
+    });
+
+    await new GitHubClient({ token: "t", fetch: fetchImpl }).deleteBranch(
+      "octo",
+      "notes",
+      "try/main/notes",
+    );
+
+    expect(calls[0]?.method).toBe("DELETE");
+  });
+
+  it("treats a branch that has already gone as done", async () => {
+    // Two devices tidying up the same abandoned experiment is an ordinary
+    // race, and the wanted state is the same either way.
+    const { fetchImpl } = fakeGitHub();
+
+    await expect(
+      new GitHubClient({ token: "t", fetch: fetchImpl }).deleteBranch("octo", "notes", "try/x/y"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/github-client/src/client.test.ts
+++ b/packages/github-client/src/client.test.ts
@@ -978,3 +978,62 @@ describe("listTree at a ref", () => {
     expect(calls.some((call) => call.url.includes("git/ref/heads/main"))).toBe(true);
   });
 });
+
+/**
+ * The author's side of "suggest an edit": a reader has opened one of these
+ * from a fork, and until now the only place to find out was github.com.
+ */
+describe("listOpenPullRequests", () => {
+  const listing = [
+    {
+      number: 7,
+      html_url: "https://github.com/octo/notes/pull/7",
+      state: "open",
+      title: "Fix the version in the runbook",
+      draft: false,
+      head: { ref: "reader:patch-1" },
+      base: { ref: "main" },
+      user: { login: "a-reader" },
+      updated_at: "2026-08-30T10:00:00Z",
+    },
+  ];
+
+  it("asks for what is open, most recently touched first", async () => {
+    const { calls, fetchImpl } = fakeGitHub({
+      "GET /repos/octo/notes/pulls?state=open&sort=updated&direction=desc&per_page=30": listing,
+    });
+
+    const pulls = await new GitHubClient({ token: "t", fetch: fetchImpl }).listOpenPullRequests(
+      "octo",
+      "notes",
+    );
+
+    expect(pulls[0]).toMatchObject({
+      number: 7,
+      title: "Fix the version in the runbook",
+      author: "a-reader",
+      updatedAt: "2026-08-30T10:00:00Z",
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("stops at the number asked for, however many pages GitHub offers", async () => {
+    const many = Array.from({ length: 30 }, (_, index) => ({
+      ...listing[0]!,
+      number: index + 1,
+    }));
+    const { fetchImpl } = fakeGitHub({
+      "GET /repos/octo/notes/pulls?state=open&sort=updated&direction=desc&per_page=3": many,
+    });
+
+    const pulls = await new GitHubClient({ token: "t", fetch: fetchImpl }).listOpenPullRequests(
+      "octo",
+      "notes",
+      3,
+    );
+
+    // A repository with four hundred open requests is not a list anybody
+    // reads to the end of.
+    expect(pulls).toHaveLength(3);
+  });
+});

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -65,6 +65,8 @@ interface ApiPullRequest {
   head: { ref: string; sha?: string };
   base: { ref: string; sha?: string };
   user?: { login: string } | null;
+  updated_at?: string;
+  created_at?: string;
   merged?: boolean;
   mergeable?: boolean | null;
   mergeable_state?: string | null;
@@ -638,6 +640,34 @@ export class GitHubClient {
     );
 
     return pulls[0] ? toPullRequest(pulls[0]) : null;
+  }
+
+  /**
+   * Every open pull request on a repository, newest first.
+   *
+   * For the author's side of "suggest an edit": a reader who spotted a mistake
+   * has opened one of these from a fork, and until now the only place to find
+   * out was github.com. Summaries only — a list is a list, and reading one
+   * costs a request of its own.
+   */
+  async listOpenPullRequests(
+    owner: string,
+    repo: string,
+    limit = 30,
+  ): Promise<(PullRequestSummary & { author: string | null; updatedAt: string })[]> {
+    const pulls = await this.transport.paginate<ApiPullRequest>(
+      `/repos/${owner}/${repo}/pulls?state=open&sort=updated&direction=desc` +
+        `&per_page=${Math.min(Math.max(limit, 1), 100)}`,
+    );
+
+    // Capped here rather than by asking for fewer: `paginate` follows every
+    // `Link: rel="next"` it is given, and a repository with four hundred open
+    // requests is not a list anybody reads to the end of.
+    return pulls.slice(0, limit).map((pull) => ({
+      ...toPullRequest(pull),
+      author: pull.user?.login ?? null,
+      updatedAt: pull.updated_at ?? pull.created_at ?? "",
+    }));
   }
 
   /**

--- a/packages/github-client/src/client.ts
+++ b/packages/github-client/src/client.ts
@@ -528,6 +528,29 @@ export class GitHubClient {
     return { name, sha: from.sha, isDefault: false, protected: false };
   }
 
+  /**
+   * Deletes a branch.
+   *
+   * For an experiment somebody has decided against. Abandoned branches are
+   * clutter in everybody else's repository too, and a "throw it away" that
+   * left one behind would be a strange kind of throwing away.
+   *
+   * A branch that is already gone is not an error: two devices tidying up the
+   * same abandoned experiment is an ordinary race, and the wanted state is the
+   * same either way.
+   */
+  async deleteBranch(owner: string, repo: string, name: string): Promise<void> {
+    try {
+      await this.transport.request(
+        `/repos/${owner}/${repo}/git/refs/heads/${encodeURIComponent(name)}`,
+        { method: "DELETE" },
+      );
+    } catch (error) {
+      if (error instanceof GitHubError && error.code === "not-found") return;
+      throw error;
+    }
+  }
+
   async getBranch(owner: string, repo: string, name: string): Promise<BranchSummary | null> {
     try {
       const { data } = await this.transport.request<{

--- a/packages/markdown-engine/src/relocate.test.ts
+++ b/packages/markdown-engine/src/relocate.test.ts
@@ -155,3 +155,62 @@ describe("repairRelativeLinks", () => {
     expect(repairRelativeLinks(before, "a/n.md", repo).content).toBe(before);
   });
 });
+
+/**
+ * A whole folder moving is not the same as a note moving out of one.
+ *
+ * The pictures come too, so the links to them must be left exactly as they
+ * are. Rewriting them pointed every image in a renamed folder back at a folder
+ * that no longer existed — the note looked fine until somebody opened it.
+ */
+describe("rewriteRelativeLinks — a folder moving wholesale", () => {
+  const move = { from: "Introduction", to: "Python 101/Introduction" };
+
+  it("leaves a link to something inside the folder alone", () => {
+    const content = "![shot](assets/a.png)";
+
+    expect(
+      rewriteRelativeLinks(content, "Introduction/what.md", "Python 101/Introduction/what.md", {
+        movedFolder: move,
+      }),
+    ).toBe(content);
+  });
+
+  it("still repoints a link to something outside it", () => {
+    // That file did not move, and the note is a level further away now.
+    expect(
+      rewriteRelativeLinks(
+        "![logo](../shared/logo.png)",
+        "Introduction/what.md",
+        "Python 101/Introduction/what.md",
+        { movedFolder: move },
+      ),
+    ).toBe("![logo](../../shared/logo.png)");
+  });
+
+  it("leaves a link to a note in a sibling subfolder of the moved folder alone", () => {
+    expect(
+      rewriteRelativeLinks(
+        "[other](../week-two/plan.md)",
+        "Introduction/week-one/what.md",
+        "Python 101/Introduction/week-one/what.md",
+        { movedFolder: move },
+      ),
+    ).toBe("[other](../week-two/plan.md)");
+  });
+
+  it("does not mistake a folder whose name merely starts the same", () => {
+    // `Intro` must not swallow `Introduction`.
+    expect(
+      rewriteRelativeLinks("![x](../Introduction/assets/a.png)", "Intro/what.md", "Deep/what.md", {
+        movedFolder: { from: "Intro", to: "Deep" },
+      }),
+    ).toBe("![x](../Introduction/assets/a.png)");
+  });
+
+  it("rewrites exactly as before when no folder is named", () => {
+    expect(
+      rewriteRelativeLinks("![shot](assets/a.png)", "Introduction/what.md", "Deep/what.md"),
+    ).toBe("![shot](../Introduction/assets/a.png)");
+  });
+});

--- a/packages/markdown-engine/src/relocate.ts
+++ b/packages/markdown-engine/src/relocate.ts
@@ -140,9 +140,49 @@ const DEFINITION = /^([ \t]{0,3}\[(?:[^[\]\\]|\\.)+\]:[ \t]*)(<[^<>\n]*>|\S+)(.*
  * and line wrapping across the whole file, turning "moved a note" into a diff
  * nobody can review.
  */
-export function rewriteRelativeLinks(markdown: string, fromPath: string, toPath: string): string {
+export interface RewriteOptions {
+  /**
+   * A folder moving wholesale, when this note is moving as part of it.
+   *
+   * Without this, moving a folder breaks every picture in it. The links inside
+   * a note are relative to where the note sits, so a note carried from
+   * `Introduction/` to `Python 101/Introduction/` has `assets/a.png` rewritten
+   * to `../../Introduction/assets/a.png` — pointing back at a folder that no
+   * longer exists, because the pictures came along too.
+   *
+   * Knowing that the whole folder moved is what tells the rewrite to leave
+   * those links alone. Links pointing *out* of the folder still have to be
+   * rewritten: they name something that did not move, and the note is now a
+   * level further away from it.
+   */
+  movedFolder?: { from: string; to: string };
+}
+
+export function rewriteRelativeLinks(
+  markdown: string,
+  fromPath: string,
+  toPath: string,
+  options: RewriteOptions = {},
+): string {
   if (normalizePath(fromPath) === normalizePath(toPath)) return markdown;
   if (dirname(normalizePath(fromPath)) === dirname(normalizePath(toPath))) return markdown;
+
+  const folder = options.movedFolder
+    ? {
+        from: normalizePath(options.movedFolder.from),
+        to: normalizePath(options.movedFolder.to),
+      }
+    : null;
+
+  /** Where a file ends up, given a folder that is moving around it. */
+  const after = (repoPath: string): string => {
+    if (!folder) return repoPath;
+    if (repoPath === folder.from) return folder.to;
+    // The slash matters: `Intro` must not swallow `Introduction`.
+    return repoPath.startsWith(`${folder.from}/`)
+      ? `${folder.to}${repoPath.slice(folder.from.length)}`
+      : repoPath;
+  };
 
   const fenced = fencedRanges(markdown);
   const inFence = (index: number) => fenced.some(([start, end]) => index >= start && index < end);
@@ -160,7 +200,7 @@ export function rewriteRelativeLinks(markdown: string, fromPath: string, toPath:
     const repoPath = resolveFromNote(fromPath, path);
     if (!repoPath) return null;
 
-    return encodeDestination(`${relativeFromNote(toPath, repoPath)}${fragment}`);
+    return encodeDestination(`${relativeFromNote(toPath, after(repoPath))}${fragment}`);
   };
 
   let result = markdown.replace(

--- a/packages/store/src/note-repository.test.ts
+++ b/packages/store/src/note-repository.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { TreeNode } from "@forkleaf/types";
 import type { RemoteGateway } from "./ports";
 import { MemoryDatabase } from "./memory-db";
 import { NoteRepository } from "./note-repository";
@@ -16,12 +17,12 @@ import { SyncEngine } from "./sync-engine";
 
 const WS = "octo/notes@main:";
 
-function repository(files: Record<string, string>, allPaths?: string[]) {
+function repository(files: Record<string, string>, allPaths?: string[], tree: TreeNode[] = []) {
   const db = new MemoryDatabase();
   const committed: { op: string; path: string; toPath?: string }[] = [];
 
   const gateway: RemoteGateway = {
-    listTree: async () => [],
+    listTree: async () => tree,
     // What the repository actually holds, images included. Defaults to the
     // notes, so tests that do not care about images need say nothing.
     listAllPaths: async () => allPaths ?? Object.keys(files),
@@ -397,6 +398,77 @@ describe("moving a folder", () => {
     const note = queued().find((change) => change.path.endsWith(".md"));
     expect(note?.op).toBe("rename");
     expect(note?.toPath).toBe("Python 101/Introduction/what-is-python.md");
+  });
+
+  /**
+   * The bug this guards: a note's links are relative to where the note sits,
+   * so moving one is normally accompanied by rewriting them. When the whole
+   * folder moves, the pictures move with it — and rewriting then pointed every
+   * image in the folder back at the folder's *old* path, which no longer
+   * exists. Every picture in a renamed folder broke immediately, and the note
+   * looked fine until somebody opened it.
+   */
+  it("leaves a link alone when what it points at is moving too", async () => {
+    const { notes, sync } = repository(files, all);
+
+    await notes.moveFolderContents(WS, "Introduction", "Python 101/Introduction", [
+      "Introduction/what-is-python.md",
+    ]);
+
+    const note = sync.pendingFor(WS).find((change) => change.path.endsWith(".md"));
+    expect(note?.content).toContain("![shot](assets/a.png)");
+    expect(note?.content).not.toContain("Introduction/assets/a.png");
+  });
+
+  it("still repoints a link to something outside the folder", async () => {
+    // That file did not move, and the note is now a level further away from
+    // it, so this one does have to be rewritten.
+    const outward = {
+      "Introduction/what-is-python.md": "# What\n\n![logo](../shared/logo.png)\n",
+    };
+    const { notes, sync } = repository(outward, [...Object.keys(outward), "shared/logo.png"]);
+
+    await notes.moveFolderContents(WS, "Introduction", "Python 101/Introduction", [
+      "Introduction/what-is-python.md",
+    ]);
+
+    const note = sync.pendingFor(WS).find((change) => change.path.endsWith(".md"));
+    expect(note?.content).toContain("![logo](../../shared/logo.png)");
+  });
+
+  /**
+   * The other half of the same report: renaming a folder that held a paper
+   * left the old folder on screen beside the new one, because the sidebar's
+   * correction knew about renames and deletes but not about moves — and a
+   * move is how everything that is not a note travels. Somebody then deleted
+   * the "duplicate", which deleted the real files.
+   */
+  it("does not leave the old folder on screen holding the files that moved", async () => {
+    const tree: TreeNode[] = [
+      {
+        kind: "folder",
+        name: "Introduction",
+        path: "Introduction",
+        children: [
+          { kind: "file", name: "what-is-python.md", path: "Introduction/what-is-python.md" },
+          { kind: "file", name: "paper.pdf", path: "Introduction/paper.pdf" },
+        ],
+      },
+    ];
+
+    const { notes } = repository(files, [...all, "Introduction/paper.pdf"], tree);
+
+    await notes.getTree(WS);
+    await notes.moveFolderContents(WS, "Introduction", "Renamed", [
+      "Introduction/what-is-python.md",
+    ]);
+
+    const shown = await notes.getTree(WS);
+    expect(shown.map((node) => node.path)).toEqual(["Renamed"]);
+    expect((shown[0]?.children ?? []).map((node) => node.path).sort()).toEqual([
+      "Renamed/paper.pdf",
+      "Renamed/what-is-python.md",
+    ]);
   });
 });
 

--- a/packages/store/src/note-repository.ts
+++ b/packages/store/src/note-repository.ts
@@ -202,18 +202,20 @@ export class NoteRepository {
     const pending = this.sync.pendingFor(workspaceId);
     if (pending.length === 0) return tree;
 
-    // Images go through the same queue and are not part of the notebook; the
-    // tree only ever lists Markdown.
-    const markdown = (path: string) => path.toLowerCase().endsWith(".md");
-
     let next = tree;
     for (const change of pending) {
       if (change.op === "delete") {
         next = withoutPath(next, change.path);
-      } else if (change.op === "rename") {
+      } else if (change.op === "rename" || change.op === "move") {
+        // `move` was missing here, and a `move` is how everything that is not
+        // a note travels — including a PDF, which the tree does list. So
+        // renaming a folder holding a paper left the old folder on screen with
+        // the paper still in it, beside the new one: the duplicate folder that
+        // appears after a rename. Deleting that "duplicate" then deleted the
+        // real files, pictures included.
         next = withoutPath(next, change.path);
-        if (change.toPath && markdown(change.toPath)) next = withPath(next, change.toPath);
-      } else if (markdown(change.path)) {
+        if (change.toPath && listed(change.toPath)) next = withPath(next, change.toPath);
+      } else if (listed(change.path)) {
         next = withPath(next, change.path);
       }
     }
@@ -539,7 +541,11 @@ export class NoteRepository {
           }
         }
 
-        if (note) await this.renameNote(note, target);
+        // The folder is named as moving, so links inside it are left alone:
+        // everything they point at is coming too. Links pointing out of it are
+        // still rewritten, since the note is now a level further away from
+        // whatever they name.
+        if (note) await this.renameNote(note, target, { movedFolder: { from, to } });
         else await this.sync.recordAssetMove(workspaceId, path, target);
       } else {
         await this.sync.recordAssetMove(workspaceId, path, target);
@@ -557,12 +563,16 @@ export class NoteRepository {
    * moved but not repointed is a broken note, and there is no moment at which
    * anyone would want to see one.
    */
-  async renameNote(note: Note, toPath: string): Promise<Note> {
+  async renameNote(
+    note: Note,
+    toPath: string,
+    options: { movedFolder?: { from: string; to: string } } = {},
+  ): Promise<Note> {
     const current = await this.db.getNote(note.id);
     const stored = current ?? note;
     const freshNote: Note = {
       ...stored,
-      content: rewriteRelativeLinks(stored.content, stored.path, toPath),
+      content: rewriteRelativeLinks(stored.content, stored.path, toPath, options),
     };
 
     const content = serializeDocument(freshNote.content, freshNote.frontmatter);
@@ -584,6 +594,17 @@ export class NoteRepository {
   title(note: Note): string {
     return deriveTitle(note.content, note.frontmatter.title, note.path);
   }
+}
+
+/**
+ * Whether the sidebar's tree lists this path at all.
+ *
+ * Markdown and PDF — the same rule the tree itself is built with. Images and
+ * everything else travel through the queue too, and correcting the tree with
+ * them would put files in the sidebar that it deliberately does not show.
+ */
+function listed(path: string): boolean {
+  return /\.(md|markdown|mdx|pdf)$/i.test(path);
 }
 
 export function noteId(workspaceId: string, path: string): string {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -428,6 +428,14 @@ export interface ExportOptions {
   renderDiagrams: boolean;
   /** Light or dark styling for HTML/PDF output. */
   theme: "light" | "dark";
+  /**
+   * Where a reader who spots a mistake should go, for a page being published.
+   *
+   * Absent for a download. A PDF in somebody's inbox has no author to reach
+   * and no repository behind it, so a "suggest an edit" link in one would be a
+   * link to a page the reader has no business seeing.
+   */
+  suggestUrl?: string | null;
 }
 
 // ─── Errors ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Eleven commits off `main` after #64. **2183 tests passing**, lint/typecheck/build clean.

---

## The bug you hit: renaming a folder

Three faults in one action, which together made renaming a folder unsafe. All three are fixed, each with a regression test that fails without the fix.

**The pictures broke.** A note's links are relative to where the note sits, so moving a note normally means rewriting them — but when the *whole folder* moves, the pictures move with it, and `assets/chart.png` was being rewritten to `../../old-folder/assets/chart.png`, which no longer exists. Every image in a renamed folder broke on the spot, and the note went on looking fine until somebody opened it. The rewrite now knows which folder is moving: links inside it are left alone, links out of it are still repointed.

**The old folder stayed on screen.** The sidebar corrects GitHub's file list with what has not been pushed yet, and it handled `delete`, `rename` and `upsert` but not `move` — which is how everything that is not a note travels, a PDF included. A folder holding a paper therefore appeared twice.

**An open tab kept pointing at the old path.** `renameNote` has always remapped the tabs; `renameFolder` never did. The next keystroke in that tab saved the note back to where it used to be, *recreating* the folder that had just been renamed with one note in it — a duplicate that survived every refresh because it was real. Tabs now follow the rename, and so do the locks on the notes in them.

Between them these explain the duplicate you were left deleting, and why deleting it destroyed images: **the duplicate was not a copy, it was the original.**

## Help now knows what the app can do

Ten features had gone in and the help dialog had not heard of one of them. Every feature is now written down there in a shape that repeats — what it is in one line, **Do** (the exact words to press), **You get** (what happens) — with tests asserting each is named there *with its command*, so a feature added without a help entry fails the suite rather than shipping invisibly.

## Features

- **Suggest a change to someone else's notes** — published pages carry **Suggest an edit**; ⌘K → **See what other people have suggested** is the author's end.
- **Borrow a note from another notebook** — a pinned `[[repo:ada/notes:runbook.md@a1b2c3d]]` written into yours.
- **Try a rewrite without losing what you had** — an experiment branch with **Keep it** and **Throw it away**.
- **Highlights that are just text files** — a line in `<name>.highlights.md`, drawn over the page. The PDF is never touched.
- **A document's text, kept beside it** — `<name>.text.md` makes a scan searchable, quotable and checkable, and stops every device re-reading a paper it has already read.
- **See what changed between two versions** — which pages differ, compared as text, and whether one is a page you quoted.
- **The paper and the note stay on the same page** — cursor and page follow each other, mapped by your own citations.
- **Publish your reading** — citations on a published page now resolve; they were dead links before.
- **The citation format, written down** — `/docs/citation-links`, plus **Copy link**.

## The one thing I did not build

**Recognising a scan's words inside ForkLeaf.** Every browser OCR engine needs WebAssembly, and this codebase deliberately refuses `wasm-unsafe-eval` in the CSP guarding the route that renders markdown from repositories the user does not control. Doing it server-side would mean sending people's documents to your server, which is the other thing the app is built not to do. Either the policy changes or the privacy promise does — that is your call, not mine, so the reasoning is written into `docs/ideas.md` instead of being quietly resolved. The half that does not need it is built, and any OCR tool can write the file.

## Checks

Verified in a browser: the folder rename end to end (one folder, tab followed, image link intact), the help topics across every tab, the citation-format docs page.

Not exercised live, because they need a connected GitHub repository: suggestions, try-a-rewrite, borrowing, version comparison, highlights, follow-along and the text sidecar. Each is covered by tests at every layer it owns — route tests, client tests against a fake GitHub, and pure tests for every file format and mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)