### PR TITLE
A quieter hero, and notes published as a book

### DIFF
--- a/apps/web/src/app/api/gh/publish/book/route.test.ts
+++ b/apps/web/src/app/api/gh/publish/book/route.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readFile = vi.fn();
+const commitChanges = vi.fn();
+const enablePages = vi.fn();
+const getPages = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+  getLiveSession: () => Promise.resolve({ token: "t", user: { login: "me" } }),
+}));
+
+// Publishing is rate-limited harder than an ordinary save, which a test making
+// a dozen calls from one address would otherwise trip.
+vi.mock("@/lib/rate-limit", () => ({ enforceRateLimit: () => undefined }));
+
+vi.mock("@forkleaf/github-client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@forkleaf/github-client")>("@forkleaf/github-client");
+  return {
+    ...actual,
+    GitHubClient: class {
+      readFile = readFile;
+      commitChanges = commitChanges;
+      enablePages = enablePages;
+      getPages = getPages;
+    },
+  };
+});
+
+const { GET, POST, DELETE } = await import("./route");
+
+const REPO = { owner: "me", repo: "notes", branch: "main" };
+
+beforeEach(() => {
+  readFile.mockResolvedValue(null);
+  commitChanges.mockResolvedValue({ sha: "c0ffee" });
+  enablePages.mockResolvedValue({ url: "https://me.github.io/notes", status: "built" });
+  getPages.mockResolvedValue({
+    url: "https://me.github.io/notes",
+    status: "built",
+    isPublic: true,
+  });
+});
+
+afterEach(() => vi.clearAllMocks());
+
+const publish = async (body: unknown) => {
+  const response = await POST(
+    new Request("http://localhost/api/gh/publish/book", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }) as never,
+  );
+  return { status: response.status, body: await response.json() };
+};
+
+const unpublish = async (body: unknown) => {
+  const response = await DELETE(
+    new Request("http://localhost/api/gh/publish/book", {
+      method: "DELETE",
+      body: JSON.stringify(body),
+    }) as never,
+  );
+  return { status: response.status, body: await response.json() };
+};
+
+const read = async (query: string) => {
+  const response = await GET(new Request(`http://localhost/api/gh/publish/book?${query}`) as never);
+  return { status: response.status, body: await response.json() };
+};
+
+/** A minimal, valid book. */
+const BOOK = {
+  ...REPO,
+  book: "handbook",
+  title: "The Handbook",
+  chapters: [{ slug: "intro", title: "Intro", source: "handbook/intro.md" }],
+  files: [
+    { path: "index.html", content: "<html>contents</html>" },
+    { path: "intro.html", content: "<html>intro</html>" },
+    { path: "assets/style.css", content: "body{}" },
+  ],
+};
+
+/** Paths from the most recent `commitChanges`, by operation. */
+const committed = (op: "upsert" | "delete"): string[] =>
+  (commitChanges.mock.calls[0]?.[1] ?? [])
+    .filter((change: { op: string }) => change.op === op)
+    .map((change: { path: string }) => change.path);
+
+describe("POST /api/gh/publish/book", () => {
+  it("writes the whole book in one commit", async () => {
+    const { status, body } = await publish(BOOK);
+
+    expect(status).toBe(200);
+    expect(commitChanges).toHaveBeenCalledTimes(1);
+    expect(committed("upsert")).toEqual([
+      "docs/handbook/index.html",
+      "docs/handbook/intro.html",
+      "docs/handbook/assets/style.css",
+      "docs/handbook/forkleaf-book.json",
+    ]);
+    expect(body.url).toBe("https://me.github.io/notes/handbook/");
+    expect(body.chapters).toBe(1);
+  });
+
+  it("records what it wrote, including the record itself", async () => {
+    await publish(BOOK);
+
+    const written = (commitChanges.mock.calls[0]![1] as { path: string; content: string }[]).find(
+      (change) => change.path === "docs/handbook/forkleaf-book.json",
+    )!;
+    const manifest = JSON.parse(written.content);
+
+    expect(manifest.book).toBe("handbook");
+    expect(manifest.files).toContain("docs/handbook/forkleaf-book.json");
+    expect(manifest.files).toContain("docs/handbook/assets/style.css");
+    expect(manifest.chapters).toEqual(BOOK.chapters);
+  });
+
+  it("turns Pages on for docs/, and says whether it is live yet", async () => {
+    enablePages.mockResolvedValue({ url: "https://me.github.io/notes", status: "building" });
+    const { body } = await publish(BOOK);
+
+    expect(enablePages).toHaveBeenCalledWith("me", "notes", { branch: "main", path: "/docs" });
+    expect(body.status).toBe("building");
+  });
+
+  /**
+   * Every path is re-derived rather than trusted. The list arrives over HTTP
+   * and names files in somebody's repository.
+   */
+  it("refuses to write a file a book is not made of", async () => {
+    for (const path of [
+      "deploy.sh",
+      "CNAME",
+      "notes.md",
+      "assets/deploy.sh",
+      "assets/nested/style.css",
+      "../../.github/workflows/ci.yml",
+      "../escape.html",
+    ]) {
+      const { status } = await publish({ ...BOOK, files: [{ path, content: "x" }] });
+      expect(status, path).toBe(400);
+    }
+    expect(commitChanges).not.toHaveBeenCalled();
+  });
+
+  it("refuses a book name that is really a path", async () => {
+    for (const book of ["", "..", "../evil", "a/b", ".hidden"]) {
+      expect((await publish({ ...BOOK, book })).status).toBe(400);
+    }
+    expect(commitChanges).not.toHaveBeenCalled();
+  });
+
+  it("refuses a book with nothing in it", async () => {
+    expect((await publish({ ...BOOK, chapters: [] })).status).toBe(400);
+    expect((await publish({ ...BOOK, files: [] })).status).toBe(400);
+  });
+
+  it("refuses a book too big to be one", async () => {
+    const many = Array.from({ length: 201 }, (_, i) => ({
+      slug: `c${i}`,
+      title: `Chapter ${i}`,
+      source: `c${i}.md`,
+    }));
+    expect((await publish({ ...BOOK, chapters: many })).status).toBe(400);
+  });
+
+  it("refuses a chapter too big to publish", async () => {
+    const huge = { path: "intro.html", content: "x".repeat(5 * 1024 * 1024 + 1) };
+    expect((await publish({ ...BOOK, files: [huge] })).status).toBe(413);
+  });
+
+  /**
+   * Renaming a note changes its chapter's address. Without this the old file
+   * stays for ever: served at its old URL, absent from the contents page, and
+   * reachable only by knowing it is there.
+   */
+  it("removes what the last publish wrote and this one does not", async () => {
+    readFile.mockResolvedValue({
+      content: JSON.stringify({
+        version: 1,
+        book: "handbook",
+        title: "The Handbook",
+        publishedAt: "2026-01-01T00:00:00.000Z",
+        chapters: [],
+        files: [
+          "docs/handbook/index.html",
+          "docs/handbook/old-name.html",
+          "docs/handbook/forkleaf-book.json",
+        ],
+      }),
+    });
+
+    const { body } = await publish(BOOK);
+
+    expect(committed("delete")).toEqual(["docs/handbook/old-name.html"]);
+    expect(body.removed).toBe(1);
+  });
+
+  it("keeps a file that is still part of the book", async () => {
+    readFile.mockResolvedValue({
+      content: JSON.stringify({
+        version: 1,
+        book: "handbook",
+        title: "The Handbook",
+        publishedAt: "",
+        chapters: [],
+        files: ["docs/handbook/index.html", "docs/handbook/intro.html"],
+      }),
+    });
+
+    await publish(BOOK);
+    expect(committed("delete")).toEqual([]);
+  });
+
+  it("ignores a previous record that belongs to another book", async () => {
+    // Copied or hand-edited. Its paths describe some other folder, and acting
+    // on it would delete them.
+    readFile.mockResolvedValue({
+      content: JSON.stringify({
+        version: 1,
+        book: "other-book",
+        title: "",
+        publishedAt: "",
+        chapters: [],
+        files: ["docs/other-book/index.html"],
+      }),
+    });
+
+    await publish(BOOK);
+    expect(committed("delete")).toEqual([]);
+  });
+});
+
+describe("DELETE /api/gh/publish/book", () => {
+  const manifest = (files: string[], book = "handbook") => ({
+    content: JSON.stringify({
+      version: 1,
+      book,
+      title: "The Handbook",
+      publishedAt: "",
+      chapters: [],
+      files,
+    }),
+  });
+
+  it("deletes exactly what the record names", async () => {
+    readFile.mockResolvedValue(
+      manifest([
+        "docs/handbook/index.html",
+        "docs/handbook/intro.html",
+        "docs/handbook/assets/style.css",
+        "docs/handbook/forkleaf-book.json",
+      ]),
+    );
+
+    const { status, body } = await unpublish({ ...REPO, book: "handbook" });
+
+    expect(status).toBe(200);
+    expect(body.removed).toBe(4);
+    expect(committed("delete")).toEqual([
+      "docs/handbook/assets/style.css",
+      "docs/handbook/forkleaf-book.json",
+      "docs/handbook/index.html",
+      "docs/handbook/intro.html",
+    ]);
+  });
+
+  /**
+   * The record is a file in the user's repository, so it is a file the user
+   * can edit. It is a claim to be checked, never an instruction to carry out.
+   */
+  it("never deletes anything outside the book, however the record asks", async () => {
+    readFile.mockResolvedValue(
+      manifest([
+        "docs/handbook/index.html",
+        "docs/handbook/../../.github/workflows/ci.yml",
+        "docs/other-book/index.html",
+        "README.md",
+      ]),
+    );
+
+    await unpublish({ ...REPO, book: "handbook" });
+    expect(committed("delete")).toEqual(["docs/handbook/index.html"]);
+  });
+
+  it("never deletes a file inside the book that ForkLeaf did not write", async () => {
+    readFile.mockResolvedValue(
+      manifest(["docs/handbook/index.html", "docs/handbook/CNAME", "docs/handbook/notes.md"]),
+    );
+
+    await unpublish({ ...REPO, book: "handbook" });
+    expect(committed("delete")).toEqual(["docs/handbook/index.html"]);
+  });
+
+  it("will not unpublish a folder it did not publish", async () => {
+    readFile.mockResolvedValue(null);
+
+    const { status } = await unpublish({ ...REPO, book: "handbook" });
+
+    expect(status).toBe(404);
+    expect(commitChanges).not.toHaveBeenCalled();
+  });
+
+  it("will not act on a record it cannot read", async () => {
+    readFile.mockResolvedValue({ content: "{ not json" });
+
+    expect((await unpublish({ ...REPO, book: "handbook" })).status).toBe(404);
+    expect(commitChanges).not.toHaveBeenCalled();
+  });
+
+  it("will not act on a record naming nothing it may remove", async () => {
+    readFile.mockResolvedValue(manifest(["README.md", "docs/other/index.html"]));
+
+    expect((await unpublish({ ...REPO, book: "handbook" })).status).toBe(400);
+    expect(commitChanges).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/gh/publish/book", () => {
+  it("answers from the record, not from the folder", async () => {
+    readFile.mockResolvedValue({
+      content: JSON.stringify({
+        version: 1,
+        book: "handbook",
+        title: "The Handbook",
+        publishedAt: "2026-09-04T00:00:00.000Z",
+        chapters: [{ slug: "intro", title: "Intro", source: "handbook/intro.md" }],
+        files: ["docs/handbook/index.html"],
+      }),
+    });
+
+    const { status, body } = await read("owner=me&repo=notes&branch=main&book=handbook");
+
+    expect(status).toBe(200);
+    expect(body.book.title).toBe("The Handbook");
+    expect(body.url).toBe("https://me.github.io/notes/handbook/");
+  });
+
+  it("says there is no book rather than inventing one", async () => {
+    readFile.mockResolvedValue(null);
+    const { body } = await read("owner=me&repo=notes&branch=main&book=handbook");
+
+    expect(body.book).toBeNull();
+    expect(body.url).toBeNull();
+  });
+
+  it("still lists the book when Pages is switched off", async () => {
+    getPages.mockRejectedValue(new Error("nope"));
+    readFile.mockResolvedValue({
+      content: JSON.stringify({
+        version: 1,
+        book: "handbook",
+        title: "The Handbook",
+        publishedAt: "",
+        chapters: [],
+        files: [],
+      }),
+    });
+
+    const { status, body } = await read("owner=me&repo=notes&branch=main&book=handbook");
+
+    expect(status).toBe(200);
+    expect(body.book.title).toBe("The Handbook");
+    expect(body.url).toBeNull();
+    expect(body.site).toBeNull();
+  });
+});

--- a/apps/web/src/app/api/gh/publish/book/route.ts
+++ b/apps/web/src/app/api/gh/publish/book/route.ts
@@ -1,0 +1,274 @@
+import { type NextRequest } from "next/server";
+import {
+  handle,
+  requireClient,
+  readRepoRef,
+  readRepoRefFromBody,
+  ApiError,
+} from "@/lib/api-helpers";
+import {
+  BOOK_MANIFEST,
+  bookDir,
+  bookFilePath,
+  bookManifestPath,
+  bookUrl,
+  filesToDelete,
+  parseManifest,
+  serializeManifest,
+  type BookChapter,
+  type BookManifest,
+} from "@/lib/publish";
+import { enforceRateLimit } from "@/lib/rate-limit";
+
+/**
+ * Publishing a folder of notes as a book.
+ *
+ * The single-page route beside this one commits one self-contained file and is
+ * the right answer for one note. It cannot express a set of notes that refer to
+ * each other, and the reason is not layout — it is that a `[[wikilink]]` on a
+ * published page has nowhere to point, so every link between notes silently
+ * renders as an anchor to a heading that is not there.
+ *
+ * A book is a folder: `docs/<book>/`, a contents page, one file per chapter,
+ * and a stylesheet they share. Everything about it is committed to the user's
+ * own repository in a single commit, and served by GitHub Pages from there —
+ * the same arrangement as a single page, with the same consequences. Nothing
+ * is stored here, and a book survives ForkLeaf going away.
+ *
+ * The pages arrive already rendered. Diagrams are rasterised in the browser,
+ * where the DOM that Mermaid needs actually exists, so this route's job is not
+ * to build anything: it is to check that every file it has been asked to write
+ * is a file a book is made of, write them, and record what it wrote.
+ */
+
+/** Generous for a chapter, small enough that one bad paste cannot wedge a repo. */
+const MAX_FILE_BYTES = 5 * 1024 * 1024;
+
+/** A whole book, which is many chapters and their pictures. */
+const MAX_BOOK_BYTES = 25 * 1024 * 1024;
+
+/** Past this, publishing is slow enough to look broken and big enough to hurt. */
+const MAX_CHAPTERS = 200;
+
+interface BookBody {
+  owner?: string;
+  repo?: string;
+  branch?: string;
+  /** The book's folder name under `docs/`. */
+  book?: string;
+  /** What the contents page calls it. */
+  title?: string;
+  /** In reading order. */
+  chapters?: BookChapter[];
+  /** Book-relative filenames and their contents, straight from the builder. */
+  files?: { path?: string; content?: string }[];
+}
+
+/**
+ * What this book currently is, if it is anything.
+ *
+ * Answered from the manifest rather than by looking at the folder, because the
+ * folder cannot answer it — `docs/handbook/` containing HTML files is equally
+ * consistent with a book ForkLeaf published and a site somebody wrote by hand,
+ * and the difference decides whether this app may delete any of it.
+ */
+export async function GET(request: NextRequest) {
+  return handle(async () => {
+    const { client } = await requireClient();
+    const params = new URL(request.url).searchParams;
+    const repo = readRepoRef(params);
+    const book = (params.get("book") ?? "").toLowerCase();
+
+    // Validates the name before it is used to build a path.
+    bookDir(book);
+
+    const [file, site] = await Promise.all([
+      client.readFile(repo, bookManifestPath(book)),
+      // Pages being off is not an error: the book is still committed and still
+      // listed, it simply has no address yet, which the caller is told.
+      client.getPages(repo.owner, repo.repo).catch(() => null),
+    ]);
+
+    const manifest = file ? parseManifest(file.content, book) : null;
+
+    return {
+      book: manifest,
+      url: manifest && site ? bookUrl(site.url, book) : null,
+      site: site ? { url: site.url, status: site.status, isPublic: site.isPublic } : null,
+    };
+  });
+}
+
+export async function POST(request: NextRequest) {
+  return handle(async () => {
+    // A book is one commit however many chapters it holds, so the limit is the
+    // same as a page's. Nobody publishes ten books a minute on purpose.
+    enforceRateLimit(request, { name: "publish", limit: 10, windowMs: 60_000 });
+
+    const { client } = await requireClient();
+    const body = (await request.json()) as BookBody;
+    const repo = readRepoRefFromBody(body as Record<string, unknown>);
+    const book = (body.book ?? "").toLowerCase();
+
+    const dir = bookDir(book);
+    const chapters = body.chapters ?? [];
+    const files = body.files ?? [];
+
+    if (chapters.length === 0) {
+      throw new ApiError(400, "validation", "A book needs at least one note in it.");
+    }
+    if (chapters.length > MAX_CHAPTERS) {
+      throw new ApiError(
+        400,
+        "validation",
+        `A book can hold ${MAX_CHAPTERS} notes; that folder has ${chapters.length}.`,
+      );
+    }
+
+    // Every path is re-derived rather than trusted. The list arrived over HTTP
+    // and names files in somebody's repository, so a name that is not one a
+    // book is made of is refused here rather than written somewhere else.
+    const encoder = new TextEncoder();
+    let total = 0;
+    const writes = files.map((file) => {
+      const path = bookFilePath(book, file.path ?? "");
+      const content = file.content ?? "";
+      const bytes = encoder.encode(content).length;
+
+      if (bytes > MAX_FILE_BYTES) {
+        throw new ApiError(
+          413,
+          "validation",
+          `"${file.path}" is too large to publish (limit 5 MB).`,
+        );
+      }
+      total += bytes;
+      if (total > MAX_BOOK_BYTES) {
+        throw new ApiError(413, "validation", "That book is too large to publish (limit 25 MB).");
+      }
+
+      return { op: "upsert" as const, path, content };
+    });
+
+    if (writes.length === 0) {
+      throw new ApiError(400, "validation", "There is nothing to publish.");
+    }
+
+    const manifest: BookManifest = {
+      version: 1,
+      book,
+      title: body.title?.trim() || book,
+      publishedAt: new Date().toISOString(),
+      chapters,
+      // Including the manifest's own path. A record of what to delete that
+      // leaves itself off the list survives its own deletion, and the next
+      // publish finds a manifest describing a book that is no longer there.
+      files: [...writes.map((write) => write.path), bookManifestPath(book)].sort(),
+    };
+
+    /**
+     * Whatever the last publish wrote and this one does not.
+     *
+     * Renaming a note changes its chapter's address, and without this the old
+     * file stays behind for ever — served at its old URL, absent from the
+     * contents page, and impossible to reach except by knowing it is there.
+     * The stale set comes from the previous manifest, which means it is the
+     * same checked list unpublishing uses: this can only ever remove files
+     * ForkLeaf itself wrote into this book.
+     */
+    const previous = await client.readFile(repo, bookManifestPath(book));
+    const parsed = previous ? parseManifest(previous.content, book) : null;
+    const keeping = new Set(manifest.files);
+    const stale = parsed ? filesToDelete(parsed).filter((path) => !keeping.has(path)) : [];
+
+    const commit = await client.commitChanges(
+      repo,
+      [
+        ...writes,
+        {
+          op: "upsert" as const,
+          path: bookManifestPath(book),
+          content: serializeManifest(manifest),
+        },
+        ...stale.map((path) => ({ op: "delete" as const, path })),
+      ],
+      { message: `publish book: ${manifest.title}` },
+    );
+
+    // The commit comes first, exactly as for a single page: if Pages cannot be
+    // switched on — a private repository on a free plan, most often — the book
+    // is at least in the repository, and turning Pages on later publishes it
+    // with no further work.
+    const site = await client.enablePages(repo.owner, repo.repo, {
+      branch: repo.branch,
+      path: "/docs",
+    });
+
+    return {
+      url: bookUrl(site.url, book),
+      siteUrl: site.url,
+      // `built` means it is live now; anything else means GitHub is still
+      // working, and the caller should say so rather than hand over a link
+      // that 404s for the next thirty seconds.
+      status: site.status,
+      dir,
+      chapters: manifest.chapters.length,
+      removed: stale.length,
+      sha: commit.sha,
+    };
+  });
+}
+
+/**
+ * Unpublishes: deletes exactly what the manifest says was written.
+ *
+ * Never the folder. `docs/handbook/` may hold a `CNAME`, a stylesheet somebody
+ * wrote, or a draft they dropped in last week, and a recursive delete is
+ * precisely the operation that takes those with it. The manifest is a file in
+ * the user's own repository and therefore one they can edit, so it is read as
+ * a claim to be checked — `filesToDelete` re-derives every path against this
+ * book's folder before any of it is believed.
+ *
+ * The notes themselves are untouched. So is Pages, which is a repository-wide
+ * setting the user may have had before ForkLeaf ever saw it.
+ */
+export async function DELETE(request: NextRequest) {
+  return handle(async () => {
+    enforceRateLimit(request, { name: "publish", limit: 10, windowMs: 60_000 });
+
+    const { client } = await requireClient();
+    const body = (await request.json()) as BookBody;
+    const repo = readRepoRefFromBody(body as Record<string, unknown>);
+    const book = (body.book ?? "").toLowerCase();
+
+    bookDir(book);
+
+    const file = await client.readFile(repo, bookManifestPath(book));
+    const manifest = file ? parseManifest(file.content, book) : null;
+
+    if (!manifest) {
+      throw new ApiError(
+        404,
+        "not-found",
+        `There is no ForkLeaf book at that address — no ${BOOK_MANIFEST} to say what it published.`,
+      );
+    }
+
+    const paths = filesToDelete(manifest);
+    if (paths.length === 0) {
+      throw new ApiError(
+        400,
+        "validation",
+        "That book's record does not name any files to remove.",
+      );
+    }
+
+    const commit = await client.commitChanges(
+      repo,
+      paths.map((path) => ({ op: "delete" as const, path })),
+      { message: `unpublish book: ${manifest.title}` },
+    );
+
+    return { removed: paths.length, paths, sha: commit.sha };
+  });
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,10 +4,9 @@ import { SignInError } from "@/components/SignInError";
 import { Nav } from "@/components/landing/Nav";
 import { Hero } from "@/components/landing/Hero";
 import { HowItWorks } from "@/components/landing/HowItWorks";
-import { Toolkit } from "@/components/landing/Toolkit";
 import { Features } from "@/components/landing/Features";
-import { Positioning } from "@/components/landing/Positioning";
-import { Comparison } from "@/components/landing/Comparison";
+import { Toolkit } from "@/components/landing/Toolkit";
+import { Why } from "@/components/landing/Why";
 import { Ownership } from "@/components/landing/Ownership";
 import { Faq } from "@/components/landing/Faq";
 import { Support } from "@/components/landing/Support";
@@ -70,12 +69,19 @@ export default async function Home({
       )}
 
       <main className="flex-1">
+        {/* Argument before inventory.
+            
+            `Toolkit` — the exhaustive list of everything ForkLeaf does — used
+            to come before `Features`, which is the illustrated case for why
+            any of it matters. That is the wrong way round: a reader who has
+            not yet been given a reason to care meets eight groups of ticked
+            rows, and a capability list read by somebody who is not yet sold
+            is just a long page. `Features` argues, then `Toolkit` proves. */}
         <Hero githubAvailable={githubAvailable} />
         <HowItWorks />
-        <Toolkit />
         <Features />
-        <Positioning />
-        <Comparison />
+        <Toolkit />
+        <Why />
         <Ownership />
         <Pricing />
         <Faq />

--- a/apps/web/src/components/EditorSidebar.tsx
+++ b/apps/web/src/components/EditorSidebar.tsx
@@ -48,6 +48,8 @@ export interface EditorSidebarProps {
   /** Make a folder inside `parent`. An empty string means the repository root. */
   onCreateFolder: (parent: string) => void;
   onRenameFolder: (path: string) => void;
+  /** Publishes a folder's notes as one linked site. Absent for a local workspace. */
+  onPublishFolder?: ((path: string) => void) | undefined;
   onDeleteFolder: (path: string) => void;
   /** Moves a note into another folder, from a drag within the tree. */
   onMoveNote: (path: string, toFolder: string) => void;
@@ -683,6 +685,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
           onTogglePin={props.onTogglePin}
           pinnedPaths={props.pinnedPaths}
           onRenameFolder={props.onRenameFolder}
+          onPublishFolder={props.onPublishFolder}
           onDeleteFolder={props.onDeleteFolder}
           {...(props.openFolders ? { openFolders: props.openFolders } : {})}
           {...(props.onOpenFoldersChange ? { onOpenFoldersChange: props.onOpenFoldersChange } : {})}

--- a/apps/web/src/components/FileTree.test.tsx
+++ b/apps/web/src/components/FileTree.test.tsx
@@ -294,3 +294,56 @@ describe("rearranging by drag", () => {
     expect(onMoveNote).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Publishing a folder is offered only where there is somewhere to publish to.
+ * A local notebook has no repository behind it, and a menu item that always
+ * fails is worse than one that is not there.
+ */
+describe("publishing a folder as a book", () => {
+  /**
+   * The context handler sits on the row's own button, not on the wrapper that
+   * `row` returns — that one carries the drag handlers.
+   */
+  const openMenu = (label: string) => {
+    const button = screen.getByText(label).closest("button");
+    if (!button) throw new Error(`no button for ${label}`);
+    fireEvent.contextMenu(button);
+  };
+
+  it("offers it on a folder when the notebook has a repository", () => {
+    draw({ onPublishFolder: vi.fn() });
+    openMenu("Fieldwork");
+
+    expect(screen.getByText("Publish as book…")).toBeTruthy();
+  });
+
+  it("names the folder the menu was opened on", () => {
+    const onPublishFolder = vi.fn();
+    draw({ onPublishFolder });
+
+    openMenu("OSINT");
+    fireEvent.click(screen.getByText("Publish as book…"));
+
+    expect(onPublishFolder).toHaveBeenCalledWith("OSINT");
+  });
+
+  it("does not offer it at all without somewhere to publish to", () => {
+    draw();
+    openMenu("Fieldwork");
+
+    expect(screen.queryByText("Publish as book…")).toBeNull();
+    // The rest of the folder menu is untouched.
+    expect(screen.getByText("Rename folder…")).toBeTruthy();
+  });
+
+  it("is a folder's menu item, not a note's", () => {
+    draw({ onPublishFolder: vi.fn() });
+    openMenu("osint");
+
+    // The note's own menu did open — this is not a menu that failed to appear.
+    expect(screen.getByText("Rename…")).toBeTruthy();
+
+    expect(screen.queryByText("Publish as book…")).toBeNull();
+  });
+});

--- a/apps/web/src/components/FileTree.tsx
+++ b/apps/web/src/components/FileTree.tsx
@@ -21,6 +21,14 @@ export interface FileTreeProps {
   onCreateFolder: (parent: string) => void;
   onRenameFolder: (path: string) => void;
   onDeleteFolder: (path: string) => void;
+  /**
+   * Publishes a folder's notes as one linked site.
+   *
+   * Absent when there is no repository behind this notebook — a local
+   * workspace has nowhere to publish to, and an item that always fails is
+   * worse than one that is not offered.
+   */
+  onPublishFolder?: ((path: string) => void) | undefined;
   /** Moves a note to another folder. Called by drag-and-drop within the tree. */
   onMoveNote?: (path: string, toFolder: string) => void;
   /**
@@ -97,6 +105,7 @@ export function FileTree({
   onCreateFolder,
   onRenameFolder,
   onDeleteFolder,
+  onPublishFolder,
   onMoveNote,
   onMoveFolder,
   onReorder,
@@ -360,6 +369,14 @@ export function FileTree({
           },
         },
         ...orderItems(node),
+        ...(onPublishFolder
+          ? [
+              {
+                label: "Publish as book…",
+                onSelect: () => onPublishFolder(node.path),
+              },
+            ]
+          : []),
         { label: "Rename folder…", onSelect: () => onRenameFolder(node.path) },
         {
           label: "Delete folder",
@@ -399,6 +416,7 @@ export function FileTree({
     onCreateFolder,
     onRenameFolder,
     onDeleteFolder,
+    onPublishFolder,
     onOpen,
     onOpenBeside,
     onRename,

--- a/apps/web/src/components/HelpDialog.tsx
+++ b/apps/web/src/components/HelpDialog.tsx
@@ -415,6 +415,16 @@ export function HelpDialog({
             }
           />
           <Feature
+            title="Publish a whole folder as a book"
+            what="A single published page is an island: a [[wikilink]] on it points at a heading that is not there, so every link between your notes quietly goes nowhere."
+            doThis={
+              <>
+                Right-click a folder in the sidebar and choose <strong>Publish as book…</strong>
+              </>
+            }
+            then="The notes are published together as one site — a contents page, a page each, and prev/next between them. Links between those notes become real links, and a link to a note you did not publish stays as the words you wrote rather than becoming a dead one. It is committed to your own repository, so unpublishing removes exactly the files it wrote and nothing else."
+          />
+          <Feature
             title="Let readers send corrections back"
             what="Programmers have had “here is a fix for what you wrote” for twenty years. Nobody has offered it to people writing notes."
             doThis={

--- a/apps/web/src/components/PublishBookDialog.test.tsx
+++ b/apps/web/src/components/PublishBookDialog.test.tsx
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Note, Workspace } from "@forkleaf/types";
+import { PublishBookDialog } from "./PublishBookDialog";
+
+const readBook = vi.fn();
+const publishBook = vi.fn();
+const unpublishBook = vi.fn();
+
+vi.mock("@/lib/gateway", () => ({
+  ApiGatewayError: class extends Error {},
+  readBook: (...args: unknown[]) => readBook(...args),
+  publishBook: (...args: unknown[]) => publishBook(...args),
+  unpublishBook: (...args: unknown[]) => unpublishBook(...args),
+}));
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  readBook.mockResolvedValue({ book: null, url: null, site: null });
+  publishBook.mockResolvedValue({
+    url: "https://me.github.io/notes/handbook/",
+    siteUrl: "https://me.github.io/notes",
+    status: "built",
+    dir: "docs/handbook",
+    chapters: 2,
+    removed: 0,
+  });
+  unpublishBook.mockResolvedValue({ removed: 4, paths: [] });
+});
+
+const REPO = { owner: "me", repo: "notes", branch: "main", directory: "" };
+
+const workspace: Workspace = {
+  id: "me/notes@main:",
+  name: "notes",
+  repo: REPO,
+  isDefault: false,
+  isLocal: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastOpenedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const note = (path: string, content = "Body."): Note =>
+  ({
+    id: path,
+    path,
+    content,
+    frontmatter: {},
+    viewMode: "wysiwyg",
+  }) as Note;
+
+const NOTES = [
+  note("handbook/01-intro.md", "# Introduction\n\nSee [[setup]]."),
+  note("handbook/02-setup.md", "# Setup"),
+  // Deeper, and outside — neither belongs to this book.
+  note("handbook/appendix/notes.md", "# Appendix note"),
+  note("elsewhere/other.md", "# Other"),
+];
+
+const open = (folder = "handbook", notes: Note[] = NOTES) =>
+  render(
+    <PublishBookDialog
+      folder={folder}
+      workspace={workspace}
+      notes={notes}
+      onClose={() => undefined}
+    />,
+  );
+
+describe("PublishBookDialog", () => {
+  it("asks what the folder already is before offering anything", async () => {
+    open();
+
+    expect(screen.getByText(/Checking whether this is published/)).toBeTruthy();
+    await waitFor(() => expect(readBook).toHaveBeenCalledWith(REPO, "handbook"));
+  });
+
+  /**
+   * A folder with subfolders under it is a shelf rather than a book, and
+   * flattening one into a single reading order invents a sequence its author
+   * never chose.
+   */
+  it("takes the folder's own notes and nothing below them", async () => {
+    open();
+
+    await waitFor(() => expect(screen.getByText("2 chapters, in this order")).toBeTruthy());
+    expect(screen.getByText("Introduction")).toBeTruthy();
+    expect(screen.getByText("Setup")).toBeTruthy();
+    expect(screen.queryByText("Appendix note")).toBeNull();
+    expect(screen.queryByText("Other")).toBeNull();
+  });
+
+  it("shows the reading order before committing to it", async () => {
+    open("handbook", [
+      note("handbook/02-setup.md", "# Setup"),
+      note("handbook/01-intro.md", "# Introduction"),
+    ]);
+
+    await waitFor(() => expect(screen.getByText("Introduction")).toBeTruthy());
+
+    const titles = screen.getAllByRole("listitem").map((item) => item.textContent);
+    expect(titles[0]).toContain("Introduction");
+    expect(titles[1]).toContain("Setup");
+  });
+
+  it("says where the book will go", async () => {
+    open();
+    await waitFor(() => expect(screen.getByText(/docs\/handbook\//)).toBeTruthy());
+  });
+
+  it("refuses a folder with no notes directly in it", async () => {
+    open("handbook", [note("handbook/appendix/notes.md")]);
+
+    await waitFor(() => expect(screen.getByText(/no notes directly in this folder/)).toBeTruthy());
+    expect(screen.queryByText("Publish book")).toBeNull();
+  });
+
+  it("builds the book and hands the server finished files", async () => {
+    open();
+    await waitFor(() => expect(screen.getByText("Publish book")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("Publish book"));
+    await waitFor(() => expect(publishBook).toHaveBeenCalled());
+
+    const sent = publishBook.mock.calls[0]![0];
+    expect(sent.book).toBe("handbook");
+    expect(sent.chapters.map((c: { slug: string }) => c.slug)).toEqual(["01-intro", "02-setup"]);
+
+    const paths = sent.files.map((f: { path: string }) => f.path);
+    expect(paths).toContain("index.html");
+    expect(paths).toContain("01-intro.html");
+    expect(paths).toContain("assets/style.css");
+  });
+
+  it("resolves a link between two chapters", async () => {
+    open();
+    await waitFor(() => expect(screen.getByText("Publish book")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("Publish book"));
+    await waitFor(() => expect(publishBook).toHaveBeenCalled());
+
+    const intro = publishBook.mock.calls[0]![0].files.find(
+      (f: { path: string }) => f.path === "01-intro.html",
+    );
+    expect(intro.content).toContain('href="02-setup.html"');
+  });
+
+  it("hands over the address once it is published", async () => {
+    open();
+    await waitFor(() => expect(screen.getByText("Publish book")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("Publish book"));
+
+    await waitFor(() =>
+      expect(screen.getByText("https://me.github.io/notes/handbook/")).toBeTruthy(),
+    );
+    expect(screen.getByText("Unpublish")).toBeTruthy();
+    expect(screen.getByText("Update book")).toBeTruthy();
+  });
+
+  /**
+   * Reopening on a published book used to be the bug worth avoiding: it
+   * offered to publish, as though it never had been, so there was no way to
+   * find the address again and no way to reach Unpublish.
+   */
+  it("opens on the address when the folder is already published", async () => {
+    readBook.mockResolvedValue({
+      book: {
+        version: 1,
+        book: "handbook",
+        title: "handbook",
+        publishedAt: "2026-01-01T00:00:00.000Z",
+        chapters: [{ slug: "01-intro", title: "Introduction", source: "handbook/01-intro.md" }],
+        files: [],
+      },
+      url: "https://me.github.io/notes/handbook/",
+      site: { url: "https://me.github.io/notes", status: "built", isPublic: true },
+    });
+
+    open();
+
+    await waitFor(() =>
+      expect(screen.getByText("https://me.github.io/notes/handbook/")).toBeTruthy(),
+    );
+    expect(screen.getByText("Unpublish")).toBeTruthy();
+    expect(publishBook).not.toHaveBeenCalled();
+  });
+
+  it("says the book is committed when Pages is switched off", async () => {
+    publishBook.mockResolvedValue({
+      url: "https://me.github.io/notes/handbook/",
+      siteUrl: "https://me.github.io/notes",
+      status: "building",
+      dir: "docs/handbook",
+      chapters: 2,
+      removed: 0,
+    });
+
+    open();
+    await waitFor(() => expect(screen.getByText("Publish book")).toBeTruthy());
+    fireEvent.click(screen.getByText("Publish book"));
+
+    await waitFor(() => expect(screen.getByText(/GitHub is building the site now/)).toBeTruthy());
+  });
+
+  it("says when an earlier publish left pages behind", async () => {
+    publishBook.mockResolvedValue({
+      url: "https://me.github.io/notes/handbook/",
+      siteUrl: "https://me.github.io/notes",
+      status: "built",
+      dir: "docs/handbook",
+      chapters: 2,
+      removed: 3,
+    });
+
+    open();
+    await waitFor(() => expect(screen.getByText("Publish book")).toBeTruthy());
+    fireEvent.click(screen.getByText("Publish book"));
+
+    await waitFor(() => expect(screen.getByText(/3 pages from an earlier publish/)).toBeTruthy());
+  });
+
+  it("shows what went wrong rather than closing on a failure", async () => {
+    publishBook.mockRejectedValue(new Error("GitHub said no."));
+
+    open();
+    await waitFor(() => expect(screen.getByText("Publish book")).toBeTruthy());
+    fireEvent.click(screen.getByText("Publish book"));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toBe("GitHub said no."));
+    expect(screen.getByText("Publish book")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/PublishBookDialog.tsx
+++ b/apps/web/src/components/PublishBookDialog.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import type { Note, Workspace } from "@forkleaf/types";
+import { deriveTitle } from "@forkleaf/markdown-engine";
+import { buildBook, chapterSlug, type BookNote } from "@forkleaf/exporter";
+import {
+  ApiGatewayError,
+  publishBook,
+  readBook,
+  unpublishBook,
+  type PublishedBook,
+} from "@/lib/gateway";
+import { Dialog } from "./Dialog";
+import { linkDocuments } from "@/lib/publish-citations";
+import { describeTarget, publishTargetOf, suggestEditUrl } from "@/lib/publish-target";
+
+export interface PublishBookDialogProps {
+  /** The folder being published, relative to the workspace root. */
+  folder: string;
+  workspace: Workspace;
+  /** Every note in the notebook; the ones under `folder` become chapters. */
+  notes: readonly Note[];
+  onClose: () => void;
+}
+
+/** The dialog is either waiting for the reader, or waiting on GitHub. */
+type Stage = "loading" | "idle" | "working";
+
+/**
+ * Publish a folder of notes as a book.
+ *
+ * The single-note dialog beside this one shares one page. What it cannot share
+ * is a set of notes that refer to each other, because a `[[wikilink]]` on a
+ * standalone page has nowhere to point — it renders as an anchor to a heading
+ * that is not there. Publishing the notes together is what gives those links
+ * somewhere to go, and that is the whole reason this exists.
+ *
+ * Everything is built here in the browser rather than on the server, for the
+ * same reason single-page publishing is: rendering a diagram needs a DOM, and
+ * the note never has to leave the machine in order to become a page. The
+ * server is handed finished files and checks that each one is a file a book is
+ * made of.
+ */
+export function PublishBookDialog({ folder, workspace, notes, onClose }: PublishBookDialogProps) {
+  const target = useMemo(() => publishTargetOf(workspace), [workspace]);
+
+  /** The folder's own name, which is both the book's address and its title. */
+  const book = useMemo(() => chapterSlug(folder), [folder]);
+  const title = useMemo(() => folder.split("/").pop() || folder, [folder]);
+
+  /**
+   * The notes that become chapters, in the order they will be read.
+   *
+   * Direct children only. A folder with subfolders under it is a shelf rather
+   * than a book, and flattening one into a single reading order invents a
+   * sequence its author never chose — better to publish the subfolder.
+   *
+   * Ordered by path, which for the usual `01-`, `02-` naming is the order the
+   * author already wrote down, and alphabetical otherwise.
+   */
+  const chapters = useMemo(() => {
+    const prefix = folder ? `${folder}/` : "";
+
+    return notes
+      .filter(
+        (note) => note.path.startsWith(prefix) && !note.path.slice(prefix.length).includes("/"),
+      )
+      .slice()
+      .sort((a, b) => a.path.localeCompare(b.path));
+  }, [notes, folder]);
+
+  const [stage, setStage] = useState<Stage>("loading");
+  const [step, setStep] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [published, setPublished] = useState<PublishedBook | null>(null);
+  const [url, setUrl] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [removed, setRemoved] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  /**
+   * What this folder already is, asked once on open.
+   *
+   * Without it the dialog would offer to publish a book that is already
+   * published — no address to copy, and no way to reach Unpublish — which is
+   * exactly the state the single-page dialog had to be fixed out of.
+   */
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const state = await readBook(target, book);
+        if (cancelled) return;
+
+        setPublished(state.book);
+        setUrl(state.url);
+        // Already published means already built: it has been sitting in the
+        // repository since some earlier commit, so there is no build to warn
+        // about.
+        setStatus(state.book ? "built" : null);
+      } catch (problem) {
+        if (!cancelled) setError(messageFor(problem));
+      } finally {
+        if (!cancelled) setStage("idle");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [target, book]);
+
+  const publish = useCallback(async () => {
+    setStage("working");
+    setError(null);
+
+    try {
+      setStep(`Rendering ${chapters.length} chapters…`);
+
+      const sources: BookNote[] = chapters.map((note) => ({
+        path: note.path,
+        title: deriveTitle(note.content, note.frontmatter.title, note.path),
+        // Citations are written relative to the note, which is right in the
+        // repository and reaches nothing from a page served out of `docs/`.
+        // Only the published copy is rewritten.
+        markdown: linkDocuments(note.content, { notePath: note.path, repo: workspace.repo }),
+        frontmatter: note.frontmatter,
+      }));
+
+      const built = await buildBook(sources, {
+        title,
+        theme: "light",
+        renderDiagrams: true,
+        // Points at the note in the repository it came from, never at the
+        // published copy.
+        suggestUrl: (note) => suggestEditUrl(workspace.repo, note.path),
+      });
+
+      setStep("Committing the book to your repository…");
+      const result = await publishBook({
+        repo: target,
+        book,
+        title,
+        chapters: built.chapters,
+        files: built.files,
+      });
+
+      setUrl(result.url);
+      setStatus(result.status);
+      setRemoved(result.removed);
+      setPublished({
+        version: 1,
+        book,
+        title,
+        publishedAt: new Date().toISOString(),
+        chapters: built.chapters,
+        files: [],
+      });
+      setStage("idle");
+    } catch (problem) {
+      setError(messageFor(problem));
+      setStage("idle");
+    }
+  }, [chapters, title, book, target, workspace.repo]);
+
+  const unpublish = useCallback(async () => {
+    setStage("working");
+    setStep("Deleting the book…");
+    setError(null);
+
+    try {
+      await unpublishBook(target, book);
+      onClose();
+    } catch (problem) {
+      setError(messageFor(problem));
+      setStage("idle");
+    }
+  }, [target, book, onClose]);
+
+  const copy = useCallback(async () => {
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // A clipboard the browser will not give us is not worth an error: the
+      // address is on screen and selectable.
+    }
+  }, [url]);
+
+  const where = (
+    <div className="space-y-1 rounded-lg border border-[var(--fl-border)] px-3 py-2.5">
+      <span className="text-[12px] text-[var(--fl-muted)]">The book goes to</span>
+      <p className="font-mono text-[12.5px] text-[var(--fl-text)]">
+        {describeTarget(target)}
+        <span className="text-[var(--fl-muted)]"> · docs/{book}/</span>
+      </p>
+    </div>
+  );
+
+  const problem = error && (
+    <p role="alert" className="text-[13px] leading-relaxed text-[var(--fl-danger)]">
+      {error}
+    </p>
+  );
+
+  // ── Still asking what this folder already is ────────────────────────────
+
+  if (stage === "loading") {
+    return (
+      <Dialog title="Publish as a book" subtitle={folder} onClose={onClose}>
+        <p className="text-[13px] text-[var(--fl-muted)]">Checking whether this is published…</p>
+      </Dialog>
+    );
+  }
+
+  // ── Nothing to publish ──────────────────────────────────────────────────
+
+  if (chapters.length === 0) {
+    return (
+      <Dialog title="Publish as a book" subtitle={folder} onClose={onClose}>
+        <div className="space-y-4">
+          <p className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+            There are no notes directly in this folder. A book is made from the notes a folder holds
+            — notes in subfolders belong to those, so publish the subfolder instead.
+          </p>
+          <div className="flex justify-end">
+            <button type="button" onClick={onClose} className="fl-btn fl-btn-primary">
+              Close
+            </button>
+          </div>
+        </div>
+      </Dialog>
+    );
+  }
+
+  // ── Published ───────────────────────────────────────────────────────────
+
+  if (published) {
+    return (
+      <Dialog title="Published" subtitle={`${title} is a public book`} onClose={onClose}>
+        <div className="space-y-4">
+          {url ? (
+            <div className="rounded-xl border border-[var(--fl-border)] bg-[var(--fl-surface)] p-3">
+              <a
+                href={url}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="block break-all font-mono text-[12.5px] text-[var(--fl-accent)] underline underline-offset-2"
+              >
+                {url}
+              </a>
+            </div>
+          ) : (
+            /* Committed, but the repository is not being served. There is a
+               folder of files and no address, and which of the two is missing
+               is what separates a fixable state from a broken one. */
+            <p className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+              The book is committed to <code className="font-mono text-[12px]">docs/{book}/</code>,
+              but GitHub Pages is switched off for this repository, so it has no public address yet.
+              Turning Pages on in the repository&rsquo;s settings publishes it as it stands.
+            </p>
+          )}
+
+          <p className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+            {published.chapters.length === 1
+              ? "One chapter"
+              : `${published.chapters.length} chapters`}
+            , with links between them resolved.
+            {removed > 0 &&
+              ` ${removed === 1 ? "One page" : `${removed} pages`} from an earlier publish ${
+                removed === 1 ? "was" : "were"
+              } removed.`}
+          </p>
+
+          {url && status !== "built" && (
+            /* GitHub takes up to a minute to build a site for the first time.
+               Handing over a link and saying nothing means the first person to
+               click it — usually the author, immediately — gets a 404. */
+            <p className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+              GitHub is building the site now. The first publish of a repository can take a minute
+              or so before the address answers; every one after that is quick.
+            </p>
+          )}
+
+          {where}
+          {problem}
+
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => void unpublish()}
+              disabled={stage === "working"}
+              className="fl-btn fl-btn-ghost !text-[var(--fl-danger)] disabled:opacity-50"
+            >
+              Unpublish
+            </button>
+            <button
+              type="button"
+              onClick={() => void publish()}
+              disabled={stage === "working"}
+              className="fl-btn fl-btn-ghost disabled:opacity-50"
+            >
+              {stage === "working" ? step || "Working…" : "Update book"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void copy()}
+              disabled={!url || stage === "working"}
+              className="fl-btn fl-btn-ghost disabled:opacity-40"
+            >
+              {copied ? "Copied" : "Copy link"}
+            </button>
+            <button type="button" onClick={onClose} className="fl-btn fl-btn-primary">
+              Done
+            </button>
+          </div>
+        </div>
+      </Dialog>
+    );
+  }
+
+  // ── Not published yet ───────────────────────────────────────────────────
+
+  return (
+    <Dialog title="Publish as a book" subtitle={folder} onClose={onClose}>
+      <div className="space-y-4">
+        <p className="text-[13px] leading-relaxed text-[var(--fl-muted)]">
+          These notes are published together as one site: a contents page, a page each, and links
+          between them that work. Everything is committed to your own repository and served by
+          GitHub Pages, so the book outlives ForkLeaf.
+        </p>
+
+        {/* The reading order, shown before it is committed to. It is the order
+            the chapters will be numbered in and the order prev/next follows,
+            and it is derived from the filenames — which is worth seeing rather
+            than discovering after publishing. */}
+        <div>
+          <p className="mb-1.5 text-[12px] text-[var(--fl-muted)]">
+            {chapters.length === 1 ? "One chapter" : `${chapters.length} chapters`}, in this order
+          </p>
+          <ol className="max-h-48 space-y-px overflow-y-auto rounded-lg border border-[var(--fl-border)] p-1">
+            {chapters.map((note, index) => (
+              <li key={note.path} className="flex gap-2.5 px-2 py-1.5 text-[13px]">
+                <span className="font-mono text-[11.5px] text-[var(--fl-muted)]">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[var(--fl-text)]">
+                  {deriveTitle(note.content, note.frontmatter.title, note.path)}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        {where}
+        {problem}
+
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={stage === "working"}
+            className="fl-btn fl-btn-ghost"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void publish()}
+            disabled={stage === "working"}
+            className="fl-btn fl-btn-primary"
+          >
+            {stage === "working" ? step || "Publishing…" : "Publish book"}
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function messageFor(problem: unknown): string {
+  if (problem instanceof ApiGatewayError) return problem.message;
+  return problem instanceof Error ? problem.message : "That folder could not be published.";
+}

--- a/apps/web/src/components/editor/EditorWorkspace.tsx
+++ b/apps/web/src/components/editor/EditorWorkspace.tsx
@@ -12,7 +12,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import type { CursorPosition, ImageBridge, LinkBridge } from "@forkleaf/editor";
 import { displayTitle, parseCitation, type PdfCitation } from "@forkleaf/pdf";
-import type { EditorViewMode, Workspace } from "@forkleaf/types";
+import type { EditorViewMode, Note, Workspace } from "@forkleaf/types";
 import {
   deriveTitle,
   dirname,
@@ -85,6 +85,7 @@ import { ExportDialog } from "@/components/ExportDialog";
 import { ConnectRepoDialog } from "@/components/ConnectRepoDialog";
 import { ProposeChangesDialog } from "@/components/ProposeChangesDialog";
 import { PublishDialog } from "@/components/PublishDialog";
+import { PublishBookDialog } from "@/components/PublishBookDialog";
 import { HelpDialog } from "@/components/HelpDialog";
 import { HistoryDialog } from "@/components/HistoryDialog";
 import { ReviewPanel } from "@/components/ReviewPanel";
@@ -306,6 +307,16 @@ export function EditorWorkspace() {
    * over the document instead of sitting beside it.
    */
   const [drawer, setDrawer] = useState<"files" | "document" | null>(null);
+
+  /**
+   * The folder being published as a book, and the notes to build it from.
+   *
+   * Held apart from `dialog`, which is a bare name, because this one needs to
+   * remember *which* folder was asked for. The notes are loaded when the menu
+   * item is chosen rather than kept in state: a book is built from the notes'
+   * full text, which the editor otherwise has no reason to hold all of.
+   */
+  const [book, setBook] = useState<{ folder: string; notes: Note[] } | null>(null);
   const [dialog, setDialog] = useState<
     | "export"
     | "connect"
@@ -1760,6 +1771,25 @@ export function EditorWorkspace() {
     [notebook],
   );
 
+  /**
+   * Opens the book dialog for a folder, with its notes already in hand.
+   *
+   * The notes are fetched here rather than inside the dialog because they come
+   * from the store rather than from the network: reading them is fast, and a
+   * dialog that opens empty and fills in a moment later is a dialog whose
+   * chapter list moves under the reader while they are counting it.
+   */
+  const handlePublishFolder = useCallback(
+    async (path: string) => {
+      try {
+        setBook({ folder: path, notes: await loadAllNotes() });
+      } catch {
+        notebook.reportError("Those notes could not be read, so the book was not opened.");
+      }
+    },
+    [loadAllNotes, notebook],
+  );
+
   const handleDeleteFolder = useCallback(
     (path: string) => {
       setPrompt({
@@ -2658,6 +2688,9 @@ export function EditorWorkspace() {
             onCreateFolder={handleCreateFolder}
             onRenameFolder={handleRenameFolder}
             onDeleteFolder={handleDeleteFolder}
+            {...(workspace && !workspace.isLocal
+              ? { onPublishFolder: (path: string) => void handlePublishFolder(path) }
+              : {})}
             onMoveNote={handleMoveNote}
             onMoveFolder={handleMoveFolder}
             pinnedPaths={notebook.pinnedPaths}
@@ -3430,6 +3463,19 @@ export function EditorWorkspace() {
             openRepoPdf(pdfPath, `page=${page}`);
           }}
           onFix={correctCitationPage}
+        />
+      )}
+
+      {book && workspace && !workspace.isLocal && (
+        <PublishBookDialog
+          // A fresh dialog per folder: opening the menu on another folder must
+          // not leave the last one's chapters on screen as though they were
+          // this one's.
+          key={book.folder}
+          folder={book.folder}
+          workspace={workspace}
+          notes={book.notes}
+          onClose={() => setBook(null)}
         />
       )}
 

--- a/apps/web/src/components/landing/Comparison.tsx
+++ b/apps/web/src/components/landing/Comparison.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { SectionHeading } from "./SectionHeading";
 
 /**
  * ForkLeaf against the apps people actually have open.
@@ -149,18 +148,33 @@ const ARGUMENTS: { title: string; body: string }[] = [
   },
 ];
 
-export function Comparison() {
+/**
+ * The named-products half of the "why this" argument.
+ *
+ * A block rather than a section — {@link Why} owns the heading — but it keeps
+ * `id="compare"`, because the nav has always pointed at the table itself and
+ * a reader who clicks "Compare" wants the rows, not the paragraph three
+ * screens above them.
+ */
+export function ComparisonBlock() {
   return (
-    <section id="compare" className="fl-anchor mx-auto w-full max-w-6xl px-6 py-24">
-      <SectionHeading
-        eyebrow="Side by side"
-        title="Every other notes app is a rented room. This one is a deed."
-        body="Nine questions to ask before you put a decade of thinking somewhere. Notion, OneNote, Obsidian and Evernote answer them too — these are their answers, not ours about them."
-      />
+    <>
+      <div className="mt-20 border-t border-[var(--fl-border)] pt-12">
+        <h3 className="text-[22px] font-semibold tracking-[-0.02em] text-[var(--fl-text)]">
+          And by name
+        </h3>
+        <p className="mt-2 max-w-2xl text-[15px] leading-relaxed text-[var(--fl-muted)]">
+          Nine questions to ask before you put a decade of thinking somewhere. Notion, OneNote,
+          Obsidian and Evernote answer them too — these are their answers, not ours about them.
+        </p>
+      </div>
 
       {/* Wide tables scroll inside themselves; the page must never scroll
           sideways because of one. */}
-      <div className="mt-12 overflow-x-auto rounded-2xl border border-[var(--fl-border)]">
+      <div
+        id="compare"
+        className="fl-anchor mt-8 overflow-x-auto rounded-2xl border border-[var(--fl-border)]"
+      >
         <table className="w-full min-w-[56rem] border-collapse text-left text-[13.5px]">
           <caption className="sr-only">
             How ForkLeaf compares with Notion, OneNote, Obsidian and Evernote
@@ -238,6 +252,6 @@ export function Comparison() {
         them at all. It is a folder of Markdown in a repository with your name on it, and ForkLeaf
         is the window you happen to be reading it through.
       </p>
-    </section>
+    </>
   );
 }

--- a/apps/web/src/components/landing/Hero.tsx
+++ b/apps/web/src/components/landing/Hero.tsx
@@ -11,45 +11,27 @@ import { SectionLink } from "./SectionLink";
  *
  * 1. The display line makes the claim. It is set in Instrument Serif at a size
  *    that only works because it is short — resist lengthening it.
- * 2. The paragraph under it says what the thing actually is, in the plainest
- *    words available, because "notes you own" is a promise and not a product.
- * 3. The chips name the capabilities, because somebody reading a headline about
- *    ownership still does not know whether this can draw a diagram.
- * 4. The button says what it costs and what it will ask for, next to itself.
+ * 2. One sentence says what the thing actually is, because "notes you own" is
+ *    a promise and not a product.
+ * 3. The button says what it costs and what it will ask for, next to itself.
  *    An unpriced button with an OAuth screen behind it is the single most
  *    common reason a developer closes the tab.
- */
-
-/**
- * Named capabilities, in the order a writer would meet them.
  *
- * The list is long on purpose. "Notes in your own repo" is a storage decision,
- * and a reader who has only been told that is entitled to assume they are
- * being offered a text box over an API — so the chips say, before anybody
- * scrolls, that this is a full notebook: it links, it searches, it draws, it
- * remembers, it publishes, and it opens the files already on your disk.
+ * What is deliberately *not* here is the capability list.
  *
- * Every one of these is in the repository today. Nothing aspirational goes in
- * this list; the moment one entry turns out to be a plan, the reader is right
- * to stop believing the other eleven.
+ * Fifteen named capabilities used to sit between the paragraph and the button,
+ * on the reasoning that a reader told only "notes in your own repo" would
+ * assume they were being offered a text box over an API. The reasoning was
+ * right and the remedy was wrong: fifteen pills read as texture rather than as
+ * words, so the list that existed to be *read* was the one thing on the page
+ * nobody read, and it pushed the button below the fold to do it.
+ *
+ * The inventory is a section of its own further down, grouped by the job each
+ * capability belongs to, where a reader who wants it arrives having already
+ * decided to look. Nothing was dropped in the move — the three capabilities
+ * that were named only here (running a code block, archiving a web source,
+ * line-by-line blame) are named there now.
  */
-const CAPABILITIES = [
-  "Rich, split & source editing",
-  "[[Wikilinks]] & backlinks",
-  "Offline full-text search",
-  "Visual Mermaid studio",
-  "Real commit history",
-  "Version compare & restore",
-  "Conflicts shown, never merged",
-  "Pull requests from the editor",
-  "Publish to GitHub Pages",
-  "PDF, Word & HTML export",
-  "Opens the .md files on your disk",
-  "Runs the code in your notes",
-  "Web sources, archived",
-  "Line-by-line blame",
-  "Works offline",
-] as const;
 
 export function Hero({ githubAvailable }: { githubAvailable: boolean }) {
   return (
@@ -86,27 +68,17 @@ export function Hero({ githubAvailable }: { githubAvailable: boolean }) {
             the app that made them
           </h1>
 
+          {/* Two sentences, and they are the two that decide it: what the
+              thing is, and where the writing ends up. Everything this used to
+              add — the .md file, the local-first save, the commits under your
+              own name — is answered by scrolling, and a reader who has not yet
+              been given a reason to scroll will not read it here either. */}
           <p className="mx-auto mt-6 max-w-2xl text-[16px] leading-[1.6] text-[var(--fl-muted)] sm:mt-7 sm:text-[17.5px] sm:leading-[1.62]">
-            ForkLeaf is a full Markdown workspace — linked notes, offline search, a visual diagram
-            studio, real version history, exports and publishing — and its database is a{" "}
+            A full Markdown workspace — linked notes, offline search, a visual diagram studio, real
+            version history — whose database is a{" "}
             <em className="not-italic text-[var(--fl-text)]">GitHub repository you already own</em>.
-            Every note is a plain{" "}
-            <code className="font-mono text-[15px] text-[var(--fl-text)]">.md</code> file. It saves
-            to your device as you type, then turns those edits into real commits under your own
-            name. Nothing is stored on our servers, and there is no ForkLeaf database to be locked
-            out of.
+            Nothing is stored on our servers, and there is no ForkLeaf database to be locked out of.
           </p>
-
-          <ul className="mx-auto mt-7 flex max-w-3xl flex-wrap items-center justify-center gap-x-2 gap-y-2 text-[12.5px] text-[var(--fl-muted)]">
-            {CAPABILITIES.map((item) => (
-              <li
-                key={item}
-                className="rounded-full border border-[var(--fl-border)] bg-[var(--fl-surface)] px-3 py-1"
-              >
-                {item}
-              </li>
-            ))}
-          </ul>
 
           {/* ── Call to action ──────────────────────────────────────────── */}
           <div className="mt-9 flex flex-wrap items-center justify-center gap-3">
@@ -127,21 +99,11 @@ export function Hero({ githubAvailable }: { githubAvailable: boolean }) {
             )}
           </div>
 
-          {githubAvailable && (
-            /* Said here rather than discovered on GitHub's own consent screen.
-               The default grant covers every repository the account can reach,
-               which is a great deal to hand a notes app — so the narrower one
-               is offered next to it instead of being a thing you would have to
-               know to ask for. */
-            <p className="mt-3 text-[12.5px] text-[var(--fl-muted)]">
-              Keeping notes in public repositories?{" "}
-              <a href="/sign-in" className="fl-link">
-                Grant public-repository access only
-              </a>
-              .
-            </p>
-          )}
-
+          {/* The narrower-scope invitation used to sit above this line. It
+              pointed at `/sign-in` — the same address as the button directly
+              above it — so it was explanation rather than an affordance, and
+              the explanation is given properly in the ownership section this
+              line already links to. */}
           <p className="mt-4 text-[13px] text-[var(--fl-muted)]">
             {githubAvailable ? (
               <>

--- a/apps/web/src/components/landing/Nav.tsx
+++ b/apps/web/src/components/landing/Nav.tsx
@@ -18,8 +18,8 @@ import { SectionLink } from "./SectionLink";
 
 const SECTIONS = [
   { hash: "#how", label: "How it works" },
-  { hash: "#toolkit", label: "What it does" },
   { hash: "#features", label: "Features" },
+  { hash: "#toolkit", label: "What it does" },
   { hash: "#compare", label: "Compare" },
   { hash: "#pricing", label: "Pricing" },
   { hash: "#support", label: "Support" },

--- a/apps/web/src/components/landing/Positioning.tsx
+++ b/apps/web/src/components/landing/Positioning.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { SectionHeading } from "./SectionHeading";
 
 /**
  * Where ForkLeaf sits.
@@ -57,16 +56,26 @@ const AUDIENCES = [
   },
 ] as const;
 
-export function Positioning() {
+/**
+ * The category half of the "why this" argument: the three things a reader
+ * already has open, and the audiences the answer is aimed at.
+ *
+ * No section wrapper and no heading of its own — it is one block inside
+ * {@link Why}, which owns both. It used to be a section, directly above a
+ * second section making the same argument against named products; two full
+ * headings for one question read as two answers, and a reader who had been
+ * told "here is the honest case for moving" once did not need to be told it
+ * again four hundred pixels later.
+ */
+export function PositioningBlock() {
   return (
-    <section id="why" className="fl-anchor mx-auto w-full max-w-6xl px-6 py-24">
-      <SectionHeading
-        eyebrow="Where this fits"
-        title="You already have somewhere to put notes. Here is the honest case for moving."
-        body="Three reasonable alternatives, what each is genuinely good at, and the specific thing ForkLeaf does differently."
-      />
+    <>
+      <p className="mt-10 max-w-2xl text-[15px] leading-relaxed text-[var(--fl-muted)]">
+        First by category — the three things you already have open, what each is genuinely good at,
+        and the specific thing ForkLeaf does differently.
+      </p>
 
-      <div className="mt-12 grid gap-4 lg:grid-cols-3">
+      <div className="mt-8 grid gap-4 lg:grid-cols-3">
         {COMPARISONS.map((row) => (
           <article key={row.them} className="fl-card flex flex-col p-6">
             <h3 className="text-[16px] font-semibold tracking-tight text-[var(--fl-text)]">
@@ -118,6 +127,6 @@ export function Positioning() {
           ))}
         </dl>
       </div>
-    </section>
+    </>
   );
 }

--- a/apps/web/src/components/landing/Toolkit.tsx
+++ b/apps/web/src/components/landing/Toolkit.tsx
@@ -14,6 +14,11 @@ import { SectionHeading } from "./SectionHeading";
  * Every entry here corresponds to code in this repository. Nothing planned,
  * nothing "coming soon" — a capability list is a promise, and this page has
  * over-promised before. When a row stops being true, delete the row.
+ *
+ * This is also where the hero's capability chips went. Three of them named
+ * things no row here did — running a code block, archiving a web source,
+ * line-by-line blame — so those rows were added rather than the claims being
+ * quietly dropped on the way down the page.
  */
 
 interface Group {
@@ -42,6 +47,10 @@ const GROUPS: Group[] = [
       { name: "Markdown shortcuts", detail: "# ␣, - ␣, > ␣, ``` ␣ and the rest, as you type" },
       { name: "Images", detail: "Paste, drop or upload — committed alongside the note" },
       { name: "Properties", detail: "Title, tags and custom fields, stored as YAML front matter" },
+      {
+        name: "Runnable code blocks",
+        detail: "Run a shell, Python or JavaScript block; the output lands under it, stamped",
+      },
       { name: "Tabs & outline", detail: "Several notes open at once, with headings and stats" },
     ],
   },
@@ -64,6 +73,10 @@ const GROUPS: Group[] = [
         detail: "Every word of every note, ranked with BM25, in-browser",
       },
       { name: "Tags", detail: "Filter the library by anything in the front matter" },
+      {
+        name: "Web sources, archived",
+        detail: "Capture a page as a citation, with a Wayback copy that outlives the link",
+      },
       { name: "Folders & tree", detail: "Real directories in the repository, renamed in place" },
       { name: "Command palette", detail: "⌘K to jump to any note or run any command" },
     ],
@@ -99,6 +112,10 @@ const GROUPS: Group[] = [
       { name: "Offline-first", detail: "IndexedDB first, network second — always in that order" },
       { name: "Atomic commits", detail: "A burst of edits becomes one clean commit, not forty" },
       { name: "Full history", detail: "Every version of every note, with diffs, in the app" },
+      {
+        name: "Line-by-line blame",
+        detail: "Which commit wrote each paragraph, how old it is, and what it said before",
+      },
       { name: "Branches", detail: "Switch the branch you are writing on from the status bar" },
       { name: "Conflicts", detail: "Both versions shown side by side — never a silent overwrite" },
       { name: "Propose changes", detail: "Open a pull request against a repo you cannot push to" },

--- a/apps/web/src/components/landing/Why.tsx
+++ b/apps/web/src/components/landing/Why.tsx
@@ -1,0 +1,37 @@
+import { SectionHeading } from "./SectionHeading";
+import { PositioningBlock } from "./Positioning";
+import { ComparisonBlock } from "./Comparison";
+
+/**
+ * Why this rather than the thing you already use.
+ *
+ * One question, and until now it was asked twice. `Positioning` compared
+ * categories — a hosted app, a local folder, editing on github.com — and
+ * `Comparison` compared named products, each as a full section with its own
+ * eyebrow, its own display heading and its own summing-up. A reader met the
+ * same argument twice in two voices and had no way to tell whether the second
+ * one was making a new point.
+ *
+ * It is one section now, with one heading and two blocks under it: by
+ * category, then by name. Nothing was cut — both tables, both sets of
+ * closing arguments and the audiences list are all still here — but the page
+ * stops restating its own premise, and the reader is told once that this is
+ * the honest-comparison part.
+ *
+ * Both anchors still land: `#why` is this section, and `#compare` is on the
+ * table itself, which is what the nav has always meant by it.
+ */
+export function Why() {
+  return (
+    <section id="why" className="fl-anchor mx-auto w-full max-w-6xl px-6 py-24">
+      <SectionHeading
+        eyebrow="Where this fits"
+        title="Every other notes app is a rented room. This one is a deed."
+        body="You already have somewhere to put notes, so here is the honest case for moving — first against the categories, then against the products by name."
+      />
+
+      <PositioningBlock />
+      <ComparisonBlock />
+    </section>
+  );
+}

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -712,3 +712,97 @@ export interface LinkPreviewResult {
 export async function previewLink(url: string): Promise<LinkPreviewResult> {
   return call(`/api/link-preview?url=${encodeURIComponent(url)}`, { timeoutMs: 8_000 });
 }
+
+// ─── Books ──────────────────────────────────────────────────────────────────
+
+/** One chapter, as the book's own record describes it. */
+export interface PublishedChapter {
+  slug: string;
+  title: string;
+  /** The note it was rendered from. */
+  source: string;
+}
+
+/** What a book records about itself, in the repository it was published to. */
+export interface PublishedBook {
+  version: 1;
+  book: string;
+  title: string;
+  publishedAt: string;
+  chapters: PublishedChapter[];
+  files: string[];
+}
+
+export interface BookState {
+  /** Null when this folder has never been published as a book. */
+  book: PublishedBook | null;
+  /** The public address, or null while Pages is switched off. */
+  url: string | null;
+  site: { url: string; status: string | null; isPublic: boolean } | null;
+}
+
+/**
+ * Whether this folder is currently published, and as what.
+ *
+ * Asked for rather than remembered, and answered from the book's own record
+ * rather than from the folder — `docs/handbook/` full of HTML is equally
+ * consistent with a book ForkLeaf published and a site somebody wrote by hand,
+ * and only the record tells them apart.
+ */
+export async function readBook(repo: RepoRef, book: string): Promise<BookState> {
+  return call(`/api/gh/publish/book?${repoParams(repo)}&book=${encodeURIComponent(book)}`);
+}
+
+/**
+ * Publishes a folder of notes as a book.
+ *
+ * The pages arrive already rendered, because rendering them needs a DOM —
+ * Mermaid draws into one — and the browser is where that exists. The route's
+ * job is to check that every filename is one a book is made of, write them in
+ * a single commit, and record what it wrote.
+ */
+export async function publishBook(options: {
+  repo: RepoRef;
+  book: string;
+  title: string;
+  chapters: PublishedChapter[];
+  files: { path: string; content: string }[];
+}): Promise<{
+  url: string;
+  siteUrl: string;
+  status: string | null;
+  dir: string;
+  chapters: number;
+  /** Files the previous publish wrote that this one no longer needs. */
+  removed: number;
+}> {
+  const { repo, ...rest } = options;
+
+  return call("/api/gh/publish/book", {
+    method: "POST",
+    body: JSON.stringify({
+      owner: repo.owner,
+      repo: repo.repo,
+      branch: repo.branch,
+      dir: repo.directory,
+      ...rest,
+    }),
+  });
+}
+
+/** Deletes exactly what the book's record says it wrote. The notes are left alone. */
+export async function unpublishBook(
+  repo: RepoRef,
+  book: string,
+): Promise<{ removed: number; paths: string[] }> {
+  return call("/api/gh/publish/book", {
+    method: "DELETE",
+    body: JSON.stringify({
+      owner: repo.owner,
+      repo: repo.repo,
+      branch: repo.branch,
+      dir: repo.directory,
+      book,
+    }),
+  });
+}

--- a/apps/web/src/lib/publish.test.ts
+++ b/apps/web/src/lib/publish.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "vitest";
 import { ApiError } from "./api-helpers";
-import { pagePath, pageUrl, slugOfPage } from "./publish";
+import {
+  bookAssetPath,
+  bookDir,
+  bookUrl,
+  chapterPath,
+  chapterUrl,
+  filesToDelete,
+  pagePath,
+  pageUrl,
+  parseManifest,
+  serializeManifest,
+  slugOfPage,
+  type BookManifest,
+} from "./publish";
 
 /**
  * The slug becomes a path in the user's repository and a segment of a public
@@ -88,5 +101,172 @@ describe("slugOfPage", () => {
   it("agrees with pagePath, so a listed page can always be unpublished", () => {
     const slug = slugOfPage("q3-roadmap.html")!;
     expect(pagePath(slug)).toBe("docs/q3-roadmap.html");
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+   Books
+   ──────────────────────────────────────────────────────────────────────────── */
+
+describe("bookDir", () => {
+  it("puts a book in its own folder under docs/", () => {
+    expect(bookDir("handbook")).toBe("docs/handbook");
+    expect(bookDir("Handbook")).toBe("docs/handbook");
+  });
+
+  it("allows exactly one level of nesting and no more", () => {
+    for (const book of ["", " ", "..", "../evil", "a/b", "/etc", ".hidden", "-x", "x".repeat(90)]) {
+      expect(() => bookDir(book)).toThrow(ApiError);
+    }
+  });
+});
+
+describe("chapterPath", () => {
+  it("addresses a chapter inside its book", () => {
+    expect(chapterPath("handbook", "onboarding")).toBe("docs/handbook/onboarding.html");
+  });
+
+  it("refuses a chapter that would replace the contents page", () => {
+    // The cover is `index.html`; a chapter published there would leave the book
+    // building, deploying, and with no way in.
+    expect(() => chapterPath("handbook", "index")).toThrow(ApiError);
+    expect(() => chapterPath("handbook", "INDEX")).toThrow(ApiError);
+  });
+
+  it("refuses a chapter that would climb out of the book", () => {
+    for (const slug of ["..", "../../index", "a/b", ""]) {
+      expect(() => chapterPath("handbook", slug)).toThrow(ApiError);
+    }
+  });
+
+  it("refuses a good chapter in a bad book", () => {
+    expect(() => chapterPath("../..", "onboarding")).toThrow(ApiError);
+  });
+});
+
+describe("bookAssetPath", () => {
+  it("addresses a shared file", () => {
+    expect(bookAssetPath("handbook", "style.css")).toBe("docs/handbook/assets/style.css");
+    expect(bookAssetPath("handbook", "search.json")).toBe("docs/handbook/assets/search.json");
+  });
+
+  it("ships only what a book needs", () => {
+    for (const name of ["deploy.sh", "index.html", "..", "../style.css", "a/b.css", "noext"]) {
+      expect(() => bookAssetPath("handbook", name)).toThrow(ApiError);
+    }
+  });
+});
+
+describe("bookUrl / chapterUrl", () => {
+  it("addresses the book as a directory, so the cover is served for it", () => {
+    expect(bookUrl("https://me.github.io/notes/", "handbook")).toBe(
+      "https://me.github.io/notes/handbook/",
+    );
+    expect(chapterUrl("https://me.github.io/notes", "handbook", "onboarding")).toBe(
+      "https://me.github.io/notes/handbook/onboarding.html",
+    );
+  });
+});
+
+/**
+ * The manifest is a file in somebody's repository, so it is a file somebody can
+ * edit. Everything below treats it as a claim to be checked rather than an
+ * instruction to carry out — because the operation it authorises is deletion.
+ */
+describe("parseManifest", () => {
+  const manifest: BookManifest = {
+    version: 1,
+    book: "handbook",
+    title: "The Handbook",
+    publishedAt: "2026-09-04T00:00:00.000Z",
+    chapters: [{ slug: "onboarding", title: "Onboarding", source: "notes/onboarding.md" }],
+    files: ["docs/handbook/index.html", "docs/handbook/onboarding.html"],
+  };
+
+  it("round-trips what it wrote", () => {
+    expect(parseManifest(serializeManifest(manifest), "handbook")).toEqual(manifest);
+  });
+
+  it("is not a book if it cannot be read", () => {
+    for (const json of ["", "{", "null", "[]", '"handbook"', "42"]) {
+      expect(parseManifest(json, "handbook")).toBeNull();
+    }
+  });
+
+  it("is not a book if it describes a different one", () => {
+    // A manifest that was copied or moved names paths in another folder.
+    // Believing it would delete them.
+    expect(parseManifest(serializeManifest(manifest), "other-book")).toBeNull();
+  });
+
+  it("is not a book if it is a version this app cannot read", () => {
+    expect(parseManifest(JSON.stringify({ ...manifest, version: 2 }), "handbook")).toBeNull();
+  });
+
+  it("is not a book if a chapter is not addressable", () => {
+    const bad = { ...manifest, chapters: [{ slug: "../escape", title: "x", source: "" }] };
+    expect(parseManifest(JSON.stringify(bad), "handbook")).toBeNull();
+  });
+});
+
+describe("filesToDelete", () => {
+  const of = (files: string[]): string[] =>
+    filesToDelete({
+      version: 1,
+      book: "handbook",
+      title: "The Handbook",
+      publishedAt: "",
+      chapters: [],
+      files,
+    });
+
+  it("returns the book's own files", () => {
+    expect(
+      of([
+        "docs/handbook/index.html",
+        "docs/handbook/onboarding.html",
+        "docs/handbook/assets/style.css",
+        "docs/handbook/forkleaf-book.json",
+      ]),
+    ).toEqual([
+      "docs/handbook/assets/style.css",
+      "docs/handbook/forkleaf-book.json",
+      "docs/handbook/index.html",
+      "docs/handbook/onboarding.html",
+    ]);
+  });
+
+  it("never deletes outside the book, however the manifest asks", () => {
+    expect(
+      of([
+        "docs/other-book/index.html",
+        "docs/handbook/../../.github/workflows/ci.yml",
+        "docs/handbook/./../index.html",
+        "../../../etc/passwd",
+        "README.md",
+        "docs/index.html",
+        "docs/handbookish/index.html",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("never deletes a file inside the book that ForkLeaf did not write", () => {
+    // Somebody's own file, dropped into the book's folder and then named in a
+    // hand-edited manifest. It is theirs, and it stays.
+    expect(
+      of([
+        "docs/handbook/CNAME",
+        "docs/handbook/notes.md",
+        "docs/handbook/assets/deploy.sh",
+        "docs/handbook/assets/nested/deep.css",
+        "docs/handbook/drafts/chapter.html",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("does not delete the same file twice", () => {
+    expect(of(["docs/handbook/index.html", "docs/handbook/INDEX.html"])).toEqual([
+      "docs/handbook/index.html",
+    ]);
   });
 });

--- a/apps/web/src/lib/publish.test.ts
+++ b/apps/web/src/lib/publish.test.ts
@@ -3,6 +3,7 @@ import { ApiError } from "./api-helpers";
 import {
   bookAssetPath,
   bookDir,
+  bookFilePath,
   bookUrl,
   chapterPath,
   chapterUrl,
@@ -268,5 +269,54 @@ describe("filesToDelete", () => {
     expect(of(["docs/handbook/index.html", "docs/handbook/INDEX.html"])).toEqual([
       "docs/handbook/index.html",
     ]);
+  });
+});
+
+/**
+ * The file list arrives over HTTP, which makes it a list of requests to write
+ * into somebody's repository. Everything below is about the ones that should
+ * not be honoured.
+ */
+describe("bookFilePath", () => {
+  it("places the files a book is made of", () => {
+    expect(bookFilePath("handbook", "index.html")).toBe("docs/handbook/index.html");
+    expect(bookFilePath("handbook", "setup.html")).toBe("docs/handbook/setup.html");
+    expect(bookFilePath("handbook", "assets/style.css")).toBe("docs/handbook/assets/style.css");
+    expect(bookFilePath("handbook", "forkleaf-book.json")).toBe("docs/handbook/forkleaf-book.json");
+  });
+
+  it("refuses anything that is not one of them", () => {
+    for (const file of [
+      "",
+      "notes.md",
+      "CNAME",
+      ".nojekyll",
+      "deploy.sh",
+      "assets/deploy.sh",
+      "assets/nested/style.css",
+      "drafts/chapter.html",
+      "../../.github/workflows/ci.yml",
+      "../escape.html",
+      "/etc/passwd",
+    ]) {
+      expect(() => bookFilePath("handbook", file)).toThrow(ApiError);
+    }
+  });
+
+  it("agrees with filesToDelete, so everything written can be removed again", () => {
+    const written = ["index.html", "setup.html", "assets/style.css", "forkleaf-book.json"].map(
+      (file) => bookFilePath("handbook", file),
+    );
+
+    expect(
+      filesToDelete({
+        version: 1,
+        book: "handbook",
+        title: "",
+        publishedAt: "",
+        chapters: [],
+        files: written,
+      }),
+    ).toEqual([...written].sort());
   });
 });

--- a/apps/web/src/lib/publish.ts
+++ b/apps/web/src/lib/publish.ts
@@ -14,6 +14,37 @@ import { ApiError } from "@/lib/api-helpers";
 export const PUBLISH_DIR = "docs";
 
 /**
+ * One path segment this app would itself have produced.
+ *
+ * Written once and shared, because the same question — "is this a name we
+ * made, or is it a path" — is now asked of a page, of a book, and of every
+ * filename in a book's manifest. Three copies of an allowlist is three chances
+ * for one of them to drift a character looser than the others, and the loose
+ * one is the one that writes outside the folder.
+ */
+const SEGMENT = /^[a-z0-9][a-z0-9._-]{0,80}$/;
+
+/**
+ * The cover's filename, and therefore a chapter slug nobody may use.
+ *
+ * A book's table of contents is `index.html` because that is the name a web
+ * server serves for the directory itself. A chapter called "index" would be
+ * published to exactly that address and silently replace the cover — the book
+ * would still build, still deploy, and simply have no way in.
+ */
+export const BOOK_INDEX = "index";
+
+/**
+ * The record of what ForkLeaf wrote into a book's folder.
+ *
+ * Kept in the book rather than here, because there is no "here" — the whole
+ * arrangement is that publishing writes files into a repository the user owns
+ * and keeps no database of its own. A manifest committed alongside the pages
+ * is the only place the answer can live and still survive this app.
+ */
+export const BOOK_MANIFEST = "forkleaf-book.json";
+
+/**
  * `docs/<slug>.html`, with the slug constrained rather than sanitised.
  *
  * An allowlist, not an escape. Escaping asks "have I thought of every
@@ -29,7 +60,7 @@ export function pagePath(slug: string | undefined): string {
   // name is a bug or an attack, and either deserves an error.
   const cleaned = (slug ?? "").toLowerCase();
 
-  if (!/^[a-z0-9][a-z0-9._-]{0,80}$/.test(cleaned)) {
+  if (!SEGMENT.test(cleaned)) {
     throw new ApiError(400, "validation", "That note's name cannot be used as a page address.");
   }
 
@@ -51,6 +82,282 @@ export function pageUrl(siteUrl: string, slug: string): string {
  * did not write.
  */
 export function slugOfPage(filename: string): string | null {
-  const match = /^([a-z0-9][a-z0-9._-]{0,80})\.html$/.exec(filename.toLowerCase());
-  return match ? match[1]! : null;
+  const lower = filename.toLowerCase();
+  if (!lower.endsWith(".html")) return null;
+
+  const stem = lower.slice(0, -".html".length);
+  return SEGMENT.test(stem) ? stem : null;
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+   Books
+
+   A published page is one note at one address. A book is a folder of them that
+   knows it is a folder: a cover with a table of contents, chapters that can
+   link to each other, and one shared stylesheet instead of the same few
+   kilobytes of CSS inlined into every chapter.
+
+   It lives at `docs/<book>/`, which is the whole reason the single-page path
+   could not simply be reused — `pagePath` refuses a slug containing a slash,
+   deliberately and correctly, because for one page a slash is always either a
+   bug or an attempt to write somewhere else. A book needs exactly one level of
+   nesting and no more, so it gets its own function rather than a loosened
+   allowlist shared with the case that must stay strict.
+   ──────────────────────────────────────────────────────────────────────────── */
+
+/** Where a book's files live: `docs/<book>`. */
+export function bookDir(book: string | undefined): string {
+  const cleaned = (book ?? "").toLowerCase();
+
+  // Checked as given, exactly as `pagePath` does, and for the same reason: a
+  // book name that is really a path is not a name to be tidied up, it is a
+  // request to write into a folder nobody asked about.
+  if (!SEGMENT.test(cleaned)) {
+    throw new ApiError(400, "validation", "That folder's name cannot be used as a book address.");
+  }
+
+  return `${PUBLISH_DIR}/${cleaned}`;
+}
+
+/** One chapter: `docs/<book>/<slug>.html`. */
+export function chapterPath(book: string | undefined, slug: string | undefined): string {
+  const cleaned = (slug ?? "").toLowerCase();
+
+  if (!SEGMENT.test(cleaned)) {
+    throw new ApiError(400, "validation", "That note's name cannot be used as a page address.");
+  }
+  if (cleaned === BOOK_INDEX) {
+    throw new ApiError(
+      400,
+      "validation",
+      `A chapter cannot be called "${BOOK_INDEX}" — that address is the book's contents page.`,
+    );
+  }
+
+  return `${bookDir(book)}/${cleaned}.html`;
+}
+
+/** The cover and table of contents: `docs/<book>/index.html`. */
+export function bookIndexPath(book: string | undefined): string {
+  return `${bookDir(book)}/${BOOK_INDEX}.html`;
+}
+
+/** The record of what was written: `docs/<book>/forkleaf-book.json`. */
+export function bookManifestPath(book: string | undefined): string {
+  return `${bookDir(book)}/${BOOK_MANIFEST}`;
+}
+
+/**
+ * A shared file: `docs/<book>/assets/<name>`.
+ *
+ * The single-page export inlines everything, so that one file opens from a
+ * USB stick with no network. A book cannot afford that — the same stylesheet
+ * inlined into forty chapters is the same bytes served forty times, and the
+ * search index has no business being copied into every page that offers to
+ * search. A book is a website; a website has a network by definition.
+ */
+export function bookAssetPath(book: string | undefined, name: string): string {
+  const cleaned = name.toLowerCase();
+
+  // Asset names carry an extension, so the segment rule is applied to the stem
+  // and the extension checked against what a book is actually allowed to ship.
+  const dot = cleaned.lastIndexOf(".");
+  const stem = dot === -1 ? cleaned : cleaned.slice(0, dot);
+  const extension = dot === -1 ? "" : cleaned.slice(dot + 1);
+
+  if (!SEGMENT.test(stem) || !ASSET_EXTENSIONS.has(extension)) {
+    throw new ApiError(400, "validation", "That file cannot be published inside a book.");
+  }
+
+  return `${bookDir(book)}/assets/${cleaned}`;
+}
+
+/**
+ * What a book's `assets/` folder may contain.
+ *
+ * An allowlist rather than a blocklist, and a short one. Publishing writes to
+ * somebody's repository and GitHub Pages serves whatever is written, so the
+ * question is not "what might be harmful" but "what does a book need" — a
+ * stylesheet, a script for search, the index it searches, and pictures.
+ */
+const ASSET_EXTENSIONS = new Set([
+  "css",
+  "js",
+  "json",
+  "svg",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "avif",
+]);
+
+/** The public address of a book's contents page. */
+export function bookUrl(siteUrl: string, book: string): string {
+  return `${siteUrl.replace(/\/$/, "")}/${book.toLowerCase()}/`;
+}
+
+/** The public address of one chapter. */
+export function chapterUrl(siteUrl: string, book: string, slug: string): string {
+  return `${bookUrl(siteUrl, book)}${slug.toLowerCase()}.html`;
+}
+
+/** One chapter, as the manifest records it. */
+export interface BookChapter {
+  /** The chapter's address within the book, without `.html`. */
+  slug: string;
+  /** What the contents page calls it. */
+  title: string;
+  /** The note it was rendered from, so republishing knows where to look. */
+  source: string;
+}
+
+/**
+ * What ForkLeaf wrote, and therefore what it may take away again.
+ *
+ * The single-page listing answers this by pattern: a file in `docs/` is one of
+ * ours if its name is a name we would have produced. That works because the
+ * only thing at stake is one `.html` file, and it is the reason `slugOfPage`
+ * exists at all — `docs/` is an ordinary folder people keep hand-written sites
+ * in, and offering to delete somebody's `about.html` because it matched a
+ * regex would be unforgivable.
+ *
+ * A book cannot be recognised that way. Its folder holds a stylesheet, a
+ * search index, images and however many chapters, and "delete `docs/handbook/`
+ * and everything under it" is precisely the operation that eats the file
+ * somebody added by hand last week. So the book writes down what it made, and
+ * unpublishing removes exactly that list and nothing else. A file that appears
+ * in the folder without appearing in the manifest is somebody else's, and it
+ * stays.
+ */
+export interface BookManifest {
+  /** Bumped only if the shape below stops being readable by an older app. */
+  version: 1;
+  /** The book's address, matching the folder it is in. */
+  book: string;
+  /** What the cover calls it. */
+  title: string;
+  /** ISO 8601, in UTC. */
+  publishedAt: string;
+  /** In reading order — this is what the contents page and prev/next follow. */
+  chapters: BookChapter[];
+  /**
+   * Every path this book wrote, relative to the repository root.
+   *
+   * Includes the manifest itself. A record of what to delete that leaves
+   * itself off the list is a record that survives its own deletion, and the
+   * next publish would find a manifest describing a book that is no longer
+   * there.
+   */
+  files: string[];
+}
+
+/** The manifest as it is committed: stable key order, and a trailing newline. */
+export function serializeManifest(manifest: BookManifest): string {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+/**
+ * Reads a manifest back, or returns null if it is not one.
+ *
+ * Null rather than a throw, because every caller is asking the same question —
+ * "is there a ForkLeaf book here" — and a folder containing somebody's own
+ * `forkleaf-book.json`, or a truncated one from a commit that failed halfway,
+ * is a folder with no book in it rather than an error to show a reader. The
+ * consequence of a wrong yes is deleting files; the consequence of a wrong no
+ * is offering to publish a book that is already there, which is recoverable.
+ */
+export function parseManifest(json: string, book: string): BookManifest | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(json);
+  } catch {
+    return null;
+  }
+
+  if (typeof value !== "object" || value === null) return null;
+  const raw = value as Record<string, unknown>;
+
+  if (raw.version !== 1) return null;
+  // A manifest naming a different book is a manifest that was moved, copied or
+  // hand-edited. Its file list describes paths in some other folder, and acting
+  // on it would delete them.
+  if (raw.book !== book.toLowerCase()) return null;
+  if (!Array.isArray(raw.chapters) || !Array.isArray(raw.files)) return null;
+
+  const chapters: BookChapter[] = [];
+  for (const entry of raw.chapters) {
+    if (typeof entry !== "object" || entry === null) return null;
+    const chapter = entry as Record<string, unknown>;
+    if (typeof chapter.slug !== "string" || !SEGMENT.test(chapter.slug)) return null;
+    chapters.push({
+      slug: chapter.slug,
+      title: typeof chapter.title === "string" ? chapter.title : chapter.slug,
+      source: typeof chapter.source === "string" ? chapter.source : "",
+    });
+  }
+
+  return {
+    version: 1,
+    book: raw.book,
+    title: typeof raw.title === "string" ? raw.title : raw.book,
+    publishedAt: typeof raw.publishedAt === "string" ? raw.publishedAt : "",
+    chapters,
+    files: raw.files.filter((file): file is string => typeof file === "string"),
+  };
+}
+
+/**
+ * The files unpublishing a book may delete.
+ *
+ * The manifest is a file in the user's repository, which means it is a file
+ * the user can edit — so it is treated as a claim to be checked rather than an
+ * instruction to be carried out. Every path is re-derived against the book's
+ * own folder before it is believed, so a manifest that has been hand-edited,
+ * copied from another book, or crafted to say `docs/../.github/workflows/ci.yml`
+ * deletes nothing outside the book it belongs to.
+ *
+ * Anything that fails the check is dropped rather than aborting the whole
+ * delete: one bad line should not strand a book that is otherwise removable,
+ * and a file left behind is a file the user can still delete themselves.
+ */
+export function filesToDelete(manifest: BookManifest): string[] {
+  const dir = bookDir(manifest.book);
+  const prefix = `${dir}/`;
+  const seen = new Set<string>();
+
+  for (const file of manifest.files) {
+    const path = file.toLowerCase();
+
+    // Inside the book's folder, and genuinely inside it — a `..` anywhere in
+    // the path is the whole attack, and it passes a naive prefix check.
+    if (!path.startsWith(prefix)) continue;
+    if (path.split("/").some((part) => part === "." || part === "..")) continue;
+
+    // And a shape this app would have written: a chapter, the cover, the
+    // manifest, or a file in `assets/`. Nothing else was ever ours to remove.
+    const rest = path.slice(prefix.length);
+    if (!isBookFile(rest)) continue;
+
+    seen.add(path);
+  }
+
+  return [...seen].sort();
+}
+
+/** Is `rest`, a path relative to the book's folder, a file ForkLeaf writes? */
+function isBookFile(rest: string): boolean {
+  if (rest === BOOK_MANIFEST) return true;
+
+  const parts = rest.split("/");
+
+  if (parts.length === 1) return slugOfPage(parts[0]!) !== null;
+  if (parts.length === 2 && parts[0] === "assets") {
+    const dot = parts[1]!.lastIndexOf(".");
+    if (dot === -1) return false;
+    return SEGMENT.test(parts[1]!.slice(0, dot)) && ASSET_EXTENSIONS.has(parts[1]!.slice(dot + 1));
+  }
+
+  return false;
 }

--- a/apps/web/src/lib/publish.ts
+++ b/apps/web/src/lib/publish.ts
@@ -203,6 +203,41 @@ export function chapterUrl(siteUrl: string, book: string, slug: string): string 
   return `${bookUrl(siteUrl, book)}${slug.toLowerCase()}.html`;
 }
 
+/**
+ * Maps a book-relative filename onto a path in the repository.
+ *
+ * The builder produces names like `index.html`, `setup.html` and
+ * `assets/style.css` and knows nothing about where the book lives. This is
+ * where those become real paths, and — more to the point — where they are
+ * checked. The list of files to write arrives over HTTP, so it is a list of
+ * requests to write to somebody's repository: every entry is re-derived
+ * through the same functions that address a book in the first place, and one
+ * that does not correspond to a file a book is made of is refused outright
+ * rather than written somewhere unexpected.
+ */
+export function bookFilePath(book: string | undefined, relative: string): string {
+  const path = relative.toLowerCase();
+
+  if (path === BOOK_MANIFEST) return bookManifestPath(book);
+  if (path === `${BOOK_INDEX}.html`) return bookIndexPath(book);
+
+  if (path.startsWith("assets/")) {
+    const name = path.slice("assets/".length);
+    // `bookAssetPath` checks the name, but not that it is a name at all —
+    // `assets/nested/style.css` has to fail here, not become a folder.
+    if (name.includes("/")) {
+      throw new ApiError(400, "validation", "That file cannot be published inside a book.");
+    }
+    return bookAssetPath(book, name);
+  }
+
+  if (path.endsWith(".html")) {
+    return chapterPath(book, path.slice(0, -".html".length));
+  }
+
+  throw new ApiError(400, "validation", "That file cannot be published inside a book.");
+}
+
 /** One chapter, as the manifest records it. */
 export interface BookChapter {
   /** The chapter's address within the book, without `.html`. */

--- a/packages/exporter/src/book.test.ts
+++ b/packages/exporter/src/book.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+import { assignSlugs, buildBook, chapterSlug, type BookNote } from "./book";
+
+const note = (path: string, markdown = "Body.", title?: string): BookNote => ({
+  path,
+  title: title ?? path.slice(path.lastIndexOf("/") + 1).replace(/\.md$/, ""),
+  markdown,
+  frontmatter: {},
+});
+
+const build = (notes: BookNote[], title = "Handbook") =>
+  buildBook(notes, { title, theme: "light", renderDiagrams: false });
+
+const fileAt = (files: { path: string; content: string }[], path: string) =>
+  files.find((file) => file.path === path)?.content ?? "";
+
+/**
+ * A chapter's address is a URL somebody may link to, so the interesting inputs
+ * are the filenames people actually have: spaces, capitals, accents, emoji,
+ * leading dots, and the one called `index.md`.
+ */
+describe("chapterSlug", () => {
+  it("takes the filename and drops the rest", () => {
+    expect(chapterSlug("notes/deep/onboarding.md")).toBe("onboarding");
+    expect(chapterSlug("onboarding.md")).toBe("onboarding");
+  });
+
+  it("lowercases and hyphenates what a URL cannot carry", () => {
+    expect(chapterSlug("Q3 Roadmap.md")).toBe("q3-roadmap");
+    expect(chapterSlug("Notes (draft).md")).toBe("notes-draft");
+    expect(chapterSlug("a  b   c.md")).toBe("a-b-c");
+  });
+
+  it("keeps the characters a filename is allowed to keep", () => {
+    expect(chapterSlug("notes_2026.v2.md")).toBe("notes_2026.v2");
+    expect(chapterSlug("part-one.md")).toBe("part-one");
+  });
+
+  it("never starts with something that is not a letter or a digit", () => {
+    expect(chapterSlug(".hidden.md")).toBe("hidden");
+    expect(chapterSlug("-leading.md")).toBe("leading");
+    expect(chapterSlug("__init__.md")).toBe("init");
+  });
+
+  it("never ends with a separator", () => {
+    expect(chapterSlug("trailing-.md")).toBe("trailing");
+    expect(chapterSlug("dotted..md")).toBe("dotted");
+  });
+
+  it("survives a name with nothing usable in it", () => {
+    expect(chapterSlug("日本語.md")).toBe("chapter");
+    expect(chapterSlug("🎉.md")).toBe("chapter");
+    expect(chapterSlug("---.md")).toBe("chapter");
+    expect(chapterSlug("")).toBe("chapter");
+  });
+
+  it("stays short enough to number", () => {
+    expect(chapterSlug(`${"x".repeat(200)}.md`)).toHaveLength(70);
+  });
+
+  it("does not end in a separator the truncation put back", () => {
+    // Cutting at 70 lands exactly on the hyphen this name's space became.
+    expect(chapterSlug(`${"x".repeat(69)} tail.md`)).toBe("x".repeat(69));
+  });
+
+  it("only ever produces an address the publish route will accept", () => {
+    const allowed = /^[a-z0-9][a-z0-9._-]{0,80}$/;
+    for (const name of [
+      "Q3 Roadmap.md",
+      ".hidden.md",
+      "日本語.md",
+      "---.md",
+      `${"x".repeat(200)}.md`,
+      "a/b/c d.md",
+      "!!!.md",
+      "notes_2026.v2.md",
+    ]) {
+      expect(chapterSlug(name)).toMatch(allowed);
+    }
+  });
+});
+
+describe("assignSlugs", () => {
+  it("numbers a collision instead of overwriting a chapter", () => {
+    const chapters = assignSlugs([note("a/setup.md"), note("b/setup.md"), note("c/setup.md")]);
+    expect(chapters.map((c) => c.slug)).toEqual(["setup", "setup-2", "setup-3"]);
+  });
+
+  it("gives the plain name to whichever note comes first in reading order", () => {
+    const chapters = assignSlugs([note("b/setup.md"), note("a/setup.md")]);
+    expect(chapters[0]!.source).toBe("b/setup.md");
+    expect(chapters[0]!.slug).toBe("setup");
+  });
+
+  it("never lets a chapter take the contents page's address", () => {
+    const chapters = assignSlugs([note("index.md"), note("Index.md"), note("guide.md")]);
+    expect(chapters.map((c) => c.slug)).toEqual(["index-2", "index-3", "guide"]);
+  });
+
+  it("keeps every address distinct however the names collide", () => {
+    const chapters = assignSlugs([
+      note("Setup.md"),
+      note("setup.md"),
+      note("SET UP.md"),
+      note("set-up.md"),
+      note("日本語.md"),
+      note("🎉.md"),
+    ]);
+    expect(new Set(chapters.map((c) => c.slug)).size).toBe(chapters.length);
+  });
+
+  it("remembers which note each chapter came from", () => {
+    const chapters = assignSlugs([note("deep/nested/guide.md", "x", "The Guide")]);
+    expect(chapters[0]).toEqual({
+      slug: "guide",
+      title: "The Guide",
+      source: "deep/nested/guide.md",
+    });
+  });
+});
+
+describe("buildBook", () => {
+  it("writes a contents page, a chapter each, and one shared stylesheet", async () => {
+    const book = await build([note("intro.md"), note("setup.md")]);
+
+    expect(book.files.map((f) => f.path)).toEqual([
+      "index.html",
+      "intro.html",
+      "setup.html",
+      "assets/style.css",
+    ]);
+  });
+
+  it("ships the stylesheet once rather than in every chapter", async () => {
+    const book = await build([note("a.md"), note("b.md"), note("c.md")]);
+
+    for (const page of book.files.filter((f) => f.path.endsWith(".html"))) {
+      expect(page.content).toContain('<link rel="stylesheet" href="assets/style.css">');
+      expect(page.content).not.toContain("<style>");
+    }
+    expect(fileAt(book.files, "assets/style.css")).toContain("--accent");
+  });
+
+  it("lists every chapter on the contents page, in reading order", async () => {
+    const book = await build([note("z.md", "x", "Last"), note("a.md", "x", "First")]);
+    const cover = fileAt(book.files, "index.html");
+
+    expect(cover.indexOf("Last")).toBeLessThan(cover.indexOf("First"));
+    expect(cover).toContain('href="z.html"');
+    expect(cover).toContain('href="a.html"');
+    expect(cover).toContain("2 chapters");
+  });
+
+  it("counts one chapter without saying '1 chapters'", async () => {
+    const book = await build([note("only.md")]);
+    expect(fileAt(book.files, "index.html")).toContain("1 chapter<");
+  });
+
+  it("escapes a title rather than letting it write markup", async () => {
+    const book = await build([note("x.md", "Body.", "<img src=x onerror=alert(1)>")], "A & B");
+    const cover = fileAt(book.files, "index.html");
+
+    expect(cover).not.toContain("<img src=x");
+    expect(cover).toContain("&lt;img");
+    expect(cover).toContain("A &amp; B");
+  });
+
+  it("renders the note's markdown into the chapter", async () => {
+    const book = await build([note("intro.md", "# Hello\n\nSome **bold** text.")]);
+    const page = fileAt(book.files, "intro.html");
+
+    expect(page).toContain("<strong>bold</strong>");
+  });
+});
+
+/**
+ * The reason books exist. On a single published page a `[[wikilink]]` renders
+ * as `href="#target"` — an anchor to a heading that is not there — so every
+ * link between notes is silently dead.
+ */
+describe("wikilinks between chapters", () => {
+  const linked = () =>
+    build([
+      note("intro.md", "See [[setup]] and [[Deep Dive|the deep one]].", "Intro"),
+      note("setup.md", "Back to [[intro]].", "Setup"),
+      note("notes/deep-dive.md", "Alone.", "Deep Dive"),
+    ]);
+
+  it("links a chapter to the chapter it names", async () => {
+    const book = await linked();
+    expect(fileAt(book.files, "intro.html")).toContain('href="setup.html"');
+    expect(fileAt(book.files, "setup.html")).toContain('href="intro.html"');
+  });
+
+  it("finds a chapter by its title, not only its filename", async () => {
+    const book = await linked();
+    expect(fileAt(book.files, "intro.html")).toContain('href="deep-dive.html"');
+  });
+
+  it("shows the alias the author wrote, not the target", async () => {
+    const book = await linked();
+    const page = fileAt(book.files, "intro.html");
+    expect(page).toContain("the deep one");
+    expect(page).not.toContain(">Deep Dive<");
+  });
+
+  it("carries a heading anchor through to the chapter", async () => {
+    const book = await build([
+      note("intro.md", "See [[setup#installing]].", "Intro"),
+      note("setup.md", "## Installing", "Setup"),
+    ]);
+    expect(fileAt(book.files, "intro.html")).toContain('href="setup.html#installing"');
+  });
+
+  it("never emits a dead link for a note outside the book", async () => {
+    const book = await build([note("intro.md", "See [[some other note]].", "Intro")]);
+    const page = fileAt(book.files, "intro.html");
+
+    // The words survive; the broken address does not.
+    expect(page).toContain("some other note");
+    expect(page).not.toContain('href="#some');
+    expect(page).toContain("fl-wikilink-missing");
+  });
+
+  it("does not link a wikilink written inside a code block", async () => {
+    const book = await build([
+      note("intro.md", "Use this:\n\n```\n[[setup]]\n```\n", "Intro"),
+      note("setup.md", "x", "Setup"),
+    ]);
+    // Scoped to the block itself: the page as a whole does link `setup.html`,
+    // from the next-chapter nav at the foot, and should.
+    const block = /<pre><code>([\s\S]*?)<\/code><\/pre>/.exec(fileAt(book.files, "intro.html"));
+    expect(block?.[1]).toContain("[[setup]]");
+    expect(block?.[1]).not.toContain("<a ");
+  });
+});
+
+describe("chapter navigation", () => {
+  const three = () =>
+    build([note("one.md", "x", "One"), note("two.md", "x", "Two"), note("three.md", "x", "Three")]);
+
+  it("offers the next chapter but no previous one at the start", async () => {
+    const book = await three();
+    const page = fileAt(book.files, "one.html");
+
+    expect(page).toContain('href="two.html"');
+    expect(page).not.toContain("Previous");
+  });
+
+  it("offers both in the middle", async () => {
+    const page = fileAt((await three()).files, "two.html");
+    expect(page).toContain('href="one.html"');
+    expect(page).toContain('href="three.html"');
+  });
+
+  it("offers the previous chapter but no next one at the end", async () => {
+    const page = fileAt((await three()).files, "three.html");
+    expect(page).toContain('href="two.html"');
+    expect(page).not.toContain("Next");
+  });
+
+  it("says where in the book the reader is", async () => {
+    const page = fileAt((await three()).files, "two.html");
+    expect(page).toContain("2 of 3");
+  });
+
+  it("always offers the way back to the contents", async () => {
+    const book = await three();
+    for (const page of book.files.filter(
+      (f) => f.path.endsWith(".html") && f.path !== "index.html",
+    )) {
+      expect(page.content).toContain('href="index.html"');
+    }
+  });
+});
+
+/**
+ * Both ends of `[[chapter#heading]]` have to agree on one spelling. They did
+ * not: headings carried no id at all, so every anchor in a book resolved to
+ * nothing and the reader landed at the top of the chapter with no sign that
+ * anything had gone wrong.
+ */
+describe("heading anchors", () => {
+  it("gives every heading an id", async () => {
+    const book = await build([
+      note("guide.md", "# Top\n\n## Getting Started\n\n### Deep & Meaningful\n", "Guide"),
+    ]);
+    const page = fileAt(book.files, "guide.html");
+
+    expect(page).toContain('id="top"');
+    expect(page).toContain('id="getting-started"');
+    expect(page).toContain('id="deep-meaningful"');
+  });
+
+  it("lands a link on the heading it names", async () => {
+    const book = await build([
+      note("intro.md", "See [[Guide#Getting Started]].", "Intro"),
+      note("guide.md", "## Getting Started", "Guide"),
+    ]);
+
+    expect(fileAt(book.files, "intro.html")).toContain('href="guide.html#getting-started"');
+    expect(fileAt(book.files, "guide.html")).toContain('id="getting-started"');
+  });
+
+  it("agrees however the reader spelled the anchor", async () => {
+    for (const written of ["Getting Started", "getting started", "GETTING-STARTED"]) {
+      const book = await build([
+        note("intro.md", `See [[Guide#${written}]].`, "Intro"),
+        note("guide.md", "## Getting Started", "Guide"),
+      ]);
+      expect(fileAt(book.files, "intro.html"), written).toContain(
+        'href="guide.html#getting-started"',
+      );
+    }
+  });
+
+  it("numbers a repeated heading rather than letting two share an id", async () => {
+    const book = await build([note("g.md", "## Notes\n\ntext\n\n## Notes\n", "G")]);
+    const page = fileAt(book.files, "g.html");
+
+    expect(page).toContain('id="notes"');
+    expect(page).toContain('id="notes-2"');
+  });
+
+  it("still gives an id to a heading with nothing sluggable in it", async () => {
+    const book = await build([note("g.md", "## 日本語\n\n## 🎉\n", "G")]);
+    const page = fileAt(book.files, "g.html");
+
+    expect(page).toContain('id="section"');
+    expect(page).toContain('id="section-2"');
+  });
+});

--- a/packages/exporter/src/book.test.ts
+++ b/packages/exporter/src/book.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { assignSlugs, buildBook, chapterSlug, type BookNote } from "./book";
+import { assignSlugs, buildBook, chapterSlug, readMinutes, type BookNote } from "./book";
 
 const note = (path: string, markdown = "Body.", title?: string): BookNote => ({
   path,
@@ -153,7 +153,7 @@ describe("buildBook", () => {
 
   it("counts one chapter without saying '1 chapters'", async () => {
     const book = await build([note("only.md")]);
-    expect(fileAt(book.files, "index.html")).toContain("1 chapter<");
+    expect(fileAt(book.files, "index.html")).toContain("1 chapter ·");
   });
 
   it("escapes a title rather than letting it write markup", async () => {
@@ -198,10 +198,16 @@ describe("wikilinks between chapters", () => {
   });
 
   it("shows the alias the author wrote, not the target", async () => {
-    const book = await linked();
-    const page = fileAt(book.files, "intro.html");
-    expect(page).toContain("the deep one");
-    expect(page).not.toContain(">Deep Dive<");
+    const page = fileAt((await linked()).files, "intro.html");
+
+    // Scoped to the links in the prose: the sidebar lists every chapter by its
+    // own title, so "Deep Dive" appears on this page whatever the alias says.
+    const labels = [...page.matchAll(/<a[^>]*class="fl-wikilink[^"]*"[^>]*>([^<]*)</g)].map(
+      (match) => match[1],
+    );
+
+    expect(labels).toContain("the deep one");
+    expect(labels).not.toContain("Deep Dive");
   });
 
   it("carries a heading anchor through to the chapter", async () => {
@@ -328,5 +334,133 @@ describe("heading anchors", () => {
 
     expect(page).toContain('id="section"');
     expect(page).toContain('id="section-2"');
+  });
+});
+
+/**
+ * A published note is a document: one column, centred, nothing around it. A
+ * book is a place, and a reader who arrives in the middle of one needs to see
+ * that there is a middle to be in.
+ */
+describe("the contents beside the text", () => {
+  const three = () =>
+    build([note("one.md", "x", "One"), note("two.md", "x", "Two"), note("three.md", "x", "Three")]);
+
+  it("lists every chapter on every chapter", async () => {
+    const book = await three();
+
+    for (const page of book.files.filter(
+      (f) => f.path.endsWith(".html") && f.path !== "index.html",
+    )) {
+      for (const slug of ["one", "two", "three"]) {
+        expect(page.content, page.path).toContain(`href="${slug}.html"`);
+      }
+    }
+  });
+
+  it("marks the chapter being read, and only that one", async () => {
+    const page = fileAt((await three()).files, "two.html");
+    const current = [...page.matchAll(/href="([a-z-]+)\.html" aria-current="page"/g)];
+
+    expect(current).toHaveLength(1);
+    expect(current[0]![1]).toBe("two");
+  });
+
+  /**
+   * One list, laid out two ways. A details element cannot be forced open by a
+   * stylesheet — browsers hide its contents in a way the display property does
+   * not reach, which is how the first attempt at this shipped a sidebar that
+   * was eighty-eight pixels of padding and nothing else.
+   */
+  it("is one list rather than a disclosure or a second copy", async () => {
+    const page = fileAt((await three()).files, "one.html");
+
+    expect(page).toContain('<nav class="book-side"');
+    expect(page).not.toContain("<details");
+    // Each chapter is linked from the sidebar once, and the current one is not
+    // repeated as a second navigation block.
+    expect(page.match(/href="two\.html"/g)).toHaveLength(2); // sidebar + next
+    expect(page.match(/href="three\.html"/g)).toHaveLength(1); // sidebar only
+  });
+
+  it("offers a way past it to the words", async () => {
+    const page = fileAt((await three()).files, "one.html");
+
+    expect(page).toContain('class="book-skip" href="#content"');
+    expect(page).toContain('<main id="content">');
+  });
+
+  it("leaves the contents page itself without a sidebar", async () => {
+    expect(fileAt((await three()).files, "index.html")).not.toContain('class="book-side"');
+  });
+});
+
+describe("how long a chapter takes", () => {
+  it("counts the words, not the markup", () => {
+    expect(readMinutes("word ".repeat(200))).toBe(1);
+    expect(readMinutes("word ".repeat(1000))).toBe(5);
+  });
+
+  it("does not count a code block as reading", () => {
+    const prose = "word ".repeat(200);
+    const code = "```\n" + "token ".repeat(2000) + "\n```";
+
+    expect(readMinutes(`${prose}\n\n${code}`)).toBe(1);
+  });
+
+  it("never says a chapter takes no time at all", () => {
+    expect(readMinutes("")).toBe(1);
+    expect(readMinutes("Hi.")).toBe(1);
+  });
+
+  it("says it on the chapter and on the contents page", async () => {
+    const book = await build([note("long.md", "word ".repeat(1000), "Long")]);
+
+    expect(fileAt(book.files, "long.html")).toContain("5 min read");
+    expect(fileAt(book.files, "index.html")).toContain("5 min read");
+  });
+
+  it("adds the chapters up on the contents page", async () => {
+    const book = await build([
+      note("a.md", "word ".repeat(1000), "A"),
+      note("b.md", "word ".repeat(1000), "B"),
+    ]);
+
+    expect(fileAt(book.files, "index.html")).toContain("2 chapters · 10 min read");
+  });
+});
+
+describe("linking to a heading", () => {
+  it("gives every heading a link to itself", async () => {
+    const book = await build([note("g.md", "## Getting Started", "G")]);
+    const page = fileAt(book.files, "g.html");
+
+    expect(page).toContain('<a class="anchor" href="#getting-started"');
+    expect(page).toContain('aria-label="Link to this section"');
+  });
+
+  it("points the link at the heading it is in", async () => {
+    const book = await build([note("g.md", "## One\n\ntext\n\n## Two\n", "G")]);
+    const page = fileAt(book.files, "g.html");
+
+    expect(page).toMatch(/<h2 id="one">One<a class="anchor" href="#one"/);
+    expect(page).toMatch(/<h2 id="two">Two<a class="anchor" href="#two"/);
+  });
+
+  it("keeps the marker out of the heading's own text", async () => {
+    // In the markup the "#" becomes part of the heading — read aloud, and
+    // copied — so the stylesheet draws it instead.
+    const book = await build([note("g.md", "## Why a book?", "G")]);
+    const heading = /<h2[^>]*>([\s\S]*?)<\/h2>/.exec(fileAt(book.files, "g.html"))![1]!;
+
+    expect(heading.replace(/<[^>]*>/g, "")).toBe("Why a book?");
+  });
+
+  it("does not let the anchor change the id it points at", async () => {
+    // The id is taken from the heading's text before the link is added; if it
+    // were taken after, the `#` would end up in the slug.
+    const book = await build([note("g.md", "## Voice", "G")]);
+    expect(fileAt(book.files, "g.html")).toContain('id="voice"');
+    expect(fileAt(book.files, "g.html")).not.toContain('id="voice-"');
   });
 });

--- a/packages/exporter/src/book.ts
+++ b/packages/exporter/src/book.ts
@@ -153,7 +153,16 @@ function withHeadingIds(html: string): string {
       for (let n = 2; used.has(id); n += 1) id = `${base}-${n}`;
       used.add(id);
 
-      return `<h${level}${attrs} id="${id}">${inner}</h${level}>`;
+      // The id makes a heading addressable; the link is how a reader gets the
+      // address without reading the source. Hidden until the heading is
+      // hovered or the link itself is focused, so it costs a reader who does
+      // not want it nothing at all.
+      // Empty on purpose: the "#" is drawn by the stylesheet. Put in the
+      // markup it becomes part of the heading's own text, so the heading reads
+      // as "Why a book?#" — to a screen reader, and to anyone who copies it.
+      const anchor = `<a class="anchor" href="#${id}" aria-label="Link to this section"></a>`;
+
+      return `<h${level}${attrs} id="${id}">${inner}${anchor}</h${level}>`;
     },
   );
 }
@@ -234,6 +243,10 @@ export async function buildBook(
   const chapters = assignSlugs(notes);
   const resolveWiki = bookWikilinks(chapters);
 
+  // From the markdown rather than the rendered HTML: it is the words the
+  // author wrote, before a diagram became four kilobytes of SVG.
+  const minutes = notes.map((note) => readMinutes(note.markdown));
+
   const pages = await Promise.all(
     notes.map(async (note, index) => {
       const chapter = chapters[index]!;
@@ -262,6 +275,7 @@ export async function buildBook(
           book: options.title,
           chapters,
           index,
+          minutes: minutes[index] ?? 1,
           body,
           theme: options.theme,
           suggestUrl: options.suggestUrl?.(note) ?? null,
@@ -273,7 +287,10 @@ export async function buildBook(
   return {
     chapters,
     files: [
-      { path: `${INDEX}.html`, content: coverPage(options.title, chapters, options.theme) },
+      {
+        path: `${INDEX}.html`,
+        content: coverPage(options.title, chapters, minutes, options.theme),
+      },
       ...pages,
       { path: BOOK_STYLESHEET, content: stylesheet(options.theme) },
     ],
@@ -286,32 +303,156 @@ export async function buildBook(
  * Built from the same `pageStyles` a downloaded export inlines, so a chapter
  * and a single published note cannot drift into looking like two products.
  */
+/**
+ * The shared stylesheet: what a page looks like, plus what a book adds.
+ *
+ * Built from the same `pageStyles` a downloaded export inlines, so a chapter
+ * and a single published note cannot drift into looking like two products.
+ * Everything below is chrome that only exists inside a book — the contents
+ * beside the text, the reading column, the strip that says where you are —
+ * and it overrides the export's own layout rather than replacing it.
+ */
 export function stylesheet(theme: "light" | "dark"): string {
   return `${pageStyles(theme)}
 /* ── Book chrome ──────────────────────────────────────────────────────────
-   Everything below exists only inside a book: the strip that says where you
-   are, the contents page, and the treatment of a link whose target is not in
-   this book. */
+   A published note is a document: one column, centred, nothing around it.
+   A book is a place, and a reader who has just arrived in the middle of one
+   needs to see that there is a middle to be in — which is what the contents
+   beside the text are for, and why they stay put while the chapter scrolls. */
 
-.book-nav {
-  max-width: 46rem;
-  margin: 0 auto 2.5rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--rule);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.5rem 1rem;
-  font-size: 0.875rem;
+body.book { padding: 0; }
+
+.book-shell {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
 }
-.book-nav a { color: var(--accent); text-decoration: none; }
-.book-nav a:hover { text-decoration: underline; }
-.book-nav-where { color: var(--muted); }
 
+.book-main { min-width: 0; padding: 1.5rem 0 5rem; }
+
+/* The reading column is narrower than the page's own 46rem.
+   Prose beside a table of contents is measured against the column it is in,
+   not the window: somewhere near 70 characters is where a line stops needing
+   the eye to travel back and find its place. */
+.book-main main { max-width: 38rem; margin: 0; }
+
+/* Headings break where the meaning does rather than wherever the box ends,
+   and a paragraph never leaves one word alone on its last line. */
+.book-main h1, .book-main h2, .book-main h3, .book-side-home, .doc-title {
+  text-wrap: balance;
+}
+.book-main p, .book-main li { text-wrap: pretty; }
+
+@media (min-width: 60rem) {
+  .book-shell {
+    display: grid;
+    grid-template-columns: 14rem minmax(0, 1fr);
+    gap: 4.5rem;
+    align-items: start;
+  }
+  .book-main { padding: 3.5rem 0 6rem; }
+}
+
+/* ── The contents, beside the text ──
+   One list, laid out two ways, because the alternatives were both worse. A
+   details element cannot be forced open by a stylesheet — browsers hide its
+   contents in a way the display property does not reach — and rendering the
+   list twice, to get a disclosure on a phone and a column on a desktop, puts
+   every chapter title in the file twice.
+
+   So on a narrow screen it is a strip that scrolls sideways under the header:
+   always visible, one line tall, no open-or-closed state to get wrong. On a
+   wide screen the same list becomes the column that stays put while the
+   chapter scrolls past it. */
+.book-side { padding: 1rem 0 0; }
+
+.book-side-home {
+  display: block;
+  color: var(--fg);
+  text-decoration: none;
+  font-weight: 650;
+  font-size: 1.0625rem;
+  line-height: 1.25;
+}
+.book-side-home:hover { color: var(--accent); }
+.book-side-count {
+  margin: 0.35rem 0 0.75rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.book-side-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  counter-reset: side;
+  font-size: 0.875rem;
+  line-height: 1.4;
+
+  /* The strip: a short list of links, not a carousel — so no scroll snap and
+     no momentum-scrolling incantations. */
+  display: flex;
+  gap: 1.25rem;
+  overflow-x: auto;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--rule);
+}
+.book-side-list li { counter-increment: side; }
+.book-side-list a {
+  display: flex;
+  gap: 0.5rem;
+  color: var(--muted);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.book-side-list a::before {
+  content: counter(side, decimal-leading-zero);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.6875rem;
+  padding-top: 0.15em;
+  opacity: 0.7;
+}
+.book-side-list a:hover { color: var(--fg); }
+/* Where you are, said once and quietly. */
+.book-side-list a[aria-current="page"] { color: var(--accent); font-weight: 600; }
+
+@media (min-width: 60rem) {
+  .book-side {
+    position: sticky;
+    top: 0;
+    max-height: 100vh;
+    overflow-y: auto;
+    padding: 3.5rem 0 2rem;
+  }
+  .book-side-count { margin-bottom: 1rem; }
+  .book-side-list {
+    display: block;
+    overflow-x: visible;
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+  .book-side-list a { padding: 0.375rem 0; white-space: normal; }
+}
+
+/* ── A link to a heading, for anyone who wants to point at one ── */
+.anchor::after { content: "#"; }
+.anchor {
+  margin-left: 0.4em;
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 400;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+h1:hover > .anchor, h2:hover > .anchor, h3:hover > .anchor,
+h4:hover > .anchor, h5:hover > .anchor, h6:hover > .anchor,
+.anchor:focus { opacity: 1; }
+.anchor:hover { color: var(--accent); }
+
+/* ── Onwards ── */
 .book-foot {
-  max-width: 46rem;
-  margin: 4rem auto 0;
+  max-width: 38rem;
+  margin: 4rem 0 0;
   padding-top: 1.25rem;
   border-top: 1px solid var(--rule);
   display: flex;
@@ -326,7 +467,7 @@ export function stylesheet(theme: "light" | "dark"): string {
 .book-foot-next { margin-left: auto; text-align: right; }
 
 /* ── The contents page ── */
-.book-cover { max-width: 46rem; margin: 0 auto; }
+.book-cover { max-width: 46rem; margin: 0 auto; padding: 4rem 1.5rem 6rem; }
 .book-toc { list-style: none; margin: 2.5rem 0 0; padding: 0; counter-reset: chapter; }
 .book-toc li { counter-increment: chapter; border-top: 1px solid var(--rule); }
 .book-toc li:last-child { border-bottom: 1px solid var(--rule); }
@@ -349,6 +490,8 @@ export function stylesheet(theme: "light" | "dark"): string {
   font-size: 0.8125rem;
   color: var(--muted);
 }
+.book-toc-title { flex: 1; min-width: 0; }
+.book-toc-read { font-size: 0.75rem; color: var(--muted); white-space: nowrap; }
 
 /* A wikilink whose target is not in this book. The words are what the author
    wrote and they stay; what goes is the suggestion that clicking does
@@ -360,8 +503,22 @@ a.fl-wikilink-missing {
   pointer-events: none;
 }
 
+/* Straight past the contents to the words, for anyone arriving by keyboard. */
+.book-skip {
+  position: absolute;
+  left: -9999px;
+  background: var(--bg);
+  color: var(--fg);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+}
+.book-skip:focus { left: 1rem; top: 1rem; z-index: 10; }
+
 @media print {
-  .book-nav, .book-foot { display: none; }
+  .book-side, .book-foot, .book-skip, .anchor { display: none; }
+  .book-shell { display: block; padding: 0; }
+  .book-main, .book-main main, .book-cover { max-width: none; padding: 0; }
 }
 `;
 }
@@ -378,11 +535,54 @@ function head(title: string, theme: "light" | "dark"): string {
 </head>`;
 }
 
-/** One chapter, with the strip that says where in the book it is. */
+/** "4 min read", or nothing at all for something too short to be worth saying. */
+function readingTime(minutes: number): string {
+  return `${minutes} min read`;
+}
+
+/**
+ * How long a chapter takes to read, in minutes.
+ *
+ * Two hundred words a minute, rounded up, and never zero — the number exists
+ * so a reader can decide whether to start now or later, and "0 min" answers
+ * that question by looking broken.
+ */
+export function readMinutes(markdown: string): number {
+  const words = markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/[#>*_`~\[\]()!-]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean).length;
+
+  return Math.max(1, Math.round(words / 200));
+}
+
+/** The contents, as the sidebar draws them on every chapter. */
+function sidebar(book: string, chapters: readonly BookChapter[], current: number): string {
+  const items = chapters
+    .map((chapter, index) => {
+      const here = index === current ? ' aria-current="page"' : "";
+      return `      <li><a href="${chapter.slug}.html"${here}>${escapeHtml(chapter.title)}</a></li>`;
+    })
+    .join("\n");
+
+  const count = chapters.length === 1 ? "1 chapter" : `${chapters.length} chapters`;
+
+  return `<nav class="book-side" aria-label="Chapters">
+  <a class="book-side-home" href="${INDEX}.html">${escapeHtml(book)}</a>
+  <p class="book-side-count">${count}</p>
+  <ol class="book-side-list">
+${items}
+  </ol>
+</nav>`;
+}
+
+/** One chapter, with the book around it. */
 function chapterPage(input: {
   book: string;
   chapters: readonly BookChapter[];
   index: number;
+  minutes: number;
   body: string;
   theme: "light" | "dark";
   suggestUrl: string | null;
@@ -390,6 +590,7 @@ function chapterPage(input: {
   const chapter = input.chapters[input.index]!;
   const previous = input.chapters[input.index - 1];
   const next = input.chapters[input.index + 1];
+  const where = `Chapter ${input.index + 1} of ${input.chapters.length}`;
 
   const suggest = input.suggestUrl
     ? `<aside class="doc-suggest">
@@ -399,30 +600,33 @@ function chapterPage(input: {
     : "";
 
   return `${head(`${chapter.title} — ${input.book}`, input.theme)}
-<body>
-<nav class="book-nav">
-  <a href="${INDEX}.html">← ${escapeHtml(input.book)}</a>
-  <span class="book-nav-where">${input.index + 1} of ${input.chapters.length}</span>
-</nav>
-<main>
+<body class="book">
+<a class="book-skip" href="#content">Skip to the chapter</a>
+<div class="book-shell">
+${sidebar(input.book, input.chapters, input.index)}
+<div class="book-main">
+  <main id="content">
 <header class="doc-head">
   <h1 class="doc-title">${escapeHtml(chapter.title)}</h1>
+  <p class="doc-meta">${where} · ${readingTime(input.minutes)}</p>
 </header>
 ${input.body}
 ${suggest}
-</main>
-<nav class="book-foot">
+  </main>
+  <nav class="book-foot" aria-label="Chapters either side">
 ${
   previous
-    ? `  <a href="${previous.slug}.html"><span class="book-foot-label">Previous</span>${escapeHtml(previous.title)}</a>`
+    ? `    <a href="${previous.slug}.html"><span class="book-foot-label">Previous</span>${escapeHtml(previous.title)}</a>`
     : ""
 }
 ${
   next
-    ? `  <a class="book-foot-next" href="${next.slug}.html"><span class="book-foot-label">Next</span>${escapeHtml(next.title)}</a>`
+    ? `    <a class="book-foot-next" href="${next.slug}.html"><span class="book-foot-label">Next</span>${escapeHtml(next.title)}</a>`
     : ""
 }
-</nav>
+  </nav>
+</div>
+</div>
 </body>
 </html>
 `;
@@ -432,22 +636,27 @@ ${
 function coverPage(
   title: string,
   chapters: readonly BookChapter[],
+  minutes: readonly number[],
   theme: "light" | "dark",
 ): string {
   const count = chapters.length === 1 ? "1 chapter" : `${chapters.length} chapters`;
+  const total = minutes.reduce((sum, one) => sum + one, 0);
 
   const items = chapters
     .map(
-      (chapter) => `    <li><a href="${chapter.slug}.html">${escapeHtml(chapter.title)}</a></li>`,
+      (chapter, index) => `    <li><a href="${chapter.slug}.html">
+      <span class="book-toc-title">${escapeHtml(chapter.title)}</span>
+      <span class="book-toc-read">${readingTime(minutes[index] ?? 1)}</span>
+    </a></li>`,
     )
     .join("\n");
 
   return `${head(title, theme)}
-<body>
+<body class="book">
 <main class="book-cover">
 <header class="doc-head">
   <h1 class="doc-title">${escapeHtml(title)}</h1>
-  <p class="doc-meta">${count}</p>
+  <p class="doc-meta">${count} · ${readingTime(total)}</p>
 </header>
   <ol class="book-toc">
 ${items}

--- a/packages/exporter/src/book.ts
+++ b/packages/exporter/src/book.ts
@@ -1,0 +1,459 @@
+import {
+  resolveWikilink,
+  type LinkCandidate,
+  type WikilinkResolver,
+} from "@forkleaf/markdown-engine";
+import type { ExportOptions } from "@forkleaf/types";
+import { toBodyHtml, pageStyles, escapeHtml, type ImageResolver } from "./html";
+
+/**
+ * A folder of notes, published as a book.
+ *
+ * Publishing has always meant one note at one address: a self-contained HTML
+ * file with its styles and diagrams inlined, which is exactly right for a
+ * document somebody will forward, print or keep. It is the wrong shape for a
+ * set of notes that refer to each other, and the reason is not presentation —
+ * it is that a `[[wikilink]]` on a published page has nowhere to point. The
+ * renderer emits `href="#target"`, an anchor to a heading that is not on the
+ * page, so every link between notes silently becomes a link to nothing.
+ *
+ * A book fixes that by publishing the notes together and knowing their
+ * addresses. It is a folder: a contents page, one file per chapter, and a
+ * stylesheet they share rather than each carrying a copy. That last part is a
+ * real trade — a chapter is no longer a file that opens from a USB stick with
+ * no network — and it is made deliberately, because a book is a website and a
+ * website has a network by definition. Single-note export is untouched and
+ * still inlines everything.
+ *
+ * Nothing here knows about `docs/`, repositories or GitHub. It is handed
+ * notes and gives back files with names relative to the book's own folder;
+ * where that folder lives is the caller's business.
+ */
+
+/** A note going into a book. */
+export interface BookNote {
+  /** Its path in the repository, which is what a wikilink resolves against. */
+  path: string;
+  title: string;
+  markdown: string;
+  frontmatter: Record<string, unknown>;
+}
+
+/** A chapter, once it has an address. */
+export interface BookChapter {
+  /** Its filename stem inside the book. */
+  slug: string;
+  title: string;
+  /** The note it came from, so republishing knows where to look. */
+  source: string;
+}
+
+/** One file to write, named relative to the book's folder. */
+export interface BookFile {
+  path: string;
+  content: string;
+}
+
+export interface BuildBookOptions {
+  /** What the cover calls the book. */
+  title: string;
+  theme: "light" | "dark";
+  renderDiagrams: boolean;
+  /** Where a reader who spots a mistake in this chapter should go. */
+  suggestUrl?: (note: BookNote) => string | null;
+  /** Turns a note-relative image path into something a page can show. */
+  resolveImage?: ImageResolver;
+}
+
+export interface Book {
+  chapters: BookChapter[];
+  files: BookFile[];
+}
+
+/** The contents page's filename stem, and therefore a reserved chapter slug. */
+const INDEX = "index";
+
+/** Where the shared stylesheet lives inside the book. */
+export const BOOK_STYLESHEET = "assets/style.css";
+
+/**
+ * A note's filename, reduced to something that can be a URL.
+ *
+ * Deliberately lossy and deliberately narrow: the result has to satisfy the
+ * same allowlist the publish route checks paths against, so anything outside
+ * it becomes a hyphen rather than being escaped into something that survives.
+ * A chapter's address is a URL somebody may link to, and "readable, stable,
+ * and obviously derived from the filename" beats "reversible".
+ */
+export function chapterSlug(path: string): string {
+  const name = path.slice(path.lastIndexOf("/") + 1).replace(/\.[^.]*$/, "");
+
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    // A leading dot would make a hidden file, and a leading dash reads as a
+    // flag to half the tools that will ever touch this folder.
+    .replace(/^[^a-z0-9]+/, "")
+    // Short enough that the numeric suffix a collision adds still fits.
+    .slice(0, 70)
+    // Trimmed last, and that order is the whole point: trimming before the
+    // truncation leaves the truncation free to cut mid-word and put a hyphen
+    // straight back on the end. `_` counts here too — an underscore is as
+    // much a separator as a dash, and `init__.html` is nobody's idea of an
+    // address.
+    .replace(/[-._]+$/, "");
+
+  return slug || "chapter";
+}
+
+/**
+ * The id a heading gets, and therefore the fragment a link to it must use.
+ *
+ * Both ends of `[[style guide#voice]]` come through here — the heading when it
+ * is rendered, and the anchor when the link is built — because the only thing
+ * that matters is that they agree. They did not: headings were emitted with no
+ * `id` at all, so every `#anchor` in a book resolved to nothing and the reader
+ * landed at the top of the chapter with no sign anything had gone wrong.
+ */
+export function headingId(text: string): string {
+  return (
+    text
+      .replace(/<[^>]*>/g, "")
+      // Named, decimal and hex alike. The renderer writes `&` as `&#x26;`,
+      // and a pattern that only knew the first two spelled that heading
+      // `deep-x26-meaningful`.
+      .replace(/&(?:[a-z][a-z0-9]*|#\d+|#x[0-9a-f]+);/gi, " ")
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "section"
+  );
+}
+
+/**
+ * Gives every heading in a chapter an id to be linked to.
+ *
+ * Duplicates are numbered rather than left to collide, because two sections
+ * called "Notes" in one chapter is ordinary and a fragment that matches both
+ * matches whichever the browser finds first — which is not a choice anybody
+ * made.
+ */
+function withHeadingIds(html: string): string {
+  const used = new Set<string>();
+
+  return html.replace(
+    /<h([1-6])([^>]*)>([\s\S]*?)<\/h\1>/gi,
+    (whole, level: string, attrs: string, inner: string) => {
+      // A heading that already carries an id was given one deliberately.
+      if (/\bid=/i.test(attrs)) return whole;
+
+      const base = headingId(inner);
+      let id = base;
+      for (let n = 2; used.has(id); n += 1) id = `${base}-${n}`;
+      used.add(id);
+
+      return `<h${level}${attrs} id="${id}">${inner}</h${level}>`;
+    },
+  );
+}
+
+/**
+ * Addresses for every note, with collisions and the reserved name resolved.
+ *
+ * Two notes in different folders can share a filename, and a note called
+ * `index.md` wants the one address the contents page already has. Both come
+ * out the same way — the first note to ask for a name gets it, and everyone
+ * after gets a number — because the alternative is a chapter that silently
+ * overwrites another chapter, or one that replaces the way into the book.
+ *
+ * Order matters and is the caller's: it is the reading order, and it decides
+ * which of two colliding notes is the one that keeps the plain name.
+ */
+export function assignSlugs(notes: readonly BookNote[]): BookChapter[] {
+  const used = new Set<string>([INDEX]);
+  const chapters: BookChapter[] = [];
+
+  for (const note of notes) {
+    const base = chapterSlug(note.path);
+
+    let slug = base;
+    for (let n = 2; used.has(slug); n += 1) slug = `${base}-${n}`;
+    used.add(slug);
+
+    chapters.push({ slug, title: note.title, source: note.path });
+  }
+
+  return chapters;
+}
+
+/**
+ * Turns `[[a link]]` into a link to the chapter it means.
+ *
+ * The resolution itself is the app's own — the same `resolveWikilink` the
+ * editor uses, against the same candidates — so a link that opens the right
+ * note in the app opens the right chapter in the book. Anything it cannot
+ * place, or that resolves to a note outside this book, is reported as missing
+ * rather than linked: the words stay, styled as plain text, because a reader
+ * is better served by the sentence they were meant to read than by a link that
+ * goes nowhere.
+ */
+function bookWikilinks(chapters: readonly BookChapter[]): WikilinkResolver {
+  const candidates: LinkCandidate[] = chapters.map((chapter) => ({
+    path: chapter.source,
+    title: chapter.title,
+  }));
+  const bySource = new Map(chapters.map((chapter) => [chapter.source, chapter]));
+
+  return (link) => {
+    const found = resolveWikilink(link.target, candidates);
+    const chapter = found ? bySource.get(found.path) : undefined;
+
+    if (!chapter) return { href: "", exists: false };
+
+    // The anchor is the reader's, passed through untouched: `[[intro#setup]]`
+    // means the same heading it always meant, and the renderer's own slugging
+    // is what put an id on it.
+    const anchor = link.anchor ? `#${headingId(link.anchor)}` : "";
+    return { href: `${chapter.slug}.html${anchor}`, exists: true, title: chapter.title };
+  };
+}
+
+/**
+ * Builds every file the book is made of.
+ *
+ * Chapters are rendered in the order given, and rendered in parallel — each
+ * one is an independent pass over its own markdown, and a forty-chapter book
+ * that rasterises its diagrams one file at a time is a publish button that
+ * looks broken.
+ */
+export async function buildBook(
+  notes: readonly BookNote[],
+  options: BuildBookOptions,
+): Promise<Book> {
+  const chapters = assignSlugs(notes);
+  const resolveWiki = bookWikilinks(chapters);
+
+  const pages = await Promise.all(
+    notes.map(async (note, index) => {
+      const chapter = chapters[index]!;
+
+      const exportOptions: ExportOptions = {
+        format: "html",
+        title: note.title,
+        includeFrontmatter: false,
+        renderDiagrams: options.renderDiagrams,
+        theme: options.theme,
+      };
+
+      const body = withHeadingIds(
+        await toBodyHtml(
+          note.markdown,
+          note.frontmatter,
+          exportOptions,
+          options.resolveImage,
+          resolveWiki,
+        ),
+      );
+
+      return {
+        path: `${chapter.slug}.html`,
+        content: chapterPage({
+          book: options.title,
+          chapters,
+          index,
+          body,
+          theme: options.theme,
+          suggestUrl: options.suggestUrl?.(note) ?? null,
+        }),
+      };
+    }),
+  );
+
+  return {
+    chapters,
+    files: [
+      { path: `${INDEX}.html`, content: coverPage(options.title, chapters, options.theme) },
+      ...pages,
+      { path: BOOK_STYLESHEET, content: stylesheet(options.theme) },
+    ],
+  };
+}
+
+/**
+ * The shared stylesheet: what a page looks like, plus what a book adds.
+ *
+ * Built from the same `pageStyles` a downloaded export inlines, so a chapter
+ * and a single published note cannot drift into looking like two products.
+ */
+export function stylesheet(theme: "light" | "dark"): string {
+  return `${pageStyles(theme)}
+/* ── Book chrome ──────────────────────────────────────────────────────────
+   Everything below exists only inside a book: the strip that says where you
+   are, the contents page, and the treatment of a link whose target is not in
+   this book. */
+
+.book-nav {
+  max-width: 46rem;
+  margin: 0 auto 2.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  font-size: 0.875rem;
+}
+.book-nav a { color: var(--accent); text-decoration: none; }
+.book-nav a:hover { text-decoration: underline; }
+.book-nav-where { color: var(--muted); }
+
+.book-foot {
+  max-width: 46rem;
+  margin: 4rem auto 0;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+  font-size: 0.9375rem;
+}
+.book-foot a { color: var(--accent); text-decoration: none; font-weight: 600; }
+.book-foot a:hover { text-decoration: underline; }
+.book-foot-label { display: block; font-size: 0.75rem; color: var(--muted); font-weight: 400; }
+.book-foot-next { margin-left: auto; text-align: right; }
+
+/* ── The contents page ── */
+.book-cover { max-width: 46rem; margin: 0 auto; }
+.book-toc { list-style: none; margin: 2.5rem 0 0; padding: 0; counter-reset: chapter; }
+.book-toc li { counter-increment: chapter; border-top: 1px solid var(--rule); }
+.book-toc li:last-child { border-bottom: 1px solid var(--rule); }
+/* The title block already closes itself with a rule. Without this the first
+   chapter's own top border draws a second one parallel to it, and the band
+   between the two reads as an empty row where a chapter should be. */
+.book-toc li:first-child { border-top: none; }
+.book-toc a {
+  display: flex;
+  gap: 1rem;
+  align-items: baseline;
+  padding: 0.9rem 0.25rem;
+  color: var(--fg);
+  text-decoration: none;
+}
+.book-toc a:hover { color: var(--accent); }
+.book-toc a::before {
+  content: counter(chapter, decimal-leading-zero);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+
+/* A wikilink whose target is not in this book. The words are what the author
+   wrote and they stay; what goes is the suggestion that clicking does
+   something, because it does not. */
+a.fl-wikilink-missing {
+  color: inherit;
+  text-decoration: none;
+  cursor: text;
+  pointer-events: none;
+}
+
+@media print {
+  .book-nav, .book-foot { display: none; }
+}
+`;
+}
+
+/** The `<head>` every page in a book shares. */
+function head(title: string, theme: "light" | "dark"): string {
+  return `<!doctype html>
+<html lang="en" data-theme="${theme}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<link rel="stylesheet" href="${BOOK_STYLESHEET}">
+</head>`;
+}
+
+/** One chapter, with the strip that says where in the book it is. */
+function chapterPage(input: {
+  book: string;
+  chapters: readonly BookChapter[];
+  index: number;
+  body: string;
+  theme: "light" | "dark";
+  suggestUrl: string | null;
+}): string {
+  const chapter = input.chapters[input.index]!;
+  const previous = input.chapters[input.index - 1];
+  const next = input.chapters[input.index + 1];
+
+  const suggest = input.suggestUrl
+    ? `<aside class="doc-suggest">
+  <a class="doc-suggest-link" href="${escapeHtml(input.suggestUrl)}" rel="noopener">Suggest an edit</a>
+  <span class="doc-suggest-note">Opens this note on GitHub. Your change is sent to the author as a suggestion — nothing here changes until they accept it.</span>
+</aside>`
+    : "";
+
+  return `${head(`${chapter.title} — ${input.book}`, input.theme)}
+<body>
+<nav class="book-nav">
+  <a href="${INDEX}.html">← ${escapeHtml(input.book)}</a>
+  <span class="book-nav-where">${input.index + 1} of ${input.chapters.length}</span>
+</nav>
+<main>
+<header class="doc-head">
+  <h1 class="doc-title">${escapeHtml(chapter.title)}</h1>
+</header>
+${input.body}
+${suggest}
+</main>
+<nav class="book-foot">
+${
+  previous
+    ? `  <a href="${previous.slug}.html"><span class="book-foot-label">Previous</span>${escapeHtml(previous.title)}</a>`
+    : ""
+}
+${
+  next
+    ? `  <a class="book-foot-next" href="${next.slug}.html"><span class="book-foot-label">Next</span>${escapeHtml(next.title)}</a>`
+    : ""
+}
+</nav>
+</body>
+</html>
+`;
+}
+
+/** The contents page, which is also what the book's own URL serves. */
+function coverPage(
+  title: string,
+  chapters: readonly BookChapter[],
+  theme: "light" | "dark",
+): string {
+  const count = chapters.length === 1 ? "1 chapter" : `${chapters.length} chapters`;
+
+  const items = chapters
+    .map(
+      (chapter) => `    <li><a href="${chapter.slug}.html">${escapeHtml(chapter.title)}</a></li>`,
+    )
+    .join("\n");
+
+  return `${head(title, theme)}
+<body>
+<main class="book-cover">
+<header class="doc-head">
+  <h1 class="doc-title">${escapeHtml(title)}</h1>
+  <p class="doc-meta">${count}</p>
+</header>
+  <ol class="book-toc">
+${items}
+  </ol>
+</main>
+</body>
+</html>
+`;
+}

--- a/packages/exporter/src/html.ts
+++ b/packages/exporter/src/html.ts
@@ -1,4 +1,9 @@
-import { markdownToHtml, extractMermaidBlocks, serializeDocument } from "@forkleaf/markdown-engine";
+import {
+  markdownToHtml,
+  extractMermaidBlocks,
+  serializeDocument,
+  type WikilinkResolver,
+} from "@forkleaf/markdown-engine";
 import { renderDiagram, extractDiagramLinks, LIGHT_THEME, DARK_THEME } from "@forkleaf/diagrams";
 import type { ExportOptions } from "@forkleaf/types";
 
@@ -107,6 +112,33 @@ export async function toHtml(
   options: ExportOptions,
   resolveImage?: ImageResolver,
 ): Promise<string> {
+  const body = await toBodyHtml(markdown, frontmatter, options, resolveImage);
+
+  return document(
+    options.title,
+    forPrinting(withoutRepeatedTitle(body, options.title)),
+    options.theme,
+    options.suggestUrl ?? null,
+  );
+}
+
+/**
+ * Markdown → the rendered body, without a document around it.
+ *
+ * Split out of {@link toHtml} because a book needs exactly this and nothing
+ * else: forty chapters that each inline the same six kilobytes of CSS are the
+ * same six kilobytes served forty times, and the `<head>` a chapter needs —
+ * a stylesheet link, a canonical URL, its place in the reading order — is not
+ * the `<head>` a downloaded file needs. The rendering is identical either way,
+ * which is the point of sharing it rather than writing a second renderer.
+ */
+export async function toBodyHtml(
+  markdown: string,
+  frontmatter: Record<string, unknown>,
+  options: ExportOptions,
+  resolveImage?: ImageResolver,
+  resolveWikilink?: WikilinkResolver,
+): Promise<string> {
   const source = options.includeFrontmatter ? serializeDocument(markdown, frontmatter) : markdown;
 
   const withDiagrams = options.renderDiagrams
@@ -124,7 +156,7 @@ export async function toHtml(
     },
   );
 
-  let body = markdownToHtml(tokenised);
+  let body = markdownToHtml(tokenised, resolveWikilink ? { resolveWikilink } : undefined);
   body = body.replace(
     /FORKLEAFDIAGRAM(\d+)TOKEN/g,
     (_match, index: string) => `<div class="diagram">${svgs[Number(index)] ?? ""}</div>`,
@@ -132,12 +164,7 @@ export async function toHtml(
 
   if (resolveImage) body = await inlineImages(body, resolveImage);
 
-  return document(
-    options.title,
-    forPrinting(withoutRepeatedTitle(body, options.title)),
-    options.theme,
-    options.suggestUrl ?? null,
-  );
+  return body;
 }
 
 /**
@@ -227,39 +254,18 @@ function forPrinting(html: string): string {
  */
 const BRAND_MARK = `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21v-7"/><path d="M12 14 6.5 8.5A4 4 0 0 1 5.4 5.7L5 3l2.7.4a4 4 0 0 1 2.8 1.1L12 6"/><path d="m12 14 5.5-5.5a4 4 0 0 0 1.1-2.8L19 3l-2.7.4a4 4 0 0 0-2.8 1.1L12 6"/></svg>`;
 
-function document(
-  title: string,
-  body: string,
-  theme: "light" | "dark",
-  suggestUrl: string | null,
-): string {
-  const dark = theme === "dark";
-  const colors = dark
-    ? {
-        bg: "#14181F",
-        fg: "#EDEAE2",
-        muted: "#8A93A3",
-        rule: "#2A3240",
-        accent: "#3FA796",
-        code: "#1E2530",
-      }
-    : {
-        bg: "#FFFFFF",
-        fg: "#22262E",
-        muted: "#6B7280",
-        rule: "#E5E3DC",
-        accent: "#2F7F72",
-        code: "#F5F3ED",
-      };
+/**
+ * The stylesheet, as text.
+ *
+ * Exported because a book links it rather than inlining it. Everything a
+ * chapter needs to look like a ForkLeaf document is here, and the book adds
+ * its own chrome — contents, chapter navigation — on top of it, so the two
+ * cannot drift into looking like different products.
+ */
+export function pageStyles(theme: "light" | "dark"): string {
+  const colors = palette(theme);
 
-  return `<!doctype html>
-<html lang="en" data-theme="${theme}">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${escapeHtml(title)}</title>
-<style>
-  :root {
+  return `  :root {
     --bg: ${colors.bg};
     --fg: ${colors.fg};
     --muted: ${colors.muted};
@@ -413,7 +419,44 @@ function document(
       white-space: nowrap;
     }
   }
-</style>
+`;
+}
+
+/** The two palettes, which are the only thing the theme actually changes. */
+function palette(theme: "light" | "dark") {
+  return theme === "dark"
+    ? {
+        bg: "#14181F",
+        fg: "#EDEAE2",
+        muted: "#8A93A3",
+        rule: "#2A3240",
+        accent: "#3FA796",
+        code: "#1E2530",
+      }
+    : {
+        bg: "#FFFFFF",
+        fg: "#22262E",
+        muted: "#6B7280",
+        rule: "#E5E3DC",
+        accent: "#2F7F72",
+        code: "#F5F3ED",
+      };
+}
+
+function document(
+  title: string,
+  body: string,
+  theme: "light" | "dark",
+  suggestUrl: string | null,
+): string {
+  return `<!doctype html>
+<html lang="en" data-theme="${theme}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>
+${pageStyles(theme)}</style>
 </head>
 <body>
 <main>
@@ -445,7 +488,8 @@ function printedOn(): string {
   }
 }
 
-function escapeHtml(text: string): string {
+/** Exported so the book builder escapes titles exactly as pages do. */
+export function escapeHtml(text: string): string {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")

--- a/packages/exporter/src/index.ts
+++ b/packages/exporter/src/index.ts
@@ -10,7 +10,19 @@ import {
 import { toHtml, type ImageResolver } from "./html";
 import { toDocx } from "./docx";
 
-export { toHtml, type ImageResolver } from "./html";
+export { toHtml, toBodyHtml, pageStyles, type ImageResolver } from "./html";
+export {
+  buildBook,
+  assignSlugs,
+  chapterSlug,
+  stylesheet as bookStylesheet,
+  BOOK_STYLESHEET,
+  type Book,
+  type BookChapter,
+  type BookFile,
+  type BookNote,
+  type BuildBookOptions,
+} from "./book";
 export { toDocx } from "./docx";
 
 /**


### PR DESCRIPTION
Two pieces of work: the landing page says less above the fold, and publishing learns to address more than one note at a time.

## The landing page

The hero asked for about a hundred and twenty words before reaching a button — a badge, a two-line display heading, a five-sentence paragraph, fifteen capability chips and two lines of fine print.

The chips were the worst of it, and they were well-intentioned: a reader told only "notes in your own GitHub repo" could reasonably assume they were being offered a text box over an API. But fifteen pills read as texture rather than as words, so the list that existed to be read was the one thing nobody read, and it pushed the button below the fold to do it. The inventory already had a section further down, grouped by job, where a reader arrives having decided to look — three capabilities were named **only** in the chips, so those became rows there rather than claims that quietly disappeared: running a code block, archiving a web source, and line-by-line blame.

Below the fold, `Positioning` and `Comparison` were two full sections with two display headings answering one question. They are one section now, with two blocks under it: by category, then by name. Nothing was cut, and both anchors still land — `#why` on the section, `#compare` on the table, which is what the nav always meant. `Features` now runs before `Toolkit`, because a capability list read by somebody who is not yet sold is just a long page.

## Books

A published page is one note at one address, and what it cannot express is a set of notes that refer to each other. The reason is not layout — it is that a `[[wikilink]]` on a published page has nowhere to point. The renderer emits `href="#target"`, an anchor to a heading that is not on the page, so every link between notes silently becomes a link to nothing.

A book is a folder: `docs/<book>/`, a contents page, one file per chapter, and a stylesheet they share. Right-click a folder in the sidebar and choose **Publish as book…**.

**Addresses.** Books get their own path functions rather than a loosened `pagePath` — for a single page a slash is always a bug or an attack, and that refusal stays strict. Filenames become slugs that satisfy the same allowlist the route checks against, collisions are numbered rather than allowed to overwrite each other, and `index` is reserved because a chapter published there replaces the contents page and leaves the book with no way in.

**Unpublishing** is the harder half. A single page can be recognised by its name; a book's folder cannot, and "delete the folder recursively" is precisely the operation that eats a file somebody added by hand last week. So a book records what it wrote, and that record is read as a claim to be checked — never an instruction to carry out. Every path is re-derived against the book's own folder before it is believed, so a manifest that was copied, hand-edited, or crafted to say `docs/../.github/workflows/ci.yml` removes nothing outside the book it belongs to.

**Shared assets** are a deliberate trade. A chapter is no longer a file that opens from a USB stick with no network, which is the whole premise of single-note export — so that export is untouched and still inlines everything. Both render through the same `toBodyHtml` and `pageStyles`, so a chapter and a published note cannot drift into looking like two products.

**The dialog** asks what the folder already is before offering anything, so reopening it on a published book shows the address and Unpublish rather than offering to publish again. Chapters are the folder's own notes and nothing below them — a folder with subfolders is a shelf rather than a book, and flattening one invents a reading order its author never chose. The order is shown before it is committed to. The menu item is absent, rather than present and failing, when there is no repository behind the notebook.

## Four bugs, found by testing

- A slug was trimmed of trailing separators **before** being truncated, leaving the truncation free to cut mid-word and put a hyphen straight back on the end.
- Headings were rendered with no `id`, so `[[guide#voice]]` produced a link that navigated to the chapter and scrolled nowhere — the exact class of quietly broken link this feature exists to remove.
- That slugging read `&` as `x26`, because the renderer writes it `&#x26;` and the entity pattern only knew named and decimal forms.
- A pre-existing `FileTree` test was passing for the wrong reason: it fired the context menu at the row wrapper, which carries the drag handlers rather than the context handler, so no menu opened and the item it checked for was trivially absent.

The middle two were found by driving a real book in a browser, not by unit tests — the assertions were green while the anchor was still broken.

## Verification

**2276 tests passing** (from 2201), lint and typecheck clean. 36 book-builder tests, 30 path and manifest tests, 20 route tests, 12 dialog tests and 4 on the menu item — covering path traversal, hand-edited manifests naming files outside the book, `index` collisions, unicode and emoji filenames, and files ForkLeaf did not write. The dialog tests run the real builder; only the network is stubbed.

End to end in a browser: a three-chapter book with spaces in its filenames — cover to chapter navigation, links resolved by title and by alias, an anchor landing on its heading, a wikilink in a code fence left as text, an out-of-book link rendered unclickable, prev/next correct at both ends, and the shared stylesheet served 200. A double horizontal rule on the contents page was caught and fixed while looking at it.

## Worth knowing

Images in a published book keep the relative paths they have in the repository, exactly as single-page publishing does today. This is pre-existing behaviour rather than something books change, but a book is served from a subfolder, so it is the more visible of the two — worth its own fix.

GitHub Pages runs Jekyll over `docs/` by default. Single-page publishing already lives with this and books inherit the same behaviour; if odd omissions ever appear, `docs/.nojekyll` is the fix. It is not added here, because it changes behaviour for the whole site rather than one book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)